### PR TITLE
Basic keys and values html export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Support data type map in Glue import. (#340)
+- Basic html export for new `keys` and `values` fields. 
 
 ### Fixed
 

--- a/datacontract/templates/partials/model_field.html
+++ b/datacontract/templates/partials/model_field.html
@@ -110,13 +110,13 @@
 {% endif %}
 
 {% if field.items %}
-{{ render_nested_partial("item", field.items, level) }}
+{{ render_nested_partial("items", field.items, level) }}
 {% endif %}
 
 {% if field.keys %}
-{{ render_nested_partial("key", field.keys, level) }}
+{{ render_nested_partial("keys", field.keys, level) }}
 {% endif %}
 
 {% if field.values %}
-{{ render_nested_partial("value", field.values, level) }}
+{{ render_nested_partial("values", field.values, level) }}
 {% endif %}

--- a/datacontract/templates/partials/model_field.html
+++ b/datacontract/templates/partials/model_field.html
@@ -112,3 +112,11 @@
 {% if field.items %}
 {{ render_nested_partial("item", field.items, level) }}
 {% endif %}
+
+{% if field.keys %}
+{{ render_nested_partial("key", field.keys, level) }}
+{% endif %}
+
+{% if field.values %}
+{{ render_nested_partial("value", field.values, level) }}
+{% endif %}


### PR DESCRIPTION
Just adds a the very basic support for the new `keys` and `values` fields for the `map` type using the current nesting.

![Bildschirmfoto 2024-07-22 um 20 27 39](https://github.com/user-attachments/assets/77c75299-e053-4685-96c2-3eef0306992e)

- [x] Tests pass
- [x] ruff format
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added
