### PR TITLE
Adding config field to Model

### DIFF
--- a/datacontract/model/data_contract_specification.py
+++ b/datacontract/model/data_contract_specification.py
@@ -98,6 +98,7 @@ class Model(pyd.BaseModel):
     namespace: str = None
     title: str = None
     fields: Dict[str, Field] = {}
+    config: Dict[str, Any] = None
 
 
 class Info(pyd.BaseModel):


### PR DESCRIPTION
The [Model specification](https://datacontract.com/#model-object) shows that Models should be able to have a [Config object](https://datacontract.com/#config-object) attached to them, but this is currently not the case. This PR is an attempt to remedy that discrepency.

I have not included any additional tests at this moment since I'm unsure that we want to export this data anywhere else at the moment. If there is a good test to be added for this, or any additional functionality that's required before this is ready to merge, please let me know.

I have run a lint against a model containing a config block and it succeeded both before and after this change.