### PR TITLE
Breaking/Changelog improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support for model import from parquet file metadata.
+- Changelog support for `Info` and `Terms` blocks.
 
 ### Changed
+- Changelog support for custom extension keys in `Models` and `Fields` blocks.
 
 ### Fixed
 - raise valid exception in DataContractSpecification.from_file if file does not exist

--- a/datacontract/breaking/breaking.py
+++ b/datacontract/breaking/breaking.py
@@ -341,14 +341,14 @@ def model_breaking_changes(
 ) -> list[BreakingChange]:
     results = list[BreakingChange]()
 
-    model_definition_fields = vars(new_model)
+    model_definition_fields = vars(new_model) | new_model.model_extra | old_model.model_extra
 
     for model_definition_field in model_definition_fields.keys():
         if model_definition_field == "fields":
             continue
 
-        old_value = getattr(old_model, model_definition_field)
-        new_value = getattr(new_model, model_definition_field)
+        old_value = getattr(old_model, model_definition_field, None)
+        new_value = getattr(new_model, model_definition_field, None)
 
         rule_name = None
         description = None
@@ -449,13 +449,13 @@ def field_breaking_changes(
 ) -> list[BreakingChange]:
     results = list[BreakingChange]()
 
-    field_definition_fields = vars(new_field)
+    field_definition_fields = vars(new_field) | new_field.model_extra | old_field.model_extra
     for field_definition_field in field_definition_fields.keys():
         if field_definition_field == "ref_obj":
             continue
 
-        old_value = getattr(old_field, field_definition_field)
-        new_value = getattr(new_field, field_definition_field)
+        old_value = getattr(old_field, field_definition_field, None)
+        new_value = getattr(new_field, field_definition_field, None)
 
         if field_definition_field == "fields":
             results.extend(
@@ -534,7 +534,7 @@ def _get_rule(rule_name) -> Severity:
     except AttributeError:
         try:
             first, *_, last = rule_name.split("_")
-            short_rule = "_".join([first, last])
+            short_rule = "__".join([first, last])
             return getattr(BreakingRules, short_rule)
         except AttributeError:
             print(f"WARNING: Breaking Rule not found for {rule_name}!")

--- a/datacontract/breaking/breaking.py
+++ b/datacontract/breaking/breaking.py
@@ -466,4 +466,5 @@ def _get_rule(rule_name) -> Severity:
 
 
 def _camel_to_snake(s):
+    s = s.replace("-", "_")
     return "".join(["_" + c.lower() if c.isupper() else c for c in s]).lstrip("_")

--- a/datacontract/breaking/breaking.py
+++ b/datacontract/breaking/breaking.py
@@ -1,6 +1,6 @@
 from datacontract.breaking.breaking_rules import BreakingRules
 from datacontract.model.breaking_change import BreakingChange, Location, Severity
-from datacontract.model.data_contract_specification import Field, Model, Quality, Info, Contact, Terms
+from datacontract.model.data_contract_specification import Contact, Field, Info, Model, Quality, Terms
 
 
 def info_breaking_changes(

--- a/datacontract/breaking/breaking_rules.py
+++ b/datacontract/breaking/breaking_rules.py
@@ -104,5 +104,10 @@ class BreakingRules:
     quality_specification_updated = Severity.WARNING
 
     # info rules
-    info_added = Severity.INFO
-    info_removed = Severity.ERROR
+    info_added = Severity.INFO  # will match `info_<somekey>_added` etc
+    info_removed = Severity.INFO
+    info_updated = Severity.INFO
+
+    contact_added = Severity.INFO
+    contact_removed = Severity.INFO
+    contact_updated = Severity.INFO

--- a/datacontract/breaking/breaking_rules.py
+++ b/datacontract/breaking/breaking_rules.py
@@ -102,3 +102,7 @@ class BreakingRules:
 
     quality_type_updated = Severity.WARNING
     quality_specification_updated = Severity.WARNING
+
+    # info rules
+    info_added = Severity.INFO
+    info_removed = Severity.ERROR

--- a/datacontract/breaking/breaking_rules.py
+++ b/datacontract/breaking/breaking_rules.py
@@ -12,6 +12,10 @@ class BreakingRules:
 
     model_type_updated = Severity.ERROR
 
+    model__removed = Severity.INFO  # To support model extension keys
+    model__added = Severity.INFO
+    model__updated = Severity.INFO
+
     # field rules
     field_added = Severity.INFO
     field_removed = Severity.ERROR
@@ -96,6 +100,10 @@ class BreakingRules:
     field_example_updated = Severity.INFO
     field_example_removed = Severity.INFO
 
+    field__removed = Severity.INFO  # To support field extension keys
+    field__added = Severity.INFO
+    field__updated = Severity.INFO
+
     # quality Rules
     quality_added = Severity.INFO
     quality_removed = Severity.WARNING
@@ -104,15 +112,15 @@ class BreakingRules:
     quality_specification_updated = Severity.WARNING
 
     # info rules
-    info_added = Severity.INFO  # will match `info_<somekey>_added` etc
-    info_removed = Severity.INFO
-    info_updated = Severity.INFO
+    info__added = Severity.INFO  # will match `info_<somekey>_added` etc
+    info__removed = Severity.INFO
+    info__updated = Severity.INFO
 
-    contact_added = Severity.INFO
-    contact_removed = Severity.INFO
-    contact_updated = Severity.INFO
+    contact__added = Severity.INFO
+    contact__removed = Severity.INFO
+    contact__updated = Severity.INFO
 
     # terms rules
-    terms_added = Severity.INFO
-    terms_removed = Severity.INFO
-    terms_updated = Severity.INFO
+    terms__added = Severity.INFO
+    terms__removed = Severity.INFO
+    terms__updated = Severity.INFO

--- a/datacontract/breaking/breaking_rules.py
+++ b/datacontract/breaking/breaking_rules.py
@@ -111,3 +111,8 @@ class BreakingRules:
     contact_added = Severity.INFO
     contact_removed = Severity.INFO
     contact_updated = Severity.INFO
+
+    # terms rules
+    terms_added = Severity.INFO
+    terms_removed = Severity.INFO
+    terms_updated = Severity.INFO

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -8,7 +8,7 @@ import yaml
 if typing.TYPE_CHECKING:
     from pyspark.sql import SparkSession
 
-from datacontract.breaking.breaking import models_breaking_changes, quality_breaking_changes
+from datacontract.breaking.breaking import models_breaking_changes, quality_breaking_changes, info_breaking_changes
 from datacontract.engines.datacontract.check_that_datacontract_contains_valid_servers_configuration import (
     check_that_datacontract_contains_valid_server_configuration,
 )
@@ -274,6 +274,15 @@ class DataContract:
         new = other.get_data_contract_specification()
 
         breaking_changes = list[BreakingChange]()
+
+        breaking_changes.extend(
+            info_breaking_changes(
+                old_info=old.info,
+                new_info=new.info,
+                new_path=other._data_contract_file,
+                include_severities=include_severities,
+            )
+        )
 
         breaking_changes.extend(
             quality_breaking_changes(

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -8,7 +8,12 @@ import yaml
 if typing.TYPE_CHECKING:
     from pyspark.sql import SparkSession
 
-from datacontract.breaking.breaking import models_breaking_changes, quality_breaking_changes, info_breaking_changes
+from datacontract.breaking.breaking import (
+    models_breaking_changes,
+    quality_breaking_changes,
+    info_breaking_changes,
+    terms_breaking_changes,
+)
 from datacontract.engines.datacontract.check_that_datacontract_contains_valid_servers_configuration import (
     check_that_datacontract_contains_valid_server_configuration,
 )
@@ -279,6 +284,15 @@ class DataContract:
             info_breaking_changes(
                 old_info=old.info,
                 new_info=new.info,
+                new_path=other._data_contract_file,
+                include_severities=include_severities,
+            )
+        )
+
+        breaking_changes.extend(
+            terms_breaking_changes(
+                old_terms=old.terms,
+                new_terms=new.terms,
                 new_path=other._data_contract_file,
                 include_severities=include_severities,
             )

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -9,9 +9,9 @@ if typing.TYPE_CHECKING:
     from pyspark.sql import SparkSession
 
 from datacontract.breaking.breaking import (
+    info_breaking_changes,
     models_breaking_changes,
     quality_breaking_changes,
-    info_breaking_changes,
     terms_breaking_changes,
 )
 from datacontract.engines.datacontract.check_that_datacontract_contains_valid_servers_configuration import (

--- a/tests/fixtures/breaking/datacontract-fields-v1.yaml
+++ b/tests/fixtures/breaking/datacontract-fields-v1.yaml
@@ -51,3 +51,5 @@ models:
         fields:
           nested_field_1:
             type: string
+      field_custom_key:
+        type: string

--- a/tests/fixtures/breaking/datacontract-fields-v2.yaml
+++ b/tests/fixtures/breaking/datacontract-fields-v2.yaml
@@ -74,6 +74,9 @@ models:
             type: string
       new_field:
         type: string
+      field_custom_key:
+        type: string
+        custom-key: some value
 definitions:
   my_definition:
     name: my_definition

--- a/tests/fixtures/breaking/datacontract-fields-v3.yaml
+++ b/tests/fixtures/breaking/datacontract-fields-v3.yaml
@@ -74,6 +74,9 @@ models:
             type: string
       new_field:
         type: string
+      field_custom_key:
+        type: string
+        custom-key: some other value
 
 definitions:
     my_definition_2:

--- a/tests/fixtures/breaking/datacontract-info-v1.yaml
+++ b/tests/fixtures/breaking/datacontract-info-v1.yaml
@@ -1,0 +1,10 @@
+dataContractSpecification: 0.9.2
+id: my-data-contract-id
+info:
+  title: My Data Contract
+  version: 0.0.1
+models:
+  orders:
+    fields:
+      column_1:
+        type: string

--- a/tests/fixtures/breaking/datacontract-info-v2.yaml
+++ b/tests/fixtures/breaking/datacontract-info-v2.yaml
@@ -1,0 +1,14 @@
+dataContractSpecification: 0.9.2
+id: my-data-contract-id
+info:
+  title: My Data Contract
+  version: 0.0.1
+  owner: Data Team
+  some-other-key: some information
+  contact:
+    email: datateam@work.com
+models:
+  orders:
+    fields:
+      column_1:
+        type: string

--- a/tests/fixtures/breaking/datacontract-info-v3.yaml
+++ b/tests/fixtures/breaking/datacontract-info-v3.yaml
@@ -1,0 +1,14 @@
+dataContractSpecification: 0.9.2
+id: my-data-contract-id
+info:
+  title: My Data Contract
+  version: 0.0.1
+  owner: Another Team
+  some-other-key: new information
+  contact:
+    email: anotherteam@work.com
+models:
+  orders:
+    fields:
+      column_1:
+        type: string

--- a/tests/fixtures/breaking/datacontract-models-v2.yaml
+++ b/tests/fixtures/breaking/datacontract-models-v2.yaml
@@ -12,7 +12,9 @@ models:
     fields:
       my_field:
         description: My Description
+    another-key: original value
   my_table_2:
     fields:
       my_field_2:
         description: My Description 2
+    some-other-key: some value

--- a/tests/fixtures/breaking/datacontract-models-v3.yaml
+++ b/tests/fixtures/breaking/datacontract-models-v3.yaml
@@ -12,6 +12,7 @@ models:
     fields:
       my_field:
         description: My Description
+    another-key: updated value
   my_table_2:
     fields:
       my_field_2:

--- a/tests/fixtures/breaking/datacontract-terms-v1.yaml
+++ b/tests/fixtures/breaking/datacontract-terms-v1.yaml
@@ -1,0 +1,10 @@
+dataContractSpecification: 0.9.2
+id: my-data-contract-id
+info:
+  title: My Data Contract
+  version: 0.0.1
+models:
+  orders:
+    fields:
+      column_1:
+        type: string

--- a/tests/fixtures/breaking/datacontract-terms-v2.yaml
+++ b/tests/fixtures/breaking/datacontract-terms-v2.yaml
@@ -1,0 +1,20 @@
+dataContractSpecification: 0.9.2
+id: my-data-contract-id
+info:
+  title: My Data Contract
+  version: 0.0.1
+terms:
+  usage: |
+    Data can be used for reports, analytics and machine learning use cases.
+    Order may be linked and joined by other tables
+  limitations: |
+    Not suitable for real-time use cases.
+    Data may not be used to identify individual customers.
+    Max data processing per day: 10 TiB
+  billing: 5000 USD per month
+  noticePeriod: P3M
+models:
+  orders:
+    fields:
+      column_1:
+        type: string

--- a/tests/fixtures/breaking/datacontract-terms-v3.yaml
+++ b/tests/fixtures/breaking/datacontract-terms-v3.yaml
@@ -1,0 +1,15 @@
+dataContractSpecification: 0.9.2
+id: my-data-contract-id
+info:
+  title: My Data Contract
+  version: 0.0.1
+terms:
+  usage: Data can be used for anything
+  billing: 1000000 GBP per month
+  noticePeriod: P1Y
+  someOtherTerms: must abide by policies
+models:
+  orders:
+    fields:
+      column_1:
+        type: string

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1066,3 +1066,97 @@ def test_info_updated():
             changed from `datateam@work.com` to `anotherteam@work.com`"""
         in output
     )
+
+
+def test_terms_added():
+    result = runner.invoke(
+        app,
+        [
+            "changelog",
+            "./fixtures/breaking/datacontract-terms-v1.yaml",
+            "./fixtures/breaking/datacontract-terms-v2.yaml",
+        ],
+    )
+    output = result.stdout
+    assert result.exit_code == 0
+    assert "1 changes: 0 error, 0 warning, 1 info\n" in output
+
+    assert (
+        """info    [terms_added] at ./fixtures/breaking/datacontract-terms-v2.yaml
+        in terms
+            added terms"""
+        in output
+    )
+
+
+def test_terms_removed():
+    result = runner.invoke(
+        app,
+        [
+            "changelog",
+            "./fixtures/breaking/datacontract-terms-v2.yaml",
+            "./fixtures/breaking/datacontract-terms-v1.yaml",
+        ],
+    )
+    output = result.stdout
+    assert result.exit_code == 0
+    assert "1 changes: 0 error, 0 warning, 1 info\n" in output
+
+    assert (
+        """info    [terms_removed] at ./fixtures/breaking/datacontract-terms-v1.yaml
+        in terms
+            removed terms"""
+        in output
+    )
+
+
+def test_terms_updated():
+    result = runner.invoke(
+        app,
+        [
+            "changelog",
+            "./fixtures/breaking/datacontract-terms-v2.yaml",
+            "./fixtures/breaking/datacontract-terms-v3.yaml",
+        ],
+    )
+    output = result.stdout
+    assert result.exit_code == 0
+    assert "5 changes: 0 error, 0 warning, 5 info\n" in output
+
+    assert (
+        """info    [terms_usage_updated] at ./fixtures/breaking/datacontract-terms-v3.yaml
+        in terms.usage
+            changed from `Data can be used for reports, analytics and machine 
+learning use cases.
+Order may be linked and joined by other tables
+` to `Data can be used for anything`"""
+        in output
+    )
+    assert (
+        """info    [terms_limitations_removed] at 
+./fixtures/breaking/datacontract-terms-v3.yaml
+        in terms.limitations
+            removed info property"""
+        in output
+    )
+    assert (
+        """info    [terms_billing_updated] at 
+./fixtures/breaking/datacontract-terms-v3.yaml
+        in terms.billing
+            changed from `5000 USD per month` to `1000000 GBP per month`"""
+        in output
+    )
+    assert (
+        """info    [terms_notice_period_updated] at 
+./fixtures/breaking/datacontract-terms-v3.yaml
+        in terms.noticePeriod
+            changed from `P3M` to `P1Y`"""
+        in output
+    )
+    assert (
+        """info    [terms_some_other_terms_added] at 
+./fixtures/breaking/datacontract-terms-v3.yaml
+        in terms.someOtherTerms
+            added with value: `must abide by policies`"""
+        in output
+    )

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -987,7 +987,7 @@ def test_info_added():
         in output
     )
     assert (
-        """info    [info_some-other-key_added] at 
+        """info    [info_some_other_key_added] at 
 ./fixtures/breaking/datacontract-info-v2.yaml
         in info.some-other-key
             added with value: `some information`"""
@@ -1020,7 +1020,7 @@ def test_info_removed():
         in output
     )
     assert (
-        """info    [info_some-other-key_removed] at 
+        """info    [info_some_other_key_removed] at 
 ./fixtures/breaking/datacontract-info-v1.yaml
         in info.some-other-key
             removed info property"""
@@ -1054,7 +1054,7 @@ def test_info_updated():
         in output
     )
     assert (
-        """info    [info_some-other-key_updated] at 
+        """info    [info_some_other_key_updated] at 
 ./fixtures/breaking/datacontract-info-v3.yaml
         in info.some-other-key
             changed from `some information` to `new information`"""

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -965,3 +965,104 @@ def test_definition_updated():
             changed from `my_example` to `my_example_2`"""
         in output
     )
+
+
+def test_info_added():
+    result = runner.invoke(
+        app,
+        [
+            "changelog",
+            "./fixtures/breaking/datacontract-info-v1.yaml",
+            "./fixtures/breaking/datacontract-info-v2.yaml",
+        ],
+    )
+    output = result.stdout
+    assert result.exit_code == 0
+    assert "3 changes: 0 error, 0 warning, 3 info\n" in output
+
+    assert (
+        """info    [info_owner_added] at ./fixtures/breaking/datacontract-info-v2.yaml
+        in info.owner
+            added with value: `Data Team`"""
+        in output
+    )
+    assert (
+        """info    [info_some-other-key_added] at 
+./fixtures/breaking/datacontract-info-v2.yaml
+        in info.some-other-key
+            added with value: `some information`"""
+        in output
+    )
+    assert (
+        """info    [contact_added] at ./fixtures/breaking/datacontract-info-v2.yaml
+        in info.contact
+            added contact"""
+        in output
+    )
+
+
+def test_info_removed():
+    result = runner.invoke(
+        app,
+        [
+            "changelog",
+            "./fixtures/breaking/datacontract-info-v2.yaml",
+            "./fixtures/breaking/datacontract-info-v1.yaml",
+        ],
+    )
+    output = result.stdout
+    assert result.exit_code == 0
+    assert "3 changes: 0 error, 0 warning, 3 info\n" in output
+    assert (
+        """info    [info_owner_removed] at ./fixtures/breaking/datacontract-info-v1.yaml
+        in info.owner
+            removed info property"""
+        in output
+    )
+    assert (
+        """info    [info_some-other-key_removed] at 
+./fixtures/breaking/datacontract-info-v1.yaml
+        in info.some-other-key
+            removed info property"""
+        in output
+    )
+    assert (
+        """info    [contact_removed] at ./fixtures/breaking/datacontract-info-v1.yaml
+        in info.contact
+            removed contact"""
+        in output
+    )
+
+
+def test_info_updated():
+    result = runner.invoke(
+        app,
+        [
+            "changelog",
+            "./fixtures/breaking/datacontract-info-v2.yaml",
+            "./fixtures/breaking/datacontract-info-v3.yaml",
+        ],
+    )
+    output = result.stdout
+    assert result.exit_code == 0
+    assert "3 changes: 0 error, 0 warning, 3 info\n" in output
+
+    assert (
+        """info    [info_owner_updated] at ./fixtures/breaking/datacontract-info-v3.yaml
+        in info.owner
+            changed from `Data Team` to `Another Team`"""
+        in output
+    )
+    assert (
+        """info    [info_some-other-key_updated] at 
+./fixtures/breaking/datacontract-info-v3.yaml
+        in info.some-other-key
+            changed from `some information` to `new information`"""
+        in output
+    )
+    assert (
+        """info    [contact_email_updated] at ./fixtures/breaking/datacontract-info-v3.yaml
+        in info.contact.email
+            changed from `datateam@work.com` to `anotherteam@work.com`"""
+        in output
+    )

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -101,7 +101,7 @@ def test_models_added():
     )
     output = result.stdout
     assert result.exit_code == 0
-    assert "2 changes: 0 error, 0 warning, 2 info\n" in output
+    assert "3 changes: 0 error, 0 warning, 3 info\n" in output
     assert (
         """info    [model_added] at ./fixtures/breaking/datacontract-models-v2.yaml
         in models.my_table_2
@@ -113,6 +113,14 @@ def test_models_added():
 ./fixtures/breaking/datacontract-models-v2.yaml
         in models.my_table.description
             added with value: `My Model Description`"""
+        in output
+    )
+
+    assert (
+        """info    [model_another-key_added] at 
+./fixtures/breaking/datacontract-models-v2.yaml
+        in models.my_table.another-key
+            added with value: `original value`"""
         in output
     )
 
@@ -128,7 +136,7 @@ def test_models_removed():
     )
     output = result.stdout
     assert result.exit_code == 0
-    assert "2 changes: 1 error, 0 warning, 1 info\n" in output
+    assert "3 changes: 1 error, 0 warning, 2 info\n" in output
     assert (
         r"""error   [model_removed] at ./fixtures/breaking/datacontract-models-v1.yaml
         in models.my_table_2
@@ -139,6 +147,13 @@ def test_models_removed():
         """info    [model_description_removed] at 
 ./fixtures/breaking/datacontract-models-v1.yaml
         in models.my_table.description
+            removed model property"""
+        in output
+    )
+    assert (
+        """info    [model_another-key_removed] at 
+./fixtures/breaking/datacontract-models-v1.yaml
+        in models.my_table.another-key
             removed model property"""
         in output
     )
@@ -155,7 +170,7 @@ def test_models_updated():
     )
     output = result.stdout
     assert result.exit_code == 0
-    assert "2 changes: 1 error, 0 warning, 1 info\n" in output
+    assert "4 changes: 1 error, 0 warning, 3 info\n" in output
     assert (
         r"""error   [model_type_updated] at ./fixtures/breaking/datacontract-models-v3.yaml
         in models.my_table.type
@@ -171,6 +186,22 @@ Description`"""
         in output
     )
 
+    assert (
+        """info    [model_another-key_updated] at 
+./fixtures/breaking/datacontract-models-v3.yaml
+        in models.my_table.another-key
+            changed from `original value` to `updated value`"""
+        in output
+    )
+
+    assert (
+        """info    [model_some-other-key_removed] at 
+./fixtures/breaking/datacontract-models-v3.yaml
+        in models.my_table_2.some-other-key
+            removed model property"""
+        in output
+    )
+
 
 def test_fields_added():
     result = runner.invoke(
@@ -183,7 +214,7 @@ def test_fields_added():
     )
     assert result.exit_code == 0
     output = result.stdout
-    assert "19 changes: 0 error, 15 warning, 4 info\n" in output
+    assert "20 changes: 0 error, 15 warning, 5 info\n" in output
     assert (
         """info    [field_added] at ./fixtures/breaking/datacontract-fields-v2.yaml
         in models.my_table.fields.new_field
@@ -302,6 +333,14 @@ def test_fields_added():
         in output
     )
 
+    assert (
+        """info    [field_custom_key_added] at 
+./fixtures/breaking/datacontract-fields-v2.yaml
+        in models.my_table.fields.field_custom_key.custom-key
+            added with value: `some value`"""
+        in output
+    )
+
 
 def test_fields_removed():
     result = runner.invoke(
@@ -314,7 +353,7 @@ def test_fields_removed():
     )
     output = result.stdout
     assert result.exit_code == 0
-    assert "19 changes: 5 error, 11 warning, 3 info\n" in output
+    assert "20 changes: 5 error, 11 warning, 4 info\n" in output
     assert (
         r"""warning [field_type_removed] at ./fixtures/breaking/datacontract-fields-v1.yaml
         in models.my_table.fields.field_type.type
@@ -435,6 +474,14 @@ def test_fields_removed():
         in output
     )
 
+    assert (
+        """info    [field_custom_key_removed] at 
+./fixtures/breaking/datacontract-fields-v1.yaml
+        in models.my_table.fields.field_custom_key.custom-key
+            removed field property"""
+        in output
+    )
+
 
 def test_fields_updated():
     result = runner.invoke(
@@ -447,7 +494,7 @@ def test_fields_updated():
     )
     output = result.stdout
     assert result.exit_code == 0
-    assert "20 changes: 15 error, 3 warning, 2 info\n" in output
+    assert "21 changes: 15 error, 3 warning, 3 info\n" in output
     assert (
         r"""error   [field_type_updated] at ./fixtures/breaking/datacontract-fields-v3.yaml
         in models.my_table.fields.field_type.type
@@ -581,6 +628,13 @@ def test_fields_updated():
         r"""error   [field_type_updated] at ./fixtures/breaking/datacontract-fields-v3.yaml
         in models.my_table.fields.field_fields.fields.nested_field_1.type
             changed from `string` to `integer`"""
+        in output
+    )
+    assert (
+        r"""info    [field_custom_key_updated] at 
+./fixtures/breaking/datacontract-fields-v3.yaml
+        in models.my_table.fields.field_custom_key.custom-key
+            changed from `some value` to `some other value`"""
         in output
     )
 


### PR DESCRIPTION
- [x] Tests pass
- [x] ruff format
- [ ] README.md updated (if relevant)
- [x] CHANGELOG.md entry added


I've added some additional functionality to the `changelog` functionality to support:
- `Info` and `Terms` blocks in the data contract (including custom extension keys)
- Custom extension keys in the `Models` and `Fields` blocks.
