### PR TITLE
Add jsonschema export handling for empty subfields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `datacontract export --format dbml`: Export to [Database Markup Language (DBML)](https://dbml.dbdiagram.io/home/) (#135)
 
+### Fixed
+
+- Fixed jsonschema export for models with empty object-typed fields (#218)
+
 ## [0.10.4] - 2024-05-17
 
 ### Added

--- a/datacontract/export/jsonschema_converter.py
+++ b/datacontract/export/jsonschema_converter.py
@@ -54,7 +54,7 @@ def to_property(field: Field) -> dict:
         property["unique"] = True
     if json_type == "object":
         # TODO: any better idea to distinguish between properties and patternProperties?
-        if next(iter(field.fields.keys())).startswith("^"):
+        if field.fields.keys() and next(iter(field.fields.keys())).startswith("^"):
             property["patternProperties"] = to_properties(field.fields)
         else:
             property["properties"] = to_properties(field.fields)

--- a/tests/fixtures/local-json-complex/datacontract.yaml
+++ b/tests/fixtures/local-json-complex/datacontract.yaml
@@ -52,6 +52,8 @@ models:
                     type: string
                     pattern: "^[0-9]{8}$"
                     required: true
+      empty_object:
+        type: object
 examples:
   - type: json # csv, json, yaml, custom
     model: sts_data

--- a/tests/test_export_jsonschema.py
+++ b/tests/test_export_jsonschema.py
@@ -158,6 +158,14 @@ def test_to_jsonschemas_complex_2():
         "connection_test",
         "key_list"
       ]
+    },
+    "empty_object": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {},
+      "required": []
     }
   },
   "required": [


### PR DESCRIPTION
Ref https://github.com/datacontract/datacontract-cli/issues/218

This PR allows for jsonschema export of object-typed fields that contain no subfields.