### PR TITLE
Fix an issue where Glue database without a location creates invalid data contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix an issue where the quality and definition `$ref` are not always resolved.
 - Fix an issue where the JSON schema validation fails for a field with type `string` and format `uuid`
+- Fix an issue where Glue database without a location creates invalid data contract
 
 ## [0.10.10] - 2024-07-18
 

--- a/datacontract/imports/glue_importer.py
+++ b/datacontract/imports/glue_importer.py
@@ -147,7 +147,7 @@ def import_glue(
     }
 
     if location_uri:
-        server_kwargs["location_uri"] = location_uri
+        server_kwargs["location"] = location_uri
 
     data_contract_specification.servers = {
         "production": Server(**server_kwargs),

--- a/datacontract/imports/glue_importer.py
+++ b/datacontract/imports/glue_importer.py
@@ -39,7 +39,7 @@ def get_glue_database(database_name: str):
 
     return (
         response["Database"]["CatalogId"],
-        response["Database"].get("LocationUri", "None"),
+        response["Database"].get("LocationUri"),
     )
 
 
@@ -140,8 +140,17 @@ def import_glue(
     if table_names is None:
         table_names = get_glue_tables(source)
 
+    server_kwargs = {
+        "type": "glue",
+        "account": catalogid,
+        "database": source
+    }
+
+    if location_uri:
+        server_kwargs["location_uri"] = location_uri
+
     data_contract_specification.servers = {
-        "production": Server(type="glue", account=catalogid, database=source, location=location_uri),
+        "production": Server(**server_kwargs),
     }
 
     for table_name in table_names:


### PR DESCRIPTION
`location_uri` with `"None"` string is considered to be None value while desearalizing to YAML.
Therefore Glue database without a location creates invalid data contract:
```
datacontract-cli git:(56f4dbe) ✗ datacontract test test1.yaml 
Testing test1.yaml
WARNING:root:Data Contract YAML is invalid. Validation error: data.servers.production must be valid exactly by one definition (0 matches found)
ERROR:root:Run operation failed: [lint] Check that data contract YAML is valid - None - failed - data.servers.production must be valid exactly by one definition (0 matches found) - datacontract
╭────────┬────────────────────────────────────────┬───────┬────────────────────────────────────────────────────╮
│ Result │ Check                                  │ Field │ Details                                            │
├────────┼────────────────────────────────────────┼───────┼────────────────────────────────────────────────────┤
│ failed │ Check that data contract YAML is valid │       │ data.servers.production must be valid exactly by   │
│        │                                        │       │ one definition (0 matches found)                   │
╰────────┴────────────────────────────────────────┴───────┴────────────────────────────────────────────────────╯
🔴 data contract is invalid, found the following errors:
1) data.servers.production must be valid exactly by one definition (0 matches found)
```

After running the same command with the proposed code:
```
datacontract-cli git:(main) ✗ datacontract test test1.yaml 
Testing test1.yaml
WARNING:root:Server type glue not yet supported by datacontract CLI
╭─────────┬─────────────────────────────────────┬───────┬────────────────────────────────────────────────────╮
│ Result  │ Check                               │ Field │ Details                                            │
├─────────┼─────────────────────────────────────┼───────┼────────────────────────────────────────────────────┤
│ warning │ Check that server type is supported │       │ Server type glue not yet supported by datacontract │
│         │                                     │       │ CLI                                                │
╰─────────┴─────────────────────────────────────┴───────┴────────────────────────────────────────────────────╯
🔴 data contract is invalid, found the following errors:
1) Server type glue not yet supported by datacontract CLI
```

Could you please confirm what makes server type to be considered as supported?
I guess at minimum implemented `import`/`export` functionality? 

- [x] Tests pass
- [x] ruff format
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added
