### PR TITLE
JSONSchema importer refactor for easier maintenance

### DIFF
--- a/datacontract/imports/jsonschema_importer.py
+++ b/datacontract/imports/jsonschema_importer.py
@@ -32,17 +32,20 @@ def import_jsonschema(data_contract_specification: DataContractSpecification, so
         required_properties = json_schema.get("required", [])
 
         fields_kwargs = jsonschema_to_args(properties, required_properties)
-        datacontract_fields = {field_name: Field(**kwargs) for field_name, kwargs in fields_kwargs.items()}
-
+        fields = {name: Field(**args) for name, args in fields_kwargs.items()}
         data_contract_specification.models[title] = Model(
-            description=description, type=type_, title=title, fields=datacontract_fields
+            description=description, type=type_, title=title, fields=fields
         )
 
-        schema_definitions = json_schema.get("definitions", {})
+        definitions = json_schema.get("definitions", {})
+        definitions_kwargs = {name: schema_to_args(schema) for name, schema in definitions.items()}
 
-        for definition_name, definition_schema in schema_definitions.items():
-            kwargs = schema_to_args(definition_schema)
-            data_contract_specification.definitions[definition_name] = Definition(name=definition_name, **kwargs)
+        for name, args in definitions_kwargs.items():
+            data_contract_specification.definitions[name] = Definition(name=name, **args)
+
+        # for definition_name, definition_schema in definitions.items():
+        #    kwargs = schema_to_args(definition_schema)
+        #    data_contract_specification.definitions[definition_name] = Definition(name=definition_name, **kwargs)
 
     except fastjsonschema.JsonSchemaException as e:
         raise DataContractException(


### PR DESCRIPTION
- REMOVED behaviour where types would be set as optional/not required if the type-schema was an array containing a `null` entry. this doesn't appear to be part of the JSONSchema spec, but we could be lenient about it and keep it?
- KEEPS the behaviour to select the first type in a list of types, so merges union-types into the first non-null-type. we should probably raise an error instead like we do with union types in arrays!
- UNWRAPPED raised exceptions for easier debugging.  if the wrapping was intentional i'll put it back in.
- unified handling of Fields and Definitions in the JSONSchema importer
- untangled logic for type-detection and required-detection
- reduced indentation where adequate

- [+] Tests pass
- [+] ruff format
- [-] CHANGELOG.md entry added (irrelevant, no features added)
