### PR TITLE
UnityImporter: Add support for complex types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `datacontract export --format jsonschema` handle optional and nullable fields (#409)
+- `datacontract import --format unity` handle nested and complex fields (#420)
+- `datacontract import --format spark` handle field descriptions (#420)
 
 
 ## [0.10.12] - 2024-09-08

--- a/datacontract/imports/spark_importer.py
+++ b/datacontract/imports/spark_importer.py
@@ -80,6 +80,8 @@ def _field_from_struct_type(spark_field: types.StructField) -> Field:
     """
     field = Field()
     field.required = not spark_field.nullable
+    field.description = spark_field.metadata.get("comment")
+
     return _type_from_data_type(field, spark_field.dataType)
 
 
@@ -121,7 +123,7 @@ def _data_type_from_spark(spark_type: types.DataType) -> str:
     """
     if isinstance(spark_type, types.StringType):
         return "string"
-    elif isinstance(spark_type, types.IntegerType):
+    elif isinstance(spark_type, (types.IntegerType, types.ShortType)):
         return "integer"
     elif isinstance(spark_type, types.LongType):
         return "long"
@@ -149,5 +151,7 @@ def _data_type_from_spark(spark_type: types.DataType) -> str:
         return "decimal"
     elif isinstance(spark_type, types.NullType):
         return "null"
+    elif isinstance(spark_type, types.VarcharType):
+        return "varchar"
     else:
         raise ValueError(f"Unsupported Spark type: {spark_type}")

--- a/datacontract/imports/unity_importer.py
+++ b/datacontract/imports/unity_importer.py
@@ -1,17 +1,37 @@
 import json
-import requests
 import os
-import typing
+from typing import List, Optional
+
+from pyspark.sql import types
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.catalog import TableInfo, ColumnInfo
 
 from datacontract.imports.importer import Importer
+from datacontract.imports.spark_importer import _field_from_struct_type
 from datacontract.model.data_contract_specification import DataContractSpecification, Model, Field
 from datacontract.model.exceptions import DataContractException
 
 
 class UnityImporter(Importer):
+    """
+    UnityImporter class for importing data contract specifications from Unity Catalog.
+    """
+
     def import_source(
         self, data_contract_specification: DataContractSpecification, source: str, import_args: dict
     ) -> DataContractSpecification:
+        """
+        Import data contract specification from a source.
+
+        :param data_contract_specification: The data contract specification to be imported.
+        :type data_contract_specification: DataContractSpecification
+        :param source: The source from which to import the data contract specification.
+        :type source: str
+        :param import_args: Additional arguments for the import process.
+        :type import_args: dict
+        :return: The imported data contract specification.
+        :rtype: DataContractSpecification
+        """
         if source is not None:
             data_contract_specification = import_unity_from_json(data_contract_specification, source)
         else:
@@ -24,9 +44,21 @@ class UnityImporter(Importer):
 def import_unity_from_json(
     data_contract_specification: DataContractSpecification, source: str
 ) -> DataContractSpecification:
+    """
+    Import data contract specification from a JSON file.
+
+    :param data_contract_specification: The data contract specification to be imported.
+    :type data_contract_specification: DataContractSpecification
+    :param source: The path to the JSON file.
+    :type source: str
+    :return: The imported data contract specification.
+    :rtype: DataContractSpecification
+    :raises DataContractException: If there is an error parsing the JSON file.
+    """
     try:
         with open(source, "r") as file:
-            unity_schema = json.loads(file.read())
+            json_contents = json.loads(file.read())
+            unity_schema = TableInfo.from_dict(json_contents)
     except json.JSONDecodeError as e:
         raise DataContractException(
             type="schema",
@@ -39,114 +71,103 @@ def import_unity_from_json(
 
 
 def import_unity_from_api(
-    data_contract_specification: DataContractSpecification, unity_table_full_name: typing.Optional[str] = None
+    data_contract_specification: DataContractSpecification, unity_table_full_name: Optional[str] = None
 ) -> DataContractSpecification:
-    databricks_instance = os.getenv("DATABRICKS_IMPORT_INSTANCE")
-    access_token = os.getenv("DATABRICKS_IMPORT_ACCESS_TOKEN")
+    """
+    Import data contract specification from Unity Catalog API.
 
-    if not databricks_instance or not access_token:
-        print("Missing environment variables for Databricks instance or access token.")
-        print("Both, $DATABRICKS_IMPORT_INSTANCE and $DATABRICKS_IMPORT_ACCESS_TOKEN must be set.")
-        exit(1)  # Exit if variables are not set
-
-    api_url = f"{databricks_instance}/api/2.1/unity-catalog/tables/{unity_table_full_name}"
-
-    headers = {"Authorization": f"Bearer {access_token}"}
-    response = requests.get(api_url, headers=headers)
-
-    if response.status_code != 200:
+    :param data_contract_specification: The data contract specification to be imported.
+    :type data_contract_specification: DataContractSpecification
+    :param unity_table_full_name: The full name of the Unity table.
+    :type unity_table_full_name: Optional[str]
+    :return: The imported data contract specification.
+    :rtype: DataContractSpecification
+    :raises DataContractException: If there is an error retrieving the schema from the API.
+    """
+    try:
+        workspace_client = WorkspaceClient()
+        unity_schema: TableInfo = workspace_client.tables.get(unity_table_full_name)
+    except Exception as e:
         raise DataContractException(
             type="schema",
             name="Retrieve unity catalog schema",
-            reason=f"Failed to retrieve unity catalog schema from databricks instance: {response.status_code} {response.text}",
+            reason=f"Failed to retrieve unity catalog schema from databricks profile: {os.getenv('DATABRICKS_CONFIG_PROFILE')}",
             engine="datacontract",
+            original_exception=e
         )
 
-    convert_unity_schema(data_contract_specification, response.json())
+    convert_unity_schema(data_contract_specification, unity_schema)
 
     return data_contract_specification
 
 
 def convert_unity_schema(
-    data_contract_specification: DataContractSpecification, unity_schema: dict
+    data_contract_specification: DataContractSpecification, unity_schema: TableInfo
 ) -> DataContractSpecification:
+    """
+    Convert Unity schema to data contract specification.
+
+    :param data_contract_specification: The data contract specification to be converted.
+    :type data_contract_specification: DataContractSpecification
+    :param unity_schema: The Unity schema to be converted.
+    :type unity_schema: TableInfo
+    :return: The converted data contract specification.
+    :rtype: DataContractSpecification
+    """
     if data_contract_specification.models is None:
         data_contract_specification.models = {}
 
-    fields = import_table_fields(unity_schema.get("columns"))
+    fields = import_table_fields(unity_schema.columns)
 
-    table_id = unity_schema.get("table_id")
+    table_id = unity_schema.name or unity_schema.table_id
 
     data_contract_specification.models[table_id] = Model(fields=fields, type="table")
 
-    if unity_schema.get("name") is not None:
-        data_contract_specification.models[table_id].title = unity_schema.get("name")
+    if unity_schema.name:
+        data_contract_specification.models[table_id].title = unity_schema.name
+
+    if unity_schema.comment:
+        data_contract_specification.models[table_id].description = unity_schema.comment
 
     return data_contract_specification
 
 
-def import_table_fields(table_fields):
+def import_table_fields(columns: List[ColumnInfo]) -> dict[str, Field]:
+    """
+    Import table fields from Unity schema columns.
+
+    Here we are first converting the `ColumnInfo.type_json` to a Spark StructField object
+    so we can leave the complexity of the Spark field types to the Spark JSON schema parser,
+    then re-use the logic in `datacontract.imports.spark_importer` to convert the StructField
+    into a Field object.
+
+    :param columns: The list of Unity schema columns.
+    :type columns: List[ColumnInfo]
+    :return: A dictionary of imported fields.
+    :rtype: dict[str, Field]
+    """
     imported_fields = {}
-    for field in table_fields:
-        field_name = field.get("name")
-        imported_fields[field_name] = Field()
-        imported_fields[field_name].required = field.get("nullable") == "false"
-        imported_fields[field_name].description = field.get("comment")
 
-        # databricks api 2.1 specifies that type_name can be any of:
-        # BOOLEAN | BYTE | SHORT | INT | LONG | FLOAT | DOUBLE | DATE | TIMESTAMP | TIMESTAMP_NTZ | STRING
-        # | BINARY | DECIMAL | INTERVAL | ARRAY | STRUCT | MAP | CHAR | NULL | USER_DEFINED_TYPE | TABLE_TYPE
-        if field.get("type_name") in ["INTERVAL", "ARRAY", "STRUCT", "MAP", "USER_DEFINED_TYPE", "TABLE_TYPE"]:
-            # complex types are not supported, yet
-            raise DataContractException(
-                type="schema",
-                result="failed",
-                name="Map unity type to data contract type",
-                reason=f"type ${field.get('type_name')} is not supported yet for unity import",
-                engine="datacontract",
-            )
-
-        imported_fields[field_name].type = map_type_from_unity(field.get("type_name"))
+    for column in columns:
+        struct_field: types.StructField = _type_json_to_spark_field(column.type_json)
+        imported_fields[column.name] = _field_from_struct_type(struct_field)
 
     return imported_fields
 
 
-def map_type_from_unity(type_str: str):
-    if type_str == "BOOLEAN":
-        return "boolean"
-    elif type_str == "BYTE":
-        return "bytes"
-    elif type_str == "SHORT":
-        return "int"
-    elif type_str == "INT":
-        return "int"
-    elif type_str == "LONG":
-        return "long"
-    elif type_str == "FLOAT":
-        return "float"
-    elif type_str == "DOUBLE":
-        return "double"
-    elif type_str == "DATE":
-        return "date"
-    elif type_str == "TIMESTAMP":
-        return "timestamp"
-    elif type_str == "TIMESTAMP_NTZ":
-        return "timestamp_ntz"
-    elif type_str == "STRING":
-        return "string"
-    elif type_str == "BINARY":
-        return "bytes"
-    elif type_str == "DECIMAL":
-        return "decimal"
-    elif type_str == "CHAR":
-        return "varchar"
-    elif type_str == "NULL":
-        return "null"
-    else:
-        raise DataContractException(
-            type="schema",
-            result="failed",
-            name="Map unity type to data contract type",
-            reason=f"Unsupported type {type_str} in unity json definition.",
-            engine="datacontract",
-        )
+def _type_json_to_spark_field(type_json: str) -> types.StructField:
+    """
+    Parses a JSON string representing a Spark field and returns a StructField object.
+
+    The reason we do this is to leverage the Spark JSON schema parser to handle the
+    complexity of the Spark field types. The field `type_json` in the Unity API is
+    the output of a `StructField.jsonValue()` call.
+
+    :param type_json: The JSON string representing the Spark field.
+    :type type_json: str
+
+    :return: The StructField object.
+    :rtype: types.StructField
+    """
+    type_dict = json.loads(type_json)
+    return types.StructField.fromJson(type_dict)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ bigquery = [
 databricks = [
   "soda-core-spark-df>=3.3.1,<3.4.0",
   "databricks-sql-connector>=3.1.2,<3.4.0",
+  "databricks-sdk>=0.32.0,<0.33.0",
   "soda-core-spark[databricks]>=3.3.1,<3.4.0"
 ]
 

--- a/tests/fixtures/databricks-unity/import/datacontract.yaml
+++ b/tests/fixtures/databricks-unity/import/datacontract.yaml
@@ -5,17 +5,18 @@ info:
   version: 0.0.1
 models:
   test_table:
+    description: string
     type: table
-    title: string
+    title: test_table
     fields:
       id:
-        type: int
-        required: false
+        type: integer
+        required: true
       name:
-        type: string
+        type: varchar
         required: false
       age:
-        type: int
+        type: integer
         required: false
       salary:
         type: decimal

--- a/tests/fixtures/databricks-unity/import/datacontract_complex_types.yaml
+++ b/tests/fixtures/databricks-unity/import/datacontract_complex_types.yaml
@@ -1,0 +1,93 @@
+dataContractSpecification: 0.9.3
+id: my-data-contract-id
+info:
+  title: My Data Contract
+  version: 0.0.1
+models:
+  test_table:
+    description: The 'test_table' contains various data types like strings, structures,
+      arrays, and maps. It includes nested structures, arrays of integers and structures,
+      maps with string keys and integer values, maps with integer keys and struct
+      values, and a JSON column. This table can be used to test and validate data
+      structures and their interactions in a controlled environment. It can also be
+      used to analyze the distribution of data types and their relationships within
+      the table.
+    type: table
+    title: test_table
+    fields:
+      id:
+        type: integer
+        required: true
+        description: Unique identifier for each test record.
+      name:
+        type: string
+        required: false
+        description: Name of the test, providing a human-readable label for identification.
+      nested_struct:
+        type: struct
+        required: false
+        description: Represents a nested structure with multiple levels of data.
+        fields:
+          field1:
+            type: string
+            required: false
+          field2:
+            type: integer
+            required: false
+      array_int:
+        type: array
+        required: false
+        description: An array of integers, allowing for the storage of multiple integer
+          values.
+        items:
+          type: integer
+          required: false
+      array_struct:
+        type: array
+        required: false
+        description: An array of structured data, where each element is a separate
+          record.
+        items:
+          type: struct
+          required: false
+          fields:
+            sub_field1:
+              type: string
+              required: false
+            sub_field2:
+              type: double
+              required: false
+      map_string_int:
+        type: map
+        required: false
+        description: A map with string keys and integer values, allowing for the storage
+          of key-value pairs.
+        keys:
+          type: string
+          required: true
+        values:
+          type: integer
+          required: false
+      map_int_struct:
+        type: map
+        required: false
+        description: A map with integer keys and structured data values, allowing
+          for the storage of key-value pairs with integer keys.
+        keys:
+          type: integer
+          required: true
+        values:
+          type: struct
+          required: false
+          fields:
+            map_struct_field1:
+              type: boolean
+              required: false
+            map_struct_field2:
+              type: float
+              required: false
+      json_column:
+        type: string
+        required: false
+        description: A column storing JSON data, allowing for the storage of complex,
+          hierarchical data structures.

--- a/tests/fixtures/databricks-unity/import/unity_table_schema.json
+++ b/tests/fixtures/databricks-unity/import/unity_table_schema.json
@@ -1,5 +1,5 @@
 {
-  "name": "string",
+  "name": "test_table",
   "catalog_name": "string",
   "schema_name": "string",
   "table_type": "MANAGED",
@@ -129,7 +129,7 @@
   },
   "enable_predictive_optimization": "DISABLE",
   "metastore_id": "string",
-  "full_name": "string",
+  "full_name": "my_catalog.my_schema.test_table",
   "data_access_configuration_id": "string",
   "created_at": 0,
   "created_by": "string",

--- a/tests/fixtures/databricks-unity/import/unity_table_schema_complex_types.json
+++ b/tests/fixtures/databricks-unity/import/unity_table_schema_complex_types.json
@@ -1,0 +1,121 @@
+{
+  "name": "test_table",
+  "catalog_name": "string",
+  "schema_name": "string",
+  "table_type": "MANAGED",
+  "comment": "The 'test_table' contains various data types like strings, structures, arrays, and maps. It includes nested structures, arrays of integers and structures, maps with string keys and integer values, maps with integer keys and struct values, and a JSON column. This table can be used to test and validate data structures and their interactions in a controlled environment. It can also be used to analyze the distribution of data types and their relationships within the table.",
+  "data_source_format": "DELTA",
+  "columns": [
+    {
+      "comment": "Unique identifier for each test record.",
+      "name": "id",
+      "nullable": false,
+      "position": 0,
+      "type_json": "{\"name\":\"id\",\"type\":\"integer\",\"nullable\":false,\"metadata\":{\"comment\":\"Unique identifier for each test record.\"}}",
+      "type_name": "INT",
+      "type_precision": 0,
+      "type_scale": 0,
+      "type_text": "int"
+    },
+    {
+      "comment": "Name of the test, providing a human-readable label for identification.",
+      "name": "name",
+      "nullable": true,
+      "position": 1,
+      "type_json": "{\"name\":\"name\",\"type\":\"string\",\"nullable\":true,\"metadata\":{\"comment\":\"Name of the test, providing a human-readable label for identification.\"}}",
+      "type_name": "STRING",
+      "type_precision": 0,
+      "type_scale": 0,
+      "type_text": "string"
+    },
+    {
+      "comment": "Represents a nested structure with multiple levels of data.",
+      "name": "nested_struct",
+      "nullable": true,
+      "position": 2,
+      "type_json": "{\"name\":\"nested_struct\",\"type\":{\"type\":\"struct\",\"fields\":[{\"name\":\"field1\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"field2\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]},\"nullable\":true,\"metadata\":{\"comment\":\"Represents a nested structure with multiple levels of data.\"}}",
+      "type_name": "STRUCT",
+      "type_precision": 0,
+      "type_scale": 0,
+      "type_text": "struct<field1:string,field2:int>"
+    },
+    {
+      "comment": "An array of integers, allowing for the storage of multiple integer values.",
+      "name": "array_int",
+      "nullable": true,
+      "position": 3,
+      "type_json": "{\"name\":\"array_int\",\"type\":{\"type\":\"array\",\"elementType\":\"integer\",\"containsNull\":true},\"nullable\":true,\"metadata\":{\"comment\":\"An array of integers, allowing for the storage of multiple integer values.\"}}",
+      "type_name": "ARRAY",
+      "type_precision": 0,
+      "type_scale": 0,
+      "type_text": "array<int>"
+    },
+    {
+      "comment": "An array of structured data, where each element is a separate record.",
+      "name": "array_struct",
+      "nullable": true,
+      "position": 4,
+      "type_json": "{\"name\":\"array_struct\",\"type\":{\"type\":\"array\",\"elementType\":{\"type\":\"struct\",\"fields\":[{\"name\":\"sub_field1\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"sub_field2\",\"type\":\"double\",\"nullable\":true,\"metadata\":{}}]},\"containsNull\":true},\"nullable\":true,\"metadata\":{\"comment\":\"An array of structured data, where each element is a separate record.\"}}",
+      "type_name": "ARRAY",
+      "type_precision": 0,
+      "type_scale": 0,
+      "type_text": "array<struct<sub_field1:string,sub_field2:double>>"
+    },
+    {
+      "comment": "A map with string keys and integer values, allowing for the storage of key-value pairs.",
+      "name": "map_string_int",
+      "nullable": true,
+      "position": 5,
+      "type_json": "{\"name\":\"map_string_int\",\"type\":{\"type\":\"map\",\"keyType\":\"string\",\"valueType\":\"integer\",\"valueContainsNull\":true},\"nullable\":true,\"metadata\":{\"comment\":\"A map with string keys and integer values, allowing for the storage of key-value pairs.\"}}",
+      "type_name": "MAP",
+      "type_precision": 0,
+      "type_scale": 0,
+      "type_text": "map<string,int>"
+    },
+    {
+      "comment": "A map with integer keys and structured data values, allowing for the storage of key-value pairs with integer keys.",
+      "name": "map_int_struct",
+      "nullable": true,
+      "position": 6,
+      "type_json": "{\"name\":\"map_int_struct\",\"type\":{\"type\":\"map\",\"keyType\":\"integer\",\"valueType\":{\"type\":\"struct\",\"fields\":[{\"name\":\"map_struct_field1\",\"type\":\"boolean\",\"nullable\":true,\"metadata\":{}},{\"name\":\"map_struct_field2\",\"type\":\"float\",\"nullable\":true,\"metadata\":{}}]},\"valueContainsNull\":true},\"nullable\":true,\"metadata\":{\"comment\":\"A map with integer keys and structured data values, allowing for the storage of key-value pairs with integer keys.\"}}",
+      "type_name": "MAP",
+      "type_precision": 0,
+      "type_scale": 0,
+      "type_text": "map<int,struct<map_struct_field1:boolean,map_struct_field2:float>>"
+    },
+    {
+      "comment": "A column storing JSON data, allowing for the storage of complex, hierarchical data structures.",
+      "name": "json_column",
+      "nullable": true,
+      "position": 7,
+      "type_json": "{\"name\":\"json_column\",\"type\":\"string\",\"nullable\":true,\"metadata\":{\"comment\":\"A column storing JSON data, allowing for the storage of complex, hierarchical data structures.\"}}",
+      "type_name": "STRING",
+      "type_precision": 0,
+      "type_scale": 0,
+      "type_text": "string"
+    }
+  ],
+  "enable_predictive_optimization": "DISABLE",
+  "metastore_id": "string",
+  "full_name": "my_catalog.my_schema.test_table",
+  "data_access_configuration_id": "string",
+  "created_at": 0,
+  "created_by": "string",
+  "updated_at": 0,
+  "updated_by": "string",
+  "deleted_at": 0,
+  "table_id": "test_table",
+  "delta_runtime_properties_kvpairs": {
+    "delta_runtime_properties": {
+      "property1": "string",
+      "property2": "string"
+    }
+  },
+  "effective_predictive_optimization_flag": {
+    "value": "DISABLE",
+    "inherited_from_type": "CATALOG",
+    "inherited_from_name": "string"
+  },
+  "pipeline_id": "string",
+  "browse_only": true
+}

--- a/tests/test_import_unity_file.py
+++ b/tests/test_import_unity_file.py
@@ -33,3 +33,31 @@ def test_import_unity():
     print("Result:\n", result.to_yaml())
     assert yaml.safe_load(result.to_yaml()) == yaml.safe_load(expected)
     assert DataContract(data_contract_str=expected).lint(enabled_linters="none").has_passed()
+
+
+def test_cli_complex_types():
+    print("running test_cli_complex_types")
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "import",
+            "--format",
+            "unity",
+            "--source",
+            "fixtures/databricks-unity/import/unity_table_schema_complex_types.json",
+        ],
+    )
+    assert result.exit_code == 0
+
+
+def test_import_unity_complex_types():
+    print("running test_import_unity_complex_types")
+    result = DataContract().import_from_source("unity", "fixtures/databricks-unity/import/unity_table_schema_complex_types.json")
+
+    with open("fixtures/databricks-unity/import/datacontract_complex_types.yaml") as file:
+        expected = file.read()
+
+    print("Result:\n", result.to_yaml())
+    assert yaml.safe_load(result.to_yaml()) == yaml.safe_load(expected)
+    assert DataContract(data_contract_str=expected).lint(enabled_linters="none").has_passed()


### PR DESCRIPTION
- [x] Tests pass
- [x] ruff format
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added

Hi maintainers 👋 I hope you don't mind that `unityimporter.py` uses code from `sparkimporter.py`? It seemed a shame to  duplicate that logic.

- `datacontract import --format unity` handle nested and complex fields (#420)
- `datacontract import --format spark` handle field descriptions (#420)
