### PR TITLE
add test for #374

### DIFF
--- a/tests/fixtures/spec/datacontract_aliases.yaml
+++ b/tests/fixtures/spec/datacontract_aliases.yaml
@@ -1,0 +1,21 @@
+dataContractSpecification: 0.9.2
+id: "123"
+info:
+  title: "Test"
+  version: 1.0.0
+  owner: my-domain-team
+models:
+  sample_model:
+    description: Sample Model
+    type: table
+    fields:
+      id:
+        type: text
+        title: ID
+        description: A unique identifier
+        $ref: '#/definitions/test'
+definitions:
+  test:
+    description: Test definition reference
+    name: refdef
+    type: text

--- a/tests/test_spec_ref.py
+++ b/tests/test_spec_ref.py
@@ -1,0 +1,15 @@
+from typer.testing import CliRunner
+
+from datacontract.data_contract import DataContract
+
+runner = CliRunner()
+
+# logging.basicConfig(level=logging.DEBUG, force=True)
+
+
+def test_aliases():
+    data_contract = DataContract(data_contract_file="fixtures/spec/datacontract_aliases.yaml", examples=True)
+    spec = data_contract.get_data_contract_specification()
+    yaml = spec.to_yaml()
+    print(yaml)
+    assert '$ref' in yaml


### PR DESCRIPTION
Finally had a chance to add a test for https://github.com/datacontract/datacontract-cli/pull/374

This should close out https://github.com/datacontract/datacontract-cli/issues/373

- [x] Tests pass
- [x] ruff format
- [ ] README.md updated (if relevant)
- [ ] CHANGELOG.md entry added
