### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix import of pyspark for type-checking when pyspark isn't required as a module (#312)- `datacontract import --format spark`: Import from Spark tables (#326)
-- Fix an issue where specifying `glue_table` as parameter did not filter the tables and returned all tables instead from `source` instead (#333)
+- Fix an issue where specifying `glue_table` as parameter did not filter the tables and instead returned all tables from `source` (#333)
 
 ## [0.10.9] - 2024-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix import of pyspark for type-checking when pyspark isn't required as a module (#312)- `datacontract import --format spark`: Import from Spark tables (#326)
-- Fix an issue where specifying `glue_table` as parameter did not filter the tables and instead returned all tables from `source` (#333)
+- Fix an issue where specifying `glue_table` as parameter did not filter the tables and instead returned all tables from `source` database (#333)
 
 ## [0.10.9] - 2024-07-03
 

--- a/README.md
+++ b/README.md
@@ -532,7 +532,7 @@ run.result
 
 Works with Spark DataFrames.
 DataFrames need to be created as named temporary views.
-Multiple temporary views are suppored if your data contract contains multiple models.
+Multiple temporary views are supported if your data contract contains multiple models.
 
 Testing DataFrames is useful to test your datasets in a pipeline before writing them to a data source.
 
@@ -1169,7 +1169,7 @@ Examples: adding models or fields
 - Add the models or fields in the datacontract.yaml
 - Increment the minor version of the datacontract.yaml on any change. Simply edit the datacontract.yaml for this.
 - You need a policy that these changes are non-breaking. That means that one cannot use the star expression in SQL to query a table under contract. Make the consequences known.
-- Fail the build in the Pull Request if a datacontract.yaml accidentially adds a breaking change even despite only a minor version change
+- Fail the build in the Pull Request if a datacontract.yaml accidentally adds a breaking change even despite only a minor version change
    ```bash
   $ datacontract breaking datacontract-from-pr.yaml datacontract-from-main.yaml
   ```

--- a/datacontract/imports/importer_factory.py
+++ b/datacontract/imports/importer_factory.py
@@ -18,7 +18,7 @@ class ImporterFactory:
         importers = self.dict_importer.copy()
         importers.update(self.dict_lazy_importer.copy())
         if name not in importers.keys():
-            raise ValueError(f"The '{name}' format is not suportted.")
+            raise ValueError(f"The '{name}' format is not supported.")
         importer_class = importers[name]
         if type(importers[name]) is tuple:
             importer_class = load_module_class(module_path=importers[name][0], class_name=importers[name][1])

--- a/tests/fixtures/avro/data/arrays.avsc
+++ b/tests/fixtures/avro/data/arrays.avsc
@@ -5,8 +5,8 @@
         "type": "int"
       },
       {
-        "name": "adresses",
-        "doc": "Adresses of a customer",
+        "name": "addresses",
+        "doc": "Addresses of a customer",
         "type": {
           "type": "array",
           "items": {

--- a/tests/fixtures/avro/data/orders.avsc
+++ b/tests/fixtures/avro/data/orders.avsc
@@ -29,8 +29,8 @@
         "type": "double"
       },
       {
-        "name": "emailadresses",
-        "doc": "Different email adresses of a customer",
+        "name": "emailaddresses",
+        "doc": "Different email addresses of a customer",
         "type": {
           "type": "array",
           "items": "string",

--- a/tests/test_import_avro.py
+++ b/tests/test_import_avro.py
@@ -55,7 +55,7 @@ models:
       orderunits:
         type: double
         required: true
-      emailadresses:
+      emailaddresses:
         type: array
         description: Different email addresses of a customer
         items:

--- a/tests/test_import_avro.py
+++ b/tests/test_import_avro.py
@@ -57,7 +57,7 @@ models:
         required: true
       emailadresses:
         type: array
-        description: Different email adresses of a customer
+        description: Different email addresses of a customer
         items:
            type: string
            format: email
@@ -98,10 +98,10 @@ models:
       orderid:
         type: int
         required: true
-      adresses:
+      addresses:
         type: array
         required: true
-        description: Adresses of a customer
+        description: Addresses of a customer
         items:
           type: object
           fields:


### PR DESCRIPTION
I accidentally introduced a typo in my previous changelog message, so let me correct it along with other typos 

- [x] Tests pass
- [x] ruff format
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added
