### PR TITLE
Modify the arguments to narrow down the import target with `--dbt-model`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Modify the arguments to narrow down the import target with `--dbt-model` (#532)
 
 
 ## [0.10.15] - 2024-10-26

--- a/datacontract/imports/dbt_importer.py
+++ b/datacontract/imports/dbt_importer.py
@@ -34,7 +34,7 @@ class DbtManifestImporter(Importer):
         return import_dbt_manifest(
             data_contract_specification=data_contract_specification,
             manifest=manifest,
-            dbt_nodes=import_args.get("dbt_nodes", []),
+            dbt_nodes=import_args.get("dbt_model", []),
             resource_types=import_args.get("resource_types", ["model"]),
         )
 

--- a/tests/test_import_dbt.py
+++ b/tests/test_import_dbt.py
@@ -193,7 +193,7 @@ models:
 
 
 def test_import_dbt_manifest_with_filter_and_empty_columns():
-    result = DataContract().import_from_source("dbt", dbt_manifest_empty_columns, dbt_nodes=["customers"])
+    result = DataContract().import_from_source("dbt", dbt_manifest_empty_columns, dbt_model=["customers"])
 
     expected = """
 dataContractSpecification: 1.1.0
@@ -215,7 +215,7 @@ models:
 
 
 def test_import_dbt_manifest_with_filter():
-    result = DataContract().import_from_source("dbt", dbt_manifest, dbt_nodes=["customers"])
+    result = DataContract().import_from_source("dbt", dbt_manifest, dbt_model=["customers"])
 
     expected = """
 dataContractSpecification: 1.1.0


### PR DESCRIPTION
resolves https://github.com/datacontract/datacontract-cli/issues/533

During the refactoring of https://github.com/datacontract/datacontract-cli/pull/366, the names of the arguments were changed. As a result, even if `--dbt-model` is specified, all models are always output. This pull request fixes that.

Since changing the argument of `datacontract import` to `--dbt-nodes` would be a breaking change for end users, we only made the change in `datacontract/imports/dbt_importer.py`.

- [x] Tests pass
- [x] ruff format
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added
