### PR TITLE
fix: load exporters dynamically

### DIFF
--- a/datacontract/export/exporter_factory.py
+++ b/datacontract/export/exporter_factory.py
@@ -1,21 +1,6 @@
-from datacontract.export.avro_idl_converter import AvroIdlExporter
-from datacontract.export.bigquery_converter import BigQueryExporter
-from datacontract.export.dbml_converter import DbmlExporter
-from datacontract.export.dbt_converter import DbtExporter, DbtSourceExporter, DbtStageExporter
-from datacontract.export.avro_converter import AvroExporter
+import importlib
+import sys
 from datacontract.export.exporter import ExportFormat, Exporter
-from datacontract.export.go_converter import GoExporter
-from datacontract.export.great_expectations_converter import GreateExpectationsExporter
-from datacontract.export.html_export import HtmlExporter
-from datacontract.export.jsonschema_converter import JsonSchemaExporter
-from datacontract.export.odcs_converter import OdcsExporter
-from datacontract.export.protobuf_converter import ProtoBufExporter
-from datacontract.export.pydantic_converter import PydanticExporter
-from datacontract.export.rdf_converter import RdfExporter
-from datacontract.export.sodacl_converter import SodaExporter
-from datacontract.export.spark_converter import SparkExporter
-from datacontract.export.sql_converter import SqlExporter, SqlQueryExporter
-from datacontract.export.terraform_converter import TerraformExporter
 
 
 class ExporterFactory:
@@ -31,24 +16,108 @@ class ExporterFactory:
         return self.dict_exporter[name](name)
 
 
+def lazy_module_import(module_path):
+    spec = importlib.util.find_spec(module_path)
+    if spec is not None:
+        loader = importlib.util.LazyLoader(spec.loader)
+        spec.loader = loader
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_path] = module
+        loader.exec_module(module)
+        return module
+
+
+def load_exporter(import_format, module_path, class_name):
+    module = lazy_module_import(module_path)
+    if module:
+        exporter_class = getattr(module, class_name)
+        exporter_factory.register_exporter(import_format, exporter_class)
+
+
 exporter_factory = ExporterFactory()
-exporter_factory.register_exporter(ExportFormat.avro, AvroExporter)
-exporter_factory.register_exporter(ExportFormat.avro_idl, AvroIdlExporter)
-exporter_factory.register_exporter(ExportFormat.bigquery, BigQueryExporter)
-exporter_factory.register_exporter(ExportFormat.dbml, DbmlExporter)
-exporter_factory.register_exporter(ExportFormat.rdf, RdfExporter)
-exporter_factory.register_exporter(ExportFormat.dbt, DbtExporter)
-exporter_factory.register_exporter(ExportFormat.dbt_sources, DbtSourceExporter)
-exporter_factory.register_exporter(ExportFormat.dbt_staging_sql, DbtStageExporter)
-exporter_factory.register_exporter(ExportFormat.jsonschema, JsonSchemaExporter)
-exporter_factory.register_exporter(ExportFormat.odcs, OdcsExporter)
-exporter_factory.register_exporter(ExportFormat.go, GoExporter)
-exporter_factory.register_exporter(ExportFormat.great_expectations, GreateExpectationsExporter)
-exporter_factory.register_exporter(ExportFormat.html, HtmlExporter)
-exporter_factory.register_exporter(ExportFormat.protobuf, ProtoBufExporter)
-exporter_factory.register_exporter(ExportFormat.pydantic_model, PydanticExporter)
-exporter_factory.register_exporter(ExportFormat.sodacl, SodaExporter)
-exporter_factory.register_exporter(ExportFormat.sql, SqlExporter)
-exporter_factory.register_exporter(ExportFormat.sql_query, SqlQueryExporter)
-exporter_factory.register_exporter(ExportFormat.terraform, TerraformExporter)
-exporter_factory.register_exporter(ExportFormat.spark, SparkExporter)
+
+load_exporter(
+    import_format=ExportFormat.avro, module_path="datacontract.export.avro_converter", class_name="AvroExporter"
+)
+
+load_exporter(
+    import_format=ExportFormat.avro_idl,
+    module_path="datacontract.export.avro_idl_converter",
+    class_name="AvroIdlExporter",
+)
+load_exporter(
+    import_format=ExportFormat.bigquery,
+    module_path="datacontract.export.bigquery_converter",
+    class_name="BigQueryExporter",
+)
+load_exporter(
+    import_format=ExportFormat.dbml, module_path="datacontract.export.dbml_converter", class_name="DbmlExporter"
+)
+load_exporter(import_format=ExportFormat.rdf, module_path="datacontract.export.rdf_converter", class_name="RdfExporter")
+load_exporter(import_format=ExportFormat.dbt, module_path="datacontract.export.dbt_converter", class_name="DbtExporter")
+load_exporter(
+    import_format=ExportFormat.dbt_sources,
+    module_path="datacontract.export.dbt_converter",
+    class_name="DbtSourceExporter",
+)
+
+
+load_exporter(
+    import_format=ExportFormat.dbt_staging_sql,
+    module_path="datacontract.export.dbt_converter",
+    class_name="DbtStageExporter",
+)
+
+
+load_exporter(
+    import_format=ExportFormat.jsonschema,
+    module_path="datacontract.export.jsonschema_converter",
+    class_name="JsonSchemaExporter",
+)
+
+load_exporter(
+    import_format=ExportFormat.odcs, module_path="datacontract.export.odcs_converter", class_name="OdcsExporter"
+)
+
+load_exporter(import_format=ExportFormat.go, module_path="datacontract.export.go_converter", class_name="GoExporter")
+
+load_exporter(
+    import_format=ExportFormat.great_expectations,
+    module_path="datacontract.export.great_expectations_converter",
+    class_name="GreateExpectationsExporter",
+)
+
+load_exporter(import_format=ExportFormat.html, module_path="datacontract.export.html_export", class_name="HtmlExporter")
+
+load_exporter(
+    import_format=ExportFormat.protobuf,
+    module_path="datacontract.export.protobuf_converter",
+    class_name="ProtoBufExporter",
+)
+
+load_exporter(
+    import_format=ExportFormat.pydantic_model,
+    module_path="datacontract.export.pydantic_converter",
+    class_name="PydanticExporter",
+)
+
+load_exporter(
+    import_format=ExportFormat.sodacl, module_path="datacontract.export.sodacl_converter", class_name="SodaExporter"
+)
+
+load_exporter(import_format=ExportFormat.sql, module_path="datacontract.export.sql_converter", class_name="SqlExporter")
+
+load_exporter(
+    import_format=ExportFormat.sql_query, module_path="datacontract.export.sql_converter", class_name="SqlQueryExporter"
+)
+
+
+load_exporter(
+    import_format=ExportFormat.terraform,
+    module_path="datacontract.export.terraform_converter",
+    class_name="TerraformExporter",
+)
+
+load_exporter(
+    import_format=ExportFormat.spark, module_path="datacontract.export.spark_converter", class_name="SparkExporter"
+)

--- a/datacontract/export/exporter_factory.py
+++ b/datacontract/export/exporter_factory.py
@@ -12,18 +12,17 @@ class ExporterFactory:
 
     def create(self, name) -> Exporter:
         if name not in self.dict_exporter.keys():
-            raise ValueError(f"Export format {name} not supported.")
+            raise ValueError(f"The '{name}' format is not supported.")
         return self.dict_exporter[name](name)
 
 
 def lazy_module_import(module_path):
-    spec = importlib.util.find_spec(module_path)
-    if spec is not None:
-        loader = importlib.util.LazyLoader(spec.loader)
-        spec.loader = loader
-        module = importlib.util.module_from_spec(spec)
+    if importlib.util.find_spec(module_path) is not None:
+        try:
+            module = importlib.import_module(module_path)
+        except ModuleNotFoundError:
+            return None
         sys.modules[module_path] = module
-        loader.exec_module(module)
         return module
 
 

--- a/datacontract/export/exporter_factory.py
+++ b/datacontract/export/exporter_factory.py
@@ -6,17 +6,28 @@ from datacontract.export.exporter import ExportFormat, Exporter
 class ExporterFactory:
     def __init__(self):
         self.dict_exporter = {}
+        self.dict_lazy_exporter = {}
 
-    def register_exporter(self, name, exporter):
+    def register_exporter(self, name: str, exporter: Exporter):
         self.dict_exporter.update({name: exporter})
 
+    def register_lazy_exporter(self, name: str, module_path: str, class_name: str):
+        self.dict_lazy_exporter.update({name: (module_path, class_name)})
+
     def create(self, name) -> Exporter:
-        if name not in self.dict_exporter.keys():
+        exporters = self.dict_exporter.copy()
+        exporters.update(self.dict_lazy_exporter.copy())
+        if name not in exporters.keys():
             raise ValueError(f"The '{name}' format is not supported.")
-        return self.dict_exporter[name](name)
+        exporter_class = exporters[name]
+        if type(exporters[name]) == tuple:
+            exporter_class = load_module_class(module_path=exporters[name][0], class_name=exporters[name][1])
+        if not exporter_class:
+            raise ValueError(f"Module {name} could not be loaded.")
+        return exporter_class(name)
 
 
-def lazy_module_import(module_path):
+def import_module(module_path):
     if importlib.util.find_spec(module_path) is not None:
         try:
             module = importlib.import_module(module_path)
@@ -26,97 +37,109 @@ def lazy_module_import(module_path):
         return module
 
 
-def load_exporter(import_format, module_path, class_name):
-    module = lazy_module_import(module_path)
-    if module:
-        exporter_class = getattr(module, class_name)
-        exporter_factory.register_exporter(import_format, exporter_class)
+def load_module_class(module_path, class_name):
+    module = import_module(module_path)
+    if not module:
+        return None
+    return getattr(module, class_name)
 
 
 exporter_factory = ExporterFactory()
 
-load_exporter(
-    import_format=ExportFormat.avro, module_path="datacontract.export.avro_converter", class_name="AvroExporter"
+exporter_factory.register_lazy_exporter(
+    name=ExportFormat.avro, module_path="datacontract.export.avro_converter", class_name="AvroExporter"
 )
 
-load_exporter(
-    import_format=ExportFormat.avro_idl,
+exporter_factory.register_lazy_exporter(
+    name=ExportFormat.avro_idl,
     module_path="datacontract.export.avro_idl_converter",
     class_name="AvroIdlExporter",
 )
-load_exporter(
-    import_format=ExportFormat.bigquery,
+
+exporter_factory.register_lazy_exporter(
+    name=ExportFormat.bigquery,
     module_path="datacontract.export.bigquery_converter",
     class_name="BigQueryExporter",
 )
-load_exporter(
-    import_format=ExportFormat.dbml, module_path="datacontract.export.dbml_converter", class_name="DbmlExporter"
+
+exporter_factory.register_lazy_exporter(
+    name=ExportFormat.dbml, module_path="datacontract.export.dbml_converter", class_name="DbmlExporter"
 )
-load_exporter(import_format=ExportFormat.rdf, module_path="datacontract.export.rdf_converter", class_name="RdfExporter")
-load_exporter(import_format=ExportFormat.dbt, module_path="datacontract.export.dbt_converter", class_name="DbtExporter")
-load_exporter(
-    import_format=ExportFormat.dbt_sources,
+
+exporter_factory.register_lazy_exporter(
+    name=ExportFormat.rdf, module_path="datacontract.export.rdf_converter", class_name="RdfExporter"
+)
+
+exporter_factory.register_lazy_exporter(
+    name=ExportFormat.dbt, module_path="datacontract.export.dbt_converter", class_name="DbtExporter"
+)
+
+exporter_factory.register_lazy_exporter(
+    name=ExportFormat.dbt_sources,
     module_path="datacontract.export.dbt_converter",
     class_name="DbtSourceExporter",
 )
 
-
-load_exporter(
-    import_format=ExportFormat.dbt_staging_sql,
+exporter_factory.register_lazy_exporter(
+    name=ExportFormat.dbt_staging_sql,
     module_path="datacontract.export.dbt_converter",
     class_name="DbtStageExporter",
 )
 
-
-load_exporter(
-    import_format=ExportFormat.jsonschema,
+exporter_factory.register_lazy_exporter(
+    name=ExportFormat.jsonschema,
     module_path="datacontract.export.jsonschema_converter",
     class_name="JsonSchemaExporter",
 )
 
-load_exporter(
-    import_format=ExportFormat.odcs, module_path="datacontract.export.odcs_converter", class_name="OdcsExporter"
+exporter_factory.register_lazy_exporter(
+    name=ExportFormat.odcs, module_path="datacontract.export.odcs_converter", class_name="OdcsExporter"
 )
 
-load_exporter(import_format=ExportFormat.go, module_path="datacontract.export.go_converter", class_name="GoExporter")
+exporter_factory.register_lazy_exporter(
+    name=ExportFormat.go, module_path="datacontract.export.go_converter", class_name="GoExporter"
+)
 
-load_exporter(
-    import_format=ExportFormat.great_expectations,
+exporter_factory.register_lazy_exporter(
+    name=ExportFormat.great_expectations,
     module_path="datacontract.export.great_expectations_converter",
     class_name="GreateExpectationsExporter",
 )
 
-load_exporter(import_format=ExportFormat.html, module_path="datacontract.export.html_export", class_name="HtmlExporter")
+exporter_factory.register_lazy_exporter(
+    name=ExportFormat.html, module_path="datacontract.export.html_export", class_name="HtmlExporter"
+)
 
-load_exporter(
-    import_format=ExportFormat.protobuf,
+exporter_factory.register_lazy_exporter(
+    name=ExportFormat.protobuf,
     module_path="datacontract.export.protobuf_converter",
     class_name="ProtoBufExporter",
 )
 
-load_exporter(
-    import_format=ExportFormat.pydantic_model,
+exporter_factory.register_lazy_exporter(
+    name=ExportFormat.pydantic_model,
     module_path="datacontract.export.pydantic_converter",
     class_name="PydanticExporter",
 )
 
-load_exporter(
-    import_format=ExportFormat.sodacl, module_path="datacontract.export.sodacl_converter", class_name="SodaExporter"
+exporter_factory.register_lazy_exporter(
+    name=ExportFormat.sodacl, module_path="datacontract.export.sodacl_converter", class_name="SodaExporter"
 )
 
-load_exporter(import_format=ExportFormat.sql, module_path="datacontract.export.sql_converter", class_name="SqlExporter")
-
-load_exporter(
-    import_format=ExportFormat.sql_query, module_path="datacontract.export.sql_converter", class_name="SqlQueryExporter"
+exporter_factory.register_lazy_exporter(
+    name=ExportFormat.sql, module_path="datacontract.export.sql_converter", class_name="SqlExporter"
 )
 
+exporter_factory.register_lazy_exporter(
+    name=ExportFormat.sql_query, module_path="datacontract.export.sql_converter", class_name="SqlQueryExporter"
+)
 
-load_exporter(
-    import_format=ExportFormat.terraform,
+exporter_factory.register_lazy_exporter(
+    name=ExportFormat.terraform,
     module_path="datacontract.export.terraform_converter",
     class_name="TerraformExporter",
 )
 
-load_exporter(
-    import_format=ExportFormat.spark, module_path="datacontract.export.spark_converter", class_name="SparkExporter"
+exporter_factory.register_lazy_exporter(
+    name=ExportFormat.spark, module_path="datacontract.export.spark_converter", class_name="SparkExporter"
 )


### PR DESCRIPTION
this PR implements dynamic module load to exporter to avoid errors when the user install a specific dependence like

`datacontract-cli[databricks]==0.10.8`

- [x] Tests pass 
