### PR TITLE
Import ODCS Contracts

### DIFF
--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -201,6 +201,7 @@ class ImportFormat(str, Enum):
     glue = "glue"
     bigquery = "bigquery"
     jsonschema = "jsonschema"
+    odcs="odcs"
 
 
 @app.command(name="import")

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -33,6 +33,7 @@ from datacontract.imports.avro_importer import import_avro
 from datacontract.imports.bigquery_importer import import_bigquery_from_api, import_bigquery_from_json
 from datacontract.imports.glue_importer import import_glue
 from datacontract.imports.jsonschema_importer import import_jsonschema
+from datacontract.imports.odcs_importer import import_odcs
 from datacontract.imports.sql_importer import import_sql
 from datacontract.integration.publish_datamesh_manager import publish_datamesh_manager
 from datacontract.integration.publish_opentelemetry import publish_opentelemetry
@@ -472,6 +473,8 @@ class DataContract:
                 data_contract_specification = import_bigquery_from_api(
                     data_contract_specification, bigquery_tables, bigquery_project, bigquery_dataset
                 )
+        elif format == "odcs":
+            data_contract_specification = import_odcs(data_contract_specification, source)
         else:
             print(f"Import format {format} not supported.")
 

--- a/datacontract/export/odcs_converter.py
+++ b/datacontract/export/odcs_converter.py
@@ -24,12 +24,22 @@ def to_odcs_yaml(data_contract_spec: DataContractSpecification):
 
     if data_contract_spec.terms is not None:
         odcs["description"] = {
-            "purpose": None,
+            "purpose": data_contract_spec.terms.description.strip() if data_contract_spec.terms.description is not None else None,
             "usage": data_contract_spec.terms.usage.strip() if data_contract_spec.terms.usage is not None else None,
             "limitations": data_contract_spec.terms.limitations.strip()
             if data_contract_spec.terms.limitations is not None
             else None,
         }
+
+    if data_contract_spec.servicelevels is not None:
+        slas = []
+        if data_contract_spec.servicelevels.availability is not None:
+            slas.append({ 'property': 'generalAvailability', 'value': data_contract_spec.servicelevels.availability.description })
+        if data_contract_spec.servicelevels.retention is not None:
+            slas.append({ 'property': 'retention', 'value': data_contract_spec.servicelevels.retention.period })
+
+        if len(slas) > 0:
+            odcs["slaProperties"] = slas
 
     odcs["type"] = "tables"  # required, TODO read from models.type?
     odcs["dataset"] = []

--- a/datacontract/imports/odcs_importer.py
+++ b/datacontract/imports/odcs_importer.py
@@ -62,7 +62,7 @@ def import_info(odcs_contract: Dict[str, Any]) -> Info:
         title = odcs_contract["quantumName"],
         version = odcs_contract["version"],
         description = odcs_contract["description"]["purpose"],
-        owner = odcs_contract["tenant"],
+        owner = odcs_contract["datasetDomain"],
         contact = Contact(name=odcs_contract["productDl"], url= odcs_contract["productFeedbackUrl"])
     )
 

--- a/datacontract/imports/odcs_importer.py
+++ b/datacontract/imports/odcs_importer.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import pprint
 from typing import Any, Dict, List
 import yaml
 from datacontract.model.data_contract_specification import Availability, Contact, DataContractSpecification, Info, Model, Field, Retention, Server, ServiceLevel, Terms
@@ -49,7 +50,6 @@ def import_odcs(data_contract_specification: DataContractSpecification, source: 
 
     data_contract_specification.id = odcs_contract["uuid"]
     data_contract_specification.info = import_info(odcs_contract)
-    data_contract_specification.servers["default"] = import_servers(odcs_contract)
     data_contract_specification.terms = import_terms(odcs_contract)
     data_contract_specification.servicelevels = import_servicelevels(odcs_contract)
     data_contract_specification.models = import_models(odcs_contract)
@@ -58,56 +58,75 @@ def import_odcs(data_contract_specification: DataContractSpecification, source: 
 
 
 def import_info(odcs_contract: Dict[str, Any]) -> Info:
-    return Info(
-        title = odcs_contract["quantumName"],
-        version = odcs_contract["version"],
-        description = odcs_contract["description"]["purpose"],
-        owner = odcs_contract["datasetDomain"],
-        contact = Contact(name=odcs_contract["productDl"], url= odcs_contract["productFeedbackUrl"])
+    info = Info(
+        title = odcs_contract.get("quantumName"),
+        version = odcs_contract.get("version")
     )
 
-def import_servers(odcs_contract: Dict[str, Any]) -> Dict[str, Server]:
-    return Server(
-        type = odcs_contract["sourceSystem"],
-        location = f"{odcs_contract['server']}/{odcs_contract['database']}"
-    )
+    if odcs_contract.get("description").get("purpose") is not None:
+        info.description = odcs_contract.get("description").get("purpose")
+    
+    if odcs_contract.get("datasetDomain") is not None:
+        info.owner = odcs_contract.get("datasetDomain")
+    
+    if odcs_contract.get("productDl") is not None or odcs_contract.get("productFeedbackUrl") is not None:
+        contact = Contact()
+        if odcs_contract.get("productDl") is not None:
+            contact.name= odcs_contract.get("productDl")
+        if odcs_contract.get("productFeedbackUrl") is not None:
+            contact.url= odcs_contract.get("productFeedbackUrl")
 
-def import_terms(odcs_contract: Dict[str, Any]) -> Terms:
-    return Terms(
-        usage = odcs_contract["description"]["usage"],
-        limitations = odcs_contract["description"]["limitations"],
-        billing = f"{odcs_contract['price']['priceAmount']} {odcs_contract['price']['priceCurrency']} / {odcs_contract['price']['priceUnit']}"
-    )
+        info.contact = contact
+
+    return info
+
+def import_terms(odcs_contract: Dict[str, Any]) -> Terms | None:
+    if odcs_contract.get("description").get("usage") is not None or odcs_contract.get("description").get("limitations") is not None or odcs_contract.get('price') is not None:
+        terms = Terms()
+        if odcs_contract.get("description").get("usage") is not None:
+            terms.usage= odcs_contract.get("description").get("usage")
+        if odcs_contract.get("description").get("limitations") is not None:
+            terms.limitations = odcs_contract.get("description").get("limitations")
+        if odcs_contract.get('price') is not None:
+            terms.billing = f"{odcs_contract.get('price').get('priceAmount')} {odcs_contract.get('price').get('priceCurrency')} / {odcs_contract.get('price').get('priceUnit')}"
+        
+        return terms
+    else:
+        return None
 
 def import_servicelevels(odcs_contract: Dict[str, Any]) -> ServiceLevel:
     # find the two properties we can map (based on the examples)
-    sla_properties = odcs_contract["slaProperties"]
+    sla_properties = odcs_contract.get("slaProperties") if odcs_contract.get("slaProperties") is not None else []
     availability = next((p for p in sla_properties if p["property"] == "generalAvailability"), None)
     retention = next((p for p in sla_properties if p["property"] == "retention"), None)
 
-    result = ServiceLevel()
+    if availability is not None or retention is not None:
+        servicelevel = ServiceLevel()
 
-    if availability is not None:
-        value = availability["value"]
-        if isinstance(value, datetime.datetime):
-            value = value.isoformat()
-        result.availability = Availability(description= value)
+        if availability is not None:
+            value = availability.get("value")
+            if isinstance(value, datetime.datetime):
+                value = value.isoformat()
+            servicelevel.availability = Availability(description= value)
 
-    if retention is not None:
-        result.retention = Retention(period=f"{retention['value']}{retention['unit']}")
-    
-    return result
+        if retention is not None:
+            servicelevel.retention = Retention(period=f"{retention.get('value')}{retention.get('unit')}")
+        
+        return servicelevel
+    else:
+        return None
 
 def import_models(odcs_contract: Dict[str, Any]) -> Dict[str, Model]:
-    custom_type_mappings = get_custom_type_mappings(odcs_contract["customProperties"])
+    custom_type_mappings = get_custom_type_mappings(odcs_contract.get("customProperties"))
 
-    odcs_tables = odcs_contract["dataset"]
+    odcs_tables = odcs_contract.get("dataset") if odcs_contract.get("dataset") is not None else []
     result = {}
 
     for table in odcs_tables:
-        model = Model(description=table["description"], type="table")
-        model.fields = import_fields(table["columns"], custom_type_mappings)
-        result[table["table"]] = model
+        description = table.get("description") if table.get("description") is not None else ''
+        model = Model(description=' '.join(description.splitlines()), type="table")
+        model.fields = import_fields(table.get("columns"), custom_type_mappings)
+        result[table.get("table")] = model
 
     return result
 
@@ -116,22 +135,23 @@ def import_fields(odcs_columns: Dict[str, Any], custom_type_mappings: Dict[str, 
     result = {}
 
     for column in odcs_columns:
-        mapped_type = map_type(column["logicalType"], custom_type_mappings)
+        mapped_type = map_type(column.get("logicalType"), custom_type_mappings)
         if mapped_type is not None:
+            description = column.get("description") if column.get("description") is not None else ''
             field = Field(
-                description= column.get("description"),
+                description= ' '.join(description.splitlines()),
                 type=mapped_type,
-                title= column.get("businessName"),
+                title= column.get("businessName") if column.get("businessName") is not None else '',
                 required= not column.get("isNullable") if column.get("isNullable") is not None else False,
                 primary= column.get("isPrimary") if column.get("isPrimary") is not None else False,
                 unique= column.get("isUnique") if column.get("isUnique") is not None else False,
-                classification= column.get("classification"),
-                tags= column.get("tags"),
+                classification= column.get("classification") if column.get("classification") is not None else '',
+                tags= column.get("tags") if column.get("tags") is not None else [],
             )
             result[column["column"]] = field
         else:
             logger.info(
-                f"Can't properly map {column['logicalName']} to the Datacontract Mapping types, as there is no equivalent or special mapping. Consider introducing a customProperty 'dc_mapping_{column['logicalName']}' that defines your expected type as the 'value'"
+                f"Can't properly map {column.get('column')} to the Datacontract Mapping types, as there is no equivalent or special mapping. Consider introducing a customProperty 'dc_mapping_{column.get('logicalName')}' that defines your expected type as the 'value'"
             )
 
     return result
@@ -140,17 +160,18 @@ def map_type(odcs_type: str, custom_mappings: Dict[str, str]) -> str|None:
     t = odcs_type.lower()
     if t in DATACONTRACT_TYPES:
         return t
-    elif custom_mappings[t] is not None:
-        return custom_mappings[t]
+    elif custom_mappings.get(t) is not None:
+        return custom_mappings.get(t)
     else:
         return None
 
 def get_custom_type_mappings(odcs_custom_properties: List[Any]) -> Dict[str, str]:
     result = {}
-    for prop in odcs_custom_properties:
-        if prop["property"].startswith("dc_mapping_"):
-            odcs_type_name = prop["property"].substring(11)
-            datacontract_type = prop["value"]
-            result[odcs_type_name] = datacontract_type
+    if odcs_custom_properties is not None:
+        for prop in odcs_custom_properties:
+            if prop["property"].startswith("dc_mapping_"):
+                odcs_type_name = prop["property"].substring(11)
+                datacontract_type = prop["value"]
+                result[odcs_type_name] = datacontract_type
     
     return result

--- a/datacontract/imports/odcs_importer.py
+++ b/datacontract/imports/odcs_importer.py
@@ -1,9 +1,8 @@
 import datetime
 import logging
-import pprint
 from typing import Any, Dict, List
 import yaml
-from datacontract.model.data_contract_specification import Availability, Contact, DataContractSpecification, Info, Model, Field, Retention, Server, ServiceLevel, Terms
+from datacontract.model.data_contract_specification import Availability, Contact, DataContractSpecification, Info, Model, Field, Retention, ServiceLevel, Terms
 from datacontract.model.exceptions import DataContractException
 
 DATACONTRACT_TYPES = [

--- a/datacontract/imports/odcs_importer.py
+++ b/datacontract/imports/odcs_importer.py
@@ -1,0 +1,156 @@
+import datetime
+import logging
+from typing import Any, Dict, List
+import yaml
+from datacontract.model.data_contract_specification import Availability, Contact, DataContractSpecification, Info, Model, Field, Retention, Server, ServiceLevel, Terms
+from datacontract.model.exceptions import DataContractException
+
+DATACONTRACT_TYPES = [
+    "string",
+    "text",
+    "varchar",
+    "number",
+    "decimal",
+    "numeric",
+    "int",
+    "integer",
+    "long",
+    "bigint",
+    "float",
+    "double",
+    "boolean",
+    "timestamp",
+    "timestamp_tz",
+    "timestamp_ntz",
+    "date",
+    "array",
+    "bytes",
+    "object",
+    "record",
+    "struct",
+    "null"
+]
+
+
+def import_odcs(data_contract_specification: DataContractSpecification, source: str) -> DataContractSpecification:
+    
+    try:
+        with open(source, "r") as file:
+            odcs_contract = yaml.safe_load(file.read())
+
+    except Exception as e:
+        raise DataContractException(
+            type="schema",
+            name="Parse ODCS contract",
+            reason=f"Failed to parse odcs contract from {source}",
+            engine="datacontract",
+            original_exception=e,
+        )
+
+    data_contract_specification.id = odcs_contract["uuid"]
+    data_contract_specification.info = import_info(odcs_contract)
+    data_contract_specification.servers["default"] = import_servers(odcs_contract)
+    data_contract_specification.terms = import_terms(odcs_contract)
+    data_contract_specification.servicelevels = import_servicelevels(odcs_contract)
+    data_contract_specification.models = import_models(odcs_contract)
+    
+    return data_contract_specification
+
+
+def import_info(odcs_contract: Dict[str, Any]) -> Info:
+    return Info(
+        title = odcs_contract["quantumName"],
+        version = odcs_contract["version"],
+        description = odcs_contract["description"]["purpose"],
+        owner = odcs_contract["tenant"],
+        contact = Contact(name=odcs_contract["productDl"], url= odcs_contract["productFeedbackUrl"])
+    )
+
+def import_servers(odcs_contract: Dict[str, Any]) -> Dict[str, Server]:
+    return Server(
+        type = odcs_contract["sourceSystem"],
+        location = f"{odcs_contract['server']}/{odcs_contract['database']}"
+    )
+
+def import_terms(odcs_contract: Dict[str, Any]) -> Terms:
+    return Terms(
+        usage = odcs_contract["description"]["usage"],
+        limitations = odcs_contract["description"]["limitations"],
+        billing = f"{odcs_contract['price']['priceAmount']} {odcs_contract['price']['priceCurrency']} / {odcs_contract['price']['priceUnit']}"
+    )
+
+def import_servicelevels(odcs_contract: Dict[str, Any]) -> ServiceLevel:
+    # find the two properties we can map (based on the examples)
+    sla_properties = odcs_contract["slaProperties"]
+    availability = next((p for p in sla_properties if p["property"] == "generalAvailability"), None)
+    retention = next((p for p in sla_properties if p["property"] == "retention"), None)
+
+    result = ServiceLevel()
+
+    if availability is not None:
+        value = availability["value"]
+        if isinstance(value, datetime.datetime):
+            value = value.isoformat()
+        result.availability = Availability(description= value)
+
+    if retention is not None:
+        result.retention = Retention(period=f"{retention['value']}{retention['unit']}")
+    
+    return result
+
+def import_models(odcs_contract: Dict[str, Any]) -> Dict[str, Model]:
+    custom_type_mappings = get_custom_type_mappings(odcs_contract["customProperties"])
+
+    odcs_tables = odcs_contract["dataset"]
+    result = {}
+
+    for table in odcs_tables:
+        model = Model(description=table["description"], type="table")
+        model.fields = import_fields(table["columns"], custom_type_mappings)
+        result[table["table"]] = model
+
+    return result
+
+def import_fields(odcs_columns: Dict[str, Any], custom_type_mappings: Dict[str, str]) -> Dict[str, Field]:
+    logger = logging.getLogger(__name__)
+    result = {}
+
+    for column in odcs_columns:
+        mapped_type = map_type(column["logicalType"], custom_type_mappings)
+        if mapped_type is not None:
+            field = Field(
+                description= column.get("description"),
+                type=mapped_type,
+                title= column.get("businessName"),
+                required= not column.get("isNullable") if column.get("isNullable") is not None else False,
+                primary= column.get("isPrimary") if column.get("isPrimary") is not None else False,
+                unique= column.get("isUnique") if column.get("isUnique") is not None else False,
+                classification= column.get("classification"),
+                tags= column.get("tags"),
+            )
+            result[column["column"]] = field
+        else:
+            logger.info(
+                f"Can't properly map {column['logicalName']} to the Datacontract Mapping types, as there is no equivalent or special mapping. Consider introducing a customProperty 'dc_mapping_{column['logicalName']}' that defines your expected type as the 'value'"
+            )
+
+    return result
+
+def map_type(odcs_type: str, custom_mappings: Dict[str, str]) -> str|None:
+    t = odcs_type.lower()
+    if t in DATACONTRACT_TYPES:
+        return t
+    elif custom_mappings[t] is not None:
+        return custom_mappings[t]
+    else:
+        return None
+
+def get_custom_type_mappings(odcs_custom_properties: List[Any]) -> Dict[str, str]:
+    result = {}
+    for prop in odcs_custom_properties:
+        if prop["property"].startswith("dc_mapping_"):
+            odcs_type_name = prop["property"].substring(11)
+            datacontract_type = prop["value"]
+            result[odcs_type_name] = datacontract_type
+    
+    return result

--- a/datacontract/model/data_contract_specification.py
+++ b/datacontract/model/data_contract_specification.py
@@ -39,6 +39,7 @@ class Terms(pyd.BaseModel):
     limitations: str = None
     billing: str = None
     noticePeriod: str = None
+    description: str = None
 
 
 class Definition(pyd.BaseModel):

--- a/tests/fixtures/odcs/adventureworks-example.datacontract.yml
+++ b/tests/fixtures/odcs/adventureworks-example.datacontract.yml
@@ -1,0 +1,3658 @@
+dataContractSpecification: 0.9.3
+id: 6aeafdc1-ed62-4c8f-bf0a-da1061c98cdb
+info:
+  title: test
+  version: 1.0.0
+models:
+  department:
+    description: Lookup table containing the departments within the Adventure Works
+      Cycles company.
+    type: table
+    fields:
+      departmentid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for Department records.
+        classification: ''
+      name:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Name of the department.
+        classification: ''
+      groupname:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Name of the group to which the department belongs.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  employee:
+    description: Employee information such as salary, department, and title.
+    type: table
+    fields:
+      businessentityid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for Employee records.  Foreign key to BusinessEntity.BusinessEntityID.
+        classification: ''
+      nationalidnumber:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Unique national identification number such as a social security
+          number.
+        classification: ''
+      loginid:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Network login.
+        classification: ''
+      jobtitle:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Work title such as Buyer or Sales Representative.
+        classification: ''
+      birthdate:
+        title: ''
+        type: date
+        required: false
+        primary: false
+        unique: false
+        description: Date of birth.
+        classification: ''
+      maritalstatus:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: M = Married, S = Single
+        classification: ''
+      gender:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: M = Male, F = Female
+        classification: ''
+      hiredate:
+        title: ''
+        type: date
+        required: false
+        primary: false
+        unique: false
+        description: Employee hired on this date.
+        classification: ''
+      salariedflag:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Job classification. 0 = Hourly, not exempt from collective bargaining.
+          1 = Salaried, exempt from collective bargaining.
+        classification: ''
+      vacationhours:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Number of available vacation hours.
+        classification: ''
+      sickleavehours:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Number of available sick leave hours.
+        classification: ''
+      currentflag:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: 0 = Inactive, 1 = Active
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+      organizationnode:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Where the employee is located in corporate hierarchy.
+        classification: ''
+  employeedepartmenthistory:
+    description: Employee department transfers.
+    type: table
+    fields:
+      businessentityid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Employee identification number. Foreign key to Employee.BusinessEntityID.
+        classification: ''
+      departmentid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Department in which the employee worked including currently.
+          Foreign key to Department.DepartmentID.
+        classification: ''
+      shiftid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Identifies which 8-hour shift the employee works. Foreign key
+          to Shift.Shift.ID.
+        classification: ''
+      startdate:
+        title: ''
+        type: date
+        required: false
+        primary: false
+        unique: false
+        description: Date the employee started work in the department.
+        classification: ''
+      enddate:
+        title: ''
+        type: date
+        required: false
+        primary: false
+        unique: false
+        description: Date the employee left the department. NULL = Current department.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  employeepayhistory:
+    description: Employee pay history.
+    type: table
+    fields:
+      businessentityid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Employee identification number. Foreign key to Employee.BusinessEntityID.
+        classification: ''
+      ratechangedate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Date the change in pay is effective
+        classification: ''
+      rate:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Salary hourly rate.
+        classification: ''
+      payfrequency:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: 1 = Salary received monthly, 2 = Salary received biweekly
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  jobcandidate:
+    description: Résumés submitted to Human Resources by job applicants.
+    type: table
+    fields:
+      jobcandidateid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for JobCandidate records.
+        classification: ''
+      businessentityid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Employee identification number if applicant was hired. Foreign
+          key to Employee.BusinessEntityID.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  shift:
+    description: Work shift lookup table.
+    type: table
+    fields:
+      shiftid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for Shift records.
+        classification: ''
+      name:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Shift description.
+        classification: ''
+      starttime:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Shift start time.
+        classification: ''
+      endtime:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Shift end time.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  address:
+    description: Street address information for customers, employees, and vendors.
+    type: table
+    fields:
+      addressid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for Address records.
+        classification: ''
+      addressline1:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: First street address line.
+        classification: ''
+      addressline2:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Second street address line.
+        classification: ''
+      city:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Name of the city.
+        classification: ''
+      stateprovinceid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Unique identification number for the state or province. Foreign
+          key to StateProvince table.
+        classification: ''
+      postalcode:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Postal code for the street address.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  addresstype:
+    description: Types of addresses stored in the Address table.
+    type: table
+    fields:
+      addresstypeid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for AddressType records.
+        classification: ''
+      name:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Address type description. For example, Billing, Home, or Shipping.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  businessentity:
+    description: Source of the ID that connects vendors, customers, and employees
+      with address and contact information.
+    type: table
+    fields:
+      businessentityid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for all customers, vendors, and employees.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  businessentityaddress:
+    description: Cross-reference table mapping customers, vendors, and employees to
+      their addresses.
+    type: table
+    fields:
+      businessentityid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. Foreign key to BusinessEntity.BusinessEntityID.
+        classification: ''
+      addressid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. Foreign key to Address.AddressID.
+        classification: ''
+      addresstypeid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. Foreign key to AddressType.AddressTypeID.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  businessentitycontact:
+    description: Cross-reference table mapping stores, vendors, and employees to people
+    type: table
+    fields:
+      businessentityid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. Foreign key to BusinessEntity.BusinessEntityID.
+        classification: ''
+      personid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. Foreign key to Person.BusinessEntityID.
+        classification: ''
+      contacttypeid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key.  Foreign key to ContactType.ContactTypeID.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  contacttype:
+    description: Lookup table containing the types of business entity contacts.
+    type: table
+    fields:
+      contacttypeid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for ContactType records.
+        classification: ''
+      name:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Contact type description.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  countryregion:
+    description: Lookup table containing the ISO standard codes for countries and
+      regions.
+    type: table
+    fields:
+      countryregioncode:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: ISO standard code for countries and regions.
+        classification: ''
+      name:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Country or region name.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  emailaddress:
+    description: Where to send a person email.
+    type: table
+    fields:
+      businessentityid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. Person associated with this email address.  Foreign
+          key to Person.BusinessEntityID
+        classification: ''
+      emailaddressid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. ID of this email address.
+        classification: ''
+      emailaddress:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: E-mail address for the person.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  password:
+    description: One way hashed authentication information
+    type: table
+    fields:
+      businessentityid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+      passwordhash:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Password for the e-mail account.
+        classification: ''
+      passwordsalt:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Random value concatenated with the password string before the
+          password is hashed.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  person:
+    description: 'Human beings involved with AdventureWorks: employees, customer contacts,
+      and vendor contacts.'
+    type: table
+    fields:
+      businessentityid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for Person records.
+        classification: ''
+      persontype:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: 'Primary type of person: SC = Store Contact, IN = Individual
+          (retail) customer, SP = Sales person, EM = Employee (non-sales), VC = Vendor
+          contact, GC = General contact'
+        classification: ''
+      namestyle:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: 0 = The data in FirstName and LastName are stored in western
+          style (first name, last name) order.  1 = Eastern style (last name, first
+          name) order.
+        classification: ''
+      title:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: A courtesy title. For example, Mr. or Ms.
+        classification: ''
+      firstname:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: First name of the person.
+        classification: ''
+      middlename:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Middle name or middle initial of the person.
+        classification: ''
+      lastname:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Last name of the person.
+        classification: ''
+      suffix:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Surname suffix. For example, Sr. or Jr.
+        classification: ''
+      emailpromotion:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: 0 = Contact does not wish to receive e-mail promotions, 1 = Contact
+          does wish to receive e-mail promotions from AdventureWorks, 2 = Contact
+          does wish to receive e-mail promotions from AdventureWorks and selected
+          partners.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  personphone:
+    description: Telephone number and type of a person.
+    type: table
+    fields:
+      businessentityid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Business entity identification number. Foreign key to Person.BusinessEntityID.
+        classification: ''
+      phonenumber:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Telephone number identification number.
+        classification: ''
+      phonenumbertypeid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Kind of phone number. Foreign key to PhoneNumberType.PhoneNumberTypeID.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  phonenumbertype:
+    description: Type of phone number of a person.
+    type: table
+    fields:
+      phonenumbertypeid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for telephone number type records.
+        classification: ''
+      name:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Name of the telephone number type
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  stateprovince:
+    description: State and province lookup table.
+    type: table
+    fields:
+      stateprovinceid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for StateProvince records.
+        classification: ''
+      stateprovincecode:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: ISO standard state or province code.
+        classification: ''
+      countryregioncode:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: ISO standard country or region code. Foreign key to CountryRegion.CountryRegionCode.
+        classification: ''
+      isonlystateprovinceflag:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: 0 = StateProvinceCode exists. 1 = StateProvinceCode unavailable,
+          using CountryRegionCode.
+        classification: ''
+      name:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: State or province description.
+        classification: ''
+      territoryid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: ID of the territory in which the state or province is located.
+          Foreign key to SalesTerritory.SalesTerritoryID.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  billofmaterials:
+    description: Items required to make bicycles and bicycle subassemblies. It identifies
+      the heirarchical relationship between a parent product and its components.
+    type: table
+    fields:
+      billofmaterialsid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for BillOfMaterials records.
+        classification: ''
+      productassemblyid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Parent product identification number. Foreign key to Product.ProductID.
+        classification: ''
+      componentid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Component identification number. Foreign key to Product.ProductID.
+        classification: ''
+      startdate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Date the component started being used in the assembly item.
+        classification: ''
+      enddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Date the component stopped being used in the assembly item.
+        classification: ''
+      unitmeasurecode:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Standard code identifying the unit of measure for the quantity.
+        classification: ''
+      bomlevel:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Indicates the depth the component is from its parent (AssemblyID).
+        classification: ''
+      perassemblyqty:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Quantity of the component needed to create the assembly.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  culture:
+    description: Lookup table containing the languages in which some AdventureWorks
+      data is stored.
+    type: table
+    fields:
+      cultureid:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for Culture records.
+        classification: ''
+      name:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Culture description.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  document:
+    description: Product maintenance documents.
+    type: table
+    fields:
+      title:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Title of the document.
+        classification: ''
+      owner:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Employee who controls the document.  Foreign key to Employee.BusinessEntityID
+        classification: ''
+      folderflag:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: 0 = This is a folder, 1 = This is a document.
+        classification: ''
+      filename:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: File name of the document
+        classification: ''
+      fileextension:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: File extension indicating the document type. For example, .doc
+          or .txt.
+        classification: ''
+      revision:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Revision number of the document.
+        classification: ''
+      changenumber:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Engineering change approval number.
+        classification: ''
+      status:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: 1 = Pending approval, 2 = Approved, 3 = Obsolete
+        classification: ''
+      documentsummary:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Document abstract.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+      documentnode:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for Document records.
+        classification: ''
+  illustration:
+    description: Bicycle assembly diagrams.
+    type: table
+    fields:
+      illustrationid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for Illustration records.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  location:
+    description: Product inventory and manufacturing locations.
+    type: table
+    fields:
+      locationid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for Location records.
+        classification: ''
+      name:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Location description.
+        classification: ''
+      costrate:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Standard hourly cost of the manufacturing location.
+        classification: ''
+      availability:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Work capacity (in hours) of the manufacturing location.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  product:
+    description: Products sold or used in the manfacturing of sold products.
+    type: table
+    fields:
+      productid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for Product records.
+        classification: ''
+      name:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Name of the product.
+        classification: ''
+      productnumber:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Unique product identification number.
+        classification: ''
+      makeflag:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: 0 = Product is purchased, 1 = Product is manufactured in-house.
+        classification: ''
+      finishedgoodsflag:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: 0 = Product is not a salable item. 1 = Product is salable.
+        classification: ''
+      color:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Product color.
+        classification: ''
+      safetystocklevel:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Minimum inventory quantity.
+        classification: ''
+      reorderpoint:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Inventory level that triggers a purchase order or work order.
+        classification: ''
+      standardcost:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Standard cost of the product.
+        classification: ''
+      listprice:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Selling price.
+        classification: ''
+      size:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Product size.
+        classification: ''
+      sizeunitmeasurecode:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Unit of measure for Size column.
+        classification: ''
+      weightunitmeasurecode:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Unit of measure for Weight column.
+        classification: ''
+      weight:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product weight.
+        classification: ''
+      daystomanufacture:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Number of days required to manufacture the product.
+        classification: ''
+      productline:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: R = Road, M = Mountain, T = Touring, S = Standard
+        classification: ''
+      class:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: H = High, M = Medium, L = Low
+        classification: ''
+      style:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: W = Womens, M = Mens, U = Universal
+        classification: ''
+      productsubcategoryid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product is a member of this product subcategory. Foreign key
+          to ProductSubCategory.ProductSubCategoryID.
+        classification: ''
+      productmodelid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product is a member of this product model. Foreign key to ProductModel.ProductModelID.
+        classification: ''
+      sellstartdate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Date the product was available for sale.
+        classification: ''
+      sellenddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Date the product was no longer available for sale.
+        classification: ''
+      discontinueddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Date the product was discontinued.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  productcategory:
+    description: High-level product categorization.
+    type: table
+    fields:
+      productcategoryid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for ProductCategory records.
+        classification: ''
+      name:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Category description.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  productcosthistory:
+    description: Changes in the cost of a product over time.
+    type: table
+    fields:
+      productid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product identification number. Foreign key to Product.ProductID
+        classification: ''
+      startdate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Product cost start date.
+        classification: ''
+      enddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Product cost end date.
+        classification: ''
+      standardcost:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Standard cost of the product.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  productdescription:
+    description: Product descriptions in several languages.
+    type: table
+    fields:
+      productdescriptionid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for ProductDescription records.
+        classification: ''
+      description:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Description of the product.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  productdocument:
+    description: Cross-reference table mapping products to related product documents.
+    type: table
+    fields:
+      productid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product identification number. Foreign key to Product.ProductID.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+      documentnode:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Document identification number. Foreign key to Document.DocumentNode.
+        classification: ''
+  productinventory:
+    description: Product inventory information.
+    type: table
+    fields:
+      productid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product identification number. Foreign key to Product.ProductID.
+        classification: ''
+      locationid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Inventory location identification number. Foreign key to Location.LocationID.
+        classification: ''
+      shelf:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Storage compartment within an inventory location.
+        classification: ''
+      bin:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Storage container on a shelf in an inventory location.
+        classification: ''
+      quantity:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Quantity of products in the inventory location.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  productlistpricehistory:
+    description: Changes in the list price of a product over time.
+    type: table
+    fields:
+      productid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product identification number. Foreign key to Product.ProductID
+        classification: ''
+      startdate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: List price start date.
+        classification: ''
+      enddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: List price end date
+        classification: ''
+      listprice:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product list price.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  productmodel:
+    description: Product model classification.
+    type: table
+    fields:
+      productmodelid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for ProductModel records.
+        classification: ''
+      name:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Product model description.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  productmodelillustration:
+    description: Cross-reference table mapping product models and illustrations.
+    type: table
+    fields:
+      productmodelid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. Foreign key to ProductModel.ProductModelID.
+        classification: ''
+      illustrationid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. Foreign key to Illustration.IllustrationID.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  productmodelproductdescriptionculture:
+    description: Cross-reference table mapping product descriptions and the language
+      the description is written in.
+    type: table
+    fields:
+      productmodelid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. Foreign key to ProductModel.ProductModelID.
+        classification: ''
+      productdescriptionid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. Foreign key to ProductDescription.ProductDescriptionID.
+        classification: ''
+      cultureid:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Culture identification number. Foreign key to Culture.CultureID.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  productphoto:
+    description: Product images.
+    type: table
+    fields:
+      productphotoid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for ProductPhoto records.
+        classification: ''
+      thumbnailphotofilename:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Small image file name.
+        classification: ''
+      largephotofilename:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Large image file name.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  productproductphoto:
+    description: Cross-reference table mapping products and product photos.
+    type: table
+    fields:
+      productid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product identification number. Foreign key to Product.ProductID.
+        classification: ''
+      productphotoid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product photo identification number. Foreign key to ProductPhoto.ProductPhotoID.
+        classification: ''
+      primary:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: 0 = Photo is not the principal image. 1 = Photo is the principal
+          image.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  productreview:
+    description: Customer reviews of products they have purchased.
+    type: table
+    fields:
+      productreviewid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for ProductReview records.
+        classification: ''
+      productid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product identification number. Foreign key to Product.ProductID.
+        classification: ''
+      reviewername:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Name of the reviewer.
+        classification: ''
+      reviewdate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Date review was submitted.
+        classification: ''
+      emailaddress:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Reviewer's e-mail address.
+        classification: ''
+      rating:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product rating given by the reviewer. Scale is 1 to 5 with 5
+          as the highest rating.
+        classification: ''
+      comments:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Reviewer's comments
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  productsubcategory:
+    description: Product subcategories. See ProductCategory table.
+    type: table
+    fields:
+      productsubcategoryid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for ProductSubcategory records.
+        classification: ''
+      productcategoryid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product category identification number. Foreign key to ProductCategory.ProductCategoryID.
+        classification: ''
+      name:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Subcategory description.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  scrapreason:
+    description: Manufacturing failure reasons lookup table.
+    type: table
+    fields:
+      scrapreasonid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for ScrapReason records.
+        classification: ''
+      name:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Failure description.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  transactionhistory:
+    description: Record of each purchase order, sales order, or work order transaction
+      year to date.
+    type: table
+    fields:
+      transactionid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for TransactionHistory records.
+        classification: ''
+      productid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product identification number. Foreign key to Product.ProductID.
+        classification: ''
+      referenceorderid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Purchase order, sales order, or work order identification number.
+        classification: ''
+      referenceorderlineid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Line number associated with the purchase order, sales order,
+          or work order.
+        classification: ''
+      transactiondate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Date and time of the transaction.
+        classification: ''
+      transactiontype:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: W = WorkOrder, S = SalesOrder, P = PurchaseOrder
+        classification: ''
+      quantity:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product quantity.
+        classification: ''
+      actualcost:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product cost.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  transactionhistoryarchive:
+    description: Transactions for previous years.
+    type: table
+    fields:
+      transactionid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for TransactionHistoryArchive records.
+        classification: ''
+      productid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product identification number. Foreign key to Product.ProductID.
+        classification: ''
+      referenceorderid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Purchase order, sales order, or work order identification number.
+        classification: ''
+      referenceorderlineid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Line number associated with the purchase order, sales order,
+          or work order.
+        classification: ''
+      transactiondate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Date and time of the transaction.
+        classification: ''
+      transactiontype:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: W = Work Order, S = Sales Order, P = Purchase Order
+        classification: ''
+      quantity:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product quantity.
+        classification: ''
+      actualcost:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product cost.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  unitmeasure:
+    description: Unit of measure lookup table.
+    type: table
+    fields:
+      unitmeasurecode:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Primary key.
+        classification: ''
+      name:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Unit of measure description.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  workorder:
+    description: Manufacturing work orders.
+    type: table
+    fields:
+      workorderid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for WorkOrder records.
+        classification: ''
+      productid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product identification number. Foreign key to Product.ProductID.
+        classification: ''
+      orderqty:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product quantity to build.
+        classification: ''
+      scrappedqty:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Quantity that failed inspection.
+        classification: ''
+      startdate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Work order start date.
+        classification: ''
+      enddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Work order end date.
+        classification: ''
+      duedate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Work order due date.
+        classification: ''
+      scrapreasonid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Reason for inspection failure.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  workorderrouting:
+    description: Work order details.
+    type: table
+    fields:
+      workorderid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. Foreign key to WorkOrder.WorkOrderID.
+        classification: ''
+      productid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. Foreign key to Product.ProductID.
+        classification: ''
+      operationsequence:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. Indicates the manufacturing process sequence.
+        classification: ''
+      locationid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Manufacturing location where the part is processed. Foreign key
+          to Location.LocationID.
+        classification: ''
+      scheduledstartdate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Planned manufacturing start date.
+        classification: ''
+      scheduledenddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Planned manufacturing end date.
+        classification: ''
+      actualstartdate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Actual start date.
+        classification: ''
+      actualenddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Actual end date.
+        classification: ''
+      actualresourcehrs:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Number of manufacturing hours used.
+        classification: ''
+      plannedcost:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Estimated manufacturing cost.
+        classification: ''
+      actualcost:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Actual manufacturing cost.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  productvendor:
+    description: Cross-reference table mapping vendors with the products they supply.
+    type: table
+    fields:
+      productid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. Foreign key to Product.ProductID.
+        classification: ''
+      businessentityid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. Foreign key to Vendor.BusinessEntityID.
+        classification: ''
+      averageleadtime:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: The average span of time (in days) between placing an order with
+          the vendor and receiving the purchased product.
+        classification: ''
+      standardprice:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: The vendor's usual selling price.
+        classification: ''
+      lastreceiptcost:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: The selling price when last purchased.
+        classification: ''
+      lastreceiptdate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Date the product was last received by the vendor.
+        classification: ''
+      minorderqty:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: The maximum quantity that should be ordered.
+        classification: ''
+      maxorderqty:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: The minimum quantity that should be ordered.
+        classification: ''
+      onorderqty:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: The quantity currently on order.
+        classification: ''
+      unitmeasurecode:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: The product's unit of measure.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  purchaseorderdetail:
+    description: Individual products associated with a specific purchase order. See
+      PurchaseOrderHeader.
+    type: table
+    fields:
+      purchaseorderid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. Foreign key to PurchaseOrderHeader.PurchaseOrderID.
+        classification: ''
+      purchaseorderdetailid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. One line number per purchased product.
+        classification: ''
+      duedate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Date the product is expected to be received.
+        classification: ''
+      orderqty:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Quantity ordered.
+        classification: ''
+      productid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product identification number. Foreign key to Product.ProductID.
+        classification: ''
+      unitprice:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Vendor's selling price of a single product.
+        classification: ''
+      receivedqty:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Quantity actually received from the vendor.
+        classification: ''
+      rejectedqty:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Quantity rejected during inspection.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  purchaseorderheader:
+    description: General purchase order information. See PurchaseOrderDetail.
+    type: table
+    fields:
+      purchaseorderid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key.
+        classification: ''
+      revisionnumber:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Incremental number to track changes to the purchase order over
+          time.
+        classification: ''
+      status:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Order current status. 1 = Pending; 2 = Approved; 3 = Rejected;
+          4 = Complete
+        classification: ''
+      employeeid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Employee who created the purchase order. Foreign key to Employee.BusinessEntityID.
+        classification: ''
+      vendorid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Vendor with whom the purchase order is placed. Foreign key to
+          Vendor.BusinessEntityID.
+        classification: ''
+      shipmethodid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Shipping method. Foreign key to ShipMethod.ShipMethodID.
+        classification: ''
+      orderdate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Purchase order creation date.
+        classification: ''
+      shipdate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Estimated shipment date from the vendor.
+        classification: ''
+      subtotal:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Purchase order subtotal. Computed as SUM(PurchaseOrderDetail.LineTotal)for
+          the appropriate PurchaseOrderID.
+        classification: ''
+      taxamt:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Tax amount.
+        classification: ''
+      freight:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Shipping cost.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  shipmethod:
+    description: Shipping company lookup table.
+    type: table
+    fields:
+      shipmethodid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for ShipMethod records.
+        classification: ''
+      name:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Shipping company name.
+        classification: ''
+      shipbase:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Minimum shipping charge.
+        classification: ''
+      shiprate:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Shipping charge per pound.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  vendor:
+    description: Companies from whom Adventure Works Cycles purchases parts or other
+      goods.
+    type: table
+    fields:
+      businessentityid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for Vendor records.  Foreign key to BusinessEntity.BusinessEntityID
+        classification: ''
+      accountnumber:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Vendor account (identification) number.
+        classification: ''
+      name:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Company name.
+        classification: ''
+      creditrating:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: 1 = Superior, 2 = Excellent, 3 = Above average, 4 = Average,
+          5 = Below average
+        classification: ''
+      preferredvendorstatus:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: 0 = Do not use if another vendor is available. 1 = Preferred
+          over other vendors supplying the same product.
+        classification: ''
+      activeflag:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: 0 = Vendor no longer used. 1 = Vendor is actively used.
+        classification: ''
+      purchasingwebserviceurl:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Vendor URL.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  countryregioncurrency:
+    description: Cross-reference table mapping ISO currency codes to a country or
+      region.
+    type: table
+    fields:
+      countryregioncode:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: ISO code for countries and regions. Foreign key to CountryRegion.CountryRegionCode.
+        classification: ''
+      currencycode:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: ISO standard currency code. Foreign key to Currency.CurrencyCode.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  creditcard:
+    description: Customer credit card information.
+    type: table
+    fields:
+      creditcardid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for CreditCard records.
+        classification: ''
+      cardtype:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Credit card name.
+        classification: ''
+      cardnumber:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Credit card number.
+        classification: ''
+      expmonth:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Credit card expiration month.
+        classification: ''
+      expyear:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Credit card expiration year.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  currency:
+    description: Lookup table containing standard ISO currencies.
+    type: table
+    fields:
+      currencycode:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: The ISO code for the Currency.
+        classification: ''
+      name:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Currency name.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  currencyrate:
+    description: Currency exchange rates.
+    type: table
+    fields:
+      currencyrateid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for CurrencyRate records.
+        classification: ''
+      currencyratedate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Date and time the exchange rate was obtained.
+        classification: ''
+      fromcurrencycode:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Exchange rate was converted from this currency code.
+        classification: ''
+      tocurrencycode:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Exchange rate was converted to this currency code.
+        classification: ''
+      averagerate:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Average exchange rate for the day.
+        classification: ''
+      endofdayrate:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Final exchange rate for the day.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  customer:
+    description: Current customer information. Also see the Person and Store tables.
+    type: table
+    fields:
+      customerid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key.
+        classification: ''
+      personid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Foreign key to Person.BusinessEntityID
+        classification: ''
+      storeid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Foreign key to Store.BusinessEntityID
+        classification: ''
+      territoryid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: ID of the territory in which the customer is located. Foreign
+          key to SalesTerritory.SalesTerritoryID.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  personcreditcard:
+    description: Cross-reference table mapping people to their credit card information
+      in the CreditCard table.
+    type: table
+    fields:
+      businessentityid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Business entity identification number. Foreign key to Person.BusinessEntityID.
+        classification: ''
+      creditcardid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Credit card identification number. Foreign key to CreditCard.CreditCardID.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  salesorderdetail:
+    description: Individual products associated with a specific sales order. See SalesOrderHeader.
+    type: table
+    fields:
+      salesorderid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. Foreign key to SalesOrderHeader.SalesOrderID.
+        classification: ''
+      salesorderdetailid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. One incremental unique number per product sold.
+        classification: ''
+      carriertrackingnumber:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Shipment tracking number supplied by the shipper.
+        classification: ''
+      orderqty:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Quantity ordered per product.
+        classification: ''
+      productid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product sold to customer. Foreign key to Product.ProductID.
+        classification: ''
+      specialofferid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Promotional code. Foreign key to SpecialOffer.SpecialOfferID.
+        classification: ''
+      unitprice:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Selling price of a single product.
+        classification: ''
+      unitpricediscount:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Discount amount.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  salesorderheader:
+    description: General sales order information.
+    type: table
+    fields:
+      salesorderid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key.
+        classification: ''
+      revisionnumber:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Incremental number to track changes to the sales order over time.
+        classification: ''
+      orderdate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Dates the sales order was created.
+        classification: ''
+      duedate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Date the order is due to the customer.
+        classification: ''
+      shipdate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Date the order was shipped to the customer.
+        classification: ''
+      status:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Order current status. 1 = In process; 2 = Approved; 3 = Backordered;
+          4 = Rejected; 5 = Shipped; 6 = Cancelled
+        classification: ''
+      onlineorderflag:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: 0 = Order placed by sales person. 1 = Order placed online by
+          customer.
+        classification: ''
+      purchaseordernumber:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Customer purchase order number reference.
+        classification: ''
+      accountnumber:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Financial accounting number reference.
+        classification: ''
+      customerid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Customer identification number. Foreign key to Customer.BusinessEntityID.
+        classification: ''
+      salespersonid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Sales person who created the sales order. Foreign key to SalesPerson.BusinessEntityID.
+        classification: ''
+      territoryid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Territory in which the sale was made. Foreign key to SalesTerritory.SalesTerritoryID.
+        classification: ''
+      billtoaddressid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Customer billing address. Foreign key to Address.AddressID.
+        classification: ''
+      shiptoaddressid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Customer shipping address. Foreign key to Address.AddressID.
+        classification: ''
+      shipmethodid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Shipping method. Foreign key to ShipMethod.ShipMethodID.
+        classification: ''
+      creditcardid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Credit card identification number. Foreign key to CreditCard.CreditCardID.
+        classification: ''
+      creditcardapprovalcode:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Approval code provided by the credit card company.
+        classification: ''
+      currencyrateid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Currency exchange rate used. Foreign key to CurrencyRate.CurrencyRateID.
+        classification: ''
+      subtotal:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Sales subtotal. Computed as SUM(SalesOrderDetail.LineTotal)for
+          the appropriate SalesOrderID.
+        classification: ''
+      taxamt:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Tax amount.
+        classification: ''
+      freight:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Shipping cost.
+        classification: ''
+      totaldue:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Total due from customer. Computed as Subtotal + TaxAmt + Freight.
+        classification: ''
+      comment:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Sales representative comments.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  salesorderheadersalesreason:
+    description: Cross-reference table mapping sales orders to sales reason codes.
+    type: table
+    fields:
+      salesorderid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. Foreign key to SalesOrderHeader.SalesOrderID.
+        classification: ''
+      salesreasonid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. Foreign key to SalesReason.SalesReasonID.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  salesperson:
+    description: Sales representative current information.
+    type: table
+    fields:
+      businessentityid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for SalesPerson records. Foreign key to Employee.BusinessEntityID
+        classification: ''
+      territoryid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Territory currently assigned to. Foreign key to SalesTerritory.SalesTerritoryID.
+        classification: ''
+      salesquota:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Projected yearly sales.
+        classification: ''
+      bonus:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Bonus due if quota is met.
+        classification: ''
+      commissionpct:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Commision percent received per sale.
+        classification: ''
+      salesytd:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Sales total year to date.
+        classification: ''
+      saleslastyear:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Sales total of previous year.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  salespersonquotahistory:
+    description: Sales performance tracking.
+    type: table
+    fields:
+      businessentityid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Sales person identification number. Foreign key to SalesPerson.BusinessEntityID.
+        classification: ''
+      quotadate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Sales quota date.
+        classification: ''
+      salesquota:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Sales quota amount.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  salesreason:
+    description: Lookup table of customer purchase reasons.
+    type: table
+    fields:
+      salesreasonid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for SalesReason records.
+        classification: ''
+      name:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Sales reason description.
+        classification: ''
+      reasontype:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Category the sales reason belongs to.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  salestaxrate:
+    description: Tax rate lookup table.
+    type: table
+    fields:
+      salestaxrateid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for SalesTaxRate records.
+        classification: ''
+      stateprovinceid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: State, province, or country/region the sales tax applies to.
+        classification: ''
+      taxtype:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: 1 = Tax applied to retail transactions, 2 = Tax applied to wholesale
+          transactions, 3 = Tax applied to all sales (retail and wholesale) transactions.
+        classification: ''
+      taxrate:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Tax rate amount.
+        classification: ''
+      name:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Tax rate description.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  salesterritory:
+    description: Sales territory lookup table.
+    type: table
+    fields:
+      territoryid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for SalesTerritory records.
+        classification: ''
+      name:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Sales territory description
+        classification: ''
+      countryregioncode:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: ISO standard country or region code. Foreign key to CountryRegion.CountryRegionCode.
+        classification: ''
+      group:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Geographic area to which the sales territory belong.
+        classification: ''
+      salesytd:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Sales in the territory year to date.
+        classification: ''
+      saleslastyear:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Sales in the territory the previous year.
+        classification: ''
+      costytd:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Business costs in the territory year to date.
+        classification: ''
+      costlastyear:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Business costs in the territory the previous year.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  salesterritoryhistory:
+    description: Sales representative transfers to other sales territories.
+    type: table
+    fields:
+      businessentityid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. The sales rep.  Foreign key to SalesPerson.BusinessEntityID.
+        classification: ''
+      territoryid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. Territory identification number. Foreign key to
+          SalesTerritory.SalesTerritoryID.
+        classification: ''
+      startdate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. Date the sales representive started work in the
+          territory.
+        classification: ''
+      enddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Date the sales representative left work in the territory.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  shoppingcartitem:
+    description: Contains online customer orders until the order is submitted or cancelled.
+    type: table
+    fields:
+      shoppingcartitemid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for ShoppingCartItem records.
+        classification: ''
+      shoppingcartid:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Shopping cart identification number.
+        classification: ''
+      quantity:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product quantity ordered.
+        classification: ''
+      productid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product ordered. Foreign key to Product.ProductID.
+        classification: ''
+      datecreated:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Date the time the record was created.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  specialoffer:
+    description: Sale discounts lookup table.
+    type: table
+    fields:
+      specialofferid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for SpecialOffer records.
+        classification: ''
+      description:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Discount description.
+        classification: ''
+      discountpct:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Discount precentage.
+        classification: ''
+      type:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Discount type category.
+        classification: ''
+      category:
+        title: ''
+        type: string
+        required: false
+        primary: false
+        unique: false
+        description: Group the discount applies to such as Reseller or Customer.
+        classification: ''
+      startdate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Discount start date.
+        classification: ''
+      enddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: Discount end date.
+        classification: ''
+      minqty:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Minimum discount percent allowed.
+        classification: ''
+      maxqty:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Maximum discount percent allowed.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  specialofferproduct:
+    description: Cross-reference table mapping products to special offer discounts.
+    type: table
+    fields:
+      specialofferid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key for SpecialOfferProduct records.
+        classification: ''
+      productid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Product identification number. Foreign key to Product.ProductID.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''
+  store:
+    description: Customers (resellers) of Adventure Works products.
+    type: table
+    fields:
+      businessentityid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: Primary key. Foreign key to Customer.BusinessEntityID.
+        classification: ''
+      name:
+        title: ''
+        type: object
+        required: false
+        primary: false
+        unique: false
+        description: Name of the store.
+        classification: ''
+      salespersonid:
+        title: ''
+        type: numeric
+        required: false
+        primary: false
+        unique: false
+        description: ID of the sales person assigned to the customer. Foreign key
+          to SalesPerson.BusinessEntityID.
+        classification: ''
+      modifieddate:
+        title: ''
+        type: timestamp
+        required: false
+        primary: false
+        unique: false
+        description: ''
+        classification: ''

--- a/tests/fixtures/odcs/full-example.datacontract.yml
+++ b/tests/fixtures/odcs/full-example.datacontract.yml
@@ -1,0 +1,48 @@
+dataContractSpecification: 0.9.3
+id: 53581432-6c55-4ba2-a65f-72344a91553a
+info:
+  title: my quantum
+  version: 1.1.0
+  description: Views built on top of the seller tables.
+  owner: seller
+  contact:
+    name: product-dl@ClimateQuantum.org
+    url: https://product-feedback.com/sellers
+terms:
+  usage: Predict sales over time
+  limitations: Data based on seller perspective, no buyer information
+  billing: 9.95 USD / megabyte
+models:
+  tbl:
+    description: Provides core payment metrics
+    type: table
+    fields:
+      txn_ref_dt:
+        title: transaction reference date
+        type: date
+        required: true
+        primary: false
+        unique: false
+        description: Reference date for transaction
+        classification: public
+      rcvr_id:
+        title: receiver id
+        type: string
+        required: true
+        primary: true
+        unique: false
+        description: A description for column rcvr_id.
+        classification: restricted
+      rcvr_cntry_code:
+        title: receiver country code
+        type: string
+        required: true
+        primary: false
+        unique: false
+        description: Country code
+        classification: public
+servicelevels:
+  availability:
+    description: '2022-05-12T09:30:10-08:00'
+  retention:
+    period: 3y

--- a/tests/fixtures/odcs/odcs-full-example.yaml
+++ b/tests/fixtures/odcs/odcs-full-example.yaml
@@ -1,0 +1,232 @@
+# What's this data contract about?
+datasetDomain: seller # Domain
+quantumName: my quantum # Data product name
+userConsumptionMode: Analytical
+version: 1.1.0 # Version (follows semantic versioning)
+status: current
+uuid: 53581432-6c55-4ba2-a65f-72344a91553a
+
+# Lots of information
+description:
+  purpose: Views built on top of the seller tables.
+  limitations: Data based on seller perspective, no buyer information
+  usage: Predict sales over time
+tenant: ClimateQuantumInc
+
+# Getting support
+productDl: product-dl@ClimateQuantum.org
+productSlackChannel: '#product-help'
+productFeedbackUrl: https://product-feedback.com/sellers
+
+# Physical parts / GCP / BigQuery specific
+sourcePlatform: googleCloudPlatform
+sourceSystem: bigQuery
+datasetProject: edw # BQ dataset
+datasetName: access_views # BQ dataset
+
+kind: DataContract
+apiVersion: v2.2.2 # Standard version (follows semantic versioning, previously known as templateVersion)
+
+type: tables
+
+# Physical access
+driver: jdbc:postgresql
+driverVersion: 1.0.0
+server: localhost:5432
+database: pypl-edw.pp_access_views
+username: '${env.username}'
+password: '${env.password}'
+schedulerAppName: name_coming_from_scheduler # NEW 2.1.0 Required if you want to schedule stuff, comes from DataALM.
+
+# Dataset, schema and quality
+dataset:
+  - table: tbl
+    physicalName: tbl_1 # NEW in v2.1.0, Optional, default value is table name + version separated by underscores, as table_1_2_0
+    priorTableName: seller_table # if needed
+    description: Provides core payment metrics
+    authoritativeDefinitions: # NEW in v2.2.0, inspired by the column-level authoritative links
+      - url: https://catalog.data.gov/dataset/air-quality
+        type: businessDefinition
+      - url: https://youtu.be/jbY1BKFj9ec
+        type: videoTutorial
+    tags: null
+    dataGranularity: Aggregation on columns txn_ref_dt, pmt_txn_id
+    columns:
+      - column: txn_ref_dt
+        isPrimary: false # NEW in v2.1.0, Optional, default value is false, indicates whether the column is primary key in the table.
+        primaryKeyPosition: -1
+        businessName: transaction reference date
+        logicalType: date
+        physicalType: date
+        isNullable: false
+        description: Reference date for transaction
+        partitionStatus: true
+        partitionKeyPosition: 1
+        clusterStatus: false
+        clusterKeyPosition: -1
+        criticalDataElementStatus: false
+        tags: []
+        classification: public
+        transformSourceTables:
+          - table_name_1
+          - table_name_2
+          - table_name_3
+        transformLogic: sel t1.txn_dt as txn_ref_dt from table_name_1 as t1, table_name_2 as t2, table_name_3 as t3 where t1.txn_dt=date-3
+        transformDescription: defines the logic in business terms; logic for dummies
+        sampleValues:
+          - 2022-10-03
+          - 2020-01-28
+      - column: rcvr_id
+        isPrimary: true # NEW in v2.1.0, Optional, default value is false, indicates whether the column is primary key in the table.
+        primaryKeyPosition: 1
+        businessName: receiver id
+        logicalType: string
+        physicalType: varchar(18)
+        isNullable: false
+        description: A description for column rcvr_id.
+        partitionStatus: false
+        partitionKeyPosition: -1
+        clusterStatus: true
+        clusterKeyPosition: 1
+        criticalDataElementStatus: false
+        tags: []
+        classification: restricted
+      - column: rcvr_cntry_code
+        isPrimary: false # NEW in v2.1.0, Optional, default value is false, indicates whether the column is primary key in the table.
+        primaryKeyPosition: -1
+        businessName: receiver country code
+        logicalType: string
+        physicalType: varchar(2)
+        isNullable: false
+        description: Country code
+        partitionStatus: false
+        partitionKeyPosition: -1
+        clusterStatus: false
+        clusterKeyPosition: -1
+        criticalDataElementStatus: false
+        tags: []
+        classification: public
+        authoritativeDefinitions:
+          - url: https://collibra.com/asset/742b358f-71a5-4ab1-bda4-dcdba9418c25
+            type: businessDefinition
+          - url: https://github.com/myorg/myrepo
+            type: transformationImplementation
+          - url: jdbc:postgresql://localhost:5432/adventureworks/tbl_1/rcvr_cntry_code
+            type: implementation
+        encryptedColumnName: rcvr_cntry_code_encrypted
+        quality:
+          - code: nullCheck
+            templateName: NullCheck
+            description: column should not contain null values
+            toolName: Elevate
+            toolRuleName: DQ.rw.tab1_2_0_0.rcvr_cntry_code.NullCheck
+            dimension: completeness # dropdown 7 values
+            type: dataQuality
+            severity: error
+            businessImpact: operational
+            scheduleCronExpression: 0 20 * * *
+            customProperties:
+              - property: FIELD_NAME
+                value:
+              - property: COMPARE_TO
+                value:
+              - property: COMPARISON_TYPE
+                value: Greater than
+    quality:
+      - code: countCheck # Required, name of the rule
+        templateName: CountCheck # NEW in v2.1.0 Required
+        description: Ensure row count is within expected volume range       # Optional
+        toolName: Elevate # Required
+        toolRuleName: DQ.rw.tab1.CountCheck # NEW in v2.1.0 Optional (Available only to the users who can change in source code edition)
+        dimension: completeness                                             # Optional
+        type: reconciliation                                                # Optional NEW in v2.1.0 default value for column level check - dataQuality and for table level reconciliation
+        severity: error                                                     # Optional NEW in v2.1.0, default value is error
+        businessImpact: operational                                         # Optional NEW in v2.1.0
+        scheduleCronExpression: 0 20 * * *                                  # Optional NEW in v2.1.0 default schedule - every day 10 a.m. UTC
+
+# Pricing
+price:
+  priceAmount: 9.95
+  priceCurrency: USD
+  priceUnit: megabyte
+
+# Stakeholders
+stakeholders:
+  - username: ceastwood
+    role: Data Scientist
+    dateIn: 2022-08-02
+    dateOut: 2022-10-01
+    replacedByUsername: mhopper
+  - username: mhopper
+    role: Data Scientist
+    dateIn: 2022-10-01
+  - username: daustin
+    role: Owner
+    comment: Keeper of the grail
+    dateIn: 2022-10-01
+
+# Roles
+roles:
+  - role: microstrategy_user_opr
+    access: read
+    firstLevelApprovers: Reporting Manager
+    secondLevelApprovers: 'mandolorian'
+  - role: bq_queryman_user_opr
+    access: read
+    firstLevelApprovers: Reporting Manager
+    secondLevelApprovers: na
+  - role: risk_data_access_opr
+    access: read
+    firstLevelApprovers: Reporting Manager
+    secondLevelApprovers: 'dathvador'
+  - role: bq_unica_user_opr
+    access: write
+    firstLevelApprovers: Reporting Manager
+    secondLevelApprovers: 'mickey'
+
+# SLA
+slaDefaultColumn: tab1.txn_ref_dt # Optional, default value is partitionColumn.
+slaProperties:
+  - property: latency # Property, see list of values in DP QoS
+    value: 4
+    unit: d # d, day, days for days; y, yr, years for years
+    column: tab1.txn_ref_dt # This would not be needed as it is the same table.column as the default one
+  - property: generalAvailability
+    value: 2022-05-12T09:30:10-08:00
+  - property: endOfSupport
+    value: 2032-05-12T09:30:10-08:00
+  - property: endOfLife
+    value: 2042-05-12T09:30:10-08:00
+  - property: retention
+    value: 3
+    unit: y
+    column: tab1.txn_ref_dt
+  - property: frequency
+    value: 1
+    valueExt: 1
+    unit: d
+    column: tab1.txn_ref_dt
+  - property: timeOfAvailability
+    value: 09:00-08:00
+    column: tab1.txn_ref_dt
+    driver: regulatory # Describes the importance of the SLA: [regulatory|analytics|operational|...]
+  - property: timeOfAvailability
+    value: 08:00-08:00
+    column: tab1.txn_ref_dt
+    driver: analytics
+
+# Tags
+tags:
+  - transactions
+
+# Custom properties
+customProperties:
+  - property: refRulesetName
+    value: gcsc.ruleset.name
+  - property: somePropertyName
+    value: property.value
+  - property: dataprocClusterName # Used for specific applications like Elevate
+    value: [cluster name]
+
+systemInstance: instance.ClimateQuantum.org
+contractCreatedTs: 2022-11-15 02:59:43

--- a/tests/fixtures/odcs/odcs-postgresql-adventureworks-contract.yaml
+++ b/tests/fixtures/odcs/odcs-postgresql-adventureworks-contract.yaml
@@ -1,0 +1,5719 @@
+version: "1.0.0"
+standardVersion: "2.2.0"
+uuid: "6aeafdc1-ed62-4c8f-bf0a-da1061c98cdb"
+quantumName: "test"
+username: "postgres"
+type: "tables"
+status: "Development"
+server: "localhost"
+kind: "managedDataset"
+driverVersion: "42.6.0"
+driver: "org.postgresql.Driver"
+description: {}
+database: "adventureworks"
+dataset:
+  - table: "department"
+    physicalName: "department"
+    description: "Lookup table containing the departments within the Adventure Works\
+      \ Cycles company."
+    columns:
+    - column: "departmentid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for Department records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/department/departmentid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "name"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Name of the department."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/department/name"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "groupname"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Name of the group to which the department belongs."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/department/groupname"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/department/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "employee"
+    physicalName: "employee"
+    description: "Employee information such as salary, department, and title."
+    columns:
+    - column: "businessentityid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key for Employee records.  Foreign key to BusinessEntity.BusinessEntityID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employee/businessentityid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "nationalidnumber"
+      logicalType: "String"
+      physicalType: "varchar[15]"
+      description: "Unique national identification number such as a social security\
+        \ number."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employee/nationalidnumber"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "loginid"
+      logicalType: "String"
+      physicalType: "varchar[256]"
+      description: "Network login."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employee/loginid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "jobtitle"
+      logicalType: "String"
+      physicalType: "varchar[50]"
+      description: "Work title such as Buyer or Sales Representative."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employee/jobtitle"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "birthdate"
+      logicalType: "Date"
+      physicalType: "date"
+      description: "Date of birth."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employee/birthdate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "maritalstatus"
+      logicalType: "String"
+      physicalType: "bpchar"
+      description: "M = Married, S = Single"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employee/maritalstatus"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "gender"
+      logicalType: "String"
+      physicalType: "bpchar"
+      description: "M = Male, F = Female"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employee/gender"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "hiredate"
+      logicalType: "Date"
+      physicalType: "date"
+      description: "Employee hired on this date."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employee/hiredate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "salariedflag"
+      logicalType: "Object"
+      physicalType: "Flag"
+      description: "Job classification. 0 = Hourly, not exempt from collective bargaining.\
+        \ 1 = Salaried, exempt from collective bargaining."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employee/salariedflag"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "vacationhours"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "Number of available vacation hours."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employee/vacationhours"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "sickleavehours"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "Number of available sick leave hours."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employee/sickleavehours"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "currentflag"
+      logicalType: "Object"
+      physicalType: "Flag"
+      description: "0 = Inactive, 1 = Active"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employee/currentflag"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employee/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employee/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "organizationnode"
+      logicalType: "String"
+      physicalType: "varchar[2147483647]"
+      description: "Where the employee is located in corporate hierarchy."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employee/organizationnode"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "employeedepartmenthistory"
+    physicalName: "employeedepartmenthistory"
+    description: "Employee department transfers."
+    columns:
+    - column: "businessentityid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Employee identification number. Foreign key to Employee.BusinessEntityID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employeedepartmenthistory/businessentityid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "departmentid"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "Department in which the employee worked including currently. Foreign\
+        \ key to Department.DepartmentID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employeedepartmenthistory/departmentid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "shiftid"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "Identifies which 8-hour shift the employee works. Foreign key\
+        \ to Shift.Shift.ID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employeedepartmenthistory/shiftid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "startdate"
+      logicalType: "Date"
+      physicalType: "date"
+      description: "Date the employee started work in the department."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employeedepartmenthistory/startdate"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "enddate"
+      logicalType: "Date"
+      physicalType: "date"
+      description: "Date the employee left the department. NULL = Current department."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employeedepartmenthistory/enddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employeedepartmenthistory/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "employeepayhistory"
+    physicalName: "employeepayhistory"
+    description: "Employee pay history."
+    columns:
+    - column: "businessentityid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Employee identification number. Foreign key to Employee.BusinessEntityID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employeepayhistory/businessentityid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "ratechangedate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Date the change in pay is effective"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employeepayhistory/ratechangedate"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "rate"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Salary hourly rate."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employeepayhistory/rate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "payfrequency"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "1 = Salary received monthly, 2 = Salary received biweekly"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employeepayhistory/payfrequency"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/employeepayhistory/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "jobcandidate"
+    physicalName: "jobcandidate"
+    description: "Résumés submitted to Human Resources by job applicants."
+    columns:
+    - column: "jobcandidateid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for JobCandidate records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/jobcandidate/jobcandidateid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "businessentityid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Employee identification number if applicant was hired. Foreign\
+        \ key to Employee.BusinessEntityID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/jobcandidate/businessentityid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "resume"
+      logicalType: "XML"
+      physicalType: "xml"
+      description: "RÃ©sumÃ© in XML format."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/jobcandidate/resume"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/jobcandidate/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "shift"
+    physicalName: "shift"
+    description: "Work shift lookup table."
+    columns:
+    - column: "shiftid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for Shift records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/shift/shiftid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "name"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Shift description."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/shift/name"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "starttime"
+      logicalType: "Timestamp"
+      physicalType: "time"
+      description: "Shift start time."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/shift/starttime"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "endtime"
+      logicalType: "Timestamp"
+      physicalType: "time"
+      description: "Shift end time."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/shift/endtime"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/shift/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "address"
+    physicalName: "address"
+    description: "Street address information for customers, employees, and vendors."
+    columns:
+    - column: "addressid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for Address records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/address/addressid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "addressline1"
+      logicalType: "String"
+      physicalType: "varchar[60]"
+      description: "First street address line."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/address/addressline1"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "addressline2"
+      logicalType: "String"
+      physicalType: "varchar[60]"
+      description: "Second street address line."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/address/addressline2"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "city"
+      logicalType: "String"
+      physicalType: "varchar[30]"
+      description: "Name of the city."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/address/city"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "stateprovinceid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Unique identification number for the state or province. Foreign\
+        \ key to StateProvince table."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/address/stateprovinceid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "postalcode"
+      logicalType: "String"
+      physicalType: "varchar[15]"
+      description: "Postal code for the street address."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/address/postalcode"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "spatiallocation"
+      logicalType: "Binary"
+      physicalType: "bytea"
+      description: "Latitude and longitude of this address."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/address/spatiallocation"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/address/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/address/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "addresstype"
+    physicalName: "addresstype"
+    description: "Types of addresses stored in the Address table."
+    columns:
+    - column: "addresstypeid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for AddressType records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/addresstype/addresstypeid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "name"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Address type description. For example, Billing, Home, or Shipping."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/addresstype/name"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/addresstype/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/addresstype/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "businessentity"
+    physicalName: "businessentity"
+    description: "Source of the ID that connects vendors, customers, and employees\
+      \ with address and contact information."
+    columns:
+    - column: "businessentityid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for all customers, vendors, and employees."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/businessentity/businessentityid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/businessentity/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/businessentity/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "businessentityaddress"
+    physicalName: "businessentityaddress"
+    description: "Cross-reference table mapping customers, vendors, and employees\
+      \ to their addresses."
+    columns:
+    - column: "businessentityid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key. Foreign key to BusinessEntity.BusinessEntityID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/businessentityaddress/businessentityid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "addressid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key. Foreign key to Address.AddressID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/businessentityaddress/addressid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "addresstypeid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key. Foreign key to AddressType.AddressTypeID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/businessentityaddress/addresstypeid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/businessentityaddress/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/businessentityaddress/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "businessentitycontact"
+    physicalName: "businessentitycontact"
+    description: "Cross-reference table mapping stores, vendors, and employees to\
+      \ people"
+    columns:
+    - column: "businessentityid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key. Foreign key to BusinessEntity.BusinessEntityID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/businessentitycontact/businessentityid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "personid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key. Foreign key to Person.BusinessEntityID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/businessentitycontact/personid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "contacttypeid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key.  Foreign key to ContactType.ContactTypeID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/businessentitycontact/contacttypeid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/businessentitycontact/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/businessentitycontact/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "contacttype"
+    physicalName: "contacttype"
+    description: "Lookup table containing the types of business entity contacts."
+    columns:
+    - column: "contacttypeid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for ContactType records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/contacttype/contacttypeid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "name"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Contact type description."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/contacttype/name"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/contacttype/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "countryregion"
+    physicalName: "countryregion"
+    description: "Lookup table containing the ISO standard codes for countries and\
+      \ regions."
+    columns:
+    - column: "countryregioncode"
+      logicalType: "String"
+      physicalType: "varchar[3]"
+      description: "ISO standard code for countries and regions."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/countryregion/countryregioncode"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "name"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Country or region name."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/countryregion/name"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/countryregion/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "emailaddress"
+    physicalName: "emailaddress"
+    description: "Where to send a person email."
+    columns:
+    - column: "businessentityid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key. Person associated with this email address.  Foreign\
+        \ key to Person.BusinessEntityID"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/emailaddress/businessentityid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "emailaddressid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key. ID of this email address."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/emailaddress/emailaddressid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "emailaddress"
+      logicalType: "String"
+      physicalType: "varchar[50]"
+      description: "E-mail address for the person."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/emailaddress/emailaddress"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/emailaddress/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/emailaddress/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "password"
+    physicalName: "password"
+    description: "One way hashed authentication information"
+    columns:
+    - column: "businessentityid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/password/businessentityid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "passwordhash"
+      logicalType: "String"
+      physicalType: "varchar[128]"
+      description: "Password for the e-mail account."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/password/passwordhash"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "passwordsalt"
+      logicalType: "String"
+      physicalType: "varchar[10]"
+      description: "Random value concatenated with the password string before the\
+        \ password is hashed."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/password/passwordsalt"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/password/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/password/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "person"
+    physicalName: "person"
+    description: "Human beings involved with AdventureWorks: employees, customer contacts,\
+      \ and vendor contacts."
+    columns:
+    - column: "businessentityid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key for Person records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/person/businessentityid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "persontype"
+      logicalType: "String"
+      physicalType: "bpchar"
+      description: "Primary type of person: SC = Store Contact, IN = Individual (retail)\
+        \ customer, SP = Sales person, EM = Employee (non-sales), VC = Vendor contact,\
+        \ GC = General contact"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/person/persontype"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "namestyle"
+      logicalType: "Object"
+      physicalType: "NameStyle"
+      description: "0 = The data in FirstName and LastName are stored in western style\
+        \ (first name, last name) order.  1 = Eastern style (last name, first name)\
+        \ order."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/person/namestyle"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "title"
+      logicalType: "String"
+      physicalType: "varchar[8]"
+      description: "A courtesy title. For example, Mr. or Ms."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/person/title"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "firstname"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "First name of the person."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/person/firstname"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "middlename"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Middle name or middle initial of the person."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/person/middlename"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "lastname"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Last name of the person."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/person/lastname"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "suffix"
+      logicalType: "String"
+      physicalType: "varchar[10]"
+      description: "Surname suffix. For example, Sr. or Jr."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/person/suffix"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "emailpromotion"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "0 = Contact does not wish to receive e-mail promotions, 1 = Contact\
+        \ does wish to receive e-mail promotions from AdventureWorks, 2 = Contact\
+        \ does wish to receive e-mail promotions from AdventureWorks and selected\
+        \ partners."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/person/emailpromotion"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "additionalcontactinfo"
+      logicalType: "XML"
+      physicalType: "xml"
+      description: "Additional contact information about the person stored in xml\
+        \ format."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/person/additionalcontactinfo"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "demographics"
+      logicalType: "XML"
+      physicalType: "xml"
+      description: "Personal information such as hobbies, and income collected from\
+        \ online shoppers. Used for sales analysis."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/person/demographics"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/person/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/person/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "personphone"
+    physicalName: "personphone"
+    description: "Telephone number and type of a person."
+    columns:
+    - column: "businessentityid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Business entity identification number. Foreign key to Person.BusinessEntityID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/personphone/businessentityid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "phonenumber"
+      logicalType: "Object"
+      physicalType: "Phone"
+      description: "Telephone number identification number."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/personphone/phonenumber"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "phonenumbertypeid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Kind of phone number. Foreign key to PhoneNumberType.PhoneNumberTypeID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/personphone/phonenumbertypeid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/personphone/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "phonenumbertype"
+    physicalName: "phonenumbertype"
+    description: "Type of phone number of a person."
+    columns:
+    - column: "phonenumbertypeid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for telephone number type records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/phonenumbertype/phonenumbertypeid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "name"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Name of the telephone number type"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/phonenumbertype/name"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/phonenumbertype/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "stateprovince"
+    physicalName: "stateprovince"
+    description: "State and province lookup table."
+    columns:
+    - column: "stateprovinceid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for StateProvince records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/stateprovince/stateprovinceid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "stateprovincecode"
+      logicalType: "String"
+      physicalType: "bpchar"
+      description: "ISO standard state or province code."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/stateprovince/stateprovincecode"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "countryregioncode"
+      logicalType: "String"
+      physicalType: "varchar[3]"
+      description: "ISO standard country or region code. Foreign key to CountryRegion.CountryRegionCode."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/stateprovince/countryregioncode"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "isonlystateprovinceflag"
+      logicalType: "Object"
+      physicalType: "Flag"
+      description: "0 = StateProvinceCode exists. 1 = StateProvinceCode unavailable,\
+        \ using CountryRegionCode."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/stateprovince/isonlystateprovinceflag"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "name"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "State or province description."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/stateprovince/name"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "territoryid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "ID of the territory in which the state or province is located.\
+        \ Foreign key to SalesTerritory.SalesTerritoryID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/stateprovince/territoryid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/stateprovince/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/stateprovince/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "billofmaterials"
+    physicalName: "billofmaterials"
+    description: "Items required to make bicycles and bicycle subassemblies. It identifies\
+      \ the heirarchical relationship between a parent product and its components."
+    columns:
+    - column: "billofmaterialsid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for BillOfMaterials records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/billofmaterials/billofmaterialsid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "productassemblyid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Parent product identification number. Foreign key to Product.ProductID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/billofmaterials/productassemblyid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "componentid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Component identification number. Foreign key to Product.ProductID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/billofmaterials/componentid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "startdate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Date the component started being used in the assembly item."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/billofmaterials/startdate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "enddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Date the component stopped being used in the assembly item."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/billofmaterials/enddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "unitmeasurecode"
+      logicalType: "String"
+      physicalType: "bpchar"
+      description: "Standard code identifying the unit of measure for the quantity."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/billofmaterials/unitmeasurecode"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "bomlevel"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "Indicates the depth the component is from its parent (AssemblyID)."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/billofmaterials/bomlevel"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "perassemblyqty"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Quantity of the component needed to create the assembly."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/billofmaterials/perassemblyqty"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/billofmaterials/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "culture"
+    physicalName: "culture"
+    description: "Lookup table containing the languages in which some AdventureWorks\
+      \ data is stored."
+    columns:
+    - column: "cultureid"
+      logicalType: "String"
+      physicalType: "bpchar"
+      description: "Primary key for Culture records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/culture/cultureid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "name"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Culture description."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/culture/name"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/culture/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "document"
+    physicalName: "document"
+    description: "Product maintenance documents."
+    columns:
+    - column: "title"
+      logicalType: "String"
+      physicalType: "varchar[50]"
+      description: "Title of the document."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/document/title"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "owner"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Employee who controls the document.  Foreign key to Employee.BusinessEntityID"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/document/owner"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "folderflag"
+      logicalType: "Object"
+      physicalType: "Flag"
+      description: "0 = This is a folder, 1 = This is a document."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/document/folderflag"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "filename"
+      logicalType: "String"
+      physicalType: "varchar[400]"
+      description: "File name of the document"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/document/filename"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "fileextension"
+      logicalType: "String"
+      physicalType: "varchar[8]"
+      description: "File extension indicating the document type. For example, .doc\
+        \ or .txt."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/document/fileextension"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "revision"
+      logicalType: "String"
+      physicalType: "bpchar"
+      description: "Revision number of the document."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/document/revision"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "changenumber"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Engineering change approval number."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/document/changenumber"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "status"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "1 = Pending approval, 2 = Approved, 3 = Obsolete"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/document/status"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "documentsummary"
+      logicalType: "String"
+      physicalType: "text"
+      description: "Document abstract."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/document/documentsummary"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "document"
+      logicalType: "Binary"
+      physicalType: "bytea"
+      description: "Complete document."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/document/document"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      description: "ROWGUIDCOL number uniquely identifying the record. Required for\
+        \ FileStream."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/document/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/document/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "documentnode"
+      logicalType: "String"
+      physicalType: "varchar[2147483647]"
+      description: "Primary key for Document records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/document/documentnode"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+  - table: "illustration"
+    physicalName: "illustration"
+    description: "Bicycle assembly diagrams."
+    columns:
+    - column: "illustrationid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for Illustration records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/illustration/illustrationid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "diagram"
+      logicalType: "XML"
+      physicalType: "xml"
+      description: "Illustrations used in manufacturing instructions. Stored as XML."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/illustration/diagram"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/illustration/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "location"
+    physicalName: "location"
+    description: "Product inventory and manufacturing locations."
+    columns:
+    - column: "locationid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for Location records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/location/locationid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "name"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Location description."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/location/name"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "costrate"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Standard hourly cost of the manufacturing location."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/location/costrate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "availability"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Work capacity (in hours) of the manufacturing location."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/location/availability"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/location/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "product"
+    physicalName: "product"
+    description: "Products sold or used in the manfacturing of sold products."
+    columns:
+    - column: "productid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for Product records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/productid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "name"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Name of the product."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/name"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "productnumber"
+      logicalType: "String"
+      physicalType: "varchar[25]"
+      description: "Unique product identification number."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/productnumber"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "makeflag"
+      logicalType: "Object"
+      physicalType: "Flag"
+      description: "0 = Product is purchased, 1 = Product is manufactured in-house."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/makeflag"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "finishedgoodsflag"
+      logicalType: "Object"
+      physicalType: "Flag"
+      description: "0 = Product is not a salable item. 1 = Product is salable."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/finishedgoodsflag"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "color"
+      logicalType: "String"
+      physicalType: "varchar[15]"
+      description: "Product color."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/color"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "safetystocklevel"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "Minimum inventory quantity."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/safetystocklevel"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "reorderpoint"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "Inventory level that triggers a purchase order or work order."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/reorderpoint"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "standardcost"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Standard cost of the product."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/standardcost"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "listprice"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Selling price."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/listprice"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "size"
+      logicalType: "String"
+      physicalType: "varchar[5]"
+      description: "Product size."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/size"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "sizeunitmeasurecode"
+      logicalType: "String"
+      physicalType: "bpchar"
+      description: "Unit of measure for Size column."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/sizeunitmeasurecode"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "weightunitmeasurecode"
+      logicalType: "String"
+      physicalType: "bpchar"
+      description: "Unit of measure for Weight column."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/weightunitmeasurecode"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "weight"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Product weight."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/weight"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "daystomanufacture"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Number of days required to manufacture the product."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/daystomanufacture"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "productline"
+      logicalType: "String"
+      physicalType: "bpchar"
+      description: "R = Road, M = Mountain, T = Touring, S = Standard"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/productline"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "class"
+      logicalType: "String"
+      physicalType: "bpchar"
+      description: "H = High, M = Medium, L = Low"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/class"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "style"
+      logicalType: "String"
+      physicalType: "bpchar"
+      description: "W = Womens, M = Mens, U = Universal"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/style"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "productsubcategoryid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Product is a member of this product subcategory. Foreign key to\
+        \ ProductSubCategory.ProductSubCategoryID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/productsubcategoryid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "productmodelid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Product is a member of this product model. Foreign key to ProductModel.ProductModelID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/productmodelid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "sellstartdate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Date the product was available for sale."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/sellstartdate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "sellenddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Date the product was no longer available for sale."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/sellenddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "discontinueddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Date the product was discontinued."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/discontinueddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/product/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "productcategory"
+    physicalName: "productcategory"
+    description: "High-level product categorization."
+    columns:
+    - column: "productcategoryid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for ProductCategory records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productcategory/productcategoryid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "name"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Category description."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productcategory/name"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productcategory/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productcategory/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "productcosthistory"
+    physicalName: "productcosthistory"
+    description: "Changes in the cost of a product over time."
+    columns:
+    - column: "productid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Product identification number. Foreign key to Product.ProductID"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productcosthistory/productid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "startdate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Product cost start date."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productcosthistory/startdate"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "enddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Product cost end date."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productcosthistory/enddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "standardcost"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Standard cost of the product."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productcosthistory/standardcost"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productcosthistory/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "productdescription"
+    physicalName: "productdescription"
+    description: "Product descriptions in several languages."
+    columns:
+    - column: "productdescriptionid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for ProductDescription records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productdescription/productdescriptionid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "description"
+      logicalType: "String"
+      physicalType: "varchar[400]"
+      description: "Description of the product."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productdescription/description"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productdescription/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productdescription/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "productdocument"
+    physicalName: "productdocument"
+    description: "Cross-reference table mapping products to related product documents."
+    columns:
+    - column: "productid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Product identification number. Foreign key to Product.ProductID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productdocument/productid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productdocument/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "documentnode"
+      logicalType: "String"
+      physicalType: "varchar[2147483647]"
+      description: "Document identification number. Foreign key to Document.DocumentNode."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productdocument/documentnode"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+  - table: "productinventory"
+    physicalName: "productinventory"
+    description: "Product inventory information."
+    columns:
+    - column: "productid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Product identification number. Foreign key to Product.ProductID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productinventory/productid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "locationid"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "Inventory location identification number. Foreign key to Location.LocationID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productinventory/locationid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "shelf"
+      logicalType: "String"
+      physicalType: "varchar[10]"
+      description: "Storage compartment within an inventory location."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productinventory/shelf"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "bin"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "Storage container on a shelf in an inventory location."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productinventory/bin"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "quantity"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "Quantity of products in the inventory location."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productinventory/quantity"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productinventory/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productinventory/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "productlistpricehistory"
+    physicalName: "productlistpricehistory"
+    description: "Changes in the list price of a product over time."
+    columns:
+    - column: "productid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Product identification number. Foreign key to Product.ProductID"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productlistpricehistory/productid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "startdate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "List price start date."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productlistpricehistory/startdate"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "enddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "List price end date"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productlistpricehistory/enddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "listprice"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Product list price."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productlistpricehistory/listprice"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productlistpricehistory/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "productmodel"
+    physicalName: "productmodel"
+    description: "Product model classification."
+    columns:
+    - column: "productmodelid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for ProductModel records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productmodel/productmodelid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "name"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Product model description."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productmodel/name"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "catalogdescription"
+      logicalType: "XML"
+      physicalType: "xml"
+      description: "Detailed product catalog information in xml format."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productmodel/catalogdescription"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "instructions"
+      logicalType: "XML"
+      physicalType: "xml"
+      description: "Manufacturing instructions in xml format."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productmodel/instructions"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productmodel/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productmodel/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "productmodelillustration"
+    physicalName: "productmodelillustration"
+    description: "Cross-reference table mapping product models and illustrations."
+    columns:
+    - column: "productmodelid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key. Foreign key to ProductModel.ProductModelID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productmodelillustration/productmodelid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "illustrationid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key. Foreign key to Illustration.IllustrationID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productmodelillustration/illustrationid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productmodelillustration/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "productmodelproductdescriptionculture"
+    physicalName: "productmodelproductdescriptionculture"
+    description: "Cross-reference table mapping product descriptions and the language\
+      \ the description is written in."
+    columns:
+    - column: "productmodelid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key. Foreign key to ProductModel.ProductModelID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productmodelproductdescriptionculture/productmodelid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "productdescriptionid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key. Foreign key to ProductDescription.ProductDescriptionID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productmodelproductdescriptionculture/productdescriptionid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "cultureid"
+      logicalType: "String"
+      physicalType: "bpchar"
+      description: "Culture identification number. Foreign key to Culture.CultureID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productmodelproductdescriptionculture/cultureid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productmodelproductdescriptionculture/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "productphoto"
+    physicalName: "productphoto"
+    description: "Product images."
+    columns:
+    - column: "productphotoid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for ProductPhoto records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productphoto/productphotoid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "thumbnailphoto"
+      logicalType: "Binary"
+      physicalType: "bytea"
+      description: "Small image of the product."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productphoto/thumbnailphoto"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "thumbnailphotofilename"
+      logicalType: "String"
+      physicalType: "varchar[50]"
+      description: "Small image file name."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productphoto/thumbnailphotofilename"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "largephoto"
+      logicalType: "Binary"
+      physicalType: "bytea"
+      description: "Large image of the product."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productphoto/largephoto"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "largephotofilename"
+      logicalType: "String"
+      physicalType: "varchar[50]"
+      description: "Large image file name."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productphoto/largephotofilename"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productphoto/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "productproductphoto"
+    physicalName: "productproductphoto"
+    description: "Cross-reference table mapping products and product photos."
+    columns:
+    - column: "productid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Product identification number. Foreign key to Product.ProductID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productproductphoto/productid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "productphotoid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Product photo identification number. Foreign key to ProductPhoto.ProductPhotoID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productproductphoto/productphotoid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "primary"
+      logicalType: "Object"
+      physicalType: "Flag"
+      description: "0 = Photo is not the principal image. 1 = Photo is the principal\
+        \ image."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productproductphoto/primary"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productproductphoto/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "productreview"
+    physicalName: "productreview"
+    description: "Customer reviews of products they have purchased."
+    columns:
+    - column: "productreviewid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for ProductReview records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productreview/productreviewid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "productid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Product identification number. Foreign key to Product.ProductID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productreview/productid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "reviewername"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Name of the reviewer."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productreview/reviewername"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "reviewdate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Date review was submitted."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productreview/reviewdate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "emailaddress"
+      logicalType: "String"
+      physicalType: "varchar[50]"
+      description: "Reviewer's e-mail address."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productreview/emailaddress"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rating"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Product rating given by the reviewer. Scale is 1 to 5 with 5 as\
+        \ the highest rating."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productreview/rating"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "comments"
+      logicalType: "String"
+      physicalType: "varchar[3850]"
+      description: "Reviewer's comments"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productreview/comments"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productreview/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "productsubcategory"
+    physicalName: "productsubcategory"
+    description: "Product subcategories. See ProductCategory table."
+    columns:
+    - column: "productsubcategoryid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for ProductSubcategory records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productsubcategory/productsubcategoryid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "productcategoryid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Product category identification number. Foreign key to ProductCategory.ProductCategoryID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productsubcategory/productcategoryid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "name"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Subcategory description."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productsubcategory/name"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productsubcategory/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productsubcategory/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "scrapreason"
+    physicalName: "scrapreason"
+    description: "Manufacturing failure reasons lookup table."
+    columns:
+    - column: "scrapreasonid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for ScrapReason records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/scrapreason/scrapreasonid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "name"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Failure description."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/scrapreason/name"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/scrapreason/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "transactionhistory"
+    physicalName: "transactionhistory"
+    description: "Record of each purchase order, sales order, or work order transaction\
+      \ year to date."
+    columns:
+    - column: "transactionid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for TransactionHistory records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/transactionhistory/transactionid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "productid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Product identification number. Foreign key to Product.ProductID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/transactionhistory/productid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "referenceorderid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Purchase order, sales order, or work order identification number."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/transactionhistory/referenceorderid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "referenceorderlineid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Line number associated with the purchase order, sales order, or\
+        \ work order."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/transactionhistory/referenceorderlineid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "transactiondate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Date and time of the transaction."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/transactionhistory/transactiondate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "transactiontype"
+      logicalType: "String"
+      physicalType: "bpchar"
+      description: "W = WorkOrder, S = SalesOrder, P = PurchaseOrder"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/transactionhistory/transactiontype"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "quantity"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Product quantity."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/transactionhistory/quantity"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "actualcost"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Product cost."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/transactionhistory/actualcost"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/transactionhistory/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "transactionhistoryarchive"
+    physicalName: "transactionhistoryarchive"
+    description: "Transactions for previous years."
+    columns:
+    - column: "transactionid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key for TransactionHistoryArchive records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/transactionhistoryarchive/transactionid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "productid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Product identification number. Foreign key to Product.ProductID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/transactionhistoryarchive/productid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "referenceorderid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Purchase order, sales order, or work order identification number."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/transactionhistoryarchive/referenceorderid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "referenceorderlineid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Line number associated with the purchase order, sales order, or\
+        \ work order."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/transactionhistoryarchive/referenceorderlineid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "transactiondate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Date and time of the transaction."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/transactionhistoryarchive/transactiondate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "transactiontype"
+      logicalType: "String"
+      physicalType: "bpchar"
+      description: "W = Work Order, S = Sales Order, P = Purchase Order"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/transactionhistoryarchive/transactiontype"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "quantity"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Product quantity."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/transactionhistoryarchive/quantity"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "actualcost"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Product cost."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/transactionhistoryarchive/actualcost"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/transactionhistoryarchive/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "unitmeasure"
+    physicalName: "unitmeasure"
+    description: "Unit of measure lookup table."
+    columns:
+    - column: "unitmeasurecode"
+      logicalType: "String"
+      physicalType: "bpchar"
+      description: "Primary key."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/unitmeasure/unitmeasurecode"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "name"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Unit of measure description."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/unitmeasure/name"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/unitmeasure/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "workorder"
+    physicalName: "workorder"
+    description: "Manufacturing work orders."
+    columns:
+    - column: "workorderid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for WorkOrder records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/workorder/workorderid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "productid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Product identification number. Foreign key to Product.ProductID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/workorder/productid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "orderqty"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Product quantity to build."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/workorder/orderqty"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "scrappedqty"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "Quantity that failed inspection."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/workorder/scrappedqty"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "startdate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Work order start date."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/workorder/startdate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "enddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Work order end date."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/workorder/enddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "duedate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Work order due date."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/workorder/duedate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "scrapreasonid"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "Reason for inspection failure."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/workorder/scrapreasonid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/workorder/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "workorderrouting"
+    physicalName: "workorderrouting"
+    description: "Work order details."
+    columns:
+    - column: "workorderid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key. Foreign key to WorkOrder.WorkOrderID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/workorderrouting/workorderid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "productid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key. Foreign key to Product.ProductID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/workorderrouting/productid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "operationsequence"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "Primary key. Indicates the manufacturing process sequence."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/workorderrouting/operationsequence"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "locationid"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "Manufacturing location where the part is processed. Foreign key\
+        \ to Location.LocationID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/workorderrouting/locationid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "scheduledstartdate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Planned manufacturing start date."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/workorderrouting/scheduledstartdate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "scheduledenddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Planned manufacturing end date."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/workorderrouting/scheduledenddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "actualstartdate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Actual start date."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/workorderrouting/actualstartdate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "actualenddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Actual end date."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/workorderrouting/actualenddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "actualresourcehrs"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Number of manufacturing hours used."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/workorderrouting/actualresourcehrs"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "plannedcost"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Estimated manufacturing cost."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/workorderrouting/plannedcost"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "actualcost"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Actual manufacturing cost."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/workorderrouting/actualcost"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/workorderrouting/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "productvendor"
+    physicalName: "productvendor"
+    description: "Cross-reference table mapping vendors with the products they supply."
+    columns:
+    - column: "productid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key. Foreign key to Product.ProductID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productvendor/productid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "businessentityid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key. Foreign key to Vendor.BusinessEntityID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productvendor/businessentityid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "averageleadtime"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "The average span of time (in days) between placing an order with\
+        \ the vendor and receiving the purchased product."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productvendor/averageleadtime"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "standardprice"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "The vendor's usual selling price."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productvendor/standardprice"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "lastreceiptcost"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "The selling price when last purchased."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productvendor/lastreceiptcost"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "lastreceiptdate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Date the product was last received by the vendor."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productvendor/lastreceiptdate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "minorderqty"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "The maximum quantity that should be ordered."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productvendor/minorderqty"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "maxorderqty"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "The minimum quantity that should be ordered."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productvendor/maxorderqty"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "onorderqty"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "The quantity currently on order."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productvendor/onorderqty"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "unitmeasurecode"
+      logicalType: "String"
+      physicalType: "bpchar"
+      description: "The product's unit of measure."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productvendor/unitmeasurecode"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/productvendor/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "purchaseorderdetail"
+    physicalName: "purchaseorderdetail"
+    description: "Individual products associated with a specific purchase order. See\
+      \ PurchaseOrderHeader."
+    columns:
+    - column: "purchaseorderid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key. Foreign key to PurchaseOrderHeader.PurchaseOrderID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/purchaseorderdetail/purchaseorderid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "purchaseorderdetailid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key. One line number per purchased product."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/purchaseorderdetail/purchaseorderdetailid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "duedate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Date the product is expected to be received."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/purchaseorderdetail/duedate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "orderqty"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "Quantity ordered."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/purchaseorderdetail/orderqty"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "productid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Product identification number. Foreign key to Product.ProductID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/purchaseorderdetail/productid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "unitprice"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Vendor's selling price of a single product."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/purchaseorderdetail/unitprice"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "receivedqty"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Quantity actually received from the vendor."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/purchaseorderdetail/receivedqty"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rejectedqty"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Quantity rejected during inspection."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/purchaseorderdetail/rejectedqty"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/purchaseorderdetail/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "purchaseorderheader"
+    physicalName: "purchaseorderheader"
+    description: "General purchase order information. See PurchaseOrderDetail."
+    columns:
+    - column: "purchaseorderid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/purchaseorderheader/purchaseorderid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "revisionnumber"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "Incremental number to track changes to the purchase order over\
+        \ time."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/purchaseorderheader/revisionnumber"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "status"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "Order current status. 1 = Pending; 2 = Approved; 3 = Rejected;\
+        \ 4 = Complete"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/purchaseorderheader/status"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "employeeid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Employee who created the purchase order. Foreign key to Employee.BusinessEntityID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/purchaseorderheader/employeeid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "vendorid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Vendor with whom the purchase order is placed. Foreign key to\
+        \ Vendor.BusinessEntityID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/purchaseorderheader/vendorid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "shipmethodid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Shipping method. Foreign key to ShipMethod.ShipMethodID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/purchaseorderheader/shipmethodid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "orderdate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Purchase order creation date."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/purchaseorderheader/orderdate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "shipdate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Estimated shipment date from the vendor."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/purchaseorderheader/shipdate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "subtotal"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Purchase order subtotal. Computed as SUM(PurchaseOrderDetail.LineTotal)for\
+        \ the appropriate PurchaseOrderID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/purchaseorderheader/subtotal"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "taxamt"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Tax amount."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/purchaseorderheader/taxamt"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "freight"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Shipping cost."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/purchaseorderheader/freight"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/purchaseorderheader/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "shipmethod"
+    physicalName: "shipmethod"
+    description: "Shipping company lookup table."
+    columns:
+    - column: "shipmethodid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for ShipMethod records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/shipmethod/shipmethodid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "name"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Shipping company name."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/shipmethod/name"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "shipbase"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Minimum shipping charge."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/shipmethod/shipbase"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "shiprate"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Shipping charge per pound."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/shipmethod/shiprate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/shipmethod/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/shipmethod/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "vendor"
+    physicalName: "vendor"
+    description: "Companies from whom Adventure Works Cycles purchases parts or other\
+      \ goods."
+    columns:
+    - column: "businessentityid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key for Vendor records.  Foreign key to BusinessEntity.BusinessEntityID"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/vendor/businessentityid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "accountnumber"
+      logicalType: "Object"
+      physicalType: "AccountNumber"
+      description: "Vendor account (identification) number."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/vendor/accountnumber"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "name"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Company name."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/vendor/name"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "creditrating"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "1 = Superior, 2 = Excellent, 3 = Above average, 4 = Average, 5\
+        \ = Below average"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/vendor/creditrating"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "preferredvendorstatus"
+      logicalType: "Object"
+      physicalType: "Flag"
+      description: "0 = Do not use if another vendor is available. 1 = Preferred over\
+        \ other vendors supplying the same product."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/vendor/preferredvendorstatus"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "activeflag"
+      logicalType: "Object"
+      physicalType: "Flag"
+      description: "0 = Vendor no longer used. 1 = Vendor is actively used."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/vendor/activeflag"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "purchasingwebserviceurl"
+      logicalType: "String"
+      physicalType: "varchar[1024]"
+      description: "Vendor URL."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/vendor/purchasingwebserviceurl"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/vendor/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "countryregioncurrency"
+    physicalName: "countryregioncurrency"
+    description: "Cross-reference table mapping ISO currency codes to a country or\
+      \ region."
+    columns:
+    - column: "countryregioncode"
+      logicalType: "String"
+      physicalType: "varchar[3]"
+      description: "ISO code for countries and regions. Foreign key to CountryRegion.CountryRegionCode."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/countryregioncurrency/countryregioncode"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "currencycode"
+      logicalType: "String"
+      physicalType: "bpchar"
+      description: "ISO standard currency code. Foreign key to Currency.CurrencyCode."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/countryregioncurrency/currencycode"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/countryregioncurrency/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "creditcard"
+    physicalName: "creditcard"
+    description: "Customer credit card information."
+    columns:
+    - column: "creditcardid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for CreditCard records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/creditcard/creditcardid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "cardtype"
+      logicalType: "String"
+      physicalType: "varchar[50]"
+      description: "Credit card name."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/creditcard/cardtype"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "cardnumber"
+      logicalType: "String"
+      physicalType: "varchar[25]"
+      description: "Credit card number."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/creditcard/cardnumber"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "expmonth"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "Credit card expiration month."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/creditcard/expmonth"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "expyear"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "Credit card expiration year."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/creditcard/expyear"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/creditcard/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "currency"
+    physicalName: "currency"
+    description: "Lookup table containing standard ISO currencies."
+    columns:
+    - column: "currencycode"
+      logicalType: "String"
+      physicalType: "bpchar"
+      description: "The ISO code for the Currency."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/currency/currencycode"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "name"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Currency name."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/currency/name"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/currency/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "currencyrate"
+    physicalName: "currencyrate"
+    description: "Currency exchange rates."
+    columns:
+    - column: "currencyrateid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for CurrencyRate records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/currencyrate/currencyrateid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "currencyratedate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Date and time the exchange rate was obtained."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/currencyrate/currencyratedate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "fromcurrencycode"
+      logicalType: "String"
+      physicalType: "bpchar"
+      description: "Exchange rate was converted from this currency code."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/currencyrate/fromcurrencycode"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "tocurrencycode"
+      logicalType: "String"
+      physicalType: "bpchar"
+      description: "Exchange rate was converted to this currency code."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/currencyrate/tocurrencycode"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "averagerate"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Average exchange rate for the day."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/currencyrate/averagerate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "endofdayrate"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Final exchange rate for the day."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/currencyrate/endofdayrate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/currencyrate/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "customer"
+    physicalName: "customer"
+    description: "Current customer information. Also see the Person and Store tables."
+    columns:
+    - column: "customerid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/customer/customerid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "personid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Foreign key to Person.BusinessEntityID"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/customer/personid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "storeid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Foreign key to Store.BusinessEntityID"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/customer/storeid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "territoryid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "ID of the territory in which the customer is located. Foreign\
+        \ key to SalesTerritory.SalesTerritoryID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/customer/territoryid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/customer/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/customer/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "personcreditcard"
+    physicalName: "personcreditcard"
+    description: "Cross-reference table mapping people to their credit card information\
+      \ in the CreditCard table."
+    columns:
+    - column: "businessentityid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Business entity identification number. Foreign key to Person.BusinessEntityID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/personcreditcard/businessentityid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "creditcardid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Credit card identification number. Foreign key to CreditCard.CreditCardID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/personcreditcard/creditcardid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/personcreditcard/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "salesorderdetail"
+    physicalName: "salesorderdetail"
+    description: "Individual products associated with a specific sales order. See\
+      \ SalesOrderHeader."
+    columns:
+    - column: "salesorderid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key. Foreign key to SalesOrderHeader.SalesOrderID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderdetail/salesorderid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "salesorderdetailid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key. One incremental unique number per product sold."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderdetail/salesorderdetailid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "carriertrackingnumber"
+      logicalType: "String"
+      physicalType: "varchar[25]"
+      description: "Shipment tracking number supplied by the shipper."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderdetail/carriertrackingnumber"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "orderqty"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "Quantity ordered per product."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderdetail/orderqty"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "productid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Product sold to customer. Foreign key to Product.ProductID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderdetail/productid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "specialofferid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Promotional code. Foreign key to SpecialOffer.SpecialOfferID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderdetail/specialofferid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "unitprice"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Selling price of a single product."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderdetail/unitprice"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "unitpricediscount"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Discount amount."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderdetail/unitpricediscount"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderdetail/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderdetail/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "salesorderheader"
+    physicalName: "salesorderheader"
+    description: "General sales order information."
+    columns:
+    - column: "salesorderid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/salesorderid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "revisionnumber"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "Incremental number to track changes to the sales order over time."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/revisionnumber"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "orderdate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Dates the sales order was created."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/orderdate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "duedate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Date the order is due to the customer."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/duedate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "shipdate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Date the order was shipped to the customer."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/shipdate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "status"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "Order current status. 1 = In process; 2 = Approved; 3 = Backordered;\
+        \ 4 = Rejected; 5 = Shipped; 6 = Cancelled"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/status"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "onlineorderflag"
+      logicalType: "Object"
+      physicalType: "Flag"
+      description: "0 = Order placed by sales person. 1 = Order placed online by customer."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/onlineorderflag"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "purchaseordernumber"
+      logicalType: "Object"
+      physicalType: "OrderNumber"
+      description: "Customer purchase order number reference."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/purchaseordernumber"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "accountnumber"
+      logicalType: "Object"
+      physicalType: "AccountNumber"
+      description: "Financial accounting number reference."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/accountnumber"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "customerid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Customer identification number. Foreign key to Customer.BusinessEntityID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/customerid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "salespersonid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Sales person who created the sales order. Foreign key to SalesPerson.BusinessEntityID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/salespersonid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "territoryid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Territory in which the sale was made. Foreign key to SalesTerritory.SalesTerritoryID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/territoryid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "billtoaddressid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Customer billing address. Foreign key to Address.AddressID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/billtoaddressid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "shiptoaddressid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Customer shipping address. Foreign key to Address.AddressID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/shiptoaddressid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "shipmethodid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Shipping method. Foreign key to ShipMethod.ShipMethodID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/shipmethodid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "creditcardid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Credit card identification number. Foreign key to CreditCard.CreditCardID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/creditcardid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "creditcardapprovalcode"
+      logicalType: "String"
+      physicalType: "varchar[15]"
+      description: "Approval code provided by the credit card company."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/creditcardapprovalcode"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "currencyrateid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Currency exchange rate used. Foreign key to CurrencyRate.CurrencyRateID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/currencyrateid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "subtotal"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Sales subtotal. Computed as SUM(SalesOrderDetail.LineTotal)for\
+        \ the appropriate SalesOrderID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/subtotal"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "taxamt"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Tax amount."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/taxamt"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "freight"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Shipping cost."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/freight"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "totaldue"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Total due from customer. Computed as Subtotal + TaxAmt + Freight."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/totaldue"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "comment"
+      logicalType: "String"
+      physicalType: "varchar[128]"
+      description: "Sales representative comments."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/comment"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheader/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "salesorderheadersalesreason"
+    physicalName: "salesorderheadersalesreason"
+    description: "Cross-reference table mapping sales orders to sales reason codes."
+    columns:
+    - column: "salesorderid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key. Foreign key to SalesOrderHeader.SalesOrderID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheadersalesreason/salesorderid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "salesreasonid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key. Foreign key to SalesReason.SalesReasonID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheadersalesreason/salesreasonid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesorderheadersalesreason/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "salesperson"
+    physicalName: "salesperson"
+    description: "Sales representative current information."
+    columns:
+    - column: "businessentityid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key for SalesPerson records. Foreign key to Employee.BusinessEntityID"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesperson/businessentityid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "territoryid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Territory currently assigned to. Foreign key to SalesTerritory.SalesTerritoryID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesperson/territoryid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "salesquota"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Projected yearly sales."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesperson/salesquota"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "bonus"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Bonus due if quota is met."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesperson/bonus"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "commissionpct"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Commision percent received per sale."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesperson/commissionpct"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "salesytd"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Sales total year to date."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesperson/salesytd"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "saleslastyear"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Sales total of previous year."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesperson/saleslastyear"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesperson/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesperson/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "salespersonquotahistory"
+    physicalName: "salespersonquotahistory"
+    description: "Sales performance tracking."
+    columns:
+    - column: "businessentityid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Sales person identification number. Foreign key to SalesPerson.BusinessEntityID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salespersonquotahistory/businessentityid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "quotadate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Sales quota date."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salespersonquotahistory/quotadate"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "salesquota"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Sales quota amount."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salespersonquotahistory/salesquota"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salespersonquotahistory/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salespersonquotahistory/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "salesreason"
+    physicalName: "salesreason"
+    description: "Lookup table of customer purchase reasons."
+    columns:
+    - column: "salesreasonid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for SalesReason records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesreason/salesreasonid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "name"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Sales reason description."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesreason/name"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "reasontype"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Category the sales reason belongs to."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesreason/reasontype"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesreason/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "salestaxrate"
+    physicalName: "salestaxrate"
+    description: "Tax rate lookup table."
+    columns:
+    - column: "salestaxrateid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for SalesTaxRate records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salestaxrate/salestaxrateid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "stateprovinceid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "State, province, or country/region the sales tax applies to."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salestaxrate/stateprovinceid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "taxtype"
+      logicalType: "Numeric"
+      physicalType: "int2"
+      description: "1 = Tax applied to retail transactions, 2 = Tax applied to wholesale\
+        \ transactions, 3 = Tax applied to all sales (retail and wholesale) transactions."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salestaxrate/taxtype"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "taxrate"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Tax rate amount."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salestaxrate/taxrate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "name"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Tax rate description."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salestaxrate/name"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salestaxrate/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salestaxrate/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "salesterritory"
+    physicalName: "salesterritory"
+    description: "Sales territory lookup table."
+    columns:
+    - column: "territoryid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for SalesTerritory records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesterritory/territoryid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "name"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Sales territory description"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesterritory/name"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "countryregioncode"
+      logicalType: "String"
+      physicalType: "varchar[3]"
+      description: "ISO standard country or region code. Foreign key to CountryRegion.CountryRegionCode."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesterritory/countryregioncode"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "group"
+      logicalType: "String"
+      physicalType: "varchar[50]"
+      description: "Geographic area to which the sales territory belong."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesterritory/group"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "salesytd"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Sales in the territory year to date."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesterritory/salesytd"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "saleslastyear"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Sales in the territory the previous year."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesterritory/saleslastyear"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "costytd"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Business costs in the territory year to date."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesterritory/costytd"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "costlastyear"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Business costs in the territory the previous year."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesterritory/costlastyear"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesterritory/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesterritory/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "salesterritoryhistory"
+    physicalName: "salesterritoryhistory"
+    description: "Sales representative transfers to other sales territories."
+    columns:
+    - column: "businessentityid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key. The sales rep.  Foreign key to SalesPerson.BusinessEntityID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesterritoryhistory/businessentityid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "territoryid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key. Territory identification number. Foreign key to SalesTerritory.SalesTerritoryID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesterritoryhistory/territoryid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "startdate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Primary key. Date the sales representive started work in the territory."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesterritoryhistory/startdate"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "enddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Date the sales representative left work in the territory."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesterritoryhistory/enddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesterritoryhistory/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/salesterritoryhistory/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "shoppingcartitem"
+    physicalName: "shoppingcartitem"
+    description: "Contains online customer orders until the order is submitted or\
+      \ cancelled."
+    columns:
+    - column: "shoppingcartitemid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for ShoppingCartItem records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/shoppingcartitem/shoppingcartitemid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "shoppingcartid"
+      logicalType: "String"
+      physicalType: "varchar[50]"
+      description: "Shopping cart identification number."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/shoppingcartitem/shoppingcartid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "quantity"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Product quantity ordered."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/shoppingcartitem/quantity"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "productid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Product ordered. Foreign key to Product.ProductID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/shoppingcartitem/productid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "datecreated"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Date the time the record was created."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/shoppingcartitem/datecreated"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/shoppingcartitem/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "specialoffer"
+    physicalName: "specialoffer"
+    description: "Sale discounts lookup table."
+    columns:
+    - column: "specialofferid"
+      logicalType: "Numeric"
+      physicalType: "serial"
+      description: "Primary key for SpecialOffer records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/specialoffer/specialofferid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "description"
+      logicalType: "String"
+      physicalType: "varchar[255]"
+      description: "Discount description."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/specialoffer/description"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "discountpct"
+      logicalType: "Numeric"
+      physicalType: "numeric"
+      description: "Discount precentage."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/specialoffer/discountpct"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "type"
+      logicalType: "String"
+      physicalType: "varchar[50]"
+      description: "Discount type category."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/specialoffer/type"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "category"
+      logicalType: "String"
+      physicalType: "varchar[50]"
+      description: "Group the discount applies to such as Reseller or Customer."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/specialoffer/category"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "startdate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Discount start date."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/specialoffer/startdate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "enddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      description: "Discount end date."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/specialoffer/enddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "minqty"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Minimum discount percent allowed."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/specialoffer/minqty"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "maxqty"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Maximum discount percent allowed."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/specialoffer/maxqty"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/specialoffer/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/specialoffer/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "specialofferproduct"
+    physicalName: "specialofferproduct"
+    description: "Cross-reference table mapping products to special offer discounts."
+    columns:
+    - column: "specialofferid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key for SpecialOfferProduct records."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/specialofferproduct/specialofferid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "productid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Product identification number. Foreign key to Product.ProductID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/specialofferproduct/productid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/specialofferproduct/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/specialofferproduct/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+  - table: "store"
+    physicalName: "store"
+    description: "Customers (resellers) of Adventure Works products."
+    columns:
+    - column: "businessentityid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "Primary key. Foreign key to Customer.BusinessEntityID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/store/businessentityid"
+      criticalDataElementStatus: false
+      primary: true
+      nullable: false
+    - column: "name"
+      logicalType: "Object"
+      physicalType: "Name"
+      description: "Name of the store."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/store/name"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "salespersonid"
+      logicalType: "Numeric"
+      physicalType: "int4"
+      description: "ID of the sales person assigned to the customer. Foreign key to\
+        \ SalesPerson.BusinessEntityID."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/store/salespersonid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "demographics"
+      logicalType: "XML"
+      physicalType: "xml"
+      description: "Demographic informationg about the store such as the number of\
+        \ employees, annual sales and store type."
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/store/demographics"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "rowguid"
+      logicalType: "UUID"
+      physicalType: "uuid"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/store/rowguid"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+    - column: "modifieddate"
+      logicalType: "Timestamp"
+      physicalType: "timestamp"
+      partitionStatus: false
+      clusterStatus: false
+      authoritativeDefinitions:
+      - type: "implementation"
+        url: "jdbc:postgresql://localhost:5432/adventureworks/store/modifieddate"
+      criticalDataElementStatus: false
+      primary: false
+      nullable: false
+contractCreatedTs: "2023-09-28 20:24:49.331 UTC"
+

--- a/tests/test_import_odcs.py
+++ b/tests/test_import_odcs.py
@@ -1,0 +1,46 @@
+import logging
+import os
+import sys
+
+import yaml
+from typer.testing import CliRunner
+
+from datacontract.cli import app
+from datacontract.data_contract import DataContract
+
+logging.basicConfig(level=logging.DEBUG, force=True)
+
+def test_cli():
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "import",
+            "--format",
+            "odcs",
+            "--source",
+            "./fixtures/odcs/odcs-full-example.yaml",
+        ],
+    )
+    assert result.exit_code == 0
+
+def test_import_full_odcs():
+    result = DataContract().import_from_source("odcs", "./fixtures/odcs/odcs-full-example.yaml")
+    expected_datacontract = read_file("fixtures/odcs/full-example.datacontract.yml")
+    assert yaml.safe_load(result.to_yaml()) == yaml.safe_load(expected_datacontract)
+    assert DataContract(data_contract_str=expected_datacontract).lint(enabled_linters="none").has_passed()
+
+def test_import_complex_odcs():
+    result = DataContract().import_from_source("odcs", "./fixtures/odcs/odcs-postgresql-adventureworks-contract.yaml")
+    expected_datacontract = read_file("fixtures/odcs/adventureworks-example.datacontract.yml")
+    assert yaml.safe_load(result.to_yaml()) == yaml.safe_load(expected_datacontract)
+    assert DataContract(data_contract_str=expected_datacontract).lint(enabled_linters="none").has_passed()
+
+
+def read_file(file):
+    if not os.path.exists(file):
+        print(f"The file '{file}' does not exist.")
+        sys.exit(1)
+    with open(file, "r") as file:
+        file_content = file.read()
+    return file_content


### PR DESCRIPTION
- support basic information for `info`, `servers`, `terms` and `servicelevels`
- support for importing tables into models
- since there is no guarantee for the type that an ODCS Contract sets, we try to simply match what we can. For all other types people might specify, we use the ability of ODCS to have `customProperties` and allow people to specify specific mappings between 'their' types and the ones they want to have in the Datacontract by adding a magic `dc_mapping_typename` custom property.

Addresses #105 

@jochenchrist this is at least missing tests, but before heading on to them I'd just wanted to get your opinion, since I think for ODCS the mapping is not as straight forward as for some of the other specs I've seen. 
We might map more things depending on more magic strings for some of the SLA Properties for example, or we could try to coerce a columns examples to strings, but I'm not sure how far we want to take this, so input is welcome, before we make this a proper PR.