### PR TITLE
Add support for decimal logical type to Avro export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support for import from Iceberg table definitions.
+- Support for decimal logical type on avro export.
 
 ## [0.10.13] - 2024-09-20
 

--- a/datacontract/export/avro_converter.py
+++ b/datacontract/export/avro_converter.py
@@ -81,9 +81,16 @@ def to_avro_type(field: Field, field_name: str) -> str | dict:
         return "null"
     if field.type in ["string", "varchar", "text"]:
         return "string"
-    elif field.type in ["number", "decimal", "numeric"]:
+    elif field.type in ["number", "numeric"]:
         # https://avro.apache.org/docs/1.11.1/specification/#decimal
         return "bytes"
+    elif field.type in ["decimal"]:
+        typeVal = {"type": "bytes", "logicalType": "decimal"}
+        if field.scale is not None:
+            typeVal["scale"] = field.scale
+        if field.precision is not None:
+            typeVal["precision"] = field.precision
+        return typeVal
     elif field.type in ["float", "double"]:
         return "double"
     elif field.type in ["integer", "int"]:

--- a/tests/fixtures/avro/export/datacontract_decimal.avsc
+++ b/tests/fixtures/avro/export/datacontract_decimal.avsc
@@ -1,0 +1,43 @@
+{
+  "type": "record",
+  "name": "MySchema",
+  "fields": [
+    {
+      "name": "price",
+      "type": {
+        "type": "bytes",
+        "logicalType": "decimal"
+      }
+    },
+    {
+      "name": "dewey_decimal",
+      "type": {
+        "type": "bytes",
+        "logicalType": "decimal",
+        "scale": 2,
+        "precision": 4
+      }
+    },
+    {
+      "name": "reading_level",
+      "type": [
+        "null",
+        {
+          "type": "bytes",
+          "logicalType": "decimal"
+        }
+      ]
+    },
+    {
+      "name": "age",
+      "type": [
+        "null",
+        {
+          "type": "bytes",
+          "logicalType": "decimal",
+          "precision": 3
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/avro/export/datacontract_decimal.yaml
+++ b/tests/fixtures/avro/export/datacontract_decimal.yaml
@@ -1,0 +1,23 @@
+dataContractSpecification: 0.9.3
+id: my-data-contract-id
+info:
+  title: My Data Contract
+  version: 0.0.1
+models:
+  MySchema:
+    fields:
+      price:
+        type: decimal
+        required: true
+      dewey_decimal:
+        type: decimal
+        required: true
+        precision: 4
+        scale: 2
+      reading_level:
+        type: decimal
+        required: false
+      age:
+        type: decimal
+        required: false
+        precision: 3

--- a/tests/test_export_avro.py
+++ b/tests/test_export_avro.py
@@ -58,6 +58,7 @@ def test_to_avro_schema_enum():
 
     assert json.loads(result) == json.loads(expected_avro_schema)
 
+
 def test_to_decimal_type():
     data_contract = DataContractSpecification.from_file("fixtures/avro/export/datacontract_decimal.yaml")
     with open("fixtures/avro/export/datacontract_decimal.avsc") as file:

--- a/tests/test_export_avro.py
+++ b/tests/test_export_avro.py
@@ -57,3 +57,13 @@ def test_to_avro_schema_enum():
     result = to_avro_schema_json(model_name, model)
 
     assert json.loads(result) == json.loads(expected_avro_schema)
+
+def test_to_decimal_type():
+    data_contract = DataContractSpecification.from_file("fixtures/avro/export/datacontract_decimal.yaml")
+    with open("fixtures/avro/export/datacontract_decimal.avsc") as file:
+        expected_avro_schema = file.read()
+
+    model_name, model = next(iter(data_contract.models.items()))
+    result = to_avro_schema_json(model_name, model)
+
+    assert json.loads(result) == json.loads(expected_avro_schema)


### PR DESCRIPTION
- [X] Tests pass
- [X] ruff format
- [X] CHANGELOG.md entry added

When converting a decimal field to avro, it will now set the logical type to "decimal" and also set the scale and precision if applicable