### PR TITLE
Import from Glue DataCatalog feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,7 +647,7 @@ data products, find the true domain owner of a field attribute)
 ### import
 
 ```
- Usage: cli.py import [OPTIONS]
+ Usage: datacontract import [OPTIONS]
 
  Create a data contract from the given source location. Prints to stdout.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It uses data contract YAML files to lint the data contract, connect to data sour
 
 ## Getting started
 
-Let's look at this data contract:
+Let's look at this data contract:  
 [https://datacontract.com/examples/orders-latest/datacontract.yaml](https://datacontract.com/examples/orders-latest/datacontract.yaml)
 
 We have a _servers_ section with endpoint details to the S3 bucket, _models_ for the structure of the data, _servicelevels_ and _quality_ attributes that describe the expected freshness and number of rows.
@@ -187,11 +187,11 @@ Commands
 
 ### init
 
-```
- Usage: datacontract init [OPTIONS] [LOCATION]
-
- Download a datacontract.yaml template and write it to file.
-
+```                                                                                                
+ Usage: datacontract init [OPTIONS] [LOCATION]                                                  
+                                                                                                
+ Download a datacontract.yaml template and write it to file.                                    
+                                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────╮
 │   location      [LOCATION]  The location (url or path) of the data contract yaml to create.  │
 │                             [default: datacontract.yaml]                                     │
@@ -209,10 +209,10 @@ Commands
 ### lint
 
 ```
- Usage: datacontract lint [OPTIONS] [LOCATION]
-
- Validate that the datacontract.yaml is correctly formatted.
-
+ Usage: datacontract lint [OPTIONS] [LOCATION]                                                                                     
+                                                                                                                                   
+ Validate that the datacontract.yaml is correctly formatted.                                                                       
+                                                                                                                                   
 ╭─ Arguments ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │   location      [LOCATION]  The location (url or path) of the data contract yaml. [default: datacontract.yaml]                  │
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
@@ -226,10 +226,10 @@ Commands
 ### test
 
 ```
- Usage: datacontract test [OPTIONS] [LOCATION]
-
- Run schema and quality tests on configured servers.
-
+ Usage: datacontract test [OPTIONS] [LOCATION]                                                                                     
+                                                                                                                                   
+ Run schema and quality tests on configured servers.                                                                               
+                                                                                                                                   
 ╭─ Arguments ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │   location      [LOCATION]  The location (url or path) of the data contract yaml. [default: datacontract.yaml]                  │
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
@@ -262,11 +262,11 @@ Data Contract CLI connects to a data source and runs schema and quality tests to
 $ datacontract test --server production datacontract.yaml
 ```
 
-To connect to the databases the `server` block in the datacontract.yaml is used to set up the connection.
+To connect to the databases the `server` block in the datacontract.yaml is used to set up the connection. 
 In addition, credentials, such as username and passwords, may be defined with environment variables.
 
 The application uses different engines, based on the server `type`.
-Internally, it connects with DuckDB, Spark, or a native connection and executes the most tests with _soda-core_ and _fastjsonschema_.
+Internally, it connects with DuckDB, Spark, or a native connection and executes the most tests with _soda-core_ and _fastjsonschema_. 
 
 Credentials are provided with environment variables.
 
@@ -452,7 +452,7 @@ dbutils.library.restartPython()
 from datacontract.data_contract import DataContract
 
 data_contract = DataContract(
-  data_contract_file="/Volumes/acme_catalog_prod/orders_latest/datacontract/datacontract.yaml",
+  data_contract_file="/Volumes/acme_catalog_prod/orders_latest/datacontract/datacontract.yaml", 
   spark=spark)
 run = data_contract.test()
 run.result
@@ -477,7 +477,7 @@ servers:
 models:
   my_table_1: # corresponds to a table
     type: table
-    fields:
+    fields: 
       my_column_1: # corresponds to a column
         type: varchar
 ```
@@ -535,7 +535,7 @@ servers:
 models:
   my_table_1: # corresponds to a table
     type: table
-    fields:
+    fields: 
       my_column_1: # corresponds to a column
         type: varchar
 ```
@@ -552,10 +552,10 @@ models:
 ### export
 
 ```
- Usage: datacontract export [OPTIONS] [LOCATION]
-
- Convert data contract to a specific format. Prints to stdout or to the specified output file.
-
+ Usage: datacontract export [OPTIONS] [LOCATION]                                                                                                                           
+                                                                                                                                                                           
+ Convert data contract to a specific format. Prints to stdout or to the specified output file.                                                                                                     
+                                                                                                                                                                           
 ╭─ Arguments ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │   location      [LOCATION]  The location (url or path) of the data contract yaml. [default: datacontract.yaml]                                                          │
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
@@ -588,9 +588,9 @@ Available export options:
 
 | Type                 | Description                                             | Status |
 |----------------------|---------------------------------------------------------|--------|
-| `html`               | Export to HTML                                          | ✅      |
-| `jsonschema`         | Export to JSON Schema                                   | ✅      |
-| `odcs`               | Export to Open Data Contract Standard (ODCS)            | ✅      |
+| `html`               | Export to HTML                                          | ✅      | 
+| `jsonschema`         | Export to JSON Schema                                   | ✅      | 
+| `odcs`               | Export to Open Data Contract Standard (ODCS)            | ✅      | 
 | `sodacl`             | Export to SodaCL quality checks in YAML format          | ✅      |
 | `dbt`                | Export to dbt models in YAML format                     | ✅      |
 | `dbt-sources`        | Export to dbt sources in YAML format                    | ✅      |
@@ -608,11 +608,11 @@ Available export options:
 
 #### Great Expectations
 
-The export function transforms a specified data contract into a comprehensive Great Expectations JSON suite.
+The export function transforms a specified data contract into a comprehensive Great Expectations JSON suite. 
 If the contract includes multiple models, you need to specify the names of the model you wish to export.
 
 ```shell
-datacontract  export datacontract.yaml --format great-expectations --model orders
+datacontract  export datacontract.yaml --format great-expectations --model orders 
 ```
 
 The export creates a list of expectations by utilizing:
@@ -622,7 +622,7 @@ The export creates a list of expectations by utilizing:
 
 #### RDF
 
-The export function converts a given data contract into a RDF representation. You have the option to
+The export function converts a given data contract into a RDF representation. You have the option to 
 add a base_url which will be used as the default prefix to resolve relative IRIs inside the document.
 
 ```shell
@@ -647,35 +647,28 @@ data products, find the true domain owner of a field attribute)
 ### import
 
 ```
- Usage: datacontract import [OPTIONS]
+ Usage: cli.py import [OPTIONS]
 
- Create a data contract from the given source file. Prints to stdout.
+ Create a data contract from the given source location. Prints to stdout.
 
-╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ *  --format        [sql|avro|glue]  The format of the source file. [default: None] [required]                   │
-│ *  --source        TEXT             The path to the file that should be imported. [default: None] [required]    │
-│    --help                           Show this message and exit.                                                 │
-╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ *  --format        [sql|avro|glue]  The format of the source file. [default: None] [required]                                    │
+│ *  --source        TEXT             The path to the file or Glue Database that should be imported. [default: None] [required]    │
+│    --help                           Show this message and exit.                                                                  │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
-Example:
+Example: 
 ```bash
 # Example import from SQL DDL
 datacontract import --format sql --source my_ddl.sql
-```
-
-Example 2:
-```bash
-# Example import all tables from AWS Glue Database
-export AWS_PROFILE=my-profile
-datacontract import --format glue --source gluedatabase1
 ```
 
 Available import options:
 
 | Type               | Description                                    | Status  |
 |--------------------|------------------------------------------------|---------|
-| `sql`              | Import from SQL DDL                            | ✅       |
+| `sql`              | Import from SQL DDL                            | ✅       | 
 | `avro`             | Import from AVRO schemas                       | ✅     |
 | `glue`             | Import from AWS Glue DataCatalog               | ✅     |
 | `protobuf`         | Import from Protobuf schemas                   | TBD     |
@@ -689,10 +682,10 @@ Available import options:
 ### breaking
 
 ```
- Usage: datacontract breaking [OPTIONS] LOCATION_OLD LOCATION_NEW
-
- Identifies breaking changes between data contracts. Prints to stdout.
-
+ Usage: datacontract breaking [OPTIONS] LOCATION_OLD LOCATION_NEW                                                            
+                                                                                                                             
+ Identifies breaking changes between data contracts. Prints to stdout.                                                       
+                                                                                                                             
 ╭─ Arguments ───────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ *    location_old      TEXT  The location (url or path) of the old data contract yaml. [default: None] [required]         │
 │ *    location_new      TEXT  The location (url or path) of the new data contract yaml. [default: None] [required]         │
@@ -705,10 +698,10 @@ Available import options:
 ### changelog
 
 ```
- Usage: datacontract changelog [OPTIONS] LOCATION_OLD LOCATION_NEW
-
- Generate a changelog between data contracts. Prints to stdout.
-
+ Usage: datacontract changelog [OPTIONS] LOCATION_OLD LOCATION_NEW                                                           
+                                                                                                                             
+ Generate a changelog between data contracts. Prints to stdout.                                                              
+                                                                                                                             
 ╭─ Arguments ───────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ *    location_old      TEXT  The location (url or path) of the old data contract yaml. [default: None] [required]         │
 │ *    location_new      TEXT  The location (url or path) of the new data contract yaml. [default: None] [required]         │
@@ -721,10 +714,10 @@ Available import options:
 ### diff
 
 ```
- Usage: datacontract diff [OPTIONS] LOCATION_OLD LOCATION_NEW
-
- PLACEHOLDER. Currently works as 'changelog' does.
-
+ Usage: datacontract diff [OPTIONS] LOCATION_OLD LOCATION_NEW                                                                
+                                                                                                                             
+ PLACEHOLDER. Currently works as 'changelog' does.                                                                           
+                                                                                                                             
 ╭─ Arguments ───────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ *    location_old      TEXT  The location (url or path) of the old data contract yaml. [default: None] [required]         │
 │ *    location_new      TEXT  The location (url or path) of the new data contract yaml. [default: None] [required]         │
@@ -841,14 +834,14 @@ Create a data contract based on the requirements from use cases.
    ```bash
    $ datacontract init
    ```
-
+   
 2. Add examples to the `datacontract.yaml`. Do not start with the data model, although you are probably tempted to do that. Examples are the fastest way to get feedback from everybody and not loose someone in the discussion.
 
 3. Create the model based on the examples. Test the model against the examples to double-check whether the model matches the examples.
     ```bash
     $ datacontract test --examples
     ```
-
+   
 4. Add quality checks and additional type constraints one by one to the contract and make sure the examples and the actual data still adheres to the contract. Check against examples for a very fast feedback loop.
     ```bash
     $ datacontract test --examples

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It uses data contract YAML files to lint the data contract, connect to data sour
 
 ## Getting started
 
-Let's look at this data contract:  
+Let's look at this data contract:
 [https://datacontract.com/examples/orders-latest/datacontract.yaml](https://datacontract.com/examples/orders-latest/datacontract.yaml)
 
 We have a _servers_ section with endpoint details to the S3 bucket, _models_ for the structure of the data, _servicelevels_ and _quality_ attributes that describe the expected freshness and number of rows.
@@ -187,11 +187,11 @@ Commands
 
 ### init
 
-```                                                                                                
- Usage: datacontract init [OPTIONS] [LOCATION]                                                  
-                                                                                                
- Download a datacontract.yaml template and write it to file.                                    
-                                                                                                
+```
+ Usage: datacontract init [OPTIONS] [LOCATION]
+
+ Download a datacontract.yaml template and write it to file.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────╮
 │   location      [LOCATION]  The location (url or path) of the data contract yaml to create.  │
 │                             [default: datacontract.yaml]                                     │
@@ -209,10 +209,10 @@ Commands
 ### lint
 
 ```
- Usage: datacontract lint [OPTIONS] [LOCATION]                                                                                     
-                                                                                                                                   
- Validate that the datacontract.yaml is correctly formatted.                                                                       
-                                                                                                                                   
+ Usage: datacontract lint [OPTIONS] [LOCATION]
+
+ Validate that the datacontract.yaml is correctly formatted.
+
 ╭─ Arguments ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │   location      [LOCATION]  The location (url or path) of the data contract yaml. [default: datacontract.yaml]                  │
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
@@ -226,10 +226,10 @@ Commands
 ### test
 
 ```
- Usage: datacontract test [OPTIONS] [LOCATION]                                                                                     
-                                                                                                                                   
- Run schema and quality tests on configured servers.                                                                               
-                                                                                                                                   
+ Usage: datacontract test [OPTIONS] [LOCATION]
+
+ Run schema and quality tests on configured servers.
+
 ╭─ Arguments ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │   location      [LOCATION]  The location (url or path) of the data contract yaml. [default: datacontract.yaml]                  │
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
@@ -262,11 +262,11 @@ Data Contract CLI connects to a data source and runs schema and quality tests to
 $ datacontract test --server production datacontract.yaml
 ```
 
-To connect to the databases the `server` block in the datacontract.yaml is used to set up the connection. 
+To connect to the databases the `server` block in the datacontract.yaml is used to set up the connection.
 In addition, credentials, such as username and passwords, may be defined with environment variables.
 
 The application uses different engines, based on the server `type`.
-Internally, it connects with DuckDB, Spark, or a native connection and executes the most tests with _soda-core_ and _fastjsonschema_. 
+Internally, it connects with DuckDB, Spark, or a native connection and executes the most tests with _soda-core_ and _fastjsonschema_.
 
 Credentials are provided with environment variables.
 
@@ -452,7 +452,7 @@ dbutils.library.restartPython()
 from datacontract.data_contract import DataContract
 
 data_contract = DataContract(
-  data_contract_file="/Volumes/acme_catalog_prod/orders_latest/datacontract/datacontract.yaml", 
+  data_contract_file="/Volumes/acme_catalog_prod/orders_latest/datacontract/datacontract.yaml",
   spark=spark)
 run = data_contract.test()
 run.result
@@ -477,7 +477,7 @@ servers:
 models:
   my_table_1: # corresponds to a table
     type: table
-    fields: 
+    fields:
       my_column_1: # corresponds to a column
         type: varchar
 ```
@@ -535,7 +535,7 @@ servers:
 models:
   my_table_1: # corresponds to a table
     type: table
-    fields: 
+    fields:
       my_column_1: # corresponds to a column
         type: varchar
 ```
@@ -552,10 +552,10 @@ models:
 ### export
 
 ```
- Usage: datacontract export [OPTIONS] [LOCATION]                                                                                                                           
-                                                                                                                                                                           
- Convert data contract to a specific format. Prints to stdout or to the specified output file.                                                                                                     
-                                                                                                                                                                           
+ Usage: datacontract export [OPTIONS] [LOCATION]
+
+ Convert data contract to a specific format. Prints to stdout or to the specified output file.
+
 ╭─ Arguments ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │   location      [LOCATION]  The location (url or path) of the data contract yaml. [default: datacontract.yaml]                                                          │
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
@@ -588,9 +588,9 @@ Available export options:
 
 | Type                 | Description                                             | Status |
 |----------------------|---------------------------------------------------------|--------|
-| `html`               | Export to HTML                                          | ✅      | 
-| `jsonschema`         | Export to JSON Schema                                   | ✅      | 
-| `odcs`               | Export to Open Data Contract Standard (ODCS)            | ✅      | 
+| `html`               | Export to HTML                                          | ✅      |
+| `jsonschema`         | Export to JSON Schema                                   | ✅      |
+| `odcs`               | Export to Open Data Contract Standard (ODCS)            | ✅      |
 | `sodacl`             | Export to SodaCL quality checks in YAML format          | ✅      |
 | `dbt`                | Export to dbt models in YAML format                     | ✅      |
 | `dbt-sources`        | Export to dbt sources in YAML format                    | ✅      |
@@ -608,11 +608,11 @@ Available export options:
 
 #### Great Expectations
 
-The export function transforms a specified data contract into a comprehensive Great Expectations JSON suite. 
+The export function transforms a specified data contract into a comprehensive Great Expectations JSON suite.
 If the contract includes multiple models, you need to specify the names of the model you wish to export.
 
 ```shell
-datacontract  export datacontract.yaml --format great-expectations --model orders 
+datacontract  export datacontract.yaml --format great-expectations --model orders
 ```
 
 The export creates a list of expectations by utilizing:
@@ -622,7 +622,7 @@ The export creates a list of expectations by utilizing:
 
 #### RDF
 
-The export function converts a given data contract into a RDF representation. You have the option to 
+The export function converts a given data contract into a RDF representation. You have the option to
 add a base_url which will be used as the default prefix to resolve relative IRIs inside the document.
 
 ```shell
@@ -647,29 +647,37 @@ data products, find the true domain owner of a field attribute)
 ### import
 
 ```
- Usage: datacontract import [OPTIONS]                                                                              
-                                                                                                                   
- Create a data contract from the given source file. Prints to stdout.                                              
-                                                                                                                   
+ Usage: datacontract import [OPTIONS]
+
+ Create a data contract from the given source file. Prints to stdout.
+
 ╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ *  --format        [sql|avro]  The format of the source file. [default: None] [required]                        │
-│ *  --source        TEXT        The path to the file that should be imported. [default: None] [required]         │
-│    --help                      Show this message and exit.                                                      │
+│ *  --format        [sql|avro|glue]  The format of the source file. [default: None] [required]                   │
+│ *  --source        TEXT             The path to the file that should be imported. [default: None] [required]    │
+│    --help                           Show this message and exit.                                                 │
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
-Example: 
+Example:
 ```bash
 # Example import from SQL DDL
 datacontract import --format sql --source my_ddl.sql
+```
+
+Example 2:
+```bash
+# Example import all tables from AWS Glue Database
+export AWS_PROFILE=my-profile
+datacontract import --format glue --source gluedatabase1
 ```
 
 Available import options:
 
 | Type               | Description                                    | Status  |
 |--------------------|------------------------------------------------|---------|
-| `sql`              | Import from SQL DDL                            | ✅       | 
+| `sql`              | Import from SQL DDL                            | ✅       |
 | `avro`             | Import from AVRO schemas                       | ✅     |
+| `glue`             | Import from AWS Glue DataCatalog               | ✅     |
 | `protobuf`         | Import from Protobuf schemas                   | TBD     |
 | `jsonschema`       | Import from JSON Schemas                       | TBD     |
 | `bigquery`         | Import from BigQuery Schemas                   | TBD     |
@@ -681,10 +689,10 @@ Available import options:
 ### breaking
 
 ```
- Usage: datacontract breaking [OPTIONS] LOCATION_OLD LOCATION_NEW                                                            
-                                                                                                                             
- Identifies breaking changes between data contracts. Prints to stdout.                                                       
-                                                                                                                             
+ Usage: datacontract breaking [OPTIONS] LOCATION_OLD LOCATION_NEW
+
+ Identifies breaking changes between data contracts. Prints to stdout.
+
 ╭─ Arguments ───────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ *    location_old      TEXT  The location (url or path) of the old data contract yaml. [default: None] [required]         │
 │ *    location_new      TEXT  The location (url or path) of the new data contract yaml. [default: None] [required]         │
@@ -697,10 +705,10 @@ Available import options:
 ### changelog
 
 ```
- Usage: datacontract changelog [OPTIONS] LOCATION_OLD LOCATION_NEW                                                           
-                                                                                                                             
- Generate a changelog between data contracts. Prints to stdout.                                                              
-                                                                                                                             
+ Usage: datacontract changelog [OPTIONS] LOCATION_OLD LOCATION_NEW
+
+ Generate a changelog between data contracts. Prints to stdout.
+
 ╭─ Arguments ───────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ *    location_old      TEXT  The location (url or path) of the old data contract yaml. [default: None] [required]         │
 │ *    location_new      TEXT  The location (url or path) of the new data contract yaml. [default: None] [required]         │
@@ -713,10 +721,10 @@ Available import options:
 ### diff
 
 ```
- Usage: datacontract diff [OPTIONS] LOCATION_OLD LOCATION_NEW                                                                
-                                                                                                                             
- PLACEHOLDER. Currently works as 'changelog' does.                                                                           
-                                                                                                                             
+ Usage: datacontract diff [OPTIONS] LOCATION_OLD LOCATION_NEW
+
+ PLACEHOLDER. Currently works as 'changelog' does.
+
 ╭─ Arguments ───────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ *    location_old      TEXT  The location (url or path) of the old data contract yaml. [default: None] [required]         │
 │ *    location_new      TEXT  The location (url or path) of the new data contract yaml. [default: None] [required]         │
@@ -833,14 +841,14 @@ Create a data contract based on the requirements from use cases.
    ```bash
    $ datacontract init
    ```
-   
+
 2. Add examples to the `datacontract.yaml`. Do not start with the data model, although you are probably tempted to do that. Examples are the fastest way to get feedback from everybody and not loose someone in the discussion.
 
 3. Create the model based on the examples. Test the model against the examples to double-check whether the model matches the examples.
     ```bash
     $ datacontract test --examples
     ```
-   
+
 4. Add quality checks and additional type constraints one by one to the contract and make sure the examples and the actual data still adheres to the contract. Check against examples for a very fast feedback loop.
     ```bash
     $ datacontract test --examples

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -204,15 +204,16 @@ def export(
 class ImportFormat(str, Enum):
     sql = "sql"
     avro = "avro"
+    glue = "glue"
 
 
 @app.command(name="import")
 def import_(
     format: Annotated[ImportFormat, typer.Option(help="The format of the source file.")],
-    source: Annotated[str, typer.Option(help="The path to the file that should be imported.")],
+    source: Annotated[str, typer.Option(help="The path to the file or Glue Database that should be imported.")],
 ):
     """
-    Create a data contract from the given source file. Prints to stdout.
+    Create a data contract from the given source location. Prints to stdout.
     """
     result = DataContract().import_from_source(format, source)
     console.print(result.to_yaml())

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -27,6 +27,7 @@ from datacontract.export.sql_converter import to_sql_ddl, to_sql_query
 from datacontract.export.terraform_converter import to_terraform
 from datacontract.imports.avro_importer import import_avro
 from datacontract.imports.sql_importer import import_sql
+from datacontract.imports.glue_importer import import_glue
 from datacontract.integration.publish_datamesh_manager import publish_datamesh_manager
 from datacontract.integration.publish_opentelemetry import publish_opentelemetry
 from datacontract.lint import resolve
@@ -476,6 +477,8 @@ class DataContract:
             data_contract_specification = import_sql(data_contract_specification, format, source)
         elif format == "avro":
             data_contract_specification = import_avro(data_contract_specification, source)
+        elif format == "glue":
+            data_contract_specification = import_glue(data_contract_specification, source)
         else:
             print(f"Import format {format} not supported.")
 

--- a/datacontract/imports/glue_importer.py
+++ b/datacontract/imports/glue_importer.py
@@ -1,0 +1,146 @@
+import boto3
+from typing import List
+
+from datacontract.model.data_contract_specification import (
+    DataContractSpecification,
+    Model,
+    Field,
+)
+
+
+def get_glue_tables(database_name: str) -> List[str]:
+    """Get the list of tables in a Glue database.
+
+    Args:
+        database_name (str): glue database to request.
+
+    Returns:
+        List[string]: List of table names
+    """
+
+    glue = boto3.client("glue")
+
+    # Set the paginator
+    paginator = glue.get_paginator("get_tables")
+
+    # Initialize an empty list to store the table names
+    table_names = []
+    try:
+        # Paginate through the tables
+        for page in paginator.paginate(DatabaseName=database_name, PaginationConfig={"PageSize": 100}):
+            # Add the tables from the current page to the list
+            table_names.extend([table["Name"] for table in page["TableList"] if "Name" in table])
+    except glue.exceptions.EntityNotFoundException:
+        print(f"Database {database_name} not found.")
+        return []
+    except Exception as e:
+        # todo catch all
+        print(f"Error: {e}")
+        return []
+
+    return table_names
+
+
+def get_glue_table_schema(database_name: str, table_name: str):
+    """Get the schema of a Glue table.
+
+    Args:
+        database_name (str): Glue database name.
+        table_name (str): Glue table name.
+
+    Returns:
+        dict: Table schema
+    """
+
+    glue = boto3.client("glue")
+
+    # Get the table schema
+    try:
+        response = glue.get_table(DatabaseName=database_name, Name=table_name)
+    except glue.exceptions.EntityNotFoundException:
+        print(f"Table {table_name} not found in database {database_name}.")
+        return {}
+    except Exception as e:
+        # todo catch all
+        print(f"Error: {e}")
+        return {}
+
+    table_schema = response["Table"]["StorageDescriptor"]["Columns"]
+
+    # when using hive partition keys, the schema is stored in the PartitionKeys field
+    if response["Table"].get("PartitionKeys") is not None:
+        for pk in response["Table"]["PartitionKeys"]:
+            table_schema.append(
+                {
+                    "Name": pk["Name"],
+                    "Type": pk["Type"],
+                    "Hive": True,
+                    "Comment": "Partition Key",
+                }
+            )
+
+    return table_schema
+
+
+def import_glue(data_contract_specification: DataContractSpecification, source: str):
+    tables = get_glue_tables(source)
+
+    for table_name in tables:
+        if data_contract_specification.models is None:
+            data_contract_specification.models = {}
+
+        table_schema = get_glue_table_schema(source, table_name)
+
+        fields = {}
+        for column in table_schema:
+            field = Field()
+            field.type = map_type_from_sql(column["Type"])
+
+            # hive partitons are required, but are not primary keys
+            if column.get("Hive"):
+                field.required = True
+
+            field.description = column.get("Comment")
+
+            fields[column["Name"]] = field
+
+        data_contract_specification.models[table_name] = Model(
+            type="table",
+            fields=fields,
+        )
+
+    return data_contract_specification
+
+
+def map_type_from_sql(sql_type: str):
+    if sql_type is None:
+        return None
+
+    if sql_type.lower().startswith("varchar"):
+        return "varchar"
+    if sql_type.lower().startswith("string"):
+        return "string"
+    if sql_type.lower().startswith("text"):
+        return "text"
+    elif sql_type.lower().startswith("byte"):
+        return "byte"
+    elif sql_type.lower().startswith("short"):
+        return "short"
+    elif sql_type.lower().startswith("integer"):
+        return "integer"
+    elif sql_type.lower().startswith("long"):
+        return "long"
+    elif sql_type.lower().startswith("bigint"):
+        return "long"
+    elif sql_type.lower().startswith("float"):
+        return "float"
+    elif sql_type.lower().startswith("double"):
+        return "double"
+    elif sql_type.lower().startswith("boolean"):
+        return "boolean"
+    elif sql_type.lower().startswith("timestamp"):
+        return "timestamp"
+    elif sql_type.lower().startswith("date"):
+        return "date"
+    else:
+        return "variant"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,9 @@ dependencies = [
   "avro==1.11.3",
   "opentelemetry-exporter-otlp-proto-grpc~=1.16.0",
   "opentelemetry-exporter-otlp-proto-http~=1.16.0",
-  "deltalake~=0.17.0"
+  "deltalake~=0.17.0",
+  "boto3<1.34.70,>=1.34.41",
+  "botocore<1.34.70,>=1.34.41"
 ]
 
 [project.optional-dependencies]
@@ -47,6 +49,7 @@ dev = [
   "ruff",
   "pytest",
   "pytest-xdist",
+  "moto",
   # testcontainers 4.x have issues with Kafka on arm
   # https://github.com/testcontainers/testcontainers-python/issues/450
   "testcontainers<4.0.0",

--- a/tests/fixtures/glue/datacontract.yaml
+++ b/tests/fixtures/glue/datacontract.yaml
@@ -3,6 +3,12 @@ id: my-data-contract-id
 info:
     title: My Data Contract
     version: 0.0.1
+servers:
+    production:
+        account: '123456789012'
+        database: test_database
+        location: s3://test_bucket/testdb
+        type: glue
 models:
     test_table:
         type: table

--- a/tests/fixtures/glue/datacontract.yaml
+++ b/tests/fixtures/glue/datacontract.yaml
@@ -1,0 +1,19 @@
+dataContractSpecification: 0.9.3
+id: my-data-contract-id
+info:
+    title: My Data Contract
+    version: 0.0.1
+models:
+    test_table:
+        type: table
+        fields:
+            field_one:
+                type: string
+            field_two:
+                type: integer
+            field_three:
+                type: timestamp
+            part_one:
+                description: Partition Key
+                required: True
+                type: string

--- a/tests/test_import_glue.py
+++ b/tests/test_import_glue.py
@@ -16,13 +16,14 @@ table_name = "test_table"
 
 
 @pytest.fixture(scope="function")
-def aws_credentials():
+def aws_credentials(monkeypatch):
     """Mocked AWS Credentials for moto."""
-    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
-    os.environ["AWS_SECURITY_TOKEN"] = "testing"
-    os.environ["AWS_SESSION_TOKEN"] = "testing"
-    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_import_glue.py
+++ b/tests/test_import_glue.py
@@ -33,6 +33,7 @@ def setup_mock_glue(aws_credentials):
         client.create_database(
             DatabaseInput={
                 "Name": db_name,
+                "LocationUri": "s3://test_bucket/testdb",
             },
         )
 

--- a/tests/test_import_glue.py
+++ b/tests/test_import_glue.py
@@ -4,14 +4,19 @@ import logging
 import yaml
 from moto import mock_aws
 import os
+import pytest
 
 from datacontract.cli import app
 from datacontract.data_contract import DataContract
 
 logging.basicConfig(level=logging.INFO, force=True)
 
+db_name = "test_database"
+table_name = "test_table"
 
-def setup_mock_glue(db_name="test_database", table_name="test_table"):
+
+@pytest.fixture(scope="function")
+def aws_credentials():
     """Mocked AWS Credentials for moto."""
     os.environ["AWS_ACCESS_KEY_ID"] = "testing"
     os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
@@ -19,49 +24,52 @@ def setup_mock_glue(db_name="test_database", table_name="test_table"):
     os.environ["AWS_SESSION_TOKEN"] = "testing"
     os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
 
-    client = boto3.client("glue")
 
-    client.create_database(
-        DatabaseInput={
-            "Name": db_name,
-        },
-    )
+@pytest.fixture(scope="function")
+def setup_mock_glue(aws_credentials):
+    with mock_aws():
+        client = boto3.client("glue")
 
-    client.create_table(
-        DatabaseName=db_name,
-        TableInput={
-            "Name": table_name,
-            "StorageDescriptor": {
-                "Columns": [
+        client.create_database(
+            DatabaseInput={
+                "Name": db_name,
+            },
+        )
+
+        client.create_table(
+            DatabaseName=db_name,
+            TableInput={
+                "Name": table_name,
+                "StorageDescriptor": {
+                    "Columns": [
+                        {
+                            "Name": "field_one",
+                            "Type": "string",
+                        },
+                        {
+                            "Name": "field_two",
+                            "Type": "integer",
+                        },
+                        {
+                            "Name": "field_three",
+                            "Type": "timestamp",
+                        },
+                    ]
+                },
+                "PartitionKeys": [
                     {
-                        "Name": "field_one",
+                        "Name": "part_one",
                         "Type": "string",
                     },
-                    {
-                        "Name": "field_two",
-                        "Type": "integer",
-                    },
-                    {
-                        "Name": "field_three",
-                        "Type": "timestamp",
-                    },
-                ]
+                ],
             },
-            "PartitionKeys": [
-                {
-                    "Name": "part_one",
-                    "Type": "string",
-                },
-            ],
-        },
-    )
+        )
+        # everything after the yield will run after the fixture is used
+        yield client
 
 
-def test_cli():
-    mock = mock_aws()
-    mock.start()
-    setup_mock_glue()
-
+@mock_aws
+def test_cli(setup_mock_glue):
     runner = CliRunner()
     result = runner.invoke(
         app,
@@ -74,14 +82,10 @@ def test_cli():
         ],
     )
     assert result.exit_code == 0
-    mock.stop()
 
 
-def test_import_glue_schema():
-    mock = mock_aws()
-    mock.start()
-    setup_mock_glue()
-
+@mock_aws
+def test_import_glue_schema(setup_mock_glue):
     result = DataContract().import_from_source("glue", "test_database")
 
     with open("fixtures/glue/datacontract.yaml") as file:
@@ -91,4 +95,3 @@ def test_import_glue_schema():
     assert yaml.safe_load(result.to_yaml()) == yaml.safe_load(expected)
     # Disable linters so we don't get "missing description" warnings
     assert DataContract(data_contract_str=expected).lint(enabled_linters=set()).has_passed()
-    mock.stop()

--- a/tests/test_import_glue.py
+++ b/tests/test_import_glue.py
@@ -1,0 +1,94 @@
+import boto3
+from typer.testing import CliRunner
+import logging
+import yaml
+from moto import mock_aws
+import os
+
+from datacontract.cli import app
+from datacontract.data_contract import DataContract
+
+logging.basicConfig(level=logging.INFO, force=True)
+
+
+def setup_mock_glue(db_name="test_database", table_name="test_table"):
+    """Mocked AWS Credentials for moto."""
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+    client = boto3.client("glue")
+
+    client.create_database(
+        DatabaseInput={
+            "Name": db_name,
+        },
+    )
+
+    client.create_table(
+        DatabaseName=db_name,
+        TableInput={
+            "Name": table_name,
+            "StorageDescriptor": {
+                "Columns": [
+                    {
+                        "Name": "field_one",
+                        "Type": "string",
+                    },
+                    {
+                        "Name": "field_two",
+                        "Type": "integer",
+                    },
+                    {
+                        "Name": "field_three",
+                        "Type": "timestamp",
+                    },
+                ]
+            },
+            "PartitionKeys": [
+                {
+                    "Name": "part_one",
+                    "Type": "string",
+                },
+            ],
+        },
+    )
+
+
+def test_cli():
+    mock = mock_aws()
+    mock.start()
+    setup_mock_glue()
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "import",
+            "--format",
+            "glue",
+            "--source",
+            "test_database",
+        ],
+    )
+    assert result.exit_code == 0
+    mock.stop()
+
+
+def test_import_glue_schema():
+    mock = mock_aws()
+    mock.start()
+    setup_mock_glue()
+
+    result = DataContract().import_from_source("glue", "test_database")
+
+    with open("fixtures/glue/datacontract.yaml") as file:
+        expected = file.read()
+
+    print("Result", result.to_yaml())
+    assert yaml.safe_load(result.to_yaml()) == yaml.safe_load(expected)
+    # Disable linters so we don't get "missing description" warnings
+    assert DataContract(data_contract_str=expected).lint(enabled_linters=set()).has_passed()
+    mock.stop()

--- a/tests/test_import_glue.py
+++ b/tests/test_import_glue.py
@@ -3,7 +3,6 @@ from typer.testing import CliRunner
 import logging
 import yaml
 from moto import mock_aws
-import os
 import pytest
 
 from datacontract.cli import app


### PR DESCRIPTION
Adding the ability to import all tables from a Glue Database into a datacontract.
Currently it supports only the aws authorisation from the environment (AWS_PROFILE or access/secret key)

