### PR TITLE
Issues/193 fix all todos in html export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract import --format jsonschema`: Import from JSON schema (#91)
 - `datacontract export --format jsonschema`: Improved export by exporting more additional information
 - `datacontract publish`: Publish the data contract to the Data Mesh Manager
+- HTML Export: Added support for Service Levels, Definitions, Examples and nested Fields (one level deep)
 
 ## [0.10.3] - 2024-05-05
 

--- a/datacontract/model/data_contract_specification.py
+++ b/datacontract/model/data_contract_specification.py
@@ -86,6 +86,7 @@ class Field(pyd.BaseModel):
     items: "Field" = None
     precision: int = None
     scale: int = None
+    example: str = None
 
 
 class Model(pyd.BaseModel):

--- a/datacontract/model/data_contract_specification.py
+++ b/datacontract/model/data_contract_specification.py
@@ -58,6 +58,7 @@ class Definition(pyd.BaseModel):
     pii: bool = None
     classification: str = None
     tags: List[str] = []
+    example: str = None
 
 
 class Field(pyd.BaseModel):

--- a/datacontract/templates/datacontract.html
+++ b/datacontract/templates/datacontract.html
@@ -468,7 +468,7 @@
               <h1 class="text-base font-semibold leading-6 text-gray-900">Definitions</h1>
               <p class="text-sm text-gray-500">Domain specific definitions in the data contract</p>
             </div>
-            <!-- one of these per definition -->
+            
             {% for definition_name, definition in datacontract.definitions.items() %}
             <div class="mt-3 flow-root">
               <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
@@ -573,8 +573,43 @@
           </section>
           {% endif %}
 
+          {% if datacontract.examples %}
+          <section id="examples">
+            <div class="px-4 sm:px-0">
+              <h1 class="text-base font-semibold leading-6 text-gray-900">Examples</h1>
+              <p class="text-sm text-gray-500">Examples for models in the data contract</p>
+            </div>
+            {% for example in datacontract.examples %}
+            <div class="mt-3 flow-root">
+              <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+                <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+                  <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg">
 
-          {# TODO add definitions #}
+                    <table class="min-w-full divide-y divide-gray-300">
+                      <thead class="bg-gray-50">
+                      <tr>
+                        <th scope="colgroup" colspan="3" class="py-2 pl-4 pr-3 text-left font-semibold text-gray-900 sm:pl-6">
+                          <span>{{ example.model }}</span>
+                          <span class="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10">{{ example.type }}</span>
+                          <div class="text-sm font-medium text-gray-500">{{ example.description }}</div>
+                        </th>
+                      </tr>
+                      </thead>
+                      <tbody class="divide-y divide-gray-200 bg-white">
+                        <tr>
+                          <td class="whitespace-nowrap py-2 pl-4 pr-2 text-sm font-medium text-gray-900 sm:pl-6 w-12/12">
+                            <pre>{{ example.data }}</pre>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+            </div>
+            {% endfor %}
+          </section>
+          {% endif %}
 
           {% if datacontract.servicelevels %}
           <section id="servicelevels">

--- a/datacontract/templates/datacontract.html
+++ b/datacontract/templates/datacontract.html
@@ -378,7 +378,6 @@
                             <div>{{ field.title }}</div>
                             {% endif %}
                             <div class="font-mono">{{ field_name }}</div>
-                            {# TODO nested fields #}
                           </div>
                         </td>
                         <td class="whitespace-nowrap px-1 py-2 text-sm text-gray-500 w-1/12">
@@ -446,10 +445,98 @@
                             <span class="inline-flex items-center rounded-md bg-yellow-50 px-1 py-1 text-xs font-medium text-yellow-600 ring-1 ring-inset ring-yellow-500/10 mr-1 mt-1">PII</span>
                             {% endif %}
                           </div>
-
                         </td>
-
                       </tr>
+                      <!-- Handle nested fields -->
+                      {% if field.fields %}
+                      <tr class="bg-gray-50">
+                        <td colspan="3" class="py-2 pl-4 pr-3 text-left font-semibold text-gray-500 sm:pl-6 text-sm font-medium">
+                          Fields contained in {{ field_name }}
+                        </td>
+                      </tr>
+                      {% for field_name, field in field.fields.items() %}
+                      <tr class="bg-gray-50">
+                        <td class="whitespace-nowrap py-2 pl-4 pr-2 text-sm font-medium text-gray-900 sm:pl-6 w-2/12 flex items-center gap-x-4">
+                          <div>
+                            &#x21b3;
+                          </div>
+                          <div class="py-2 text-sm">
+                            {% if field.title %}
+                            <div>{{ field.title }}</div>
+                            {% endif %}
+                            <div class="font-mono">{{ field_name }}</div>
+                          </div>
+                        </td>
+                        <td class="whitespace-nowrap px-1 py-2 text-sm text-gray-500 w-1/12">
+                          {% if field.type %}
+                          {{ field.type }}
+                          {% endif %}
+                        </td>
+                        <td class="px-3 py-2 text-sm text-gray-500 w-7/12">
+                          {% if field.description %}
+                          <div class="text-gray-500">{{ field.description }}</div>
+                          {% else %}
+                          <div class="text-gray-400">No description</div>
+                          {% endif %}
+
+                          {% if field.example %}
+                          <div class="mt-1 italic">
+                            Example: <span class="font-mono">{{ field.example }}</span>
+                          </div>
+                          {% endif %}
+
+                          <div>
+                            {% if field.primary %}
+                            <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mr-1 mt-1">primary</span>
+                            {% endif %}
+                            {% if field.required %}
+                            <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mr-1 mt-1">required</span>
+                            {% endif %}
+                            {% if field.unique %}
+                            <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mr-1 mt-1">unique</span>
+                            {% endif %}
+                            {% if field.format %}
+                            <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mr-1 mt-1">format:{{ field.format }}</span>
+                            {% endif %}
+                            {% if field.minLength %}
+                            <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mr-1 mt-1">minLength:{{ field.minLength }}</span>
+                            {% endif %}
+                            {% if field.maxLength %}
+                            <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mr-1 mt-1">maxLength:{{ field.maxLength }}</span>
+                            {% endif %}
+                            {% if field.pattern %}
+                            <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mr-1 mt-1">pattern:{{ field.pattern }}</span>
+                            {% endif %}
+                            {% if field.precision %}
+                            <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mr-1 mt-1">precision:{{ field.precision }}</span>
+                            {% endif %}
+                            {% if field.scale %}
+                            <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mr-1 mt-1">scale:{{ field.scale }}</span>
+                            {% endif %}
+                            {% if field.minimum %}
+                            <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mr-1 mt-1">minimum:{{ field.minimum }}</span>
+                            {% endif %}
+                            {% if field.exclusiveMinimum %}
+                            <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mr-1 mt-1">exclusiveMinimum:{{ field.exclusiveMinimum }}</span>
+                            {% endif %}
+                            {% if field.maximum %}
+                            <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mr-1 mt-1">maximum:{{ field.maximum }}</span>
+                            {% endif %}
+                            {% if field.exclusiveMaximum %}
+                            <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mr-1 mt-1">exclusiveMaximum:{{ field.exclusiveMaximum }}</span>
+                            {% endif %}
+                            {% if field.classification %}
+                            <span class="inline-flex items-center rounded-md bg-blue-50 px-1 py-1 text-xs font-medium text-blue-600 ring-1 ring-inset ring-blue-500/10 mr-1 mt-1">{{ field.classification }}</span>
+                            {% endif %}
+                            {% if field.pii %}
+                            <span class="inline-flex items-center rounded-md bg-yellow-50 px-1 py-1 text-xs font-medium text-yellow-600 ring-1 ring-inset ring-yellow-500/10 mr-1 mt-1">PII</span>
+                            {% endif %}
+                          </div>
+                        </td>
+                      </tr>
+                      {% endfor %}
+                      {% endif %}
+
                       {% endfor %}
 
                       </tbody>

--- a/datacontract/templates/datacontract.html
+++ b/datacontract/templates/datacontract.html
@@ -461,6 +461,118 @@
             {% endfor %}
 
           </section>
+          
+          {% if datacontract.definitions %}
+          <section id="definitions">
+            <div class="px-4 sm:px-0">
+              <h1 class="text-base font-semibold leading-6 text-gray-900">Definitions</h1>
+              <p class="text-sm text-gray-500">Domain specific definitions in the data contract</p>
+            </div>
+            <!-- one of these per definition -->
+            {% for definition_name, definition in datacontract.definitions.items() %}
+            <div class="mt-3 flow-root">
+              <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+                <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+                  <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg">
+
+                    <table class="min-w-full divide-y divide-gray-300">
+                      <thead class="bg-gray-50">
+                      <tr>
+                        <th scope="colgroup" colspan="3" class="py-2 pl-4 pr-3 text-left font-semibold text-gray-900 sm:pl-6">
+                          <span>{{ definition_name }}</span>
+                          <span class="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10">{{ definition.domain }}</span>
+                          <div class="text-sm font-medium text-gray-500">{{ definition.description }}</div>
+                        </th>
+                      </tr>
+                      </thead>
+                      <tbody class="divide-y divide-gray-200 bg-white">
+                        <tr>
+                          <td class="whitespace-nowrap py-2 pl-4 pr-2 text-sm font-medium text-gray-900 sm:pl-6 w-2/12">
+                            <div class="py-2 text-sm">
+                              {% if definition.title %}
+                              <div>{{ definition.title }}</div>
+                              {% endif %}
+                              <div class="font-mono">{{ definition.name }}</div>
+                            </div>
+                          </td>
+                          <td class="whitespace-nowrap px-1 py-2 text-sm text-gray-500 w-1/12">
+                            <div class="py-2 text-sm">
+                              {{ definition.type }}
+                              {% if definition.format %}
+                                <span class="inline-flex items-center rounded-md bg-blue-50 px-1 py-1 text-xs font-medium text-blue-600 ring-1 ring-inset ring-blue-500/10 mr-1 mt-1">{{ definition.format }}</span>
+                              {% endif %}
+                            </div>
+                            {% if definition.enum %}
+                            <div class="py-2 text-sm">
+                              Allowed values:
+                              {% for value in definition.enum %}
+                              <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mr-1 mt-1">{{ value }}</span>
+                              {% endfor %}
+                            </div>
+                            {% endif %}
+                          </td>
+                          <td class="px-3 py-2 text-sm text-gray-500 w-9/12">
+                            {% if definition.example %}
+                            <div class="mt-1 italic">
+                              Example: <span class="font-mono">{{ definition.example }}</span>
+                            </div>
+                            {% endif %}
+                            {% if definition.tags %}
+                            <div>
+                              Tags:
+                              {% for tag in definition.tags %}
+                              <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mr-1 mt-1">{{ tag }}</span>
+                              {% endfor %}
+                            </div>
+                            {% endif %}
+                            <div>
+                              {% if definition.minLength %}
+                              <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mr-1 mt-1">minLength:{{ definition.minLength }}</span>
+                              {% endif %}
+                              {% if definition.maxLength %}
+                              <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mr-1 mt-1">maxLength:{{ definition.maxLength }}</span>
+                              {% endif %}
+                              {% if definition.pattern %}
+                              <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mr-1 mt-1">pattern:{{ definition.pattern }}</span>
+                              {% endif %}
+                              {% if definition.precision %}
+                              <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mr-1 mt-1">precision:{{ definition.precision }}</span>
+                              {% endif %}
+                              {% if definition.scale %}
+                              <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mr-1 mt-1">scale:{{ definition.scale }}</span>
+                              {% endif %}
+                              {% if definition.minimum %}
+                              <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mr-1 mt-1">minimum:{{ definition.minimum }}</span>
+                              {% endif %}
+                              {% if definition.exclusiveMinimum %}
+                              <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mr-1 mt-1">exclusiveMinimum:{{ definition.exclusiveMinimum }}</span>
+                              {% endif %}
+                              {% if definition.maximum %}
+                              <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mr-1 mt-1">maximum:{{ definition.maximum }}</span>
+                              {% endif %}
+                              {% if definition.exclusiveMaximum %}
+                              <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mr-1 mt-1">exclusiveMaximum:{{ definition.exclusiveMaximum }}</span>
+                              {% endif %}
+                              {% if definition.classification %}
+                              <span class="inline-flex items-center rounded-md bg-blue-50 px-1 py-1 text-xs font-medium text-blue-600 ring-1 ring-inset ring-blue-500/10 mr-1 mt-1">{{ definition.classification }}</span>
+                              {% endif %}
+                              {% if definition.pii %}
+                              <span class="inline-flex items-center rounded-md bg-yellow-50 px-1 py-1 text-xs font-medium text-yellow-600 ring-1 ring-inset ring-yellow-500/10 mr-1 mt-1">PII</span>
+                              {% endif %}
+                            </div>
+                          </td>
+  
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+            </div>
+            {% endfor %}
+          </section>
+          {% endif %}
+
 
           {# TODO add definitions #}
 

--- a/datacontract/templates/datacontract.html
+++ b/datacontract/templates/datacontract.html
@@ -371,7 +371,6 @@
                       <tbody class="divide-y divide-gray-200 bg-white">
 
                       {% for field_name, field in model.fields.items() %}
-
                       <tr>
                         <td class="whitespace-nowrap py-2 pl-4 pr-2 text-sm font-medium text-gray-900 sm:pl-6 w-2/12">
                           <div class="py-2 text-sm">
@@ -396,7 +395,7 @@
 
                           {% if field.example %}
                           <div class="mt-1 italic">
-                            Example: {{ field.example }}
+                            Example: <span class="font-mono">{{ field.example }}</span>
                           </div>
                           {% endif %}
 


### PR DESCRIPTION
This not only addresses the Examples mentioned in #193 but additionaly

- exports Definitions
- adds Examples of fields in the Models section (code was there but never did anything)
- exports nested fields of fields in the Models section. This currently only goes one level deep, as it already is a proper pain without partials ;)