### PR TITLE
fix: json schema import with deeply nested non-required objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - raise valid exception in DataContractSpecification.from_file if file does not exist
+- Fix importing JSON Schemas containing deeply nested objects without `required` array
 
 ## [0.10.14] - 2024-10-26
 

--- a/datacontract/imports/jsonschema_importer.py
+++ b/datacontract/imports/jsonschema_importer.py
@@ -111,7 +111,8 @@ def schema_to_args(property_schema, is_required: bool = None) -> dict:
     nested_properties = property_schema.get("properties")
     if nested_properties is not None:
         # recursive call for complex nested properties
-        field_kwargs["fields"] = jsonschema_to_args(nested_properties, property_schema["required"])
+        required = property_schema.get("required", [])
+        field_kwargs["fields"] = jsonschema_to_args(nested_properties, required)
 
     return field_kwargs
 

--- a/tests/fixtures/import/football_deeply_nested_no_required.json
+++ b/tests/fixtures/import/football_deeply_nested_no_required.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "FootballSchema",
+  "description": "Schema for football team and person details, where team is nested under the person",
+  "type": "object",
+  "properties": {
+    "person": {
+      "type": "object",
+      "properties": {
+        "first_name": { "type": "string" },
+        "last_name": { "type": "string" },
+        "age": { "type": "integer" },
+        "football_team": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "league": { "type": "string" },
+            "year_founded": { "type": "integer" }
+          }
+        }
+      },
+      "required": ["first_name", "last_name", "age"]
+    }
+  },
+  "required": ["person"]
+}

--- a/tests/fixtures/import/football_deeply_nested_no_required_datacontract.yml
+++ b/tests/fixtures/import/football_deeply_nested_no_required_datacontract.yml
@@ -1,0 +1,38 @@
+dataContractSpecification: 1.1.0
+id: my-data-contract-id
+info:
+  title: My Data Contract
+  version: 0.0.1
+models:
+  FootballSchema:
+    description: Schema for football team and person details, where team is nested under the person
+    type: object
+    title: FootballSchema
+    fields:
+      person:
+        type: object
+        required: true
+        fields:
+          first_name:
+            type: string
+            required: true
+          last_name:
+            type: string
+            required: true
+          age:
+            type: integer
+            required: true
+          football_team:
+            type: object
+            required: false
+            fields:
+              name:
+                type: string
+                required: false
+              league:
+                type: string
+                required: false
+              year_founded:
+                type: integer
+                required: false
+

--- a/tests/test_import_jsonschema.py
+++ b/tests/test_import_jsonschema.py
@@ -42,3 +42,14 @@ def test_import_json_schema_football():
 
     print("Result:\n", result.to_yaml())
     assert yaml.safe_load(result.to_yaml()) == yaml.safe_load(expected)
+
+
+def test_import_json_schema_football_deeply_nested_no_required():
+    result = DataContract().import_from_source("jsonschema", "fixtures/import/football_deeply_nested_no_required.json")
+
+    with open("fixtures/import/football_deeply_nested_no_required_datacontract.yml") as file:
+        expected = file.read()
+        assert DataContract(data_contract_str=expected).lint(enabled_linters="none").has_passed()
+
+    print("Result:\n", result.to_yaml())
+    assert yaml.safe_load(result.to_yaml()) == yaml.safe_load(expected)


### PR DESCRIPTION
- [x] Tests pass
- [x] ruff format
- [ ] ~~README.md updated (if relevant)~~
- [x] CHANGELOG.md entry added

Importing JSON Schemas containing deeply nested objects without a `required` array currently fails with `KeyError: 'required'` due to indexed access of `property_schema["required"]`.

JSON Schema supports omitting `required` if all fields in an object are optional, so the importer should allow for this.

Note: top-level properties are not affected, this is only affecting nested objects.

Test and fixtures added, confirmed test fails (as described above) prior to changes.