### PR TITLE
Bugfix import avro with logicalType and default values

### DIFF
--- a/datacontract/export/avro_converter.py
+++ b/datacontract/export/avro_converter.py
@@ -33,6 +33,8 @@ def to_avro_field(field, field_name):
     avro_field = {"name": field_name}
     if field.description is not None:
         avro_field["doc"] = field.description
+    if field.logicalType is not None:
+        avro_field["logicalType"] = field.logicalType
     avro_field["type"] = to_avro_type(field, field_name)
     return avro_field
 

--- a/datacontract/export/avro_converter.py
+++ b/datacontract/export/avro_converter.py
@@ -35,6 +35,8 @@ def to_avro_field(field, field_name):
         avro_field["doc"] = field.description
     if field.logicalType is not None:
         avro_field["logicalType"] = field.logicalType
+    if field.default is not None:
+        avro_field["default"] = field.default
     avro_field["type"] = to_avro_type(field, field_name)
     return avro_field
 

--- a/datacontract/imports/avro_importer.py
+++ b/datacontract/imports/avro_importer.py
@@ -43,8 +43,11 @@ def import_record_fields(record_fields):
         imported_fields[field.name] = Field()
         imported_fields[field.name].required = True
         imported_fields[field.name].description = field.doc
+        if 'default' in field.props:
+            imported_fields[field.name].default = field.props['default']
+
         for prop in field.other_props:
-            imported_fields[field.name].__setattr__(prop, field.other_props[prop])
+            imported_fields[field.name].__setattr__(prop, field.other_props[prop])                
 
         if field.type.type == "record":
             imported_fields[field.name].type = "object"

--- a/datacontract/model/data_contract_specification.py
+++ b/datacontract/model/data_contract_specification.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 import pydantic as pyd
 import yaml
@@ -80,6 +80,7 @@ class Field(pyd.BaseModel):
     exclusiveMinimum: int = None
     maximum: int = None
     exclusiveMaximum: int = None
+    logicalType: Optional[str] = None
     enum: List[str] = []
     tags: List[str] = []
     fields: Dict[str, "Field"] = {}

--- a/datacontract/model/data_contract_specification.py
+++ b/datacontract/model/data_contract_specification.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Any
 
 import pydantic as pyd
 import yaml
@@ -81,6 +81,7 @@ class Field(pyd.BaseModel):
     maximum: int = None
     exclusiveMaximum: int = None
     logicalType: Optional[str] = None
+    default: Optional[Any] = None
     enum: List[str] = []
     tags: List[str] = []
     fields: Dict[str, "Field"] = {}

--- a/tests/fixtures/avro/data/logicalTypes.avsc
+++ b/tests/fixtures/avro/data/logicalTypes.avsc
@@ -1,0 +1,18 @@
+{
+    "type": "record",
+    "name": "Test",
+    "namespace": "mynamespace.com",
+    "fields": [
+        {"name": "test_id", "type": "string", "doc": "id documentation test"},
+        {"name": "device_id", "type": "int"},
+        {"name": "test_value", "type": "double"},
+        {"name": "num_items", "type": "int"},
+        {"name": "processed_timestamp", 
+                 "type": "long",
+                 "doc": "The date the event was processed: for more info https://avro.apache.org/docs/current/spec.html#Local+timestamp+%28microsecond+precision%29",
+                 "logicalType": "local-timestamp-micros"},
+        {"name": "description", "type": "string"},
+        {"name": "is_processed", "type": "boolean",
+                  "default": false}  
+    ]    
+}

--- a/tests/fixtures/kafka-avro-remote/datacontract_logicalType.yaml
+++ b/tests/fixtures/kafka-avro-remote/datacontract_logicalType.yaml
@@ -23,7 +23,7 @@ models:
       processed_timestamp:
         type: long
         required: true
-        description: "The date the event was processed: for more info https://avro.apache.org/docs/current/spec.html#Local+timestamp+%28microsecond+precision%29"
+        description: 'The date the event was processed: for more info https://avro.apache.org/docs/current/spec.html#Local+timestamp+%28microsecond+precision%29'
         logicalType: local-timestamp-micros
       description:
         type: string
@@ -31,3 +31,4 @@ models:
       is_processed:
         type: boolean
         required: true
+        default: false

--- a/tests/fixtures/kafka-avro-remote/datacontract_logicalType.yaml
+++ b/tests/fixtures/kafka-avro-remote/datacontract_logicalType.yaml
@@ -1,0 +1,33 @@
+dataContractSpecification: 0.9.3
+id: my-data-contract-id
+info:
+  title: My Data Contract
+  version: 0.0.1
+models:
+  Test:
+    namespace: mynamespace.com
+    fields:
+      test_id:
+        type: string
+        required: true
+        description: id documentation test
+      device_id:
+        type: int
+        required: true
+      test_value:
+        type: double
+        required: true
+      num_items:
+        type: int
+        required: true
+      processed_timestamp:
+        type: long
+        required: true
+        description: "The date the event was processed: for more info https://avro.apache.org/docs/current/spec.html#Local+timestamp+%28microsecond+precision%29"
+        logicalType: local-timestamp-micros
+      description:
+        type: string
+        required: true
+      is_processed:
+        type: boolean
+        required: true

--- a/tests/test_export_avro.py
+++ b/tests/test_export_avro.py
@@ -110,7 +110,8 @@ def test_to_avro_schema_with_logicalTypes():
     },
     {
       "name": "is_processed",
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     }
   ]
 }

--- a/tests/test_export_avro.py
+++ b/tests/test_export_avro.py
@@ -71,3 +71,52 @@ def test_to_avro_schema():
     result = to_avro_schema_json(model_name, model)
 
     assert json.loads(result) == json.loads(expected_avro_schema)
+
+
+def test_to_avro_schema_with_logicalTypes():
+    data_contract = DataContractSpecification.from_file("fixtures/kafka-avro-remote/datacontract_logicalType.yaml")
+    expected_avro_schema = """
+  {
+  "type": "record",
+  "name": "Test",
+  "namespace": "mynamespace.com",
+  "fields": [
+    {
+      "name": "test_id",
+      "doc": "id documentation test",
+      "type": "string"
+    },
+    {
+      "name": "device_id",
+      "type": "int"
+    },
+    {
+      "name": "test_value",
+      "type": "double"
+    },
+    {
+      "name": "num_items",
+      "type": "int"
+    },
+    {
+      "name": "processed_timestamp",
+      "doc": "The date the event was processed: for more info https://avro.apache.org/docs/current/spec.html#Local+timestamp+%28microsecond+precision%29",
+      "logicalType": "local-timestamp-micros",
+      "type": "long"
+    },
+    {
+      "name": "description",
+      "type": "string"
+    },
+    {
+      "name": "is_processed",
+      "type": "boolean"
+    }
+  ]
+}
+"""
+
+    model_name, model = next(iter(data_contract.models.items()))
+    result = to_avro_schema_json(model_name, model)
+
+    assert json.loads(result) == json.loads(expected_avro_schema)

--- a/tests/test_import_avro.py
+++ b/tests/test_import_avro.py
@@ -210,3 +210,47 @@ models:
     print("Result:\n", result.to_yaml())
     assert yaml.safe_load(result.to_yaml()) == yaml.safe_load(expected)
     assert DataContract(data_contract_str=expected).lint(enabled_linters="none").has_passed()
+
+
+def test_import_avro_logicalTypes():
+    result = DataContract().import_from_source("avro", "fixtures/avro/data/logicalTypes.avsc")
+
+    expected = """
+dataContractSpecification: 0.9.3
+id: my-data-contract-id
+info:
+  title: My Data Contract
+  version: 0.0.1
+models:
+  Test:
+    namespace: mynamespace.com
+    fields:
+      test_id:
+        type: string
+        required: true
+        description: id documentation test
+      device_id:
+        type: int
+        required: true
+      test_value:
+        type: double
+        required: true
+      num_items:
+        type: int
+        required: true
+      processed_timestamp:
+        type: long
+        required: true
+        description: 'The date the event was processed: for more info 
+https://avro.apache.org/docs/current/spec.html#Local+timestamp+%28microsecond+precision%29'
+        logicalType: local-timestamp-micros
+      description:
+        type: string
+        required: true
+      is_processed:
+        type: boolean
+        required: true
+"""
+    print("Result:\n", result.to_yaml())
+    assert yaml.safe_load(result.to_yaml()) == yaml.safe_load(expected)
+    assert DataContract(data_contract_str=expected).lint(enabled_linters="none").has_passed()

--- a/tests/test_import_avro.py
+++ b/tests/test_import_avro.py
@@ -241,8 +241,7 @@ models:
       processed_timestamp:
         type: long
         required: true
-        description: 'The date the event was processed: for more info 
-https://avro.apache.org/docs/current/spec.html#Local+timestamp+%28microsecond+precision%29'
+        description: 'The date the event was processed: for more info https://avro.apache.org/docs/current/spec.html#Local+timestamp+%28microsecond+precision%29'
         logicalType: local-timestamp-micros
       description:
         type: string
@@ -250,6 +249,7 @@ https://avro.apache.org/docs/current/spec.html#Local+timestamp+%28microsecond+pr
       is_processed:
         type: boolean
         required: true
+        default: false
 """
     print("Result:\n", result.to_yaml())
     assert yaml.safe_load(result.to_yaml()) == yaml.safe_load(expected)


### PR DESCRIPTION
If the avro being imported contains default or logicalType, the datacontract definition skips it on both sides.
This bug fix will enable importing avro definitions that support logicalType and/or default values for fields. 