### PR TITLE
feat: add array and struct field management in glue importer

### DIFF
--- a/tests/fixtures/glue/datacontract.yaml
+++ b/tests/fixtures/glue/datacontract.yaml
@@ -23,6 +23,27 @@ models:
                 type: decimal
                 precision: 6
                 scale: 2
+            field_five:
+                type: struct
+                fields:
+                    sub_field_one:
+                        type: string
+                    sub_field_two:
+                        type: boolean
+            field_six:
+                type: array
+                items:
+                    item_field_one:
+                        type: string
+            field_seven:
+                type: array
+                items:
+                    type: struct
+                    fields:
+                        sub_field_three:
+                            type: string
+                        sub_field_four:
+                            type: integer
             part_one:
                 description: Partition Key
                 required: True

--- a/tests/fixtures/glue/datacontract.yaml
+++ b/tests/fixtures/glue/datacontract.yaml
@@ -33,8 +33,7 @@ models:
             field_six:
                 type: array
                 items:
-                    item_field_one:
-                        type: string
+                    type: string
             field_seven:
                 type: array
                 items:

--- a/tests/test_import_glue.py
+++ b/tests/test_import_glue.py
@@ -56,6 +56,15 @@ def setup_mock_glue(aws_credentials):
                             "Type": "timestamp",
                         },
                         {"Name": "field_four", "Type": "decimal(6,2)"},
+                        {
+                            "Name": "field_five",
+                            "Type": "struct<sub_field_one:string, sub_field_two: boolean>",
+                        },
+                        {"Name": "field_six", "Type": "array<item_field_one:string>"},
+                        {
+                            "Name": "field_seven",
+                            "Type": "array<struct<sub_field_three:string, sub_field_four:int>>",
+                        },
                     ]
                 },
                 "PartitionKeys": [
@@ -116,7 +125,11 @@ def test_import_glue_schema(setup_mock_glue):
     print("Result", result.to_yaml())
     assert yaml.safe_load(result.to_yaml()) == yaml.safe_load(expected)
     # Disable linters so we don't get "missing description" warnings
-    assert DataContract(data_contract_str=expected).lint(enabled_linters=set()).has_passed()
+    assert (
+        DataContract(data_contract_str=expected)
+        .lint(enabled_linters=set())
+        .has_passed()
+    )
 
 
 @mock_aws
@@ -130,4 +143,8 @@ def test_import_glue_schema_with_table_filters(setup_mock_glue):
     print("Result", result.to_yaml())
     assert yaml.safe_load(result.to_yaml()) == yaml.safe_load(expected)
     # Disable linters so we don't get "missing description" warnings
-    assert DataContract(data_contract_str=expected).lint(enabled_linters=set()).has_passed()
+    assert (
+        DataContract(data_contract_str=expected)
+        .lint(enabled_linters=set())
+        .has_passed()
+    )

--- a/tests/test_import_glue.py
+++ b/tests/test_import_glue.py
@@ -60,7 +60,7 @@ def setup_mock_glue(aws_credentials):
                             "Name": "field_five",
                             "Type": "struct<sub_field_one:string, sub_field_two: boolean>",
                         },
-                        {"Name": "field_six", "Type": "array<item_field_one:string>"},
+                        {"Name": "field_six", "Type": "array<string>"},
                         {
                             "Name": "field_seven",
                             "Type": "array<struct<sub_field_three:string, sub_field_four:int>>",
@@ -125,11 +125,7 @@ def test_import_glue_schema(setup_mock_glue):
     print("Result", result.to_yaml())
     assert yaml.safe_load(result.to_yaml()) == yaml.safe_load(expected)
     # Disable linters so we don't get "missing description" warnings
-    assert (
-        DataContract(data_contract_str=expected)
-        .lint(enabled_linters=set())
-        .has_passed()
-    )
+    assert DataContract(data_contract_str=expected).lint(enabled_linters=set()).has_passed()
 
 
 @mock_aws
@@ -143,8 +139,4 @@ def test_import_glue_schema_with_table_filters(setup_mock_glue):
     print("Result", result.to_yaml())
     assert yaml.safe_load(result.to_yaml()) == yaml.safe_load(expected)
     # Disable linters so we don't get "missing description" warnings
-    assert (
-        DataContract(data_contract_str=expected)
-        .lint(enabled_linters=set())
-        .has_passed()
-    )
+    assert DataContract(data_contract_str=expected).lint(enabled_linters=set()).has_passed()


### PR DESCRIPTION
For now when Glue table contains array or struct field, it is returned as "variant" and items or subfields aren't retrieve.
