### PR TITLE
Only import pyspark when actually required, otherwise use it for LSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+- Fix import of pyspark for type-checking when pyspark isn't required as a module (#312)
 
 ## [0.10.9] - 2024-07-03
 

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -4,7 +4,9 @@ import tempfile
 import typing
 
 import yaml
-from pyspark.sql import SparkSession
+
+if typing.TYPE_CHECKING:
+    from pyspark.sql import SparkSession
 
 from datacontract.breaking.breaking import models_breaking_changes, quality_breaking_changes
 from datacontract.engines.datacontract.check_that_datacontract_contains_valid_servers_configuration import (

--- a/datacontract/engines/soda/check_soda_execute.py
+++ b/datacontract/engines/soda/check_soda_execute.py
@@ -1,6 +1,9 @@
 import logging
+import typing
 
-from pyspark.sql import SparkSession
+if typing.TYPE_CHECKING:
+    from pyspark.sql import SparkSession
+
 from soda.scan import Scan
 
 from datacontract.engines.soda.connections.bigquery import to_bigquery_soda_configuration


### PR DESCRIPTION
Resolves issue reported in #312 

- [x] Tests pass
- [x] ruff format
- [x] CHANGELOG.md entry added
