### PR TITLE
feat: Propagate all env vars with DATACONTRACT_SNOWFLAKE_ prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,14 +588,31 @@ models:
 ```
 
 #### Environment Variables
+All [parameters supported by Soda](https://docs.soda.io/soda/connect-snowflake.html), uppercased and prepended by `DATACONTRACT_SNOWFLAKE_` prefix.  
+For example:
 
-| Environment Variable               | Example            | Description                                         |
-|------------------------------------|--------------------|-----------------------------------------------------|
-| `DATACONTRACT_SNOWFLAKE_USERNAME`  | `datacontract`     | Username                                            |
-| `DATACONTRACT_SNOWFLAKE_PASSWORD`  | `mysecretpassword` | Password                                            |
-| `DATACONTRACT_SNOWFLAKE_ROLE`      | `DATAVALIDATION`   | The snowflake role to use.                          |
-| `DATACONTRACT_SNOWFLAKE_WAREHOUSE` | `COMPUTE_WH`       | The Snowflake Warehouse to use executing the tests. |
+| Soda parameter       | Environment Variable                        | 
+|----------------------|---------------------------------------------|
+| `username`           | `DATACONTRACT_SNOWFLAKE_USERNAME`           |
+| `password`           | `DATACONTRACT_SNOWFLAKE_PASSWORD`           |
+| `warehouse`          | `DATACONTRACT_SNOWFLAKE_WAREHOUSE`          |
+| `role`               | `DATACONTRACT_SNOWFLAKE_ROLE`               |
+| `connection_timeout` | `DATACONTRACT_SNOWFLAKE_CONNECTION_TIMEOUT` |
 
+Beware, that parameters:
+* `account`
+* `database`
+* `schema`
+
+are obtained from the `servers` section of the YAML-file.  
+E.g. from the example above:
+```yaml
+servers:
+  snowflake:
+    account: abcdefg-xn12345
+    database: ORDER_DB
+    schema: ORDERS_PII_V2
+```
 
 
 ### Kafka

--- a/datacontract/engines/soda/connections/snowflake.py
+++ b/datacontract/engines/soda/connections/snowflake.py
@@ -4,17 +4,20 @@ import yaml
 
 
 def to_snowflake_soda_configuration(server):
+    prefix = "DATACONTRACT_SNOWFLAKE_"
+    snowflake_soda_params = {k.replace(prefix, "").lower(): v for k, v in os.environ.items() if k.startswith(prefix)}
+
+    # backward compatibility
+    if "connection_timeout" not in snowflake_soda_params:
+        snowflake_soda_params["connection_timeout"] = "5"  # minutes
+
     soda_configuration = {
         f"data_source {server.type}": {
             "type": "snowflake",
-            "username": os.getenv("DATACONTRACT_SNOWFLAKE_USERNAME"),
-            "password": os.getenv("DATACONTRACT_SNOWFLAKE_PASSWORD"),
-            "role": os.getenv("DATACONTRACT_SNOWFLAKE_ROLE"),
             "account": server.account,
             "database": server.database,
             "schema": server.schema_,
-            "warehouse": os.getenv("DATACONTRACT_SNOWFLAKE_WAREHOUSE"),
-            "connection_timeout": 5,  # minutes
+            **snowflake_soda_params,
         }
     }
     soda_configuration_str = yaml.dump(soda_configuration)


### PR DESCRIPTION
[Soda documentation](https://docs.soda.io/soda/connect-snowflake.html) states that [all parameters](https://docs.snowflake.com/developer-guide/python-connector/python-connector-api#functions) from the Snowflake Python Connector are supported.
Thus, we only need to propagate them from environmental variables to the underlying Soda configuration.

This change will allow a lot of flexibility when connecting to Snowflake.
For example, OAuth and RSA key authentication, custom session timezone, etc. 
