### PR TITLE
fix: default `precision` and `scale` parameters for `DecimalType`

### DIFF
--- a/datacontract/export/spark_converter.py
+++ b/datacontract/export/spark_converter.py
@@ -128,7 +128,7 @@ def to_data_type(field: Field) -> types.DataType:
     if field_type in ["string", "varchar", "text"]:
         return types.StringType()
     if field_type in ["number", "decimal", "numeric"]:
-        precision = field.precision if field.precision is not None else 10
+        precision = field.precision if field.precision is not None else 38
         scale = field.scale if field.scale is not None else 0
         return types.DecimalType(precision=precision, scale=scale)
     if field_type in ["integer", "int"]:

--- a/datacontract/export/spark_converter.py
+++ b/datacontract/export/spark_converter.py
@@ -128,7 +128,9 @@ def to_data_type(field: Field) -> types.DataType:
     if field_type in ["string", "varchar", "text"]:
         return types.StringType()
     if field_type in ["number", "decimal", "numeric"]:
-        return types.DecimalType(precision=field.precision, scale=field.scale)
+        precision = field.precision if field.precision is not None else 10
+        scale = field.scale if field.scale is not None else 0
+        return types.DecimalType(precision=precision, scale=scale)
     if field_type in ["integer", "int"]:
         return types.IntegerType()
     if field_type == "long":


### PR DESCRIPTION
- [ ] Tests pass
- [X] ruff format
- [ ] README.md updated (if relevant)
- [ ] CHANGELOG.md entry added

In a previous PR (https://github.com/datacontract/datacontract-cli/pull/419), I did not consider the case where `precision` and `scale` are not provided in the data contract. This change allows defining `type: decimal` without adding `precision` and/or `scale` values.