### PR TITLE
Add support for trinoType field for custom Trino types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support for import from Iceberg table definitions.
+- Support for custom Trino types
 
 ## [0.10.13] - 2024-09-20
 

--- a/README.md
+++ b/README.md
@@ -724,6 +724,10 @@ models:
     fields:
       my_column_1: # corresponds to a column
         type: varchar
+      my_column_2: # corresponds to a column with custom trino type
+        type: object
+        config:
+          trinoType: row(en_us varchar, pt_br varchar)
 ```
 
 #### Environment Variables

--- a/datacontract/export/sql_type_converter.py
+++ b/datacontract/export/sql_type_converter.py
@@ -323,25 +323,27 @@ def get_type_config(field: Field, config_attr: str) -> dict[str, str] | None:
 
 def convert_type_to_trino(field: Field) -> None | str:
     """Convert from supported datacontract types to equivalent trino types"""
-    field_type = field.type
+    if field.config and "trinoType" in field.config:
+        return field.config["trinoType"]
 
-    if field_type.lower() in ["string", "text", "varchar"]:
+    field_type = field.type.lower()
+    if field_type in ["string", "text", "varchar"]:
         return "varchar"
     # tinyint, smallint not supported by data contract
-    if field_type.lower() in ["number", "decimal", "numeric"]:
+    if field_type in ["number", "decimal", "numeric"]:
         # precision and scale not supported by data contract
         return "decimal"
-    if field_type.lower() in ["int", "integer"]:
+    if field_type in ["int", "integer"]:
         return "integer"
-    if field_type.lower() in ["long", "bigint"]:
+    if field_type in ["long", "bigint"]:
         return "bigint"
-    if field_type.lower() in ["float"]:
+    if field_type in ["float"]:
         return "real"
-    if field_type.lower() in ["timestamp", "timestamp_tz"]:
+    if field_type in ["timestamp", "timestamp_tz"]:
         return "timestamp(3) with time zone"
-    if field_type.lower() in ["timestamp_ntz"]:
+    if field_type in ["timestamp_ntz"]:
         return "timestamp(3)"
-    if field_type.lower() in ["bytes"]:
+    if field_type in ["bytes"]:
         return "varbinary"
-    if field_type.lower() in ["object", "record", "struct"]:
+    if field_type in ["object", "record", "struct"]:
         return "json"


### PR DESCRIPTION
# Description
This PR adds support for custom Trino types using `trinoType` field under `config` on the field definition.

# Issue
Trino has custom data types, for example `ROW` ([docs](https://trino.io/docs/current/language/types.html#row)), which were not supported by the default type definitions.
Similarly to what is used with other server types, I've added a custom field named `trinoType`, which enables any custom types to be used.

- [x] Tests pass
- [x] ruff format
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added
