### PR TITLE
feat(export/jsonschema): supports array type

### DIFF
--- a/datacontract/export/jsonschema_converter.py
+++ b/datacontract/export/jsonschema_converter.py
@@ -52,6 +52,8 @@ def to_property(field: Field) -> dict:
         else:
             property["properties"] = to_properties(field.fields)
         property["required"] = to_required(field.fields)
+    if json_type == "array":
+        property["items"] = to_property(field.items)
 
     if field.pattern:
         property["pattern"] = field.pattern

--- a/tests/fixtures/local-json-complex/data/sts_data.json
+++ b/tests/fixtures/local-json-complex/data/sts_data.json
@@ -1,4 +1,15 @@
 {
+    "array_test_string": ["test1", "test2"],
+    "array_test_object": [
+        {
+            "key": "key1",
+            "value": "value1"
+        },
+        {
+            "key": "key2",
+            "value": "value2"
+        }
+    ],
     "id": "11111111",
     "sts_data": {
         "connection_test": "SUCCESS",
@@ -11,5 +22,4 @@
             }
         }
     }
-
-}
+  }

--- a/tests/fixtures/local-json-complex/datacontract.yaml
+++ b/tests/fixtures/local-json-complex/datacontract.yaml
@@ -8,6 +8,25 @@ models:
   sts_data:
     type: table
     fields:
+      array_test_string:
+        type: array
+        required: true
+        items:
+          type: string
+          required: true
+      array_test_object:
+        type: array
+        required: true
+        items:
+          type: object
+          required: true
+          fields:
+            key:
+              type: string
+              required: true
+            value:
+              type: string
+              required: true
       id:
         type: string
         minLength: 1
@@ -38,6 +57,17 @@ examples:
     model: sts_data
     data: | # expressed as string or inline yaml or via "$ref: data.csv"
       {
+        "array_test_string": ["test1", "test2"],
+        "array_test_object": [
+            {
+                "key": "key1",
+                "value": "value1"
+            },
+            {
+                "key": "key2",
+                "value": "value2"
+            }
+        ],
         "id": "11111111",
         "sts_data": {
             "connection_test": "SUCCESS",

--- a/tests/test_export_jsonschema.py
+++ b/tests/test_export_jsonschema.py
@@ -175,6 +175,30 @@ def test_to_jsonschemas_complex_2():
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "array_test_string": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "array_test_object": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "value"
+        ]
+      }
+    },
     "id": {
       "type": "string",
       "pattern": "^[0-9]{8}$",
@@ -221,6 +245,8 @@ def test_to_jsonschemas_complex_2():
     }
   },
   "required": [
+    "array_test_string",
+    "array_test_object",
     "id",
     "sts_data"
   ]


### PR DESCRIPTION
Thanks for merging the previous export/jsonschema PR.
I added a bit of code so that it can supports "array" type. (adjusted test code accordingly as well).
Have a look and give some comments if any. Thanks.