### PR TITLE
chore: extend `ruff` to handle order of imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,7 +179,7 @@ ipython_config.py
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.

--- a/datacontract/catalog/catalog.py
+++ b/datacontract/catalog/catalog.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from pathlib import Path
 
 import pytz
-from jinja2 import PackageLoader, Environment, select_autoescape
+from jinja2 import Environment, PackageLoader, select_autoescape
 
 from datacontract.data_contract import DataContract
 from datacontract.export.html_export import get_version

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -1,7 +1,6 @@
 from importlib import metadata
 from pathlib import Path
-from typing import Iterable, Optional
-from typing import List
+from typing import Iterable, List, Optional
 
 import typer
 import uvicorn
@@ -13,10 +12,10 @@ from typer.core import TyperGroup
 from typing_extensions import Annotated
 
 from datacontract import web
-from datacontract.catalog.catalog import create_index_html, create_data_contract_html
+from datacontract.catalog.catalog import create_data_contract_html, create_index_html
 from datacontract.data_contract import DataContract, ExportFormat
 from datacontract.imports.importer import ImportFormat
-from datacontract.init.download_datacontract_file import download_datacontract_file, FileExistsException
+from datacontract.init.download_datacontract_file import FileExistsException, download_datacontract_file
 from datacontract.integration.datamesh_manager import publish_data_contract_to_datamesh_manager
 
 DEFAULT_DATA_CONTRACT_SCHEMA_URL = "https://datacontract.com/datacontract.schema.json"

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -17,7 +17,6 @@ from datacontract.engines.soda.check_soda_execute import check_soda_execute
 from datacontract.export.exporter import ExportFormat
 from datacontract.export.exporter_factory import exporter_factory
 from datacontract.imports.importer_factory import importer_factory
-
 from datacontract.integration.datamesh_manager import publish_test_results_to_datamesh_manager
 from datacontract.integration.opentelemetry import publish_test_results_to_opentelemetry
 from datacontract.lint import resolve
@@ -28,10 +27,10 @@ from datacontract.lint.linters.field_reference_linter import FieldReferenceLinte
 from datacontract.lint.linters.notice_period_linter import NoticePeriodLinter
 from datacontract.lint.linters.quality_schema_linter import QualityUsesSchemaLinter
 from datacontract.lint.linters.valid_constraints_linter import ValidFieldConstraintsLinter
-from datacontract.model.breaking_change import BreakingChanges, BreakingChange, Severity
+from datacontract.model.breaking_change import BreakingChange, BreakingChanges, Severity
 from datacontract.model.data_contract_specification import DataContractSpecification, Server
 from datacontract.model.exceptions import DataContractException
-from datacontract.model.run import Run, Check
+from datacontract.model.run import Check, Run
 
 
 class DataContract:

--- a/datacontract/engines/datacontract/check_that_datacontract_file_exists.py
+++ b/datacontract/engines/datacontract/check_that_datacontract_file_exists.py
@@ -1,6 +1,6 @@
 import os
 
-from datacontract.model.run import Run, Check
+from datacontract.model.run import Check, Run
 
 
 def check_that_datacontract_file_exists(run: Run, file_path: str):

--- a/datacontract/engines/fastjsonschema/check_jsonschema.py
+++ b/datacontract/engines/fastjsonschema/check_jsonschema.py
@@ -8,7 +8,7 @@ from datacontract.engines.fastjsonschema.s3.s3_read_files import yield_s3_files
 from datacontract.export.jsonschema_converter import to_jsonschema
 from datacontract.model.data_contract_specification import DataContractSpecification, Server
 from datacontract.model.exceptions import DataContractException
-from datacontract.model.run import Run, Check
+from datacontract.model.run import Check, Run
 
 
 def validate_json_stream(model_name, validate, json_stream):

--- a/datacontract/engines/soda/check_soda_execute.py
+++ b/datacontract/engines/soda/check_soda_execute.py
@@ -12,7 +12,7 @@ from datacontract.engines.soda.connections.sqlserver import to_sqlserver_soda_co
 from datacontract.engines.soda.connections.trino import to_trino_soda_configuration
 from datacontract.export.sodacl_converter import to_sodacl_yaml
 from datacontract.model.data_contract_specification import DataContractSpecification, Server
-from datacontract.model.run import Run, Check, Log
+from datacontract.model.run import Check, Log, Run
 
 
 def check_soda_execute(run: Run, data_contract: DataContractSpecification, server: Server, spark, tmp_dir):

--- a/datacontract/engines/soda/connections/duckdb.py
+++ b/datacontract/engines/soda/connections/duckdb.py
@@ -1,6 +1,7 @@
 import os
 
 import duckdb
+
 from datacontract.export.csv_type_converter import convert_to_duckdb_csv_type
 from datacontract.model.run import Run
 

--- a/datacontract/engines/soda/connections/kafka.py
+++ b/datacontract/engines/soda/connections/kafka.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 from datacontract.export.avro_converter import to_avro_schema_json
-from datacontract.model.data_contract_specification import DataContractSpecification, Server, Field
+from datacontract.model.data_contract_specification import DataContractSpecification, Field, Server
 from datacontract.model.exceptions import DataContractException
 
 
@@ -69,8 +69,8 @@ def read_kafka_topic(spark, data_contract: DataContractSpecification, server: Se
 
 def process_avro_format(df, model_name, model):
     try:
-        from pyspark.sql.functions import col, expr
         from pyspark.sql.avro.functions import from_avro
+        from pyspark.sql.functions import col, expr
     except ImportError as e:
         raise DataContractException(
             type="schema",
@@ -167,21 +167,21 @@ def to_struct_type(fields):
 def to_struct_field(field_name: str, field: Field):
     try:
         from pyspark.sql.types import (
-            StructType,
-            StructField,
-            StringType,
+            ArrayType,
+            BinaryType,
+            BooleanType,
+            DataType,
+            DateType,
             DecimalType,
             DoubleType,
             IntegerType,
             LongType,
-            BooleanType,
-            TimestampType,
-            TimestampNTZType,
-            DateType,
-            BinaryType,
-            ArrayType,
             NullType,
-            DataType,
+            StringType,
+            StructField,
+            StructType,
+            TimestampNTZType,
+            TimestampType,
         )
     except ImportError as e:
         raise DataContractException(

--- a/datacontract/export/avro_idl_converter.py
+++ b/datacontract/export/avro_idl_converter.py
@@ -3,11 +3,10 @@ from dataclasses import dataclass
 from enum import Enum
 from io import StringIO
 
+from datacontract.export.exporter import Exporter
 from datacontract.lint.resolve import inline_definitions_into_data_contract
 from datacontract.model.data_contract_specification import DataContractSpecification, Field
 from datacontract.model.exceptions import DataContractException
-
-from datacontract.export.exporter import Exporter
 
 
 class AvroPrimitiveType(Enum):

--- a/datacontract/export/bigquery_converter.py
+++ b/datacontract/export/bigquery_converter.py
@@ -2,10 +2,9 @@ import json
 import logging
 from typing import Dict, List
 
-from datacontract.model.data_contract_specification import Model, Field, Server
-from datacontract.model.exceptions import DataContractException
-
 from datacontract.export.exporter import Exporter, _check_models_for_export
+from datacontract.model.data_contract_specification import Field, Model, Server
+from datacontract.model.exceptions import DataContractException
 
 
 class BigQueryExporter(Exporter):

--- a/datacontract/export/data_caterer_converter.py
+++ b/datacontract/export/data_caterer_converter.py
@@ -3,7 +3,7 @@ from typing import Dict
 import yaml
 
 from datacontract.export.exporter import Exporter
-from datacontract.model.data_contract_specification import DataContractSpecification, Model, Field, Server
+from datacontract.model.data_contract_specification import DataContractSpecification, Field, Model, Server
 
 
 class DataCatererExporter(Exporter):

--- a/datacontract/export/dbml_converter.py
+++ b/datacontract/export/dbml_converter.py
@@ -3,13 +3,11 @@ from importlib.metadata import version
 from typing import Tuple
 
 import pytz
-from datacontract.model.exceptions import DataContractException
 
 import datacontract.model.data_contract_specification as spec
-from datacontract.export.sql_type_converter import convert_to_sql_type
-
-
 from datacontract.export.exporter import Exporter
+from datacontract.export.sql_type_converter import convert_to_sql_type
+from datacontract.model.exceptions import DataContractException
 
 
 class DbmlExporter(Exporter):

--- a/datacontract/export/dbt_converter.py
+++ b/datacontract/export/dbt_converter.py
@@ -2,10 +2,9 @@ from typing import Dict
 
 import yaml
 
-from datacontract.export.sql_type_converter import convert_to_sql_type
-from datacontract.model.data_contract_specification import DataContractSpecification, Model, Field
-
 from datacontract.export.exporter import Exporter, _check_models_for_export
+from datacontract.export.sql_type_converter import convert_to_sql_type
+from datacontract.model.data_contract_specification import DataContractSpecification, Field, Model
 
 
 class DbtExporter(Exporter):

--- a/datacontract/export/exporter.py
+++ b/datacontract/export/exporter.py
@@ -1,6 +1,6 @@
+import typing
 from abc import ABC, abstractmethod
 from enum import Enum
-import typing
 
 from datacontract.model.data_contract_specification import DataContractSpecification
 

--- a/datacontract/export/exporter_factory.py
+++ b/datacontract/export/exporter_factory.py
@@ -1,6 +1,7 @@
 import importlib
 import sys
-from datacontract.export.exporter import ExportFormat, Exporter
+
+from datacontract.export.exporter import Exporter, ExportFormat
 
 
 class ExporterFactory:

--- a/datacontract/export/go_converter.py
+++ b/datacontract/export/go_converter.py
@@ -1,6 +1,7 @@
-import datacontract.model.data_contract_specification as spec
-from typing import List
 import re
+from typing import List
+
+import datacontract.model.data_contract_specification as spec
 from datacontract.export.exporter import Exporter
 
 

--- a/datacontract/export/great_expectations_converter.py
+++ b/datacontract/export/great_expectations_converter.py
@@ -1,10 +1,10 @@
 import json
-from typing import Dict, List, Any
+from typing import Any, Dict, List
 
 import yaml
 
-from datacontract.model.data_contract_specification import DataContractSpecification, Field, Quality
 from datacontract.export.exporter import Exporter, _check_models_for_export
+from datacontract.model.data_contract_specification import DataContractSpecification, Field, Quality
 
 
 class GreateExpectationsExporter(Exporter):

--- a/datacontract/export/html_export.py
+++ b/datacontract/export/html_export.py
@@ -7,8 +7,8 @@ import pytz
 import yaml
 from jinja2 import Environment, PackageLoader, select_autoescape
 
-from datacontract.model.data_contract_specification import DataContractSpecification
 from datacontract.export.exporter import Exporter
+from datacontract.model.data_contract_specification import DataContractSpecification
 
 
 class HtmlExporter(Exporter):

--- a/datacontract/export/jsonschema_converter.py
+++ b/datacontract/export/jsonschema_converter.py
@@ -1,9 +1,8 @@
 import json
 from typing import Dict
 
-from datacontract.model.data_contract_specification import DataContractSpecification, Model, Field
-
 from datacontract.export.exporter import Exporter, _check_models_for_export
+from datacontract.model.data_contract_specification import DataContractSpecification, Field, Model
 
 
 class JsonSchemaExporter(Exporter):

--- a/datacontract/export/odcs_v2_exporter.py
+++ b/datacontract/export/odcs_v2_exporter.py
@@ -2,8 +2,8 @@ from typing import Dict
 
 import yaml
 
-from datacontract.model.data_contract_specification import DataContractSpecification, Model, Field
 from datacontract.export.exporter import Exporter
+from datacontract.model.data_contract_specification import DataContractSpecification, Field, Model
 
 
 class OdcsV2Exporter(Exporter):

--- a/datacontract/export/odcs_v3_exporter.py
+++ b/datacontract/export/odcs_v3_exporter.py
@@ -3,7 +3,7 @@ from typing import Dict
 import yaml
 
 from datacontract.export.exporter import Exporter
-from datacontract.model.data_contract_specification import DataContractSpecification, Model, Field
+from datacontract.model.data_contract_specification import DataContractSpecification, Field, Model
 
 
 class OdcsV3Exporter(Exporter):

--- a/datacontract/export/protobuf_converter.py
+++ b/datacontract/export/protobuf_converter.py
@@ -1,5 +1,5 @@
-from datacontract.model.data_contract_specification import DataContractSpecification
 from datacontract.export.exporter import Exporter
+from datacontract.model.data_contract_specification import DataContractSpecification
 
 
 class ProtoBufExporter(Exporter):

--- a/datacontract/export/rdf_converter.py
+++ b/datacontract/export/rdf_converter.py
@@ -1,9 +1,8 @@
 from pydantic import BaseModel
-from rdflib import Graph, Literal, BNode, RDF, URIRef, Namespace
-
-from datacontract.model.data_contract_specification import DataContractSpecification
+from rdflib import RDF, BNode, Graph, Literal, Namespace, URIRef
 
 from datacontract.export.exporter import Exporter
+from datacontract.model.data_contract_specification import DataContractSpecification
 
 
 class RdfExporter(Exporter):

--- a/datacontract/export/spark_converter.py
+++ b/datacontract/export/spark_converter.py
@@ -1,10 +1,11 @@
 from pyspark.sql import types
+
+from datacontract.export.exporter import Exporter
 from datacontract.model.data_contract_specification import (
     DataContractSpecification,
-    Model,
     Field,
+    Model,
 )
-from datacontract.export.exporter import Exporter
 
 
 class SparkExporter(Exporter):

--- a/datacontract/export/sql_converter.py
+++ b/datacontract/export/sql_converter.py
@@ -1,7 +1,6 @@
+from datacontract.export.exporter import Exporter, _check_models_for_export, _determine_sql_server_type
 from datacontract.export.sql_type_converter import convert_to_sql_type
 from datacontract.model.data_contract_specification import DataContractSpecification, Model
-
-from datacontract.export.exporter import Exporter, _check_models_for_export, _determine_sql_server_type
 
 
 class SqlExporter(Exporter):

--- a/datacontract/export/sqlalchemy_converter.py
+++ b/datacontract/export/sqlalchemy_converter.py
@@ -2,8 +2,7 @@ import ast
 import typing
 
 import datacontract.model.data_contract_specification as spec
-from datacontract.export.exporter import Exporter
-from datacontract.export.exporter import _determine_sql_server_type
+from datacontract.export.exporter import Exporter, _determine_sql_server_type
 
 
 class SQLAlchemyExporter(Exporter):

--- a/datacontract/export/terraform_converter.py
+++ b/datacontract/export/terraform_converter.py
@@ -1,7 +1,7 @@
 import re
 
-from datacontract.model.data_contract_specification import DataContractSpecification, Server
 from datacontract.export.exporter import Exporter
+from datacontract.model.data_contract_specification import DataContractSpecification, Server
 
 
 class TerraformExporter(Exporter):

--- a/datacontract/imports/avro_importer.py
+++ b/datacontract/imports/avro_importer.py
@@ -3,7 +3,7 @@ from typing import Dict, List
 import avro.schema
 
 from datacontract.imports.importer import Importer
-from datacontract.model.data_contract_specification import DataContractSpecification, Model, Field
+from datacontract.model.data_contract_specification import DataContractSpecification, Field, Model
 from datacontract.model.exceptions import DataContractException
 
 

--- a/datacontract/imports/bigquery_importer.py
+++ b/datacontract/imports/bigquery_importer.py
@@ -3,7 +3,7 @@ import logging
 from typing import List
 
 from datacontract.imports.importer import Importer
-from datacontract.model.data_contract_specification import DataContractSpecification, Model, Field
+from datacontract.model.data_contract_specification import DataContractSpecification, Field, Model
 from datacontract.model.exceptions import DataContractException
 
 

--- a/datacontract/imports/dbml_importer.py
+++ b/datacontract/imports/dbml_importer.py
@@ -1,11 +1,11 @@
-from pydbml import PyDBML, Database
 from typing import List
 
+from pydbml import Database, PyDBML
 from pyparsing import ParseException
 
 from datacontract.imports.importer import Importer
 from datacontract.imports.sql_importer import map_type_from_sql
-from datacontract.model.data_contract_specification import DataContractSpecification, Model, Field
+from datacontract.model.data_contract_specification import DataContractSpecification, Field, Model
 from datacontract.model.exceptions import DataContractException
 
 

--- a/datacontract/imports/dbt_importer.py
+++ b/datacontract/imports/dbt_importer.py
@@ -1,10 +1,11 @@
 import json
 from typing import TypedDict
 
-from datacontract.imports.importer import Importer
-from datacontract.model.data_contract_specification import DataContractSpecification, Field, Model
 from dbt.artifacts.resources.v1.components import ColumnInfo
 from dbt.contracts.graph.manifest import Manifest
+
+from datacontract.imports.importer import Importer
+from datacontract.model.data_contract_specification import DataContractSpecification, Field, Model
 
 
 class DBTImportArgs(TypedDict, total=False):

--- a/datacontract/imports/glue_importer.py
+++ b/datacontract/imports/glue_importer.py
@@ -1,11 +1,13 @@
-import boto3
-from typing import List, Dict, Generator
 import re
+from typing import Dict, Generator, List
+
+import boto3
+
 from datacontract.imports.importer import Importer
 from datacontract.model.data_contract_specification import (
     DataContractSpecification,
-    Model,
     Field,
+    Model,
     Server,
 )
 

--- a/datacontract/imports/iceberg_importer.py
+++ b/datacontract/imports/iceberg_importer.py
@@ -1,12 +1,11 @@
-from typing import Dict, Any
+from typing import Any, Dict
+
+from pydantic import ValidationError
+from pyiceberg import types as iceberg_types
+from pyiceberg.schema import Schema
 
 from datacontract.imports.importer import Importer
-from datacontract.model.data_contract_specification import DataContractSpecification, Model, Field
-
-from pyiceberg.schema import Schema
-from pyiceberg import types as iceberg_types
-from pydantic import ValidationError
-
+from datacontract.model.data_contract_specification import DataContractSpecification, Field, Model
 from datacontract.model.exceptions import DataContractException
 
 

--- a/datacontract/imports/importer_factory.py
+++ b/datacontract/imports/importer_factory.py
@@ -1,6 +1,7 @@
 import importlib.util
 import sys
-from datacontract.imports.importer import ImportFormat, Importer
+
+from datacontract.imports.importer import Importer, ImportFormat
 
 
 class ImporterFactory:

--- a/datacontract/imports/jsonschema_importer.py
+++ b/datacontract/imports/jsonschema_importer.py
@@ -3,7 +3,7 @@ import json
 import fastjsonschema
 
 from datacontract.imports.importer import Importer
-from datacontract.model.data_contract_specification import DataContractSpecification, Model, Field, Definition
+from datacontract.model.data_contract_specification import DataContractSpecification, Definition, Field, Model
 from datacontract.model.exceptions import DataContractException
 
 

--- a/datacontract/imports/odcs_v2_importer.py
+++ b/datacontract/imports/odcs_v2_importer.py
@@ -6,16 +6,16 @@ import yaml
 
 from datacontract.imports.importer import Importer
 from datacontract.model.data_contract_specification import (
+    DATACONTRACT_TYPES,
     Availability,
     Contact,
     DataContractSpecification,
+    Field,
     Info,
     Model,
-    Field,
     Retention,
     ServiceLevel,
     Terms,
-    DATACONTRACT_TYPES,
 )
 from datacontract.model.exceptions import DataContractException
 

--- a/datacontract/imports/odcs_v3_importer.py
+++ b/datacontract/imports/odcs_v3_importer.py
@@ -8,16 +8,16 @@ import yaml
 from datacontract.imports.importer import Importer
 from datacontract.lint.resources import read_resource
 from datacontract.model.data_contract_specification import (
+    DATACONTRACT_TYPES,
     Availability,
     DataContractSpecification,
+    Field,
     Info,
     Model,
-    Field,
     Retention,
     Server,
     ServiceLevel,
     Terms,
-    DATACONTRACT_TYPES,
 )
 from datacontract.model.exceptions import DataContractException
 

--- a/datacontract/imports/spark_importer.py
+++ b/datacontract/imports/spark_importer.py
@@ -1,9 +1,10 @@
 from pyspark.sql import DataFrame, SparkSession, types
+
 from datacontract.imports.importer import Importer
 from datacontract.model.data_contract_specification import (
     DataContractSpecification,
-    Model,
     Field,
+    Model,
     Server,
 )
 

--- a/datacontract/imports/sql_importer.py
+++ b/datacontract/imports/sql_importer.py
@@ -1,7 +1,7 @@
 from simple_ddl_parser import parse_from_file
 
 from datacontract.imports.importer import Importer
-from datacontract.model.data_contract_specification import DataContractSpecification, Model, Field
+from datacontract.model.data_contract_specification import DataContractSpecification, Field, Model
 
 
 class SqlImporter(Importer):

--- a/datacontract/imports/unity_importer.py
+++ b/datacontract/imports/unity_importer.py
@@ -2,13 +2,13 @@ import json
 import os
 from typing import List, Optional
 
-from pyspark.sql import types
 from databricks.sdk import WorkspaceClient
-from databricks.sdk.service.catalog import TableInfo, ColumnInfo
+from databricks.sdk.service.catalog import ColumnInfo, TableInfo
+from pyspark.sql import types
 
 from datacontract.imports.importer import Importer
 from datacontract.imports.spark_importer import _field_from_struct_type
-from datacontract.model.data_contract_specification import DataContractSpecification, Model, Field
+from datacontract.model.data_contract_specification import DataContractSpecification, Field, Model
 from datacontract.model.exceptions import DataContractException
 
 

--- a/datacontract/integration/opentelemetry.py
+++ b/datacontract/integration/opentelemetry.py
@@ -12,7 +12,6 @@ from opentelemetry.sdk.metrics.export import ConsoleMetricExporter, PeriodicExpo
 
 from datacontract.model.run import Run
 
-
 # Publishes metrics of a test run.
 # Metric contains the values:
 # 0 == test run passed,

--- a/datacontract/lint/lint.py
+++ b/datacontract/lint/lint.py
@@ -1,9 +1,10 @@
 import abc
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Sequence, Any, cast
+from typing import Any, Sequence, cast
 
 from datacontract.model.run import Check
+
 from ..model.data_contract_specification import DataContractSpecification
 
 """This module contains linter definitions for linting a data contract.

--- a/datacontract/lint/linters/description_linter.py
+++ b/datacontract/lint/linters/description_linter.py
@@ -1,4 +1,5 @@
 from datacontract.model.data_contract_specification import DataContractSpecification
+
 from ..lint import Linter, LinterResult
 
 

--- a/datacontract/lint/linters/example_model_linter.py
+++ b/datacontract/lint/linters/example_model_linter.py
@@ -5,6 +5,7 @@ import json
 import yaml
 
 from datacontract.model.data_contract_specification import DataContractSpecification, Example
+
 from ..lint import Linter, LinterResult
 
 

--- a/datacontract/lint/linters/field_pattern_linter.py
+++ b/datacontract/lint/linters/field_pattern_linter.py
@@ -1,6 +1,7 @@
 import re
 
 from datacontract.model.data_contract_specification import DataContractSpecification
+
 from ..lint import Linter, LinterResult
 
 

--- a/datacontract/lint/linters/field_reference_linter.py
+++ b/datacontract/lint/linters/field_reference_linter.py
@@ -1,4 +1,5 @@
 from datacontract.model.data_contract_specification import DataContractSpecification
+
 from ..lint import Linter, LinterResult
 
 

--- a/datacontract/lint/linters/notice_period_linter.py
+++ b/datacontract/lint/linters/notice_period_linter.py
@@ -1,6 +1,7 @@
 import re
 
 from datacontract.model.data_contract_specification import DataContractSpecification
+
 from ..lint import Linter, LinterResult
 
 

--- a/datacontract/lint/linters/quality_schema_linter.py
+++ b/datacontract/lint/linters/quality_schema_linter.py
@@ -1,6 +1,7 @@
 import yaml
 
 from datacontract.model.data_contract_specification import DataContractSpecification, Model
+
 from ..lint import Linter, LinterResult
 
 

--- a/datacontract/lint/linters/valid_constraints_linter.py
+++ b/datacontract/lint/linters/valid_constraints_linter.py
@@ -1,4 +1,5 @@
 from datacontract.model.data_contract_specification import DataContractSpecification, Field
+
 from ..lint import Linter, LinterResult
 
 

--- a/datacontract/lint/schema.py
+++ b/datacontract/lint/schema.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Dict, Any
+from typing import Any, Dict
 
 import requests
 

--- a/datacontract/model/data_contract_specification.py
+++ b/datacontract/model/data_contract_specification.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Dict, Optional, Any
+from typing import Any, Dict, List, Optional
 
 import pydantic as pyd
 import yaml

--- a/datacontract/web.py
+++ b/datacontract/web.py
@@ -1,11 +1,10 @@
-from typing import Annotated, Union, Optional
+from typing import Annotated, Optional, Union
 
 import typer
 from fastapi import FastAPI, File
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, PlainTextResponse
 
 from datacontract.data_contract import DataContract, ExportFormat
-from fastapi.responses import PlainTextResponse
 
 app = FastAPI()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,3 +133,8 @@ log_cli_level = "INFO"
 
 [tool.ruff]
 line-length = 120
+
+[tool.ruff.lint]
+extend-select = [
+    "I",   # re-order imports in alphabetic order
+]

--- a/tests/fixtures/local-delta/helper/create_delta_files.py
+++ b/tests/fixtures/local-delta/helper/create_delta_files.py
@@ -1,7 +1,7 @@
 import os
-from deltalake import write_deltalake
 
 import pandas as pd
+from deltalake import write_deltalake
 
 # Ensure the required directory exists
 output_dir = "../data"

--- a/tests/test_export_avro_idl.py
+++ b/tests/test_export_avro_idl.py
@@ -5,11 +5,11 @@ from typer.testing import CliRunner
 import datacontract.model.data_contract_specification as spec
 from datacontract.cli import app
 from datacontract.export.avro_idl_converter import (
-    _contract_to_avro_idl_ir,
-    AvroPrimitiveType,
-    AvroPrimitiveField,
-    AvroModelType,
     AvroIDLProtocol,
+    AvroModelType,
+    AvroPrimitiveField,
+    AvroPrimitiveType,
+    _contract_to_avro_idl_ir,
     to_avro_idl,
 )
 from datacontract.lint.resolve import resolve_data_contract_from_location

--- a/tests/test_export_bigquery.py
+++ b/tests/test_export_bigquery.py
@@ -1,4 +1,5 @@
 import json
+
 from typer.testing import CliRunner
 
 from datacontract.cli import app

--- a/tests/test_export_great_expectations.py
+++ b/tests/test_export_great_expectations.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, Any
+from typing import Any, Dict
 
 import pytest
 from typer.testing import CliRunner

--- a/tests/test_export_spark.py
+++ b/tests/test_export_spark.py
@@ -1,6 +1,7 @@
-from typer.testing import CliRunner
 from pyspark.sql import types
 from pyspark.testing import assertSchemaEqual
+from typer.testing import CliRunner
+
 from datacontract.cli import app
 from datacontract.export.spark_converter import to_spark_dict
 from datacontract.model.data_contract_specification import DataContractSpecification

--- a/tests/test_export_sqlalchemy.py
+++ b/tests/test_export_sqlalchemy.py
@@ -1,10 +1,10 @@
 import ast
 from textwrap import dedent
 
+import pytest
+
 import datacontract.export.sqlalchemy_converter as conv
 import datacontract.model.data_contract_specification as spec
-
-import pytest
 
 
 # These tests would be easier if AST nodes were comparable.

--- a/tests/test_import_glue.py
+++ b/tests/test_import_glue.py
@@ -1,8 +1,8 @@
 import boto3
-from typer.testing import CliRunner
+import pytest
 import yaml
 from moto import mock_aws
-import pytest
+from typer.testing import CliRunner
 
 from datacontract.cli import app
 from datacontract.data_contract import DataContract

--- a/tests/test_import_iceberg.py
+++ b/tests/test_import_iceberg.py
@@ -1,14 +1,11 @@
 import pytest
-
-from datacontract.imports.iceberg_importer import load_and_validate_iceberg_schema
-from datacontract.model.exceptions import DataContractException
-from datacontract.cli import app
-
 from pyiceberg.schema import Schema
-from pyiceberg.types import NestedField, IntegerType
-
+from pyiceberg.types import IntegerType, NestedField
 from typer.testing import CliRunner
 
+from datacontract.cli import app
+from datacontract.imports.iceberg_importer import load_and_validate_iceberg_schema
+from datacontract.model.exceptions import DataContractException
 
 expected = """
 dataContractSpecification: 1.1.0

--- a/tests/test_import_spark.py
+++ b/tests/test_import_spark.py
@@ -1,14 +1,10 @@
-import yaml
 import pytest
-from pyspark.sql import types
-
-from pyspark.sql import SparkSession
-
-from datacontract.data_contract import DataContract
-
+import yaml
+from pyspark.sql import SparkSession, types
 from typer.testing import CliRunner
-from datacontract.cli import app
 
+from datacontract.cli import app
+from datacontract.data_contract import DataContract
 
 expected = """
 dataContractSpecification: 1.1.0

--- a/tests/test_integration_opentelemetry.py
+++ b/tests/test_integration_opentelemetry.py
@@ -4,7 +4,7 @@ from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExp
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
 from opentelemetry.metrics import Observation
 
-from datacontract.integration.opentelemetry import _to_observation, Telemetry
+from datacontract.integration.opentelemetry import Telemetry, _to_observation
 from datacontract.model.run import Run
 
 # logging.basicConfig(level=logging.DEBUG, force=True)

--- a/tests/test_roundtrip_jsonschema.py
+++ b/tests/test_roundtrip_jsonschema.py
@@ -1,5 +1,7 @@
 import json
+
 from typer.testing import CliRunner
+
 from datacontract.cli import app
 from datacontract.data_contract import DataContract
 from datacontract.export.jsonschema_converter import to_jsonschemas

--- a/tests/test_test_dataframe.py
+++ b/tests/test_test_dataframe.py
@@ -1,15 +1,15 @@
-import pytest
+from datetime import datetime
 
+import pytest
 from dotenv import load_dotenv
-from pyspark.sql import SparkSession, Row
+from pyspark.sql import Row, SparkSession
 from pyspark.sql.types import (
-    StructType,
-    StructField,
-    StringType,
     IntegerType,
+    StringType,
+    StructField,
+    StructType,
     TimestampType,
 )
-from datetime import datetime
 
 from datacontract.data_contract import DataContract
 

--- a/tests/test_test_kafka.py
+++ b/tests/test_test_kafka.py
@@ -12,7 +12,6 @@ from testcontainers.kafka import KafkaContainer
 
 from datacontract.data_contract import DataContract
 
-
 datacontract = "fixtures/kafka/datacontract.yaml"
 
 

--- a/tests/test_test_s3_delta.py
+++ b/tests/test_test_s3_delta.py
@@ -1,5 +1,5 @@
-import os
 import glob
+import os
 
 import pytest
 from testcontainers.minio import MinioContainer


### PR DESCRIPTION
Extend `ruff` to re-order project imports by alphabetical order. This is controlled by the addition in the `pyproject.toml` file.

- [ ] Tests pass
- [X] ruff format
- [ ] README.md updated (if relevant)
- [ ] CHANGELOG.md entry added
