### PR TITLE
feat: add output option to datacontract import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `engine` used to run checks
   - `sql_server_type` to define the type of SQL Server to use when engine is `sql`
 - Changelog support for `Info` and `Terms` blocks.
+- `datacontract import` now has `--output` option for saving Data Contract to file
 
 ### Changed
 - Changelog support for custom extension keys in `Models` and `Fields` blocks.

--- a/README.md
+++ b/README.md
@@ -749,19 +749,19 @@ models:
 ### export
 
 ```
-
- Usage: datacontract export [OPTIONS] [LOCATION]
-
- Convert data contract to a specific format. Prints to stdout or to the specified output file.
-
+ Usage: datacontract export [OPTIONS] [LOCATION]                                                                                  
+                                                                                                                                  
+ Convert data contract to a specific format. Saves to file specified by `output` option if present, otherwise prints to stdout.      
+                                                                                                                                  
 ╭─ Arguments ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │   location      [LOCATION]  The location (url or path) of the data contract yaml. [default: datacontract.yaml]                 │
 ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ *  --format        [jsonschema|pydantic-model|sodacl|dbt|dbt-sources|db  The export format. [default: None] [required]         │
-│                    t-staging-sql|odcs|rdf|avro|protobuf|great-expectati                                                        │
-│                    ons|terraform|avro-idl|sql|sql-query|html|go|bigquer                                                        │
-│                    y|dbml|spark|sqlalchemy|data-caterer|dcs]                                                                       │
+│                    t-staging-sql|odcs|odcs_v2|odcs_v3|rdf|avro|protobuf                                                        │
+│                    |great-expectations|terraform|avro-idl|sql|sql-query                                                        │
+│                    |html|go|bigquery|dbml|spark|sqlalchemy|data-caterer                                                        │
+│                    |dcs]                                                                                                       │
 │    --output        PATH                                                  Specify the file path where the exported data will be │
 │                                                                          saved. If no path is provided, the output will be     │
 │                                                                          printed to stdout.                                    │
@@ -771,6 +771,12 @@ models:
 │                                                                          file to refer to a model, e.g., `orders`, or `all`    │
 │                                                                          for all models (default).                             │
 │                                                                          [default: all]                                        │
+│    --schema        TEXT                                                  The location (url or path) of the Data Contract       │
+│                                                                          Specification JSON Schema                             │
+│                                                                          [default:                                             │
+│                                                                          https://datacontract.com/datacontract.schema.json]    │
+│    --engine        TEXT                                                  [engine] The engine used for great expection run.     │
+│                                                                          [default: None]                                       │
 │    --help                                                                Show this message and exit.                           │
 ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ RDF Options ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
@@ -781,12 +787,11 @@ models:
 │                                detect the sql dialect via the specified servers in the data contract.                          │
 │                                [default: auto]                                                                                 │
 ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
-
 ```
 
 ```bash
 # Example export data contract as HTML
-datacontract export --format html > datacontract.html
+datacontract export --format html --output datacontract.html
 ```
 
 Available export options:
@@ -944,14 +949,20 @@ models:
 ### import
 
 ```
- Usage: datacontract import [OPTIONS]
-
- Create a data contract from the given source location. Prints to stdout.                                                      
+ Usage: datacontract import [OPTIONS]                                                                                          
+                                                                                                                               
+ Create a data contract from the given source location. Saves to file specified by `output` option if present, otherwise
+ prints to stdout.                                                                                                                    
                                                                                                                                
 ╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ *  --format                       [sql|avro|dbt|dbml|glue|jsonschema|bigquery  The format of the source file.               │
 │                                   |odcs|unity|spark|iceberg|parquet]           [default: None]                              │
 │                                                                                [required]                                   │
+│    --output                       PATH                                         Specify the file path where the Data         │
+│                                                                                Contract will be saved. If no path is        │
+│                                                                                provided, the output will be printed to      │
+│                                                                                stdout.                                      │
+│                                                                                [default: None]                              │
 │    --source                       TEXT                                         The path to the file or Glue Database that   │
 │                                                                                should be imported.                          │
 │                                                                                [default: None]                              │
@@ -991,6 +1002,8 @@ Example:
 ```bash
 # Example import from SQL DDL
 datacontract import --format sql --source my_ddl.sql
+# To save to file
+datacontract import --format sql --source my_ddl.sql --output datacontract.yaml
 ```
 
 Available import options:

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -208,7 +208,7 @@ def export(
     ] = None,
 ):
     """
-    Convert data contract to a specific format. console.prints to stdout.
+    Convert data contract to a specific format. Saves to file specified by `output` option if present, otherwise prints to stdout.
     """
     # TODO exception handling
     result = DataContract(data_contract_file=location, schema_location=schema, server=server).export(
@@ -231,6 +231,12 @@ def export(
 @app.command(name="import")
 def import_(
     format: Annotated[ImportFormat, typer.Option(help="The format of the source file.")],
+    output: Annotated[
+        Path,
+        typer.Option(
+            help="Specify the file path where the Data Contract will be saved. If no path is provided, the output will be printed to stdout."
+        ),
+    ] = None,
     source: Annotated[
         Optional[str],
         typer.Option(help="The path to the file or Glue Database that should be imported."),
@@ -276,7 +282,7 @@ def import_(
     ] = None,
 ):
     """
-    Create a data contract from the given source location. Prints to stdout.
+    Create a data contract from the given source location. Saves to file specified by `output` option if present, otherwise prints to stdout.
     """
     result = DataContract().import_from_source(
         format=format,
@@ -291,7 +297,12 @@ def import_(
         dbml_table=dbml_table,
         iceberg_table=iceberg_table,
     )
-    console.print(result.to_yaml())
+    if output is None:
+        console.print(result.to_yaml())
+    else:
+        with output.open("w") as f:
+            f.write(result.to_yaml())
+        console.print(f"Written result to {output}")
 
 
 @app.command(name="publish")

--- a/tests/test_import_jsonschema.py
+++ b/tests/test_import_jsonschema.py
@@ -1,3 +1,6 @@
+import os
+from pathlib import Path
+
 import yaml
 from typer.testing import CliRunner
 
@@ -20,6 +23,31 @@ def test_cli():
         ],
     )
     assert result.exit_code == 0
+
+
+def test_cli_with_output(tmp_path: Path):
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "import",
+            "--format",
+            "jsonschema",
+            "--source",
+            "fixtures/import/orders_union-types.json",
+            "--output",
+            tmp_path / "datacontract.yaml",
+        ],
+    )
+    assert result.exit_code == 0
+    assert os.path.exists(tmp_path / "datacontract.yaml")
+
+    with open(tmp_path / "datacontract.yaml") as file:
+        actual = file.read()
+    with open("fixtures/import/orders_union-types_datacontract.yml") as file:
+        expected = file.read()
+
+    assert yaml.safe_load(actual) == yaml.safe_load(expected)
 
 
 def test_import_json_schema_orders():


### PR DESCRIPTION
- [x] Tests pass
- [x] ruff format
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added

`datacontract export` supports `--output` option but `datacontract import` does not. When using the CLI via Docker this causes weird outputs when writing to file using `>` due to the 80 column limit _(FYI this can actually be increased with `docker run -e COLUMNS=n` but I think its good to have consistent API with `export`)_.

I have added a test to `tests/test_import_jsonschema.py` as JSON Schema is the domain I am currently working in, but I'm happy to add tests elsewhere if necessary.