### PR TITLE
Add pre-commit hook configuration

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,15 @@
+- id: datacontract-linting
+  name: Data Contract Linter
+  description: This hook lint the data contract.
+  entry: datacontract lint
+  files: "datacontract*.yaml"
+  language: python
+  types: [yaml]
+
+- id: datacontract-testing
+  name: Data Contract Tester
+  description: This hook test the data contract.
+  entry: datacontract test
+  files: "datacontract*.yaml"
+  language: python
+  types: [yaml]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,4 +1,4 @@
-- id: datacontract-linting
+- id: datacontract-lint
   name: Data Contract Linter
   description: This hook lint the data contract.
   entry: datacontract lint
@@ -6,7 +6,7 @@
   language: python
   types: [yaml]
 
-- id: datacontract-testing
+- id: datacontract-test
   name: Data Contract Tester
   description: This hook test the data contract.
   entry: datacontract test

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,6 +4,7 @@
   entry: datacontract lint
   files: "datacontract*.yaml"
   language: python
+  additional_dependencies: ['.[all]']
   types: [yaml]
 
 - id: datacontract-test
@@ -12,4 +13,5 @@
   entry: datacontract test
   files: "datacontract*.yaml"
   language: python
+  additional_dependencies: ['.[all]']
   types: [yaml]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - add `--schema` option for the `catalog` and `export` command to provide the schema also locally
+- Integrate support into the pre-commit workflow. For further details, please refer to the information provided [here](./README.md#use-with-pre-commit).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1204,6 +1204,12 @@ repos:
         args: ["--server", "production"]
 ```
 
+### Available Hook IDs
+
+| Hook ID           | Description              | Dependency |
+| ----------------- | ------------------------ | ---------- |
+| datacontract-lint | Runs the lint subcommand. | Python3    |
+| datacontract-test | Runs the test subcommand. Please look at [test](#test) section for all available arguments. | Python3 |
 
 ## Release Steps
 

--- a/README.md
+++ b/README.md
@@ -1190,6 +1190,19 @@ docker compose run --rm datacontract --version
 
 This command runs the container momentarily to check the version of the `datacontract` CLI. The `--rm` flag ensures that the container is automatically removed after the command executes, keeping your environment clean.
 
+## Use with pre-commit
+
+To run `datacontract-cli` as part of a [pre-commit](https://pre-commit.com/) workflow, add something like the below to the `repos` list in the project's `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/datacontract/datacontract-cli
+    rev: "v0.10.9"
+    hooks:
+      - id: datacontract-lint
+      - id: datacontract-test
+        args: ["--server", "production"]
+```
 
 
 ## Release Steps


### PR DESCRIPTION
This pull-request is implementation of issue #279

Currently, main branch (Commit hash: 0c139521a680b22f1bcbb08bab5250d4197a1265) and tag [v0.10.8](https://github.com/datacontract/datacontract-cli/releases/tag/v0.10.8) are getting the following error.

```bash
Traceback (most recent call last):
  File "/var/folders/pb/3h4kqhbs01g8qqhj9vpp8kvc0000gn/T/tmplr11kfy7/repo36bh8g_4/py_env-python3.12/bin/datacontract", line 5, in <module>
    from datacontract.cli import app
  File "/private/var/folders/pb/3h4kqhbs01g8qqhj9vpp8kvc0000gn/T/tmplr11kfy7/repo36bh8g_4/py_env-python3.12/lib/python3.12/site-packages/datacontract/cli.py", line 16, in <module>
    from datacontract import web
  File "/private/var/folders/pb/3h4kqhbs01g8qqhj9vpp8kvc0000gn/T/tmplr11kfy7/repo36bh8g_4/py_env-python3.12/lib/python3.12/site-packages/datacontract/web.py", line 7, in <module>
    from datacontract.data_contract import DataContract, ExportFormat
  File "/private/var/folders/pb/3h4kqhbs01g8qqhj9vpp8kvc0000gn/T/tmplr11kfy7/repo36bh8g_4/py_env-python3.12/lib/python3.12/site-packages/datacontract/data_contract.py", line 7, in <module>
    from pyspark.sql import SparkSession
ModuleNotFoundError: No module named 'pyspark'
```

On the other hand, tag [v0.10.7](https://github.com/datacontract/datacontract-cli/releases/tag/v0.10.7) works well. You can find an example from [here](https://github.com/burakince/datacontract-cli/blob/v0.10.7-rc1/.pre-commit-hooks.yaml).

Simply, you can use the following configuration in your `.pre-commit-config.yaml` and test the idea.

```yaml
repos:
  - repo: https://github.com/burakince/datacontract-cli
    rev: "v0.10.7-rc1"
    hooks:
      - id: datacontract-linting
```

Additionally, you can test your local pre-commit hook changes in an example test repository. Please follow these steps:

* Please first, [install](https://pre-commit.com/#installation) pre-commit to your system.
* Clone the original cli repository with `git clone git@github.com:datacontract/datacontract-cli.git` command.
* And create another folder and git repository inside of the test repo. `mkdir test-repo && cd test-repo && git init`.
* Add an example data contract YAML file inside of test repository.
* Run the following command in test repository and it must use settings from other local `datacontract-cli` folder.

```bash
pre-commit try-repo ../datacontract-cli datacontract-linting --verbose --all-files
```

- [x] Tests pass
- [x] README.md updated
- [x] CHANGELOG.md entry added
