### PR TITLE
Type conversion when importing contracts into dbt and exporting contracts from dbt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Type conversion when importing contracts into dbt and exporting contracts from dbt (#534)
 
 ### Fixed
 - Modify the arguments to narrow down the import target with `--dbt-model` (#532)

--- a/datacontract/imports/dbt_importer.py
+++ b/datacontract/imports/dbt_importer.py
@@ -4,6 +4,7 @@ from typing import TypedDict
 from dbt.artifacts.resources.v1.components import ColumnInfo
 from dbt.contracts.graph.manifest import Manifest
 
+from datacontract.imports.bigquery_importer import map_type_from_bigquery
 from datacontract.imports.importer import Importer
 from datacontract.model.data_contract_specification import DataContractSpecification, Field, Model
 
@@ -58,7 +59,7 @@ def import_dbt_manifest(
     """
     data_contract_specification.info.title = manifest.metadata.project_name
     data_contract_specification.info.dbt_version = manifest.metadata.dbt_version
-
+    adapter_type = manifest.metadata.adapter_type
     data_contract_specification.models = data_contract_specification.models or {}
     for model_contents in manifest.nodes.values():
         # Only intressted in processing models.
@@ -73,19 +74,24 @@ def import_dbt_manifest(
         dc_model = Model(
             description=model_contents.description,
             tags=model_contents.tags,
-            fields=create_fields(columns=model_contents.columns),
+            fields=create_fields(columns=model_contents.columns, adapter_type=adapter_type),
         )
 
         data_contract_specification.models[model_contents.name] = dc_model
 
     return data_contract_specification
 
+def convert_data_type_by_adapter_type(data_type: str, adapter_type: str) -> str:
+    if adapter_type == "bigquery":
+        return map_type_from_bigquery.get(data_type, "")
+    return data_type
 
-def create_fields(columns: dict[str, ColumnInfo]) -> dict[str, Field]:
+
+def create_fields(columns: dict[str, ColumnInfo], adapter_type: str) -> dict[str, Field]:
     fields = {
         column.name: Field(
             description=column.description,
-            type=column.data_type if column.data_type else "",
+            type=convert_data_type_by_adapter_type(column.data_type, adapter_type) if column.data_type else "",
             tags=column.tags,
         )
         for column in columns.values()

--- a/datacontract/imports/dbt_importer.py
+++ b/datacontract/imports/dbt_importer.py
@@ -83,7 +83,7 @@ def import_dbt_manifest(
 
 def convert_data_type_by_adapter_type(data_type: str, adapter_type: str) -> str:
     if adapter_type == "bigquery":
-        return map_type_from_bigquery.get(data_type, "")
+        return map_type_from_bigquery(data_type)
     return data_type
 
 

--- a/tests/fixtures/dbt/export/datacontract.yaml
+++ b/tests/fixtures/dbt/export/datacontract.yaml
@@ -1,0 +1,68 @@
+dataContractSpecification: 1.1.0
+id: orders-unit-test
+info:
+  title: Orders Unit Test
+  version: 1.0.0
+  status: active
+  owner: checkout
+  description: The orders data contract
+  contact:
+    email: team-orders@example.com
+    url: https://wiki.example.com/teams/checkout
+  otherField: otherValue
+terms:
+  usage: This data contract serves to demo datacontract CLI export.
+  limitations: Not intended to use in production
+  billing: free
+  noticePeriod: P3M
+servers:
+  production:
+    type: bigquery
+    environment: production
+    account: my-account
+    database: my-database
+    schema: my-schema
+    roles:
+      - name: analyst_us
+        description: Access to the data for US region
+models:
+  orders:
+    title: orders
+    type: table
+    description: The orders model
+    fields:
+      order_id:
+        title: Order ID
+        type: varchar
+        unique: true
+        required: true
+        minLength: 8
+        maxLength: 10
+        pii: true
+        classification: sensitive
+        tags:
+          - order_id
+        pattern: ^B[0-9]+$
+        examples:
+          - B12345678
+          - B12345679
+      order_total:
+        type: bigint
+        required: true
+        description: The order_total field
+        minimum: 0
+        maximum: 1000000
+        quality:
+          - type: sql
+            description: 95% of all order total values are expected to be between 10 and 499 EUR.
+            query: |
+              SELECT quantile_cont(order_total, 0.95) AS percentile_95
+              FROM orders
+            mustBeBetween: [1000, 49900]
+      order_status:
+        type: text
+        required: true
+        enum:
+          - pending
+          - shipped
+          - delivered

--- a/tests/fixtures/dbt/import/manifest_jaffle_bigquery.json
+++ b/tests/fixtures/dbt/import/manifest_jaffle_bigquery.json
@@ -1,0 +1,12727 @@
+{
+    "metadata": {
+        "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+        "dbt_version": "1.8.0",
+        "generated_at": "2024-07-09T00:33:06.822862Z",
+        "invocation_id": "116abb11-be27-40b9-817f-e9debb5bd770",
+        "env": {},
+        "project_name": "jaffle_shop",
+        "project_id": "06e5b98c2db46f8a72cc4f66410e9b3b",
+        "user_id": "a9b24267-c9cb-49bb-ac4c-ae76c1eea8ee",
+        "send_anonymous_usage_stats": true,
+        "adapter_type": "duckdb"
+    },
+    "nodes": {
+        "seed.jaffle_shop.raw_customers": {
+            "database": "jaffle_shop",
+            "schema": "main",
+            "name": "raw_customers",
+            "resource_type": "seed",
+            "package_name": "jaffle_shop",
+            "path": "raw_customers.csv",
+            "original_file_path": "seeds/raw_customers.csv",
+            "unique_id": "seed.jaffle_shop.raw_customers",
+            "fqn": [
+                "jaffle_shop",
+                "raw_customers"
+            ],
+            "alias": "raw_customers",
+            "checksum": {
+                "name": "sha256",
+                "checksum": "357d173dda65a741ad97d6683502286cc2655bb396ab5f4dfad12b8c39bd2a63"
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": null,
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "seed",
+                "incremental_strategy": null,
+                "persist_docs": {},
+                "post-hook": [],
+                "pre-hook": [],
+                "quoting": {},
+                "column_types": {},
+                "full_refresh": null,
+                "unique_key": null,
+                "on_schema_change": "ignore",
+                "on_configuration_change": "apply",
+                "grants": {},
+                "packages": [],
+                "docs": {
+                    "show": true,
+                    "node_color": null
+                },
+                "contract": {
+                    "enforced": false,
+                    "alias_types": true
+                },
+                "delimiter": ",",
+                "quote_columns": null
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1720483776.0257878,
+            "relation_name": "\"jaffle_shop\".\"main\".\"raw_customers\"",
+            "raw_code": "",
+            "root_path": "/Users/C10017Q/projetos/jaffle-shop-classic",
+            "depends_on": {
+                "macros": []
+            }
+        },
+        "seed.jaffle_shop.raw_orders": {
+            "database": "jaffle_shop",
+            "schema": "main",
+            "name": "raw_orders",
+            "resource_type": "seed",
+            "package_name": "jaffle_shop",
+            "path": "raw_orders.csv",
+            "original_file_path": "seeds/raw_orders.csv",
+            "unique_id": "seed.jaffle_shop.raw_orders",
+            "fqn": [
+                "jaffle_shop",
+                "raw_orders"
+            ],
+            "alias": "raw_orders",
+            "checksum": {
+                "name": "sha256",
+                "checksum": "ddecd7adf70a07a88b9c302aec2a03fce615b925c2c06f2d5ef99a5c97b41250"
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": null,
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "seed",
+                "incremental_strategy": null,
+                "persist_docs": {},
+                "post-hook": [],
+                "pre-hook": [],
+                "quoting": {},
+                "column_types": {},
+                "full_refresh": null,
+                "unique_key": null,
+                "on_schema_change": "ignore",
+                "on_configuration_change": "apply",
+                "grants": {},
+                "packages": [],
+                "docs": {
+                    "show": true,
+                    "node_color": null
+                },
+                "contract": {
+                    "enforced": false,
+                    "alias_types": true
+                },
+                "delimiter": ",",
+                "quote_columns": null
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1720483776.027658,
+            "relation_name": "\"jaffle_shop\".\"main\".\"raw_orders\"",
+            "raw_code": "",
+            "root_path": "/Users/C10017Q/projetos/jaffle-shop-classic",
+            "depends_on": {
+                "macros": []
+            }
+        },
+        "seed.jaffle_shop.raw_payments": {
+            "database": "jaffle_shop",
+            "schema": "main",
+            "name": "raw_payments",
+            "resource_type": "seed",
+            "package_name": "jaffle_shop",
+            "path": "raw_payments.csv",
+            "original_file_path": "seeds/raw_payments.csv",
+            "unique_id": "seed.jaffle_shop.raw_payments",
+            "fqn": [
+                "jaffle_shop",
+                "raw_payments"
+            ],
+            "alias": "raw_payments",
+            "checksum": {
+                "name": "sha256",
+                "checksum": "6de0626a8db9c1750eefd1b2e17fac4c2a4b9f778eb50532d8b377b90de395e6"
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": null,
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "seed",
+                "incremental_strategy": null,
+                "persist_docs": {},
+                "post-hook": [],
+                "pre-hook": [],
+                "quoting": {},
+                "column_types": {},
+                "full_refresh": null,
+                "unique_key": null,
+                "on_schema_change": "ignore",
+                "on_configuration_change": "apply",
+                "grants": {},
+                "packages": [],
+                "docs": {
+                    "show": true,
+                    "node_color": null
+                },
+                "contract": {
+                    "enforced": false,
+                    "alias_types": true
+                },
+                "delimiter": ",",
+                "quote_columns": null
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1720483776.029127,
+            "relation_name": "\"jaffle_shop\".\"main\".\"raw_payments\"",
+            "raw_code": "",
+            "root_path": "/Users/C10017Q/projetos/jaffle-shop-classic",
+            "depends_on": {
+                "macros": []
+            }
+        },
+        "model.jaffle_shop.orders": {
+            "database": "jaffle_shop",
+            "schema": "main",
+            "name": "orders",
+            "resource_type": "model",
+            "package_name": "jaffle_shop",
+            "path": "orders.sql",
+            "original_file_path": "models/orders.sql",
+            "unique_id": "model.jaffle_shop.orders",
+            "fqn": [
+                "jaffle_shop",
+                "orders"
+            ],
+            "alias": "orders",
+            "checksum": {
+                "name": "sha256",
+                "checksum": "27f8c79aad1cfd8411ab9c3d2ce8da1d787f7f05c58bbee1d247510dc426be0f"
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": null,
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "table",
+                "incremental_strategy": null,
+                "persist_docs": {},
+                "post-hook": [],
+                "pre-hook": [],
+                "quoting": {},
+                "column_types": {},
+                "full_refresh": null,
+                "unique_key": null,
+                "on_schema_change": "ignore",
+                "on_configuration_change": "apply",
+                "grants": {},
+                "packages": [],
+                "docs": {
+                    "show": true,
+                    "node_color": null
+                },
+                "contract": {
+                    "enforced": false,
+                    "alias_types": true
+                },
+                "access": "protected"
+            },
+            "tags": [],
+            "description": "This table has basic information about orders, as well as some derived facts based on payments",
+            "columns": {
+                "order_id": {
+                    "name": "order_id",
+                    "description": "This is a unique identifier for an order",
+                    "meta": {},
+                    "data_type": "integer",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "customer_id": {
+                    "name": "customer_id",
+                    "description": "Foreign key to the customers table",
+                    "meta": {},
+                    "data_type": "integer",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "order_date": {
+                    "name": "order_date",
+                    "description": "Date (UTC) that the order was placed",
+                    "meta": {},
+                    "data_type": "date",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "status": {
+                    "name": "status",
+                    "description": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |",
+                    "meta": {},
+                    "data_type": "varchar",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "credit_card_amount": {
+                    "name": "credit_card_amount",
+                    "description": "Amount of the order (AUD) paid for by credit card",
+                    "meta": {},
+                    "data_type": "double",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "coupon_amount": {
+                    "name": "coupon_amount",
+                    "description": "Amount of the order (AUD) paid for by coupon",
+                    "meta": {},
+                    "data_type": "double",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "bank_transfer_amount": {
+                    "name": "bank_transfer_amount",
+                    "description": "Amount of the order (AUD) paid for by bank transfer",
+                    "meta": {},
+                    "data_type": "double",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "gift_card_amount": {
+                    "name": "gift_card_amount",
+                    "description": "Amount of the order (AUD) paid for by gift card",
+                    "meta": {},
+                    "data_type": "double",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "amount": {
+                    "name": "amount",
+                    "description": "Total amount (AUD) of the order",
+                    "meta": {},
+                    "data_type": "double",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                }
+            },
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": "jaffle_shop://models/schema.yml",
+            "build_path": "target/run/jaffle_shop/models/orders.sql",
+            "unrendered_config": {
+                "materialized": "table"
+            },
+            "created_at": 1720485033.194873,
+            "relation_name": "\"jaffle_shop\".\"main\".\"orders\"",
+            "raw_code": "{% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}\n\nwith orders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\npayments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        {% for payment_method in payment_methods -%}\n        sum(case when payment_method = '{{ payment_method }}' then amount else 0 end) as {{ payment_method }}_amount,\n        {% endfor -%}\n\n        sum(amount) as total_amount\n\n    from payments\n\n    group by order_id\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        {% for payment_method in payment_methods -%}\n\n        order_payments.{{ payment_method }}_amount,\n\n        {% endfor -%}\n\n        order_payments.total_amount as amount\n\n    from orders\n\n\n    left join order_payments\n        on orders.order_id = order_payments.order_id\n\n)\n\nselect * from final",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "stg_orders",
+                    "package": null,
+                    "version": null
+                },
+                {
+                    "name": "stg_payments",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [],
+                "nodes": [
+                    "model.jaffle_shop.stg_orders",
+                    "model.jaffle_shop.stg_payments"
+                ]
+            },
+            "compiled_path": "target/compiled/jaffle_shop/models/orders.sql",
+            "compiled": true,
+            "compiled_code": "\n\nwith orders as (\n\n    select * from \"jaffle_shop\".\"main\".\"stg_orders\"\n\n),\n\npayments as (\n\n    select * from \"jaffle_shop\".\"main\".\"stg_payments\"\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        sum(case when payment_method = 'credit_card' then amount else 0 end) as credit_card_amount,\n        sum(case when payment_method = 'coupon' then amount else 0 end) as coupon_amount,\n        sum(case when payment_method = 'bank_transfer' then amount else 0 end) as bank_transfer_amount,\n        sum(case when payment_method = 'gift_card' then amount else 0 end) as gift_card_amount,\n        sum(amount) as total_amount\n\n    from payments\n\n    group by order_id\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        order_payments.credit_card_amount,\n\n        order_payments.coupon_amount,\n\n        order_payments.bank_transfer_amount,\n\n        order_payments.gift_card_amount,\n\n        order_payments.total_amount as amount\n\n    from orders\n\n\n    left join order_payments\n        on orders.order_id = order_payments.order_id\n\n)\n\nselect * from final",
+            "extra_ctes_injected": true,
+            "extra_ctes": [],
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "access": "protected",
+            "constraints": [],
+            "version": null,
+            "latest_version": null,
+            "deprecation_date": null
+        },
+        "test.jaffle_shop.not_null_orders_order_id.cf6c17daed": {
+            "database": "jaffle_shop",
+            "schema": "main_dbt_test__audit",
+            "name": "not_null_orders_order_id",
+            "resource_type": "test",
+            "package_name": "jaffle_shop",
+            "path": "not_null_orders_order_id.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.jaffle_shop.not_null_orders_order_id.cf6c17daed",
+            "fqn": [
+                "jaffle_shop",
+                "not_null_orders_order_id"
+            ],
+            "alias": "not_null_orders_order_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1720485033.232358,
+            "relation_name": null,
+            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "orders",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null"
+                ],
+                "nodes": [
+                    "model.jaffle_shop.orders"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "order_id",
+            "file_key_name": "models.orders",
+            "attached_node": "model.jaffle_shop.orders",
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "order_id",
+                    "model": "{{ get_where_subquery(ref('orders')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "test.jaffle_shop.unique_orders_order_id.fed79b3a6e": {
+            "database": "jaffle_shop",
+            "schema": "main_dbt_test__audit",
+            "name": "unique_orders_order_id",
+            "resource_type": "test",
+            "package_name": "jaffle_shop",
+            "path": "unique_orders_order_id.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.jaffle_shop.unique_orders_order_id.fed79b3a6e",
+            "fqn": [
+                "jaffle_shop",
+                "unique_orders_order_id"
+            ],
+            "alias": "unique_orders_order_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1720485033.233409,
+            "relation_name": null,
+            "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "orders",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_unique"
+                ],
+                "nodes": [
+                    "model.jaffle_shop.orders"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "order_id",
+            "file_key_name": "models.orders",
+            "attached_node": "model.jaffle_shop.orders",
+            "test_metadata": {
+                "name": "unique",
+                "kwargs": {
+                    "column_name": "order_id",
+                    "model": "{{ get_where_subquery(ref('orders')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "test.jaffle_shop.not_null_orders_customer_id.c5f02694af": {
+            "database": "jaffle_shop",
+            "schema": "main_dbt_test__audit",
+            "name": "not_null_orders_customer_id",
+            "resource_type": "test",
+            "package_name": "jaffle_shop",
+            "path": "not_null_orders_customer_id.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.jaffle_shop.not_null_orders_customer_id.c5f02694af",
+            "fqn": [
+                "jaffle_shop",
+                "not_null_orders_customer_id"
+            ],
+            "alias": "not_null_orders_customer_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1720485033.2342532,
+            "relation_name": null,
+            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "orders",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null"
+                ],
+                "nodes": [
+                    "model.jaffle_shop.orders"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "customer_id",
+            "file_key_name": "models.orders",
+            "attached_node": "model.jaffle_shop.orders",
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "customer_id",
+                    "model": "{{ get_where_subquery(ref('orders')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2": {
+            "database": "jaffle_shop",
+            "schema": "main_dbt_test__audit",
+            "name": "relationships_orders_customer_id__customer_id__ref_customers_",
+            "resource_type": "test",
+            "package_name": "jaffle_shop",
+            "path": "relationships_orders_customer_id__customer_id__ref_customers_.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2",
+            "fqn": [
+                "jaffle_shop",
+                "relationships_orders_customer_id__customer_id__ref_customers_"
+            ],
+            "alias": "relationships_orders_customer_id__customer_id__ref_customers_",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1720485033.2351098,
+            "relation_name": null,
+            "raw_code": "{{ test_relationships(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "customers",
+                    "package": null,
+                    "version": null
+                },
+                {
+                    "name": "orders",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_relationships",
+                    "macro.dbt.get_where_subquery"
+                ],
+                "nodes": [
+                    "model.jaffle_shop.customers",
+                    "model.jaffle_shop.orders"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "customer_id",
+            "file_key_name": "models.orders",
+            "attached_node": "model.jaffle_shop.orders",
+            "test_metadata": {
+                "name": "relationships",
+                "kwargs": {
+                    "to": "ref('customers')",
+                    "field": "customer_id",
+                    "column_name": "customer_id",
+                    "model": "{{ get_where_subquery(ref('orders')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "test.jaffle_shop.accepted_values_orders_status__completed__placed__return_pending__returned__shipped.a015b8fc5d": {
+            "database": "jaffle_shop",
+            "schema": "main_dbt_test__audit",
+            "name": "accepted_values_orders_status__completed__placed__return_pending__returned__shipped",
+            "resource_type": "test",
+            "package_name": "jaffle_shop",
+            "path": "accepted_values_orders_f4e1f689b0b48313bf62bb1dfd327741.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.jaffle_shop.accepted_values_orders_status__completed__placed__return_pending__returned__shipped.a015b8fc5d",
+            "fqn": [
+                "jaffle_shop",
+                "accepted_values_orders_status__completed__placed__return_pending__returned__shipped"
+            ],
+            "alias": "accepted_values_orders_f4e1f689b0b48313bf62bb1dfd327741",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": "accepted_values_orders_f4e1f689b0b48313bf62bb1dfd327741",
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {
+                "alias": "accepted_values_orders_f4e1f689b0b48313bf62bb1dfd327741"
+            },
+            "created_at": 1720485033.241823,
+            "relation_name": null,
+            "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_orders_f4e1f689b0b48313bf62bb1dfd327741\") }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "orders",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_accepted_values",
+                    "macro.dbt.get_where_subquery"
+                ],
+                "nodes": [
+                    "model.jaffle_shop.orders"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "status",
+            "file_key_name": "models.orders",
+            "attached_node": "model.jaffle_shop.orders",
+            "test_metadata": {
+                "name": "accepted_values",
+                "kwargs": {
+                    "values": [
+                        "completed",
+                        "placed",
+                        "return_pending",
+                        "returned",
+                        "shipped"
+                    ],
+                    "column_name": "status",
+                    "model": "{{ get_where_subquery(ref('orders')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59": {
+            "database": "jaffle_shop",
+            "schema": "main_dbt_test__audit",
+            "name": "not_null_orders_credit_card_amount",
+            "resource_type": "test",
+            "package_name": "jaffle_shop",
+            "path": "not_null_orders_credit_card_amount.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59",
+            "fqn": [
+                "jaffle_shop",
+                "not_null_orders_credit_card_amount"
+            ],
+            "alias": "not_null_orders_credit_card_amount",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1720485033.247241,
+            "relation_name": null,
+            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "orders",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null"
+                ],
+                "nodes": [
+                    "model.jaffle_shop.orders"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "credit_card_amount",
+            "file_key_name": "models.orders",
+            "attached_node": "model.jaffle_shop.orders",
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "credit_card_amount",
+                    "model": "{{ get_where_subquery(ref('orders')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625": {
+            "database": "jaffle_shop",
+            "schema": "main_dbt_test__audit",
+            "name": "not_null_orders_coupon_amount",
+            "resource_type": "test",
+            "package_name": "jaffle_shop",
+            "path": "not_null_orders_coupon_amount.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625",
+            "fqn": [
+                "jaffle_shop",
+                "not_null_orders_coupon_amount"
+            ],
+            "alias": "not_null_orders_coupon_amount",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1720485033.248306,
+            "relation_name": null,
+            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "orders",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null"
+                ],
+                "nodes": [
+                    "model.jaffle_shop.orders"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "coupon_amount",
+            "file_key_name": "models.orders",
+            "attached_node": "model.jaffle_shop.orders",
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "coupon_amount",
+                    "model": "{{ get_where_subquery(ref('orders')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49": {
+            "database": "jaffle_shop",
+            "schema": "main_dbt_test__audit",
+            "name": "not_null_orders_bank_transfer_amount",
+            "resource_type": "test",
+            "package_name": "jaffle_shop",
+            "path": "not_null_orders_bank_transfer_amount.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49",
+            "fqn": [
+                "jaffle_shop",
+                "not_null_orders_bank_transfer_amount"
+            ],
+            "alias": "not_null_orders_bank_transfer_amount",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1720485033.249193,
+            "relation_name": null,
+            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "orders",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null"
+                ],
+                "nodes": [
+                    "model.jaffle_shop.orders"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "bank_transfer_amount",
+            "file_key_name": "models.orders",
+            "attached_node": "model.jaffle_shop.orders",
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "bank_transfer_amount",
+                    "model": "{{ get_where_subquery(ref('orders')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a": {
+            "database": "jaffle_shop",
+            "schema": "main_dbt_test__audit",
+            "name": "not_null_orders_gift_card_amount",
+            "resource_type": "test",
+            "package_name": "jaffle_shop",
+            "path": "not_null_orders_gift_card_amount.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a",
+            "fqn": [
+                "jaffle_shop",
+                "not_null_orders_gift_card_amount"
+            ],
+            "alias": "not_null_orders_gift_card_amount",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1720485033.250258,
+            "relation_name": null,
+            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "orders",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null"
+                ],
+                "nodes": [
+                    "model.jaffle_shop.orders"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "gift_card_amount",
+            "file_key_name": "models.orders",
+            "attached_node": "model.jaffle_shop.orders",
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "gift_card_amount",
+                    "model": "{{ get_where_subquery(ref('orders')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "test.jaffle_shop.not_null_orders_amount.106140f9fd": {
+            "database": "jaffle_shop",
+            "schema": "main_dbt_test__audit",
+            "name": "not_null_orders_amount",
+            "resource_type": "test",
+            "package_name": "jaffle_shop",
+            "path": "not_null_orders_amount.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.jaffle_shop.not_null_orders_amount.106140f9fd",
+            "fqn": [
+                "jaffle_shop",
+                "not_null_orders_amount"
+            ],
+            "alias": "not_null_orders_amount",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1720485033.251141,
+            "relation_name": null,
+            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "orders",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null"
+                ],
+                "nodes": [
+                    "model.jaffle_shop.orders"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "amount",
+            "file_key_name": "models.orders",
+            "attached_node": "model.jaffle_shop.orders",
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "amount",
+                    "model": "{{ get_where_subquery(ref('orders')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "model.jaffle_shop.stg_customers": {
+            "database": "jaffle_shop",
+            "schema": "main",
+            "name": "stg_customers",
+            "resource_type": "model",
+            "package_name": "jaffle_shop",
+            "path": "staging/stg_customers.sql",
+            "original_file_path": "models/staging/stg_customers.sql",
+            "unique_id": "model.jaffle_shop.stg_customers",
+            "fqn": [
+                "jaffle_shop",
+                "staging",
+                "stg_customers"
+            ],
+            "alias": "stg_customers",
+            "checksum": {
+                "name": "sha256",
+                "checksum": "80e3223cd54387e11fa16cd0f4cbe15f8ff74dcd9900b93856b9e39416178c9d"
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": null,
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "view",
+                "incremental_strategy": null,
+                "persist_docs": {},
+                "post-hook": [],
+                "pre-hook": [],
+                "quoting": {},
+                "column_types": {},
+                "full_refresh": null,
+                "unique_key": null,
+                "on_schema_change": "ignore",
+                "on_configuration_change": "apply",
+                "grants": {},
+                "packages": [],
+                "docs": {
+                    "show": true,
+                    "node_color": null
+                },
+                "contract": {
+                    "enforced": false,
+                    "alias_types": true
+                },
+                "access": "protected"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {
+                "customer_id": {
+                    "name": "customer_id",
+                    "description": "",
+                    "meta": {},
+                    "data_type": "integer",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "first_name": {
+                    "name": "first_name",
+                    "description": "",
+                    "meta": {},
+                    "data_type": "varchar",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "last_name": {
+                    "name": "last_name",
+                    "description": "",
+                    "meta": {},
+                    "data_type": "varchar",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                }
+            },
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": "jaffle_shop://models/staging/schema.yml",
+            "build_path": "target/run/jaffle_shop/models/staging/stg_customers.sql",
+            "unrendered_config": {
+                "materialized": "view"
+            },
+            "created_at": 1720485141.5922072,
+            "relation_name": "\"jaffle_shop\".\"main\".\"stg_customers\"",
+            "raw_code": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_customers') }}\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "raw_customers",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [],
+                "nodes": [
+                    "seed.jaffle_shop.raw_customers"
+                ]
+            },
+            "compiled_path": "target/compiled/jaffle_shop/models/staging/stg_customers.sql",
+            "compiled": true,
+            "compiled_code": "with source as (\n    select * from \"jaffle_shop\".\"main\".\"raw_customers\"\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
+            "extra_ctes_injected": true,
+            "extra_ctes": [],
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "access": "protected",
+            "constraints": [],
+            "version": null,
+            "latest_version": null,
+            "deprecation_date": null
+        },
+        "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa": {
+            "database": "jaffle_shop",
+            "schema": "main_dbt_test__audit",
+            "name": "not_null_stg_customers_customer_id",
+            "resource_type": "test",
+            "package_name": "jaffle_shop",
+            "path": "not_null_stg_customers_customer_id.sql",
+            "original_file_path": "models/staging/schema.yml",
+            "unique_id": "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa",
+            "fqn": [
+                "jaffle_shop",
+                "staging",
+                "not_null_stg_customers_customer_id"
+            ],
+            "alias": "not_null_stg_customers_customer_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1720485141.592731,
+            "relation_name": null,
+            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "stg_customers",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null"
+                ],
+                "nodes": [
+                    "model.jaffle_shop.stg_customers"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "customer_id",
+            "file_key_name": "models.stg_customers",
+            "attached_node": "model.jaffle_shop.stg_customers",
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "customer_id",
+                    "model": "{{ get_where_subquery(ref('stg_customers')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada": {
+            "database": "jaffle_shop",
+            "schema": "main_dbt_test__audit",
+            "name": "unique_stg_customers_customer_id",
+            "resource_type": "test",
+            "package_name": "jaffle_shop",
+            "path": "unique_stg_customers_customer_id.sql",
+            "original_file_path": "models/staging/schema.yml",
+            "unique_id": "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada",
+            "fqn": [
+                "jaffle_shop",
+                "staging",
+                "unique_stg_customers_customer_id"
+            ],
+            "alias": "unique_stg_customers_customer_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1720485141.593724,
+            "relation_name": null,
+            "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "stg_customers",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_unique"
+                ],
+                "nodes": [
+                    "model.jaffle_shop.stg_customers"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "customer_id",
+            "file_key_name": "models.stg_customers",
+            "attached_node": "model.jaffle_shop.stg_customers",
+            "test_metadata": {
+                "name": "unique",
+                "kwargs": {
+                    "column_name": "customer_id",
+                    "model": "{{ get_where_subquery(ref('stg_customers')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "model.jaffle_shop.stg_orders": {
+            "database": "jaffle_shop",
+            "schema": "main",
+            "name": "stg_orders",
+            "resource_type": "model",
+            "package_name": "jaffle_shop",
+            "path": "staging/stg_orders.sql",
+            "original_file_path": "models/staging/stg_orders.sql",
+            "unique_id": "model.jaffle_shop.stg_orders",
+            "fqn": [
+                "jaffle_shop",
+                "staging",
+                "stg_orders"
+            ],
+            "alias": "stg_orders",
+            "checksum": {
+                "name": "sha256",
+                "checksum": "f4f881cb09d2c4162200fc331d7401df6d1abd4fed492554a7db70dede347108"
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": null,
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "view",
+                "incremental_strategy": null,
+                "persist_docs": {},
+                "post-hook": [],
+                "pre-hook": [],
+                "quoting": {},
+                "column_types": {},
+                "full_refresh": null,
+                "unique_key": null,
+                "on_schema_change": "ignore",
+                "on_configuration_change": "apply",
+                "grants": {},
+                "packages": [],
+                "docs": {
+                    "show": true,
+                    "node_color": null
+                },
+                "contract": {
+                    "enforced": false,
+                    "alias_types": true
+                },
+                "access": "protected"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {
+                "order_id": {
+                    "name": "order_id",
+                    "description": "",
+                    "meta": {},
+                    "data_type": "integer",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "customer_id": {
+                    "name": "customer_id",
+                    "description": "",
+                    "meta": {},
+                    "data_type": "integer",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "order_date": {
+                    "name": "order_date",
+                    "description": "",
+                    "meta": {},
+                    "data_type": "date",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "status": {
+                    "name": "status",
+                    "description": "",
+                    "meta": {},
+                    "data_type": "varchar",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                }
+            },
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": "jaffle_shop://models/staging/schema.yml",
+            "build_path": "target/run/jaffle_shop/models/staging/stg_orders.sql",
+            "unrendered_config": {
+                "materialized": "view"
+            },
+            "created_at": 1720485148.2909172,
+            "relation_name": "\"jaffle_shop\".\"main\".\"stg_orders\"",
+            "raw_code": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_orders') }}\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "raw_orders",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [],
+                "nodes": [
+                    "seed.jaffle_shop.raw_orders"
+                ]
+            },
+            "compiled_path": "target/compiled/jaffle_shop/models/staging/stg_orders.sql",
+            "compiled": true,
+            "compiled_code": "with source as (\n    select * from \"jaffle_shop\".\"main\".\"raw_orders\"\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed",
+            "extra_ctes_injected": true,
+            "extra_ctes": [],
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "access": "protected",
+            "constraints": [],
+            "version": null,
+            "latest_version": null,
+            "deprecation_date": null
+        },
+        "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64": {
+            "database": "jaffle_shop",
+            "schema": "main_dbt_test__audit",
+            "name": "not_null_stg_orders_order_id",
+            "resource_type": "test",
+            "package_name": "jaffle_shop",
+            "path": "not_null_stg_orders_order_id.sql",
+            "original_file_path": "models/staging/schema.yml",
+            "unique_id": "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64",
+            "fqn": [
+                "jaffle_shop",
+                "staging",
+                "not_null_stg_orders_order_id"
+            ],
+            "alias": "not_null_stg_orders_order_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1720485148.291411,
+            "relation_name": null,
+            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "stg_orders",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null"
+                ],
+                "nodes": [
+                    "model.jaffle_shop.stg_orders"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "order_id",
+            "file_key_name": "models.stg_orders",
+            "attached_node": "model.jaffle_shop.stg_orders",
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "order_id",
+                    "model": "{{ get_where_subquery(ref('stg_orders')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a": {
+            "database": "jaffle_shop",
+            "schema": "main_dbt_test__audit",
+            "name": "unique_stg_orders_order_id",
+            "resource_type": "test",
+            "package_name": "jaffle_shop",
+            "path": "unique_stg_orders_order_id.sql",
+            "original_file_path": "models/staging/schema.yml",
+            "unique_id": "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a",
+            "fqn": [
+                "jaffle_shop",
+                "staging",
+                "unique_stg_orders_order_id"
+            ],
+            "alias": "unique_stg_orders_order_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1720485148.2923388,
+            "relation_name": null,
+            "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "stg_orders",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_unique"
+                ],
+                "nodes": [
+                    "model.jaffle_shop.stg_orders"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "order_id",
+            "file_key_name": "models.stg_orders",
+            "attached_node": "model.jaffle_shop.stg_orders",
+            "test_metadata": {
+                "name": "unique",
+                "kwargs": {
+                    "column_name": "order_id",
+                    "model": "{{ get_where_subquery(ref('stg_orders')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "test.jaffle_shop.accepted_values_stg_orders_status__completed__placed__return_pending__returned__shipped.8adcbb5d61": {
+            "database": "jaffle_shop",
+            "schema": "main_dbt_test__audit",
+            "name": "accepted_values_stg_orders_status__completed__placed__return_pending__returned__shipped",
+            "resource_type": "test",
+            "package_name": "jaffle_shop",
+            "path": "accepted_values_stg_orders_caa1f8602e075d2ff0c7f0f9bac2fbb0.sql",
+            "original_file_path": "models/staging/schema.yml",
+            "unique_id": "test.jaffle_shop.accepted_values_stg_orders_status__completed__placed__return_pending__returned__shipped.8adcbb5d61",
+            "fqn": [
+                "jaffle_shop",
+                "staging",
+                "accepted_values_stg_orders_status__completed__placed__return_pending__returned__shipped"
+            ],
+            "alias": "accepted_values_stg_orders_caa1f8602e075d2ff0c7f0f9bac2fbb0",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": "accepted_values_stg_orders_caa1f8602e075d2ff0c7f0f9bac2fbb0",
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {
+                "alias": "accepted_values_stg_orders_caa1f8602e075d2ff0c7f0f9bac2fbb0"
+            },
+            "created_at": 1720485148.293184,
+            "relation_name": null,
+            "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_stg_orders_caa1f8602e075d2ff0c7f0f9bac2fbb0\") }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "stg_orders",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_accepted_values",
+                    "macro.dbt.get_where_subquery"
+                ],
+                "nodes": [
+                    "model.jaffle_shop.stg_orders"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "status",
+            "file_key_name": "models.stg_orders",
+            "attached_node": "model.jaffle_shop.stg_orders",
+            "test_metadata": {
+                "name": "accepted_values",
+                "kwargs": {
+                    "values": [
+                        "completed",
+                        "placed",
+                        "return_pending",
+                        "returned",
+                        "shipped"
+                    ],
+                    "column_name": "status",
+                    "model": "{{ get_where_subquery(ref('stg_orders')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "model.jaffle_shop.stg_payments": {
+            "database": "jaffle_shop",
+            "schema": "main",
+            "name": "stg_payments",
+            "resource_type": "model",
+            "package_name": "jaffle_shop",
+            "path": "staging/stg_payments.sql",
+            "original_file_path": "models/staging/stg_payments.sql",
+            "unique_id": "model.jaffle_shop.stg_payments",
+            "fqn": [
+                "jaffle_shop",
+                "staging",
+                "stg_payments"
+            ],
+            "alias": "stg_payments",
+            "checksum": {
+                "name": "sha256",
+                "checksum": "9c1ee3bfb10e07c2dfc325d55925da0e521887136d9051768cb8acf09dc86bda"
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": null,
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "view",
+                "incremental_strategy": null,
+                "persist_docs": {},
+                "post-hook": [],
+                "pre-hook": [],
+                "quoting": {},
+                "column_types": {},
+                "full_refresh": null,
+                "unique_key": null,
+                "on_schema_change": "ignore",
+                "on_configuration_change": "apply",
+                "grants": {},
+                "packages": [],
+                "docs": {
+                    "show": true,
+                    "node_color": null
+                },
+                "contract": {
+                    "enforced": false,
+                    "alias_types": true
+                },
+                "access": "protected"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {
+                "payment_id": {
+                    "name": "payment_id",
+                    "description": "",
+                    "meta": {},
+                    "data_type": "integer",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "order_id": {
+                    "name": "order_id",
+                    "description": "",
+                    "meta": {},
+                    "data_type": "integer",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "payment_method": {
+                    "name": "payment_method",
+                    "description": "",
+                    "meta": {},
+                    "data_type": "varchar",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "amount": {
+                    "name": "amount",
+                    "description": "",
+                    "meta": {},
+                    "data_type": "double",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                }
+            },
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": "jaffle_shop://models/staging/schema.yml",
+            "build_path": "target/run/jaffle_shop/models/staging/stg_payments.sql",
+            "unrendered_config": {
+                "materialized": "view"
+            },
+            "created_at": 1720485154.929448,
+            "relation_name": "\"jaffle_shop\".\"main\".\"stg_payments\"",
+            "raw_code": "with source as (\n    \n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_payments') }}\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        -- `amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "raw_payments",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [],
+                "nodes": [
+                    "seed.jaffle_shop.raw_payments"
+                ]
+            },
+            "compiled_path": "target/compiled/jaffle_shop/models/staging/stg_payments.sql",
+            "compiled": true,
+            "compiled_code": "with source as (\n    select * from \"jaffle_shop\".\"main\".\"raw_payments\"\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        -- `amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
+            "extra_ctes_injected": true,
+            "extra_ctes": [],
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "access": "protected",
+            "constraints": [],
+            "version": null,
+            "latest_version": null,
+            "deprecation_date": null
+        },
+        "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075": {
+            "database": "jaffle_shop",
+            "schema": "main_dbt_test__audit",
+            "name": "not_null_stg_payments_payment_id",
+            "resource_type": "test",
+            "package_name": "jaffle_shop",
+            "path": "not_null_stg_payments_payment_id.sql",
+            "original_file_path": "models/staging/schema.yml",
+            "unique_id": "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075",
+            "fqn": [
+                "jaffle_shop",
+                "staging",
+                "not_null_stg_payments_payment_id"
+            ],
+            "alias": "not_null_stg_payments_payment_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1720485154.929976,
+            "relation_name": null,
+            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "stg_payments",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null"
+                ],
+                "nodes": [
+                    "model.jaffle_shop.stg_payments"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "payment_id",
+            "file_key_name": "models.stg_payments",
+            "attached_node": "model.jaffle_shop.stg_payments",
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "payment_id",
+                    "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "test.jaffle_shop.unique_stg_payments_payment_id.3744510712": {
+            "database": "jaffle_shop",
+            "schema": "main_dbt_test__audit",
+            "name": "unique_stg_payments_payment_id",
+            "resource_type": "test",
+            "package_name": "jaffle_shop",
+            "path": "unique_stg_payments_payment_id.sql",
+            "original_file_path": "models/staging/schema.yml",
+            "unique_id": "test.jaffle_shop.unique_stg_payments_payment_id.3744510712",
+            "fqn": [
+                "jaffle_shop",
+                "staging",
+                "unique_stg_payments_payment_id"
+            ],
+            "alias": "unique_stg_payments_payment_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1720485154.9312499,
+            "relation_name": null,
+            "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "stg_payments",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_unique"
+                ],
+                "nodes": [
+                    "model.jaffle_shop.stg_payments"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "payment_id",
+            "file_key_name": "models.stg_payments",
+            "attached_node": "model.jaffle_shop.stg_payments",
+            "test_metadata": {
+                "name": "unique",
+                "kwargs": {
+                    "column_name": "payment_id",
+                    "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "test.jaffle_shop.accepted_values_stg_payments_payment_method__bank_transfer__coupon__credit_card__gift_card.1ff927f246": {
+            "database": "jaffle_shop",
+            "schema": "main_dbt_test__audit",
+            "name": "accepted_values_stg_payments_payment_method__bank_transfer__coupon__credit_card__gift_card",
+            "resource_type": "test",
+            "package_name": "jaffle_shop",
+            "path": "accepted_values_stg_payments_1631b799e58c1bfcca64830f56b597b6.sql",
+            "original_file_path": "models/staging/schema.yml",
+            "unique_id": "test.jaffle_shop.accepted_values_stg_payments_payment_method__bank_transfer__coupon__credit_card__gift_card.1ff927f246",
+            "fqn": [
+                "jaffle_shop",
+                "staging",
+                "accepted_values_stg_payments_payment_method__bank_transfer__coupon__credit_card__gift_card"
+            ],
+            "alias": "accepted_values_stg_payments_1631b799e58c1bfcca64830f56b597b6",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": "accepted_values_stg_payments_1631b799e58c1bfcca64830f56b597b6",
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {
+                "alias": "accepted_values_stg_payments_1631b799e58c1bfcca64830f56b597b6"
+            },
+            "created_at": 1720485154.932263,
+            "relation_name": null,
+            "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_stg_payments_1631b799e58c1bfcca64830f56b597b6\") }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "stg_payments",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_accepted_values",
+                    "macro.dbt.get_where_subquery"
+                ],
+                "nodes": [
+                    "model.jaffle_shop.stg_payments"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "payment_method",
+            "file_key_name": "models.stg_payments",
+            "attached_node": "model.jaffle_shop.stg_payments",
+            "test_metadata": {
+                "name": "accepted_values",
+                "kwargs": {
+                    "values": [
+                        "bank_transfer",
+                        "coupon",
+                        "credit_card",
+                        "gift_card"
+                    ],
+                    "column_name": "payment_method",
+                    "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "model.jaffle_shop.customers": {
+            "database": "jaffle_shop",
+            "schema": "main",
+            "name": "customers",
+            "resource_type": "model",
+            "package_name": "jaffle_shop",
+            "path": "customers.sql",
+            "original_file_path": "models/customers.sql",
+            "unique_id": "model.jaffle_shop.customers",
+            "fqn": [
+                "jaffle_shop",
+                "customers"
+            ],
+            "alias": "customers",
+            "checksum": {
+                "name": "sha256",
+                "checksum": "60bd72e33da43fff3a7e7609135c17cd4468bd22afec0735dd36018bfb5af30a"
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": null,
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "table",
+                "incremental_strategy": null,
+                "persist_docs": {},
+                "post-hook": [],
+                "pre-hook": [],
+                "quoting": {},
+                "column_types": {},
+                "full_refresh": null,
+                "unique_key": null,
+                "on_schema_change": "ignore",
+                "on_configuration_change": "apply",
+                "grants": {},
+                "packages": [],
+                "docs": {
+                    "show": true,
+                    "node_color": null
+                },
+                "contract": {
+                    "enforced": false,
+                    "alias_types": true
+                },
+                "access": "protected"
+            },
+            "tags": ["TABLE_PII"],
+            "description": "This table has basic information about a customer, as well as some derived facts based on a customer's orders",
+            "columns": {
+                "customer_id": {
+                    "name": "customer_id",
+                    "description": "This is a unique identifier for a customer",
+                    "meta": {},
+                    "data_type": "integer",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "first_name": {
+                    "name": "first_name",
+                    "description": "Customer's first name. PII.",
+                    "meta": {},
+                    "data_type": "varchar",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": ["PII"]
+                },
+                "last_name": {
+                    "name": "last_name",
+                    "description": "Customer's last name. PII.",
+                    "meta": {},
+                    "data_type": "varchar",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": ["PII"]
+                },
+                "first_order": {
+                    "name": "first_order",
+                    "description": "Date (UTC) of a customer's first order",
+                    "meta": {},
+                    "data_type": "date",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "most_recent_order": {
+                    "name": "most_recent_order",
+                    "description": "Date (UTC) of a customer's most recent order",
+                    "meta": {},
+                    "data_type": "date",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "number_of_orders": {
+                    "name": "number_of_orders",
+                    "description": "Count of the number of orders a customer has placed",
+                    "meta": {},
+                    "data_type": "bigint",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                },
+                "customer_lifetime_value": {
+                    "name": "customer_lifetime_value",
+                    "description": "",
+                    "meta": {},
+                    "data_type": "double",
+                    "constraints": [],
+                    "quote": null,
+                    "tags": []
+                }
+            },
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": "jaffle_shop://models/schema.yml",
+            "build_path": "target/run/jaffle_shop/models/customers.sql",
+            "unrendered_config": {
+                "materialized": "table"
+            },
+            "created_at": 1720485169.4153018,
+            "relation_name": "\"jaffle_shop\".\"main\".\"customers\"",
+            "raw_code": "with customers as (\n\n    select * from {{ ref('stg_customers') }}\n\n),\n\norders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\npayments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\ncustomer_orders as (\n\n        select\n        customer_id,\n\n        min(order_date) as first_order,\n        max(order_date) as most_recent_order,\n        count(order_id) as number_of_orders\n    from orders\n\n    group by customer_id\n\n),\n\ncustomer_payments as (\n\n    select\n        orders.customer_id,\n        sum(amount) as total_amount\n\n    from payments\n\n    left join orders on\n         payments.order_id = orders.order_id\n\n    group by orders.customer_id\n\n),\n\nfinal as (\n\n    select\n        customers.customer_id,\n        customers.first_name,\n        customers.last_name,\n        customer_orders.first_order,\n        customer_orders.most_recent_order,\n        customer_orders.number_of_orders,\n        customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders\n        on customers.customer_id = customer_orders.customer_id\n\n    left join customer_payments\n        on  customers.customer_id = customer_payments.customer_id\n\n)\n\nselect * from final",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "stg_customers",
+                    "package": null,
+                    "version": null
+                },
+                {
+                    "name": "stg_orders",
+                    "package": null,
+                    "version": null
+                },
+                {
+                    "name": "stg_payments",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [],
+                "nodes": [
+                    "model.jaffle_shop.stg_customers",
+                    "model.jaffle_shop.stg_orders",
+                    "model.jaffle_shop.stg_payments"
+                ]
+            },
+            "compiled_path": "target/compiled/jaffle_shop/models/customers.sql",
+            "compiled": true,
+            "compiled_code": "with customers as (\n\n    select * from \"jaffle_shop\".\"main\".\"stg_customers\"\n\n),\n\norders as (\n\n    select * from \"jaffle_shop\".\"main\".\"stg_orders\"\n\n),\n\npayments as (\n\n    select * from \"jaffle_shop\".\"main\".\"stg_payments\"\n\n),\n\ncustomer_orders as (\n\n        select\n        customer_id,\n\n        min(order_date) as first_order,\n        max(order_date) as most_recent_order,\n        count(order_id) as number_of_orders\n    from orders\n\n    group by customer_id\n\n),\n\ncustomer_payments as (\n\n    select\n        orders.customer_id,\n        sum(amount) as total_amount\n\n    from payments\n\n    left join orders on\n         payments.order_id = orders.order_id\n\n    group by orders.customer_id\n\n),\n\nfinal as (\n\n    select\n        customers.customer_id,\n        customers.first_name,\n        customers.last_name,\n        customer_orders.first_order,\n        customer_orders.most_recent_order,\n        customer_orders.number_of_orders,\n        customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders\n        on customers.customer_id = customer_orders.customer_id\n\n    left join customer_payments\n        on  customers.customer_id = customer_payments.customer_id\n\n)\n\nselect * from final",
+            "extra_ctes_injected": true,
+            "extra_ctes": [],
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "access": "protected",
+            "constraints": [],
+            "version": null,
+            "latest_version": null,
+            "deprecation_date": null
+        },
+        "test.jaffle_shop.not_null_customers_customer_id.5c9bf9911d": {
+            "database": "jaffle_shop",
+            "schema": "main_dbt_test__audit",
+            "name": "not_null_customers_customer_id",
+            "resource_type": "test",
+            "package_name": "jaffle_shop",
+            "path": "not_null_customers_customer_id.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.jaffle_shop.not_null_customers_customer_id.5c9bf9911d",
+            "fqn": [
+                "jaffle_shop",
+                "not_null_customers_customer_id"
+            ],
+            "alias": "not_null_customers_customer_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1720485169.415812,
+            "relation_name": null,
+            "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "customers",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null"
+                ],
+                "nodes": [
+                    "model.jaffle_shop.customers"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "customer_id",
+            "file_key_name": "models.customers",
+            "attached_node": "model.jaffle_shop.customers",
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "customer_id",
+                    "model": "{{ get_where_subquery(ref('customers')) }}"
+                },
+                "namespace": null
+            }
+        },
+        "test.jaffle_shop.unique_customers_customer_id.c5af1ff4b1": {
+            "database": "jaffle_shop",
+            "schema": "main_dbt_test__audit",
+            "name": "unique_customers_customer_id",
+            "resource_type": "test",
+            "package_name": "jaffle_shop",
+            "path": "unique_customers_customer_id.sql",
+            "original_file_path": "models/schema.yml",
+            "unique_id": "test.jaffle_shop.unique_customers_customer_id.c5af1ff4b1",
+            "fqn": [
+                "jaffle_shop",
+                "unique_customers_customer_id"
+            ],
+            "alias": "unique_customers_customer_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "group": null,
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "store_failures_as": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0"
+            },
+            "tags": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "group": null,
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "build_path": null,
+            "unrendered_config": {},
+            "created_at": 1720485169.416735,
+            "relation_name": null,
+            "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "refs": [
+                {
+                    "name": "customers",
+                    "package": null,
+                    "version": null
+                }
+            ],
+            "sources": [],
+            "metrics": [],
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_unique"
+                ],
+                "nodes": [
+                    "model.jaffle_shop.customers"
+                ]
+            },
+            "compiled_path": null,
+            "contract": {
+                "enforced": false,
+                "alias_types": true,
+                "checksum": null
+            },
+            "column_name": "customer_id",
+            "file_key_name": "models.customers",
+            "attached_node": "model.jaffle_shop.customers",
+            "test_metadata": {
+                "name": "unique",
+                "kwargs": {
+                    "column_name": "customer_id",
+                    "model": "{{ get_where_subquery(ref('customers')) }}"
+                },
+                "namespace": null
+            }
+        }
+    },
+    "sources": {},
+    "macros": {
+        "macro.dbt_duckdb.duckdb__get_binding_char": {
+            "name": "duckdb__get_binding_char",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/seed.sql",
+            "original_file_path": "macros/seed.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__get_binding_char",
+            "macro_sql": "{% macro duckdb__get_binding_char() %}\n  {{ return(adapter.get_binding_char()) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4117608,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__get_batch_size": {
+            "name": "duckdb__get_batch_size",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/seed.sql",
+            "original_file_path": "macros/seed.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__get_batch_size",
+            "macro_sql": "{% macro duckdb__get_batch_size() %}\n  {{ return(10000) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.411907,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__load_csv_rows": {
+            "name": "duckdb__load_csv_rows",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/seed.sql",
+            "original_file_path": "macros/seed.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__load_csv_rows",
+            "macro_sql": "{% macro duckdb__load_csv_rows(model, agate_table) %}\n    {% if config.get('fast', true) %}\n        {% set seed_file_path = adapter.get_seed_file_path(model) %}\n        {% set delimiter = config.get('delimiter', ',') %}\n        {% set sql %}\n          COPY {{ this.render() }} FROM '{{ seed_file_path }}' (FORMAT CSV, HEADER TRUE, DELIMITER '{{ delimiter }}')\n        {% endset %}\n        {% do adapter.add_query(sql, abridge_sql_log=True) %}\n        {{ return(sql) }}\n    {% endif %}\n\n    {% set batch_size = get_batch_size() %}\n    {% set agate_table = adapter.convert_datetimes_to_strs(agate_table) %}\n    {% set cols_sql = get_seed_column_quoted_csv(model, agate_table.column_names) %}\n    {% set bindings = [] %}\n\n    {% set statements = [] %}\n\n    {% for chunk in agate_table.rows | batch(batch_size) %}\n        {% set bindings = [] %}\n\n        {% for row in chunk %}\n            {% do bindings.extend(row) %}\n        {% endfor %}\n\n        {% set sql %}\n            insert into {{ this.render() }} ({{ cols_sql }}) values\n            {% for row in chunk -%}\n                ({%- for column in agate_table.column_names -%}\n                    {{ get_binding_char() }}\n                    {%- if not loop.last%},{%- endif %}\n                {%- endfor -%})\n                {%- if not loop.last%},{%- endif %}\n            {%- endfor %}\n        {% endset %}\n\n        {% do adapter.add_query(sql, bindings=bindings, abridge_sql_log=True) %}\n\n        {% if loop.index0 == 0 %}\n            {% do statements.append(sql) %}\n        {% endif %}\n    {% endfor %}\n\n    {# Return SQL so we can render it out into the compiled files #}\n    {{ return(statements[0]) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_batch_size",
+                    "macro.dbt.get_seed_column_quoted_csv",
+                    "macro.dbt.get_binding_char"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.414165,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__snapshot_merge_sql": {
+            "name": "duckdb__snapshot_merge_sql",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/snapshot_helper.sql",
+            "original_file_path": "macros/snapshot_helper.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__snapshot_merge_sql",
+            "macro_sql": "{% macro duckdb__snapshot_merge_sql(target, source, insert_cols) -%}\n    {%- set insert_cols_csv = insert_cols | join(', ') -%}\n\n    update {{ target }} as DBT_INTERNAL_TARGET\n    set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to\n    from {{ source }} as DBT_INTERNAL_SOURCE\n    where DBT_INTERNAL_SOURCE.dbt_scd_id::text = DBT_INTERNAL_TARGET.dbt_scd_id::text\n      and DBT_INTERNAL_SOURCE.dbt_change_type::text in ('update'::text, 'delete'::text)\n      and DBT_INTERNAL_TARGET.dbt_valid_to is null;\n\n    insert into {{ target }} ({{ insert_cols_csv }})\n    select {% for column in insert_cols -%}\n        DBT_INTERNAL_SOURCE.{{ column }} {%- if not loop.last %}, {%- endif %}\n    {%- endfor %}\n    from {{ source }} as DBT_INTERNAL_SOURCE\n    where DBT_INTERNAL_SOURCE.dbt_change_type::text = 'insert'::text;\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.415136,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.build_snapshot_staging_table": {
+            "name": "build_snapshot_staging_table",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/snapshot_helper.sql",
+            "original_file_path": "macros/snapshot_helper.sql",
+            "unique_id": "macro.dbt_duckdb.build_snapshot_staging_table",
+            "macro_sql": "{% macro build_snapshot_staging_table(strategy, sql, target_relation) %}\n    {% set temp_relation = make_temp_relation(target_relation) %}\n\n    {% set select = snapshot_staging_table(strategy, sql, target_relation) %}\n\n    {% call statement('build_snapshot_staging_relation') %}\n        {{ create_table_as(False, temp_relation, select) }}\n    {% endcall %}\n\n    {% do return(temp_relation) %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.make_temp_relation",
+                    "macro.dbt.snapshot_staging_table",
+                    "macro.dbt.statement",
+                    "macro.dbt.create_table_as"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.415675,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__post_snapshot": {
+            "name": "duckdb__post_snapshot",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/snapshot_helper.sql",
+            "original_file_path": "macros/snapshot_helper.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__post_snapshot",
+            "macro_sql": "{% macro duckdb__post_snapshot(staging_relation) %}\n    {% do return(drop_relation(staging_relation)) %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.drop_relation"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.415958,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__get_catalog": {
+            "name": "duckdb__get_catalog",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/catalog.sql",
+            "original_file_path": "macros/catalog.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__get_catalog",
+            "macro_sql": "{% macro duckdb__get_catalog(information_schema, schemas) -%}\n  {%- call statement('catalog', fetch_result=True) -%}\n    with relations AS (\n      select\n        t.table_name\n        , t.database_name\n        , t.schema_name\n        , 'BASE TABLE' as table_type\n        , {{ adapter.catalog_comment('t') }} as table_comment\n      from duckdb_tables() t\n      WHERE t.database_name = '{{ database }}'\n      UNION ALL\n      SELECT v.view_name as table_name\n      , v.database_name\n      , v.schema_name\n      , 'VIEW' as table_type\n      , {{ adapter.catalog_comment('v') }} as table_comment\n      from duckdb_views() v\n      WHERE v.database_name = '{{ database }}'\n    )\n    select\n        '{{ database }}' as table_database,\n        r.schema_name as table_schema,\n        r.table_name,\n        r.table_type,\n        r.table_comment,\n        c.column_name,\n        c.column_index as column_index,\n        c.data_type as column_type,\n        {{ adapter.catalog_comment('c') }} as column_comment,\n        '' as table_owner\n    FROM relations r JOIN duckdb_columns() c ON r.schema_name = c.schema_name AND r.table_name = c.table_name\n    WHERE (\n        {%- for schema in schemas -%}\n          upper(r.schema_name) = upper('{{ schema }}'){%- if not loop.last %} or {% endif -%}\n        {%- endfor -%}\n    )\n    ORDER BY\n        r.schema_name,\n        r.table_name,\n        c.column_index\n  {%- endcall -%}\n  {{ return(load_result('catalog').table) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.417027,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__create_schema": {
+            "name": "duckdb__create_schema",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__create_schema",
+            "macro_sql": "{% macro duckdb__create_schema(relation) -%}\n  {%- call statement('create_schema') -%}\n    {% set sql %}\n        select type from duckdb_databases()\n        where database_name='{{ relation.database }}'\n        and type='sqlite'\n    {% endset %}\n    {% set results = run_query(sql) %}\n    {% if results|length == 0 %}\n        create schema if not exists {{ relation.without_identifier() }}\n    {% else %}\n        {% if relation.schema!='main' %}\n            {{ exceptions.raise_compiler_error(\n                \"Schema must be 'main' when writing to sqlite \"\n                ~ \"instead got \" ~ relation.schema\n            )}}\n        {% endif %}\n    {% endif %}\n  {%- endcall -%}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement",
+                    "macro.dbt.run_query"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.42521,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__drop_schema": {
+            "name": "duckdb__drop_schema",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__drop_schema",
+            "macro_sql": "{% macro duckdb__drop_schema(relation) -%}\n  {%- call statement('drop_schema') -%}\n    drop schema if exists {{ relation.without_identifier() }} cascade\n  {%- endcall -%}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.425386,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__list_schemas": {
+            "name": "duckdb__list_schemas",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__list_schemas",
+            "macro_sql": "{% macro duckdb__list_schemas(database) -%}\n  {% set sql %}\n    select schema_name\n    from system.information_schema.schemata\n    {% if database is not none %}\n    where catalog_name = '{{ database }}'\n    {% endif %}\n  {% endset %}\n  {{ return(run_query(sql)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.run_query"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4256341,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__check_schema_exists": {
+            "name": "duckdb__check_schema_exists",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__check_schema_exists",
+            "macro_sql": "{% macro duckdb__check_schema_exists(information_schema, schema) -%}\n  {% set sql -%}\n        select count(*)\n        from system.information_schema.schemata\n        where schema_name = '{{ schema }}'\n        and catalog_name = '{{ information_schema.database }}'\n  {%- endset %}\n  {{ return(run_query(sql)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.run_query"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.425865,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.get_column_names": {
+            "name": "get_column_names",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "unique_id": "macro.dbt_duckdb.get_column_names",
+            "macro_sql": "{% macro get_column_names() %}\n  {# loop through user_provided_columns to get column names #}\n    {%- set user_provided_columns = model['columns'] -%}\n    (\n    {% for i in user_provided_columns %}\n      {% set col = user_provided_columns[i] %}\n      {{ col['name'] }} {{ \",\" if not loop.last }}\n    {% endfor %}\n  )\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4261918,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__create_table_as": {
+            "name": "duckdb__create_table_as",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__create_table_as",
+            "macro_sql": "{% macro duckdb__create_table_as(temporary, relation, compiled_code, language='sql') -%}\n  {%- if language == 'sql' -%}\n    {% set contract_config = config.get('contract') %}\n    {% if contract_config.enforced %}\n      {{ get_assert_columns_equivalent(compiled_code) }}\n    {% endif %}\n    {%- set sql_header = config.get('sql_header', none) -%}\n\n    {{ sql_header if sql_header is not none }}\n\n    create {% if temporary: -%}temporary{%- endif %} table\n      {{ relation.include(database=(not temporary), schema=(not temporary)) }}\n  {% if contract_config.enforced and not temporary %}\n    {#-- DuckDB doesnt support constraints on temp tables --#}\n    {{ get_table_columns_and_constraints() }} ;\n    insert into {{ relation }} {{ get_column_names() }} (\n      {{ get_select_subquery(compiled_code) }}\n    );\n  {% else %}\n    as (\n      {{ compiled_code }}\n    );\n  {% endif %}\n  {%- elif language == 'python' -%}\n    {{ py_write_table(temporary=temporary, relation=relation, compiled_code=compiled_code) }}\n  {%- else -%}\n      {% do exceptions.raise_compiler_error(\"duckdb__create_table_as macro didn't get supported language, it got %s\" % language) %}\n  {%- endif -%}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_assert_columns_equivalent",
+                    "macro.dbt.get_table_columns_and_constraints",
+                    "macro.dbt_duckdb.get_column_names",
+                    "macro.dbt.get_select_subquery",
+                    "macro.dbt_duckdb.py_write_table"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.427795,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.py_write_table": {
+            "name": "py_write_table",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "unique_id": "macro.dbt_duckdb.py_write_table",
+            "macro_sql": "{% macro py_write_table(temporary, relation, compiled_code) -%}\n{{ compiled_code }}\n\ndef materialize(df, con):\n    try:\n        import pyarrow\n        pyarrow_available = True\n    except ImportError:\n        pyarrow_available = False\n    finally:\n        if pyarrow_available and isinstance(df, pyarrow.Table):\n            # https://github.com/duckdb/duckdb/issues/6584\n            import pyarrow.dataset\n    con.execute('create table {{ relation }} as select * from df')\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.428014,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__create_view_as": {
+            "name": "duckdb__create_view_as",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__create_view_as",
+            "macro_sql": "{% macro duckdb__create_view_as(relation, sql) -%}\n  {% set contract_config = config.get('contract') %}\n  {% if contract_config.enforced %}\n    {{ get_assert_columns_equivalent(sql) }}\n  {%- endif %}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n  create view {{ relation }} as (\n    {{ sql }}\n  );\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_assert_columns_equivalent"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4284,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__get_columns_in_relation": {
+            "name": "duckdb__get_columns_in_relation",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__get_columns_in_relation",
+            "macro_sql": "{% macro duckdb__get_columns_in_relation(relation) -%}\n  {% call statement('get_columns_in_relation', fetch_result=True) %}\n      select\n          column_name,\n          data_type,\n          character_maximum_length,\n          numeric_precision,\n          numeric_scale\n\n      from system.information_schema.columns\n      where table_name = '{{ relation.identifier }}'\n      {% if relation.schema %}\n      and table_schema = '{{ relation.schema }}'\n      {% endif %}\n      {% if relation.database %}\n      and table_catalog = '{{ relation.database }}'\n      {% endif %}\n      order by ordinal_position\n\n  {% endcall %}\n  {% set table = load_result('get_columns_in_relation').table %}\n  {{ return(sql_convert_columns_in_relation(table)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement",
+                    "macro.dbt.sql_convert_columns_in_relation"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4288452,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__list_relations_without_caching": {
+            "name": "duckdb__list_relations_without_caching",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__list_relations_without_caching",
+            "macro_sql": "{% macro duckdb__list_relations_without_caching(schema_relation) %}\n  {% call statement('list_relations_without_caching', fetch_result=True) -%}\n    select\n      '{{ schema_relation.database }}' as database,\n      table_name as name,\n      table_schema as schema,\n      CASE table_type\n        WHEN 'BASE TABLE' THEN 'table'\n        WHEN 'VIEW' THEN 'view'\n        WHEN 'LOCAL TEMPORARY' THEN 'table'\n        END as type\n    from system.information_schema.tables\n    where table_schema = '{{ schema_relation.schema }}'\n    and table_catalog = '{{ schema_relation.database }}'\n  {% endcall %}\n  {{ return(load_result('list_relations_without_caching').table) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.429146,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__drop_relation": {
+            "name": "duckdb__drop_relation",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__drop_relation",
+            "macro_sql": "{% macro duckdb__drop_relation(relation) -%}\n  {% call statement('drop_relation', auto_begin=False) -%}\n    drop {{ relation.type }} if exists {{ relation }} cascade\n  {%- endcall %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.429336,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__rename_relation": {
+            "name": "duckdb__rename_relation",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__rename_relation",
+            "macro_sql": "{% macro duckdb__rename_relation(from_relation, to_relation) -%}\n  {% set target_name = adapter.quote_as_configured(to_relation.identifier, 'identifier') %}\n  {% call statement('rename_relation') -%}\n    alter {{ to_relation.type }} {{ from_relation }} rename to {{ target_name }}\n  {%- endcall %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4296021,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__make_temp_relation": {
+            "name": "duckdb__make_temp_relation",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__make_temp_relation",
+            "macro_sql": "{% macro duckdb__make_temp_relation(base_relation, suffix) %}\n    {% set tmp_identifier = base_relation.identifier ~ suffix ~ py_current_timestring() %}\n    {% do return(base_relation.incorporate(\n                                  path={\n                                    \"identifier\": tmp_identifier,\n                                    \"schema\": none,\n                                    \"database\": none\n                                  })) -%}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.py_current_timestring"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.429921,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__current_timestamp": {
+            "name": "duckdb__current_timestamp",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__current_timestamp",
+            "macro_sql": "{% macro duckdb__current_timestamp() -%}\n  now()\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.429992,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__snapshot_string_as_time": {
+            "name": "duckdb__snapshot_string_as_time",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__snapshot_string_as_time",
+            "macro_sql": "{% macro duckdb__snapshot_string_as_time(timestamp) -%}\n    {%- set result = \"'\" ~ timestamp ~ \"'::timestamp\" -%}\n    {{ return(result) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4301498,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__snapshot_get_time": {
+            "name": "duckdb__snapshot_get_time",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__snapshot_get_time",
+            "macro_sql": "{% macro duckdb__snapshot_get_time() -%}\n  {{ current_timestamp() }}::timestamp\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.current_timestamp"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.430254,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__get_incremental_default_sql": {
+            "name": "duckdb__get_incremental_default_sql",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__get_incremental_default_sql",
+            "macro_sql": "{% macro duckdb__get_incremental_default_sql(arg_dict) %}\n  {% do return(get_incremental_delete_insert_sql(arg_dict)) %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_incremental_delete_insert_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.430387,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.location_exists": {
+            "name": "location_exists",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "unique_id": "macro.dbt_duckdb.location_exists",
+            "macro_sql": "{% macro location_exists(location) -%}\n  {% do return(adapter.location_exists(location)) %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4305222,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.write_to_file": {
+            "name": "write_to_file",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "unique_id": "macro.dbt_duckdb.write_to_file",
+            "macro_sql": "{% macro write_to_file(relation, location, options) -%}\n  {% call statement('write_to_file') -%}\n    copy {{ relation }} to '{{ location }}' ({{ options }})\n  {%- endcall %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4307132,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.store_relation": {
+            "name": "store_relation",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "unique_id": "macro.dbt_duckdb.store_relation",
+            "macro_sql": "{% macro store_relation(plugin, relation, location, format, config) -%}\n  {%- set column_list = adapter.get_columns_in_relation(relation) -%}\n  {% do adapter.store_relation(plugin, relation, column_list, location, format, config) %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4310322,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.render_write_options": {
+            "name": "render_write_options",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/adapters.sql",
+            "original_file_path": "macros/adapters.sql",
+            "unique_id": "macro.dbt_duckdb.render_write_options",
+            "macro_sql": "{% macro render_write_options(config) -%}\n  {% set options = config.get('options', {}) %}\n  {% if options is not mapping %}\n    {% do exceptions.raise_compiler_error(\"The options argument must be a dictionary\") %}\n  {% endif %}\n\n  {% for k in options %}\n    {% set _ = options.update({k: render(options[k])}) %}\n  {% endfor %}\n\n  {# legacy top-level write options #}\n  {% if config.get('format') %}\n    {% set _ = options.update({'format': render(config.get('format'))}) %}\n  {% endif %}\n  {% if config.get('delimiter') %}\n    {% set _ = options.update({'delimiter': render(config.get('delimiter'))}) %}\n  {% endif %}\n\n  {% do return(options) %}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4320471,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb_escape_comment": {
+            "name": "duckdb_escape_comment",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/persist_docs.sql",
+            "original_file_path": "macros/persist_docs.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb_escape_comment",
+            "macro_sql": "{% macro duckdb_escape_comment(comment) -%}\n  {% if comment is not string %}\n    {% do exceptions.raise_compiler_error('cannot escape a non-string: ' ~ comment) %}\n  {% endif %}\n  {%- set magic = '$dbt_comment_literal_block$' -%}\n  {%- if magic in comment -%}\n    {%- do exceptions.raise_compiler_error('The string ' ~ magic ~ ' is not allowed in comments.') -%}\n  {%- endif -%}\n  {{ magic }}{{ comment }}{{ magic }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4335911,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__alter_relation_comment": {
+            "name": "duckdb__alter_relation_comment",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/persist_docs.sql",
+            "original_file_path": "macros/persist_docs.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__alter_relation_comment",
+            "macro_sql": "{% macro duckdb__alter_relation_comment(relation, comment) %}\n  {% set escaped_comment = duckdb_escape_comment(comment) %}\n  comment on {{ relation.type }} {{ relation }} is {{ escaped_comment }};\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb_escape_comment"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4339142,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__alter_column_comment": {
+            "name": "duckdb__alter_column_comment",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/persist_docs.sql",
+            "original_file_path": "macros/persist_docs.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__alter_column_comment",
+            "macro_sql": "{% macro duckdb__alter_column_comment(relation, column_dict) %}\n  {% set existing_columns = adapter.get_columns_in_relation(relation) | map(attribute=\"name\") | list %}\n  {% for column_name in column_dict if (column_name in existing_columns) %}\n    {% set comment = column_dict[column_name]['description'] %}\n    {% set escaped_comment = duckdb_escape_comment(comment) %}\n    comment on column {{ relation }}.{{ adapter.quote(column_name) if column_dict[column_name]['quote'] else column_name }} is {{ escaped_comment }};\n  {% endfor %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb_escape_comment"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4345129,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__get_delete_insert_merge_sql": {
+            "name": "duckdb__get_delete_insert_merge_sql",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/incremental_helper.sql",
+            "original_file_path": "macros/incremental_helper.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__get_delete_insert_merge_sql",
+            "macro_sql": "{% macro duckdb__get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates) -%}\n\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n\n    {% if unique_key %}\n        {% if unique_key is sequence and unique_key is not string %}\n            delete from {{target }} as DBT_INCREMENTAL_TARGET\n            using {{ source }}\n            where (\n                {% for key in unique_key %}\n                    {{ source }}.{{ key }} = DBT_INCREMENTAL_TARGET.{{ key }}\n                    {{ \"and \" if not loop.last}}\n                {% endfor %}\n                {% if incremental_predicates %}\n                    {% for predicate in incremental_predicates %}\n                        and {{ predicate }}\n                    {% endfor %}\n                {% endif %}\n            );\n        {% else %}\n            delete from {{ target }}\n            where (\n                {{ unique_key }}) in (\n                select ({{ unique_key }})\n                from {{ source }}\n            )\n            {%- if incremental_predicates %}\n                {% for predicate in incremental_predicates %}\n                    and {{ predicate }}\n                {% endfor %}\n            {%- endif -%};\n\n        {% endif %}\n    {% endif %}\n\n    insert into {{ target }} ({{ dest_cols_csv }})\n    (\n        select {{ dest_cols_csv }}\n        from {{ source }}\n    )\n\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_quoted_csv"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.436508,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__alter_relation_add_remove_columns": {
+            "name": "duckdb__alter_relation_add_remove_columns",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/columns.sql",
+            "original_file_path": "macros/columns.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__alter_relation_add_remove_columns",
+            "macro_sql": "{% macro duckdb__alter_relation_add_remove_columns(relation, add_columns, remove_columns) %}\n\n  {% if add_columns %}\n    {% for column in add_columns %}\n      {% set sql -%}\n         alter {{ relation.type }} {{ relation }} add column\n           {{ column.name }} {{ column.data_type }}\n      {%- endset -%}\n      {% do run_query(sql) %}\n    {% endfor %}\n  {% endif %}\n\n  {% if remove_columns %}\n    {% for column in remove_columns %}\n      {% set sql -%}\n        alter {{ relation.type }} {{ relation }} drop column\n          {{ column.name }}\n      {%- endset -%}\n      {% do run_query(sql) %}\n    {% endfor %}\n  {% endif %}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.run_query"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.437406,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.materialization_table_duckdb": {
+            "name": "materialization_table_duckdb",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/materializations/table.sql",
+            "original_file_path": "macros/materializations/table.sql",
+            "unique_id": "macro.dbt_duckdb.materialization_table_duckdb",
+            "macro_sql": "{% materialization table, adapter=\"duckdb\", supported_languages=['sql', 'python'] %}\n\n  {%- set language = model['language'] -%}\n\n  {%- set existing_relation = load_cached_relation(this) -%}\n  {%- set target_relation = this.incorporate(type='table') %}\n  {%- set intermediate_relation =  make_intermediate_relation(target_relation) -%}\n  -- the intermediate_relation should not already exist in the database; get_relation\n  -- will return None in that case. Otherwise, we get a relation that we can drop\n  -- later, before we try to use this name for the current operation\n  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}\n  /*\n      See ../view/view.sql for more information about this relation.\n  */\n  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}\n  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}\n  -- as above, the backup_relation should not already exist\n  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}\n  -- grab current tables grants config for comparision later on\n  {% set grant_config = config.get('grants') %}\n\n  -- drop the temp relations if they exist already in the database\n  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n  {{ drop_relation_if_exists(preexisting_backup_relation) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% call statement('main', language=language) -%}\n    {{- create_table_as(False, intermediate_relation, compiled_code, language) }}\n  {%- endcall %}\n\n  -- cleanup\n  {% if existing_relation is not none %}\n      {{ adapter.rename_relation(existing_relation, backup_relation) }}\n  {% endif %}\n\n  {{ adapter.rename_relation(intermediate_relation, target_relation) }}\n\n  {% do create_indexes(target_relation) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  -- `COMMIT` happens here\n  {{ adapter.commit() }}\n\n  -- finally, drop the existing/backup relation after the commit\n  {{ drop_relation_if_exists(backup_relation) }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n{% endmaterialization %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.load_cached_relation",
+                    "macro.dbt.make_intermediate_relation",
+                    "macro.dbt.make_backup_relation",
+                    "macro.dbt.drop_relation_if_exists",
+                    "macro.dbt.run_hooks",
+                    "macro.dbt.statement",
+                    "macro.dbt.create_table_as",
+                    "macro.dbt.create_indexes",
+                    "macro.dbt.should_revoke",
+                    "macro.dbt.apply_grants",
+                    "macro.dbt.persist_docs"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.440376,
+            "supported_languages": [
+                "sql",
+                "python"
+            ]
+        },
+        "macro.dbt_duckdb.materialization_external_duckdb": {
+            "name": "materialization_external_duckdb",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/materializations/external.sql",
+            "original_file_path": "macros/materializations/external.sql",
+            "unique_id": "macro.dbt_duckdb.materialization_external_duckdb",
+            "macro_sql": "{% materialization external, adapter=\"duckdb\", supported_languages=['sql', 'python'] %}\n\n  {%- set location = render(config.get('location', default=external_location(this, config))) -%})\n  {%- set rendered_options = render_write_options(config) -%}\n  {%- set format = config.get('format', 'parquet') -%}\n  {%- set write_options = adapter.external_write_options(location, rendered_options) -%}\n  {%- set read_location = adapter.external_read_location(location, rendered_options) -%}\n\n  -- set language - python or sql\n  {%- set language = model['language'] -%}\n\n  {%- set target_relation = this.incorporate(type='view') %}\n\n  -- Continue as normal materialization\n  {%- set existing_relation = load_cached_relation(this) -%}\n  {%- set temp_relation =  make_intermediate_relation(this.incorporate(type='table'), suffix='__dbt_tmp') -%}\n  {%- set intermediate_relation =  make_intermediate_relation(target_relation, suffix='__dbt_int') -%}\n  -- the intermediate_relation should not already exist in the database; get_relation\n  -- will return None in that case. Otherwise, we get a relation that we can drop\n  -- later, before we try to use this name for the current operation\n  {%- set preexisting_temp_relation = load_cached_relation(temp_relation) -%}\n  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}\n  /*\n      See ../view/view.sql for more information about this relation.\n  */\n  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}\n  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}\n  -- as above, the backup_relation should not already exist\n  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}\n  -- grab current tables grants config for comparision later on\n  {% set grant_config = config.get('grants') %}\n\n  -- drop the temp relations if they exist already in the database\n  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n  {{ drop_relation_if_exists(preexisting_temp_relation) }}\n  {{ drop_relation_if_exists(preexisting_backup_relation) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% call statement('create_table', language=language) -%}\n    {{- create_table_as(False, temp_relation, compiled_code, language) }}\n  {%- endcall %}\n\n  -- write an temp relation into file\n  {{ write_to_file(temp_relation, location, write_options) }}\n  -- create a view on top of the location\n  {% call statement('main', language='sql') -%}\n    create or replace view {{ intermediate_relation }} as (\n        select * from '{{ read_location }}'\n    );\n  {%- endcall %}\n\n  -- cleanup\n  {% if existing_relation is not none %}\n      {{ adapter.rename_relation(existing_relation, backup_relation) }}\n  {% endif %}\n\n  {{ adapter.rename_relation(intermediate_relation, target_relation) }}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  -- `COMMIT` happens here\n  {{ adapter.commit() }}\n\n  -- finally, drop the existing/backup relation after the commit\n  {{ drop_relation_if_exists(backup_relation) }}\n  {{ drop_relation_if_exists(temp_relation) }}\n\n  -- register table into glue\n  {%- set plugin_name = config.get('plugin') -%}\n  {%- set glue_register = config.get('glue_register', default=false) -%}\n  {%- set partition_columns = config.get('partition_columns', []) -%}\n  {% if plugin_name is not none or glue_register is true %}\n    {% if glue_register %}\n      {# legacy hack to set the glue database name, deprecate this #}\n      {%- set plugin_name = 'glue|' ~ config.get('glue_database', 'default') -%}\n    {% endif %}\n    {% do store_relation(plugin_name, target_relation, location, format, config) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmaterialization %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.external_location",
+                    "macro.dbt_duckdb.render_write_options",
+                    "macro.dbt.load_cached_relation",
+                    "macro.dbt.make_intermediate_relation",
+                    "macro.dbt.make_backup_relation",
+                    "macro.dbt.drop_relation_if_exists",
+                    "macro.dbt.run_hooks",
+                    "macro.dbt.statement",
+                    "macro.dbt.create_table_as",
+                    "macro.dbt_duckdb.write_to_file",
+                    "macro.dbt.should_revoke",
+                    "macro.dbt.apply_grants",
+                    "macro.dbt.persist_docs",
+                    "macro.dbt_duckdb.store_relation"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.445555,
+            "supported_languages": [
+                "sql",
+                "python"
+            ]
+        },
+        "macro.dbt_duckdb.materialization_incremental_duckdb": {
+            "name": "materialization_incremental_duckdb",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/materializations/incremental.sql",
+            "original_file_path": "macros/materializations/incremental.sql",
+            "unique_id": "macro.dbt_duckdb.materialization_incremental_duckdb",
+            "macro_sql": "{% materialization incremental, adapter=\"duckdb\", supported_languages=['sql', 'python'] -%}\n\n  {%- set language = model['language'] -%}\n  -- only create temp tables if using local duckdb, as it is not currently supported for remote databases\n  {%- set temporary = not adapter.is_motherduck() -%}\n\n  -- relations\n  {%- set existing_relation = load_cached_relation(this) -%}\n  {%- set target_relation = this.incorporate(type='table') -%}\n  {%- set temp_relation = make_temp_relation(target_relation)-%}\n  {%- set intermediate_relation = make_intermediate_relation(target_relation)-%}\n  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}\n  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}\n\n  -- configs\n  {%- set unique_key = config.get('unique_key') -%}\n  {%- set full_refresh_mode = (should_full_refresh()  or existing_relation.is_view) -%}\n  {%- set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') -%}\n\n  -- the temp_ and backup_ relations should not already exist in the database; get_relation\n  -- will return None in that case. Otherwise, we get a relation that we can drop\n  -- later, before we try to use this name for the current operation. This has to happen before\n  -- BEGIN, in a separate transaction\n  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation)-%}\n  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}\n   -- grab current tables grants config for comparision later on\n  {% set grant_config = config.get('grants') %}\n  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n  {{ drop_relation_if_exists(preexisting_backup_relation) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  {% set to_drop = [] %}\n\n  {% if existing_relation is none %}\n    {% set build_sql = create_table_as(False, target_relation, compiled_code, language) %}\n  {% elif full_refresh_mode %}\n    {% set build_sql = create_table_as(False, intermediate_relation, compiled_code, language) %}\n    {% set need_swap = true %}\n  {% else %}\n    {% if not temporary %}\n      -- if not using a temporary table we will update the temp relation to use a different temp schema (\"dbt_temp\" by default)\n      {% set temp_relation = temp_relation.incorporate(path=adapter.get_temp_relation_path(this)) %}\n      {% do run_query(create_schema(temp_relation)) %}\n      -- then drop the temp relation after we insert the incremental data into the target relation\n      {% do to_drop.append(temp_relation) %}\n    {% endif %}\n    {% if language == 'python' %}\n      {% set build_python = create_table_as(False, temp_relation, compiled_code, language) %}\n      {% call statement(\"pre\", language=language) %}\n        {{- build_python }}\n      {% endcall %}\n    {% else %} {# SQL #}\n      {% do run_query(create_table_as(temporary, temp_relation, compiled_code, language)) %}\n    {% endif %}\n    {% do adapter.expand_target_column_types(\n             from_relation=temp_relation,\n             to_relation=target_relation) %}\n    {#-- Process schema changes. Returns dict of changes if successful. Use source columns for upserting/merging --#}\n    {% set dest_columns = process_schema_changes(on_schema_change, temp_relation, existing_relation) %}\n    {% if not dest_columns %}\n      {% set dest_columns = adapter.get_columns_in_relation(existing_relation) %}\n    {% endif %}\n\n    {#-- Get the incremental_strategy, the macro to use for the strategy, and build the sql --#}\n    {% set incremental_strategy = config.get('incremental_strategy') or 'default' %}\n    {% set incremental_predicates = config.get('predicates', none) or config.get('incremental_predicates', none) %}\n    {% set strategy_sql_macro_func = adapter.get_incremental_strategy_macro(context, incremental_strategy) %}\n    {% set strategy_arg_dict = ({'target_relation': target_relation, 'temp_relation': temp_relation, 'unique_key': unique_key, 'dest_columns': dest_columns, 'incremental_predicates': incremental_predicates }) %}\n    {% set build_sql = strategy_sql_macro_func(strategy_arg_dict) %}\n    {% set language = \"sql\" %}\n\n  {% endif %}\n\n  {% call statement(\"main\", language=language) %}\n      {{- build_sql }}\n  {% endcall %}\n\n  {% if need_swap %}\n      {% do adapter.rename_relation(target_relation, backup_relation) %}\n      {% do adapter.rename_relation(intermediate_relation, target_relation) %}\n      {% do to_drop.append(backup_relation) %}\n  {% endif %}\n\n  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {% if existing_relation is none or existing_relation.is_view or should_full_refresh() %}\n    {% do create_indexes(target_relation) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  -- `COMMIT` happens here\n  {% do adapter.commit() %}\n\n  {% for rel in to_drop %}\n      {% do adapter.drop_relation(rel) %}\n  {% endfor %}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{%- endmaterialization %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.load_cached_relation",
+                    "macro.dbt.make_temp_relation",
+                    "macro.dbt.make_intermediate_relation",
+                    "macro.dbt.make_backup_relation",
+                    "macro.dbt.should_full_refresh",
+                    "macro.dbt.incremental_validate_on_schema_change",
+                    "macro.dbt.drop_relation_if_exists",
+                    "macro.dbt.run_hooks",
+                    "macro.dbt.create_table_as",
+                    "macro.dbt.run_query",
+                    "macro.dbt.create_schema",
+                    "macro.dbt.statement",
+                    "macro.dbt.process_schema_changes",
+                    "macro.dbt.should_revoke",
+                    "macro.dbt.apply_grants",
+                    "macro.dbt.persist_docs",
+                    "macro.dbt.create_indexes"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.452378,
+            "supported_languages": [
+                "sql",
+                "python"
+            ]
+        },
+        "macro.dbt_duckdb.duckdb__dateadd": {
+            "name": "duckdb__dateadd",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/utils/dateadd.sql",
+            "original_file_path": "macros/utils/dateadd.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__dateadd",
+            "macro_sql": "{% macro duckdb__dateadd(datepart, interval, from_date_or_timestamp) %}\n\n    date_add({{ from_date_or_timestamp }}, interval ({{ interval }}) {{ datepart }})\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.452644,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__listagg": {
+            "name": "duckdb__listagg",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/utils/listagg.sql",
+            "original_file_path": "macros/utils/listagg.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__listagg",
+            "macro_sql": "{% macro duckdb__listagg(measure, delimiter_text, order_by_clause, limit_num) -%}\n    {% if limit_num -%}\n    list_aggr(\n        (array_agg(\n            {{ measure }}\n            {% if order_by_clause -%}\n            {{ order_by_clause }}\n            {%- endif %}\n        ))[1:{{ limit_num }}],\n        'string_agg',\n        {{ delimiter_text }}\n        )\n    {%- else %}\n    string_agg(\n        {{ measure }},\n        {{ delimiter_text }}\n        {% if order_by_clause -%}\n        {{ order_by_clause }}\n        {%- endif %}\n        )\n    {%- endif %}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4531982,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__datediff": {
+            "name": "duckdb__datediff",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/utils/datediff.sql",
+            "original_file_path": "macros/utils/datediff.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__datediff",
+            "macro_sql": "{% macro duckdb__datediff(first_date, second_date, datepart) -%}\n    date_diff('{{ datepart }}', {{ first_date }}::timestamp, {{ second_date}}::timestamp )\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.453505,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__any_value": {
+            "name": "duckdb__any_value",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/utils/any_value.sql",
+            "original_file_path": "macros/utils/any_value.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__any_value",
+            "macro_sql": "{% macro duckdb__any_value(expression) -%}\n\n    arbitrary({{ expression }})\n\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.45364,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.register_upstream_external_models": {
+            "name": "register_upstream_external_models",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/utils/upstream.sql",
+            "original_file_path": "macros/utils/upstream.sql",
+            "unique_id": "macro.dbt_duckdb.register_upstream_external_models",
+            "macro_sql": "{%- macro register_upstream_external_models() -%}\n{% if execute %}\n{% set upstream_nodes = {} %}\n{% set upstream_schemas = {} %}\n{% for node in selected_resources %}\n  {% for upstream_node in graph['nodes'][node]['depends_on']['nodes'] %}\n    {% if upstream_node not in upstream_nodes and upstream_node not in selected_resources %}\n      {% do upstream_nodes.update({upstream_node: None}) %}\n      {% set upstream = graph['nodes'].get(upstream_node) %}\n      {% if upstream\n         and upstream.resource_type in ('model', 'seed')\n         and upstream.config.materialized=='external'\n      %}\n        {%- set upstream_rel = api.Relation.create(\n          database=upstream['database'],\n          schema=upstream['schema'],\n          identifier=upstream['alias']\n        ) -%}\n        {%- set location = upstream.config.get('location', external_location(upstream_rel, upstream.config)) -%}\n        {%- set rendered_options = render_write_options(upstream.config) -%}\n        {%- set upstream_location = adapter.external_read_location(location, rendered_options) -%}\n        {% if upstream_rel.schema not in upstream_schemas %}\n          {% call statement('main', language='sql') -%}\n            create schema if not exists {{ upstream_rel.schema }}\n          {%- endcall %}\n          {% do upstream_schemas.update({upstream_rel.schema: None}) %}\n        {% endif %}\n        {% call statement('main', language='sql') -%}\n          create or replace view {{ upstream_rel }} as (\n            select * from '{{ upstream_location }}'\n          );\n        {%- endcall %}\n      {%- endif %}\n    {% endif %}\n  {% endfor %}\n{% endfor %}\n{% do adapter.commit() %}\n{% endif %}\n{%- endmacro -%}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.external_location",
+                    "macro.dbt_duckdb.render_write_options",
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.455858,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__split_part": {
+            "name": "duckdb__split_part",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/utils/splitpart.sql",
+            "original_file_path": "macros/utils/splitpart.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__split_part",
+            "macro_sql": "{% macro duckdb__split_part(string_text, delimiter_text, part_number) %}\n    string_split({{ string_text }}, {{ delimiter_text }})[ {{ part_number }} ]\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.45629,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.duckdb__last_day": {
+            "name": "duckdb__last_day",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/utils/lastday.sql",
+            "original_file_path": "macros/utils/lastday.sql",
+            "unique_id": "macro.dbt_duckdb.duckdb__last_day",
+            "macro_sql": "{% macro duckdb__last_day(date, datepart) -%}\n\n    {%- if datepart == 'quarter' -%}\n    -- duckdb dateadd does not support quarter interval.\n    cast(\n        {{dbt.dateadd('day', '-1',\n        dbt.dateadd('month', '3', dbt.date_trunc(datepart, date))\n        )}}\n        as date)\n    {%- else -%}\n    {{dbt.default_last_day(date, datepart)}}\n    {%- endif -%}\n\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.dateadd",
+                    "macro.dbt.date_trunc",
+                    "macro.dbt.default_last_day"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.45679,
+            "supported_languages": null
+        },
+        "macro.dbt_duckdb.external_location": {
+            "name": "external_location",
+            "resource_type": "macro",
+            "package_name": "dbt_duckdb",
+            "path": "macros/utils/external_location.sql",
+            "original_file_path": "macros/utils/external_location.sql",
+            "unique_id": "macro.dbt_duckdb.external_location",
+            "macro_sql": "{%- macro external_location(relation, config) -%}\n  {%- if config.get('options', {}).get('partition_by') is none -%}\n    {%- set format = config.get('format', 'parquet') -%}\n    {{- adapter.external_root() }}/{{ relation.identifier }}.{{ format }}\n  {%- else -%}\n    {{- adapter.external_root() }}/{{ relation.identifier }}\n  {%- endif -%}\n{%- endmacro -%}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4574668,
+            "supported_languages": null
+        },
+        "macro.dbt.run_hooks": {
+            "name": "run_hooks",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/hooks.sql",
+            "original_file_path": "macros/materializations/hooks.sql",
+            "unique_id": "macro.dbt.run_hooks",
+            "macro_sql": "{% macro run_hooks(hooks, inside_transaction=True) %}\n  {% for hook in hooks | selectattr('transaction', 'equalto', inside_transaction)  %}\n    {% if not inside_transaction and loop.first %}\n      {% call statement(auto_begin=inside_transaction) %}\n        commit;\n      {% endcall %}\n    {% endif %}\n    {% set rendered = render(hook.get('sql')) | trim %}\n    {% if (rendered | length) > 0 %}\n      {% call statement(auto_begin=inside_transaction) %}\n        {{ rendered }}\n      {% endcall %}\n    {% endif %}\n  {% endfor %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.458501,
+            "supported_languages": null
+        },
+        "macro.dbt.make_hook_config": {
+            "name": "make_hook_config",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/hooks.sql",
+            "original_file_path": "macros/materializations/hooks.sql",
+            "unique_id": "macro.dbt.make_hook_config",
+            "macro_sql": "{% macro make_hook_config(sql, inside_transaction) %}\n    {{ tojson({\"sql\": sql, \"transaction\": inside_transaction}) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.458751,
+            "supported_languages": null
+        },
+        "macro.dbt.before_begin": {
+            "name": "before_begin",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/hooks.sql",
+            "original_file_path": "macros/materializations/hooks.sql",
+            "unique_id": "macro.dbt.before_begin",
+            "macro_sql": "{% macro before_begin(sql) %}\n    {{ make_hook_config(sql, inside_transaction=False) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.make_hook_config"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4589062,
+            "supported_languages": null
+        },
+        "macro.dbt.in_transaction": {
+            "name": "in_transaction",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/hooks.sql",
+            "original_file_path": "macros/materializations/hooks.sql",
+            "unique_id": "macro.dbt.in_transaction",
+            "macro_sql": "{% macro in_transaction(sql) %}\n    {{ make_hook_config(sql, inside_transaction=True) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.make_hook_config"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.459146,
+            "supported_languages": null
+        },
+        "macro.dbt.after_commit": {
+            "name": "after_commit",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/hooks.sql",
+            "original_file_path": "macros/materializations/hooks.sql",
+            "unique_id": "macro.dbt.after_commit",
+            "macro_sql": "{% macro after_commit(sql) %}\n    {{ make_hook_config(sql, inside_transaction=False) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.make_hook_config"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.459601,
+            "supported_languages": null
+        },
+        "macro.dbt.set_sql_header": {
+            "name": "set_sql_header",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/configs.sql",
+            "original_file_path": "macros/materializations/configs.sql",
+            "unique_id": "macro.dbt.set_sql_header",
+            "macro_sql": "{% macro set_sql_header(config) -%}\n  {{ config.set('sql_header', caller()) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.460144,
+            "supported_languages": null
+        },
+        "macro.dbt.should_full_refresh": {
+            "name": "should_full_refresh",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/configs.sql",
+            "original_file_path": "macros/materializations/configs.sql",
+            "unique_id": "macro.dbt.should_full_refresh",
+            "macro_sql": "{% macro should_full_refresh() %}\n  {% set config_full_refresh = config.get('full_refresh') %}\n  {% if config_full_refresh is none %}\n    {% set config_full_refresh = flags.FULL_REFRESH %}\n  {% endif %}\n  {% do return(config_full_refresh) %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.460431,
+            "supported_languages": null
+        },
+        "macro.dbt.should_store_failures": {
+            "name": "should_store_failures",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/configs.sql",
+            "original_file_path": "macros/materializations/configs.sql",
+            "unique_id": "macro.dbt.should_store_failures",
+            "macro_sql": "{% macro should_store_failures() %}\n  {% set config_store_failures = config.get('store_failures') %}\n  {% if config_store_failures is none %}\n    {% set config_store_failures = flags.STORE_FAILURES %}\n  {% endif %}\n  {% do return(config_store_failures) %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.460711,
+            "supported_languages": null
+        },
+        "macro.dbt.snapshot_merge_sql": {
+            "name": "snapshot_merge_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/snapshots/snapshot_merge.sql",
+            "original_file_path": "macros/materializations/snapshots/snapshot_merge.sql",
+            "unique_id": "macro.dbt.snapshot_merge_sql",
+            "macro_sql": "{% macro snapshot_merge_sql(target, source, insert_cols) -%}\n  {{ adapter.dispatch('snapshot_merge_sql', 'dbt')(target, source, insert_cols) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__snapshot_merge_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.461129,
+            "supported_languages": null
+        },
+        "macro.dbt.default__snapshot_merge_sql": {
+            "name": "default__snapshot_merge_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/snapshots/snapshot_merge.sql",
+            "original_file_path": "macros/materializations/snapshots/snapshot_merge.sql",
+            "unique_id": "macro.dbt.default__snapshot_merge_sql",
+            "macro_sql": "{% macro default__snapshot_merge_sql(target, source, insert_cols) -%}\n    {%- set insert_cols_csv = insert_cols | join(', ') -%}\n\n    merge into {{ target }} as DBT_INTERNAL_DEST\n    using {{ source }} as DBT_INTERNAL_SOURCE\n    on DBT_INTERNAL_SOURCE.dbt_scd_id = DBT_INTERNAL_DEST.dbt_scd_id\n\n    when matched\n     and DBT_INTERNAL_DEST.dbt_valid_to is null\n     and DBT_INTERNAL_SOURCE.dbt_change_type in ('update', 'delete')\n        then update\n        set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to\n\n    when not matched\n     and DBT_INTERNAL_SOURCE.dbt_change_type = 'insert'\n        then insert ({{ insert_cols_csv }})\n        values ({{ insert_cols_csv }})\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.46207,
+            "supported_languages": null
+        },
+        "macro.dbt.strategy_dispatch": {
+            "name": "strategy_dispatch",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/snapshots/strategies.sql",
+            "original_file_path": "macros/materializations/snapshots/strategies.sql",
+            "unique_id": "macro.dbt.strategy_dispatch",
+            "macro_sql": "{% macro strategy_dispatch(name) -%}\n{% set original_name = name %}\n  {% if '.' in name %}\n    {% set package_name, name = name.split(\".\", 1) %}\n  {% else %}\n    {% set package_name = none %}\n  {% endif %}\n\n  {% if package_name is none %}\n    {% set package_context = context %}\n  {% elif package_name in context %}\n    {% set package_context = context[package_name] %}\n  {% else %}\n    {% set error_msg %}\n        Could not find package '{{package_name}}', called with '{{original_name}}'\n    {% endset %}\n    {{ exceptions.raise_compiler_error(error_msg | trim) }}\n  {% endif %}\n\n  {%- set search_name = 'snapshot_' ~ name ~ '_strategy' -%}\n\n  {% if search_name not in package_context %}\n    {% set error_msg %}\n        The specified strategy macro '{{name}}' was not found in package '{{ package_name }}'\n    {% endset %}\n    {{ exceptions.raise_compiler_error(error_msg | trim) }}\n  {% endif %}\n  {{ return(package_context[search_name]) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4663649,
+            "supported_languages": null
+        },
+        "macro.dbt.snapshot_hash_arguments": {
+            "name": "snapshot_hash_arguments",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/snapshots/strategies.sql",
+            "original_file_path": "macros/materializations/snapshots/strategies.sql",
+            "unique_id": "macro.dbt.snapshot_hash_arguments",
+            "macro_sql": "{% macro snapshot_hash_arguments(args) -%}\n  {{ adapter.dispatch('snapshot_hash_arguments', 'dbt')(args) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__snapshot_hash_arguments"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.466774,
+            "supported_languages": null
+        },
+        "macro.dbt.default__snapshot_hash_arguments": {
+            "name": "default__snapshot_hash_arguments",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/snapshots/strategies.sql",
+            "original_file_path": "macros/materializations/snapshots/strategies.sql",
+            "unique_id": "macro.dbt.default__snapshot_hash_arguments",
+            "macro_sql": "{% macro default__snapshot_hash_arguments(args) -%}\n    md5({%- for arg in args -%}\n        coalesce(cast({{ arg }} as varchar ), '')\n        {% if not loop.last %} || '|' || {% endif %}\n    {%- endfor -%})\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4670131,
+            "supported_languages": null
+        },
+        "macro.dbt.snapshot_timestamp_strategy": {
+            "name": "snapshot_timestamp_strategy",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/snapshots/strategies.sql",
+            "original_file_path": "macros/materializations/snapshots/strategies.sql",
+            "unique_id": "macro.dbt.snapshot_timestamp_strategy",
+            "macro_sql": "{% macro snapshot_timestamp_strategy(node, snapshotted_rel, current_rel, config, target_exists) %}\n    {% set primary_key = config['unique_key'] %}\n    {% set updated_at = config['updated_at'] %}\n    {% set invalidate_hard_deletes = config.get('invalidate_hard_deletes', false) %}\n\n    {#/*\n        The snapshot relation might not have an {{ updated_at }} value if the\n        snapshot strategy is changed from `check` to `timestamp`. We\n        should use a dbt-created column for the comparison in the snapshot\n        table instead of assuming that the user-supplied {{ updated_at }}\n        will be present in the historical data.\n\n        See https://github.com/dbt-labs/dbt-core/issues/2350\n    */ #}\n    {% set row_changed_expr -%}\n        ({{ snapshotted_rel }}.dbt_valid_from < {{ current_rel }}.{{ updated_at }})\n    {%- endset %}\n\n    {% set scd_id_expr = snapshot_hash_arguments([primary_key, updated_at]) %}\n\n    {% do return({\n        \"unique_key\": primary_key,\n        \"updated_at\": updated_at,\n        \"row_changed\": row_changed_expr,\n        \"scd_id\": scd_id_expr,\n        \"invalidate_hard_deletes\": invalidate_hard_deletes\n    }) %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.snapshot_hash_arguments"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.467669,
+            "supported_languages": null
+        },
+        "macro.dbt.snapshot_string_as_time": {
+            "name": "snapshot_string_as_time",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/snapshots/strategies.sql",
+            "original_file_path": "macros/materializations/snapshots/strategies.sql",
+            "unique_id": "macro.dbt.snapshot_string_as_time",
+            "macro_sql": "{% macro snapshot_string_as_time(timestamp) -%}\n    {{ adapter.dispatch('snapshot_string_as_time', 'dbt')(timestamp) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__snapshot_string_as_time"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.467825,
+            "supported_languages": null
+        },
+        "macro.dbt.default__snapshot_string_as_time": {
+            "name": "default__snapshot_string_as_time",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/snapshots/strategies.sql",
+            "original_file_path": "macros/materializations/snapshots/strategies.sql",
+            "unique_id": "macro.dbt.default__snapshot_string_as_time",
+            "macro_sql": "{% macro default__snapshot_string_as_time(timestamp) %}\n    {% do exceptions.raise_not_implemented(\n        'snapshot_string_as_time macro not implemented for adapter '+adapter.type()\n    ) %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.468062,
+            "supported_languages": null
+        },
+        "macro.dbt.snapshot_check_all_get_existing_columns": {
+            "name": "snapshot_check_all_get_existing_columns",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/snapshots/strategies.sql",
+            "original_file_path": "macros/materializations/snapshots/strategies.sql",
+            "unique_id": "macro.dbt.snapshot_check_all_get_existing_columns",
+            "macro_sql": "{% macro snapshot_check_all_get_existing_columns(node, target_exists, check_cols_config) -%}\n    {%- if not target_exists -%}\n        {#-- no table yet -> return whatever the query does --#}\n        {{ return((false, query_columns)) }}\n    {%- endif -%}\n\n    {#-- handle any schema changes --#}\n    {%- set target_relation = adapter.get_relation(database=node.database, schema=node.schema, identifier=node.alias) -%}\n\n    {% if check_cols_config == 'all' %}\n        {%- set query_columns = get_columns_in_query(node['compiled_code']) -%}\n\n    {% elif check_cols_config is iterable and (check_cols_config | length) > 0 %}\n        {#-- query for proper casing/quoting, to support comparison below --#}\n        {%- set select_check_cols_from_target -%}\n            {#-- N.B. The whitespace below is necessary to avoid edge case issue with comments --#}\n            {#-- See: https://github.com/dbt-labs/dbt-core/issues/6781 --#}\n            select {{ check_cols_config | join(', ') }} from (\n                {{ node['compiled_code'] }}\n            ) subq\n        {%- endset -%}\n        {% set query_columns = get_columns_in_query(select_check_cols_from_target) %}\n\n    {% else %}\n        {% do exceptions.raise_compiler_error(\"Invalid value for 'check_cols': \" ~ check_cols_config) %}\n    {% endif %}\n\n    {%- set existing_cols = adapter.get_columns_in_relation(target_relation) | map(attribute = 'name') | list -%}\n    {%- set ns = namespace() -%} {#-- handle for-loop scoping with a namespace --#}\n    {%- set ns.column_added = false -%}\n\n    {%- set intersection = [] -%}\n    {%- for col in query_columns -%}\n        {%- if col in existing_cols -%}\n            {%- do intersection.append(adapter.quote(col)) -%}\n        {%- else -%}\n            {% set ns.column_added = true %}\n        {%- endif -%}\n    {%- endfor -%}\n    {{ return((ns.column_added, intersection)) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_columns_in_query"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4699268,
+            "supported_languages": null
+        },
+        "macro.dbt.snapshot_check_strategy": {
+            "name": "snapshot_check_strategy",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/snapshots/strategies.sql",
+            "original_file_path": "macros/materializations/snapshots/strategies.sql",
+            "unique_id": "macro.dbt.snapshot_check_strategy",
+            "macro_sql": "{% macro snapshot_check_strategy(node, snapshotted_rel, current_rel, config, target_exists) %}\n    {% set check_cols_config = config['check_cols'] %}\n    {% set primary_key = config['unique_key'] %}\n    {% set invalidate_hard_deletes = config.get('invalidate_hard_deletes', false) %}\n    {% set updated_at = config.get('updated_at', snapshot_get_time()) %}\n\n    {% set column_added = false %}\n\n    {% set column_added, check_cols = snapshot_check_all_get_existing_columns(node, target_exists, check_cols_config) %}\n\n    {%- set row_changed_expr -%}\n    (\n    {%- if column_added -%}\n        {{ get_true_sql() }}\n    {%- else -%}\n    {%- for col in check_cols -%}\n        {{ snapshotted_rel }}.{{ col }} != {{ current_rel }}.{{ col }}\n        or\n        (\n            (({{ snapshotted_rel }}.{{ col }} is null) and not ({{ current_rel }}.{{ col }} is null))\n            or\n            ((not {{ snapshotted_rel }}.{{ col }} is null) and ({{ current_rel }}.{{ col }} is null))\n        )\n        {%- if not loop.last %} or {% endif -%}\n    {%- endfor -%}\n    {%- endif -%}\n    )\n    {%- endset %}\n\n    {% set scd_id_expr = snapshot_hash_arguments([primary_key, updated_at]) %}\n\n    {% do return({\n        \"unique_key\": primary_key,\n        \"updated_at\": updated_at,\n        \"row_changed\": row_changed_expr,\n        \"scd_id\": scd_id_expr,\n        \"invalidate_hard_deletes\": invalidate_hard_deletes\n    }) %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.snapshot_get_time",
+                    "macro.dbt.snapshot_check_all_get_existing_columns",
+                    "macro.dbt.get_true_sql",
+                    "macro.dbt.snapshot_hash_arguments"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.47153,
+            "supported_languages": null
+        },
+        "macro.dbt.create_columns": {
+            "name": "create_columns",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/snapshots/helpers.sql",
+            "original_file_path": "macros/materializations/snapshots/helpers.sql",
+            "unique_id": "macro.dbt.create_columns",
+            "macro_sql": "{% macro create_columns(relation, columns) %}\n  {{ adapter.dispatch('create_columns', 'dbt')(relation, columns) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__create_columns"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4760451,
+            "supported_languages": null
+        },
+        "macro.dbt.default__create_columns": {
+            "name": "default__create_columns",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/snapshots/helpers.sql",
+            "original_file_path": "macros/materializations/snapshots/helpers.sql",
+            "unique_id": "macro.dbt.default__create_columns",
+            "macro_sql": "{% macro default__create_columns(relation, columns) %}\n  {% for column in columns %}\n    {% call statement() %}\n      alter table {{ relation }} add column \"{{ column.name }}\" {{ column.data_type }};\n    {% endcall %}\n  {% endfor %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.476317,
+            "supported_languages": null
+        },
+        "macro.dbt.post_snapshot": {
+            "name": "post_snapshot",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/snapshots/helpers.sql",
+            "original_file_path": "macros/materializations/snapshots/helpers.sql",
+            "unique_id": "macro.dbt.post_snapshot",
+            "macro_sql": "{% macro post_snapshot(staging_relation) %}\n  {{ adapter.dispatch('post_snapshot', 'dbt')(staging_relation) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__post_snapshot"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.476471,
+            "supported_languages": null
+        },
+        "macro.dbt.default__post_snapshot": {
+            "name": "default__post_snapshot",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/snapshots/helpers.sql",
+            "original_file_path": "macros/materializations/snapshots/helpers.sql",
+            "unique_id": "macro.dbt.default__post_snapshot",
+            "macro_sql": "{% macro default__post_snapshot(staging_relation) %}\n    {# no-op #}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.476558,
+            "supported_languages": null
+        },
+        "macro.dbt.get_true_sql": {
+            "name": "get_true_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/snapshots/helpers.sql",
+            "original_file_path": "macros/materializations/snapshots/helpers.sql",
+            "unique_id": "macro.dbt.get_true_sql",
+            "macro_sql": "{% macro get_true_sql() %}\n  {{ adapter.dispatch('get_true_sql', 'dbt')() }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_true_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4766889,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_true_sql": {
+            "name": "default__get_true_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/snapshots/helpers.sql",
+            "original_file_path": "macros/materializations/snapshots/helpers.sql",
+            "unique_id": "macro.dbt.default__get_true_sql",
+            "macro_sql": "{% macro default__get_true_sql() %}\n    {{ return('TRUE') }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4767969,
+            "supported_languages": null
+        },
+        "macro.dbt.snapshot_staging_table": {
+            "name": "snapshot_staging_table",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/snapshots/helpers.sql",
+            "original_file_path": "macros/materializations/snapshots/helpers.sql",
+            "unique_id": "macro.dbt.snapshot_staging_table",
+            "macro_sql": "{% macro snapshot_staging_table(strategy, source_sql, target_relation) -%}\n  {{ adapter.dispatch('snapshot_staging_table', 'dbt')(strategy, source_sql, target_relation) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__snapshot_staging_table"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.476979,
+            "supported_languages": null
+        },
+        "macro.dbt.default__snapshot_staging_table": {
+            "name": "default__snapshot_staging_table",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/snapshots/helpers.sql",
+            "original_file_path": "macros/materializations/snapshots/helpers.sql",
+            "unique_id": "macro.dbt.default__snapshot_staging_table",
+            "macro_sql": "{% macro default__snapshot_staging_table(strategy, source_sql, target_relation) -%}\n\n    with snapshot_query as (\n\n        {{ source_sql }}\n\n    ),\n\n    snapshotted_data as (\n\n        select *,\n            {{ strategy.unique_key }} as dbt_unique_key\n\n        from {{ target_relation }}\n        where dbt_valid_to is null\n\n    ),\n\n    insertions_source_data as (\n\n        select\n            *,\n            {{ strategy.unique_key }} as dbt_unique_key,\n            {{ strategy.updated_at }} as dbt_updated_at,\n            {{ strategy.updated_at }} as dbt_valid_from,\n            nullif({{ strategy.updated_at }}, {{ strategy.updated_at }}) as dbt_valid_to,\n            {{ strategy.scd_id }} as dbt_scd_id\n\n        from snapshot_query\n    ),\n\n    updates_source_data as (\n\n        select\n            *,\n            {{ strategy.unique_key }} as dbt_unique_key,\n            {{ strategy.updated_at }} as dbt_updated_at,\n            {{ strategy.updated_at }} as dbt_valid_from,\n            {{ strategy.updated_at }} as dbt_valid_to\n\n        from snapshot_query\n    ),\n\n    {%- if strategy.invalidate_hard_deletes %}\n\n    deletes_source_data as (\n\n        select\n            *,\n            {{ strategy.unique_key }} as dbt_unique_key\n        from snapshot_query\n    ),\n    {% endif %}\n\n    insertions as (\n\n        select\n            'insert' as dbt_change_type,\n            source_data.*\n\n        from insertions_source_data as source_data\n        left outer join snapshotted_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key\n        where snapshotted_data.dbt_unique_key is null\n           or (\n                snapshotted_data.dbt_unique_key is not null\n            and (\n                {{ strategy.row_changed }}\n            )\n        )\n\n    ),\n\n    updates as (\n\n        select\n            'update' as dbt_change_type,\n            source_data.*,\n            snapshotted_data.dbt_scd_id\n\n        from updates_source_data as source_data\n        join snapshotted_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key\n        where (\n            {{ strategy.row_changed }}\n        )\n    )\n\n    {%- if strategy.invalidate_hard_deletes -%}\n    ,\n\n    deletes as (\n\n        select\n            'delete' as dbt_change_type,\n            source_data.*,\n            {{ snapshot_get_time() }} as dbt_valid_from,\n            {{ snapshot_get_time() }} as dbt_updated_at,\n            {{ snapshot_get_time() }} as dbt_valid_to,\n            snapshotted_data.dbt_scd_id\n\n        from snapshotted_data\n        left join deletes_source_data as source_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key\n        where source_data.dbt_unique_key is null\n    )\n    {%- endif %}\n\n    select * from insertions\n    union all\n    select * from updates\n    {%- if strategy.invalidate_hard_deletes %}\n    union all\n    select * from deletes\n    {%- endif %}\n\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.snapshot_get_time"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.477767,
+            "supported_languages": null
+        },
+        "macro.dbt.build_snapshot_table": {
+            "name": "build_snapshot_table",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/snapshots/helpers.sql",
+            "original_file_path": "macros/materializations/snapshots/helpers.sql",
+            "unique_id": "macro.dbt.build_snapshot_table",
+            "macro_sql": "{% macro build_snapshot_table(strategy, sql) -%}\n  {{ adapter.dispatch('build_snapshot_table', 'dbt')(strategy, sql) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__build_snapshot_table"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.477945,
+            "supported_languages": null
+        },
+        "macro.dbt.default__build_snapshot_table": {
+            "name": "default__build_snapshot_table",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/snapshots/helpers.sql",
+            "original_file_path": "macros/materializations/snapshots/helpers.sql",
+            "unique_id": "macro.dbt.default__build_snapshot_table",
+            "macro_sql": "{% macro default__build_snapshot_table(strategy, sql) %}\n\n    select *,\n        {{ strategy.scd_id }} as dbt_scd_id,\n        {{ strategy.updated_at }} as dbt_updated_at,\n        {{ strategy.updated_at }} as dbt_valid_from,\n        nullif({{ strategy.updated_at }}, {{ strategy.updated_at }}) as dbt_valid_to\n    from (\n        {{ sql }}\n    ) sbq\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.478165,
+            "supported_languages": null
+        },
+        "macro.dbt.build_snapshot_staging_table": {
+            "name": "build_snapshot_staging_table",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/snapshots/helpers.sql",
+            "original_file_path": "macros/materializations/snapshots/helpers.sql",
+            "unique_id": "macro.dbt.build_snapshot_staging_table",
+            "macro_sql": "{% macro build_snapshot_staging_table(strategy, sql, target_relation) %}\n    {% set temp_relation = make_temp_relation(target_relation) %}\n\n    {% set select = snapshot_staging_table(strategy, sql, target_relation) %}\n\n    {% call statement('build_snapshot_staging_relation') %}\n        {{ create_table_as(True, temp_relation, select) }}\n    {% endcall %}\n\n    {% do return(temp_relation) %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.make_temp_relation",
+                    "macro.dbt.snapshot_staging_table",
+                    "macro.dbt.statement",
+                    "macro.dbt.create_table_as"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4785438,
+            "supported_languages": null
+        },
+        "macro.dbt.materialization_snapshot_default": {
+            "name": "materialization_snapshot_default",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/snapshots/snapshot.sql",
+            "original_file_path": "macros/materializations/snapshots/snapshot.sql",
+            "unique_id": "macro.dbt.materialization_snapshot_default",
+            "macro_sql": "{% materialization snapshot, default %}\n  {%- set config = model['config'] -%}\n\n  {%- set target_table = model.get('alias', model.get('name')) -%}\n\n  {%- set strategy_name = config.get('strategy') -%}\n  {%- set unique_key = config.get('unique_key') %}\n  -- grab current tables grants config for comparision later on\n  {%- set grant_config = config.get('grants') -%}\n\n  {% set target_relation_exists, target_relation = get_or_create_relation(\n          database=model.database,\n          schema=model.schema,\n          identifier=target_table,\n          type='table') -%}\n\n  {%- if not target_relation.is_table -%}\n    {% do exceptions.relation_wrong_type(target_relation, 'table') %}\n  {%- endif -%}\n\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  {% set strategy_macro = strategy_dispatch(strategy_name) %}\n  {% set strategy = strategy_macro(model, \"snapshotted_data\", \"source_data\", config, target_relation_exists) %}\n\n  {% if not target_relation_exists %}\n\n      {% set build_sql = build_snapshot_table(strategy, model['compiled_code']) %}\n      {% set final_sql = create_table_as(False, target_relation, build_sql) %}\n\n  {% else %}\n\n      {{ adapter.valid_snapshot_target(target_relation) }}\n\n      {% set staging_table = build_snapshot_staging_table(strategy, sql, target_relation) %}\n\n      -- this may no-op if the database does not require column expansion\n      {% do adapter.expand_target_column_types(from_relation=staging_table,\n                                               to_relation=target_relation) %}\n\n      {% set missing_columns = adapter.get_missing_columns(staging_table, target_relation)\n                                   | rejectattr('name', 'equalto', 'dbt_change_type')\n                                   | rejectattr('name', 'equalto', 'DBT_CHANGE_TYPE')\n                                   | rejectattr('name', 'equalto', 'dbt_unique_key')\n                                   | rejectattr('name', 'equalto', 'DBT_UNIQUE_KEY')\n                                   | list %}\n\n      {% do create_columns(target_relation, missing_columns) %}\n\n      {% set source_columns = adapter.get_columns_in_relation(staging_table)\n                                   | rejectattr('name', 'equalto', 'dbt_change_type')\n                                   | rejectattr('name', 'equalto', 'DBT_CHANGE_TYPE')\n                                   | rejectattr('name', 'equalto', 'dbt_unique_key')\n                                   | rejectattr('name', 'equalto', 'DBT_UNIQUE_KEY')\n                                   | list %}\n\n      {% set quoted_source_columns = [] %}\n      {% for column in source_columns %}\n        {% do quoted_source_columns.append(adapter.quote(column.name)) %}\n      {% endfor %}\n\n      {% set final_sql = snapshot_merge_sql(\n            target = target_relation,\n            source = staging_table,\n            insert_cols = quoted_source_columns\n         )\n      %}\n\n  {% endif %}\n\n  {% call statement('main') %}\n      {{ final_sql }}\n  {% endcall %}\n\n  {% set should_revoke = should_revoke(target_relation_exists, full_refresh_mode=False) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {% if not target_relation_exists %}\n    {% do create_indexes(target_relation) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {{ adapter.commit() }}\n\n  {% if staging_table is defined %}\n      {% do post_snapshot(staging_table) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmaterialization %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_or_create_relation",
+                    "macro.dbt.run_hooks",
+                    "macro.dbt.strategy_dispatch",
+                    "macro.dbt.build_snapshot_table",
+                    "macro.dbt.create_table_as",
+                    "macro.dbt.build_snapshot_staging_table",
+                    "macro.dbt.create_columns",
+                    "macro.dbt.snapshot_merge_sql",
+                    "macro.dbt.statement",
+                    "macro.dbt.should_revoke",
+                    "macro.dbt.apply_grants",
+                    "macro.dbt.persist_docs",
+                    "macro.dbt.create_indexes",
+                    "macro.dbt.post_snapshot"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.48448,
+            "supported_languages": [
+                "sql"
+            ]
+        },
+        "macro.dbt.materialization_test_default": {
+            "name": "materialization_test_default",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/tests/test.sql",
+            "original_file_path": "macros/materializations/tests/test.sql",
+            "unique_id": "macro.dbt.materialization_test_default",
+            "macro_sql": "{%- materialization test, default -%}\n\n  {% set relations = [] %}\n\n  {% if should_store_failures() %}\n\n    {% set identifier = model['alias'] %}\n    {% set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) %}\n\n    {% set store_failures_as = config.get('store_failures_as') %}\n    -- if `--store-failures` is invoked via command line and `store_failures_as` is not set,\n    -- config.get('store_failures_as', 'table') returns None, not 'table'\n    {% if store_failures_as == none %}{% set store_failures_as = 'table' %}{% endif %}\n    {% if store_failures_as not in ['table', 'view'] %}\n        {{ exceptions.raise_compiler_error(\n            \"'\" ~ store_failures_as ~ \"' is not a valid value for `store_failures_as`. \"\n            \"Accepted values are: ['ephemeral', 'table', 'view']\"\n        ) }}\n    {% endif %}\n\n    {% set target_relation = api.Relation.create(\n        identifier=identifier, schema=schema, database=database, type=store_failures_as) -%} %}\n\n    {% if old_relation %}\n        {% do adapter.drop_relation(old_relation) %}\n    {% endif %}\n\n    {% call statement(auto_begin=True) %}\n        {{ get_create_sql(target_relation, sql) }}\n    {% endcall %}\n\n    {% do relations.append(target_relation) %}\n\n    {% set main_sql %}\n        select *\n        from {{ target_relation }}\n    {% endset %}\n\n    {{ adapter.commit() }}\n\n  {% else %}\n\n      {% set main_sql = sql %}\n\n  {% endif %}\n\n  {% set limit = config.get('limit') %}\n  {% set fail_calc = config.get('fail_calc') %}\n  {% set warn_if = config.get('warn_if') %}\n  {% set error_if = config.get('error_if') %}\n\n  {% call statement('main', fetch_result=True) -%}\n\n    {{ get_test_sql(main_sql, fail_calc, warn_if, error_if, limit)}}\n\n  {%- endcall %}\n\n  {{ return({'relations': relations}) }}\n\n{%- endmaterialization -%}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.should_store_failures",
+                    "macro.dbt.statement",
+                    "macro.dbt.get_create_sql",
+                    "macro.dbt.get_test_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.486943,
+            "supported_languages": [
+                "sql"
+            ]
+        },
+        "macro.dbt.get_test_sql": {
+            "name": "get_test_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/tests/helpers.sql",
+            "original_file_path": "macros/materializations/tests/helpers.sql",
+            "unique_id": "macro.dbt.get_test_sql",
+            "macro_sql": "{% macro get_test_sql(main_sql, fail_calc, warn_if, error_if, limit) -%}\n  {{ adapter.dispatch('get_test_sql', 'dbt')(main_sql, fail_calc, warn_if, error_if, limit) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_test_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.487975,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_test_sql": {
+            "name": "default__get_test_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/tests/helpers.sql",
+            "original_file_path": "macros/materializations/tests/helpers.sql",
+            "unique_id": "macro.dbt.default__get_test_sql",
+            "macro_sql": "{% macro default__get_test_sql(main_sql, fail_calc, warn_if, error_if, limit) -%}\n    select\n      {{ fail_calc }} as failures,\n      {{ fail_calc }} {{ warn_if }} as should_warn,\n      {{ fail_calc }} {{ error_if }} as should_error\n    from (\n      {{ main_sql }}\n      {{ \"limit \" ~ limit if limit != none }}\n    ) dbt_internal_test\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.488236,
+            "supported_languages": null
+        },
+        "macro.dbt.get_unit_test_sql": {
+            "name": "get_unit_test_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/tests/helpers.sql",
+            "original_file_path": "macros/materializations/tests/helpers.sql",
+            "unique_id": "macro.dbt.get_unit_test_sql",
+            "macro_sql": "{% macro get_unit_test_sql(main_sql, expected_fixture_sql, expected_column_names) -%}\n  {{ adapter.dispatch('get_unit_test_sql', 'dbt')(main_sql, expected_fixture_sql, expected_column_names) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_unit_test_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.488418,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_unit_test_sql": {
+            "name": "default__get_unit_test_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/tests/helpers.sql",
+            "original_file_path": "macros/materializations/tests/helpers.sql",
+            "unique_id": "macro.dbt.default__get_unit_test_sql",
+            "macro_sql": "{% macro default__get_unit_test_sql(main_sql, expected_fixture_sql, expected_column_names) -%}\n-- Build actual result given inputs\nwith dbt_internal_unit_test_actual as (\n  select\n    {% for expected_column_name in expected_column_names %}{{expected_column_name}}{% if not loop.last -%},{% endif %}{%- endfor -%}, {{ dbt.string_literal(\"actual\") }} as {{ adapter.quote(\"actual_or_expected\") }}\n  from (\n    {{ main_sql }}\n  ) _dbt_internal_unit_test_actual\n),\n-- Build expected result\ndbt_internal_unit_test_expected as (\n  select\n    {% for expected_column_name in expected_column_names %}{{expected_column_name}}{% if not loop.last -%}, {% endif %}{%- endfor -%}, {{ dbt.string_literal(\"expected\") }} as {{ adapter.quote(\"actual_or_expected\") }}\n  from (\n    {{ expected_fixture_sql }}\n  ) _dbt_internal_unit_test_expected\n)\n-- Union actual and expected results\nselect * from dbt_internal_unit_test_actual\nunion all\nselect * from dbt_internal_unit_test_expected\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.string_literal"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4889312,
+            "supported_languages": null
+        },
+        "macro.dbt.get_where_subquery": {
+            "name": "get_where_subquery",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/tests/where_subquery.sql",
+            "original_file_path": "macros/materializations/tests/where_subquery.sql",
+            "unique_id": "macro.dbt.get_where_subquery",
+            "macro_sql": "{% macro get_where_subquery(relation) -%}\n    {% do return(adapter.dispatch('get_where_subquery', 'dbt')(relation)) %}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_where_subquery"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.489258,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_where_subquery": {
+            "name": "default__get_where_subquery",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/tests/where_subquery.sql",
+            "original_file_path": "macros/materializations/tests/where_subquery.sql",
+            "unique_id": "macro.dbt.default__get_where_subquery",
+            "macro_sql": "{% macro default__get_where_subquery(relation) -%}\n    {% set where = config.get('where', '') %}\n    {% if where %}\n        {%- set filtered -%}\n            (select * from {{ relation }} where {{ where }}) dbt_subquery\n        {%- endset -%}\n        {% do return(filtered) %}\n    {%- else -%}\n        {% do return(relation) %}\n    {%- endif -%}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.489585,
+            "supported_languages": null
+        },
+        "macro.dbt.materialization_unit_default": {
+            "name": "materialization_unit_default",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/tests/unit.sql",
+            "original_file_path": "macros/materializations/tests/unit.sql",
+            "unique_id": "macro.dbt.materialization_unit_default",
+            "macro_sql": "{%- materialization unit, default -%}\n\n  {% set relations = [] %}\n\n  {% set expected_rows = config.get('expected_rows') %}\n  {% set expected_sql = config.get('expected_sql') %}\n  {% set tested_expected_column_names = expected_rows[0].keys() if (expected_rows | length ) > 0 else get_columns_in_query(sql) %} %}\n\n  {%- set target_relation = this.incorporate(type='table') -%}\n  {%- set temp_relation = make_temp_relation(target_relation)-%}\n  {% do run_query(get_create_table_as_sql(True, temp_relation, get_empty_subquery_sql(sql))) %}\n  {%- set columns_in_relation = adapter.get_columns_in_relation(temp_relation) -%}\n  {%- set column_name_to_data_types = {} -%}\n  {%- for column in columns_in_relation -%}\n  {%-   do column_name_to_data_types.update({column.name|lower: column.data_type}) -%}\n  {%- endfor -%}\n\n  {% if not expected_sql %}\n  {%   set expected_sql = get_expected_sql(expected_rows, column_name_to_data_types) %}\n  {% endif %}\n  {% set unit_test_sql = get_unit_test_sql(sql, expected_sql, tested_expected_column_names) %}\n\n  {% call statement('main', fetch_result=True) -%}\n\n    {{ unit_test_sql }}\n\n  {%- endcall %}\n\n  {% do adapter.drop_relation(temp_relation) %}\n\n  {{ return({'relations': relations}) }}\n\n{%- endmaterialization -%}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_columns_in_query",
+                    "macro.dbt.make_temp_relation",
+                    "macro.dbt.run_query",
+                    "macro.dbt.get_create_table_as_sql",
+                    "macro.dbt.get_empty_subquery_sql",
+                    "macro.dbt.get_expected_sql",
+                    "macro.dbt.get_unit_test_sql",
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.491332,
+            "supported_languages": [
+                "sql"
+            ]
+        },
+        "macro.dbt.materialization_materialized_view_default": {
+            "name": "materialization_materialized_view_default",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/materialized_view.sql",
+            "original_file_path": "macros/materializations/models/materialized_view.sql",
+            "unique_id": "macro.dbt.materialization_materialized_view_default",
+            "macro_sql": "{% materialization materialized_view, default %}\n    {% set existing_relation = load_cached_relation(this) %}\n    {% set target_relation = this.incorporate(type=this.MaterializedView) %}\n    {% set intermediate_relation = make_intermediate_relation(target_relation) %}\n    {% set backup_relation_type = target_relation.MaterializedView if existing_relation is none else existing_relation.type %}\n    {% set backup_relation = make_backup_relation(target_relation, backup_relation_type) %}\n\n    {{ materialized_view_setup(backup_relation, intermediate_relation, pre_hooks) }}\n\n        {% set build_sql = materialized_view_get_build_sql(existing_relation, target_relation, backup_relation, intermediate_relation) %}\n\n        {% if build_sql == '' %}\n            {{ materialized_view_execute_no_op(target_relation) }}\n        {% else %}\n            {{ materialized_view_execute_build_sql(build_sql, existing_relation, target_relation, post_hooks) }}\n        {% endif %}\n\n    {{ materialized_view_teardown(backup_relation, intermediate_relation, post_hooks) }}\n\n    {{ return({'relations': [target_relation]}) }}\n\n{% endmaterialization %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.load_cached_relation",
+                    "macro.dbt.make_intermediate_relation",
+                    "macro.dbt.make_backup_relation",
+                    "macro.dbt.materialized_view_setup",
+                    "macro.dbt.materialized_view_get_build_sql",
+                    "macro.dbt.materialized_view_execute_no_op",
+                    "macro.dbt.materialized_view_execute_build_sql",
+                    "macro.dbt.materialized_view_teardown"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4960058,
+            "supported_languages": [
+                "sql"
+            ]
+        },
+        "macro.dbt.materialized_view_setup": {
+            "name": "materialized_view_setup",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/materialized_view.sql",
+            "original_file_path": "macros/materializations/models/materialized_view.sql",
+            "unique_id": "macro.dbt.materialized_view_setup",
+            "macro_sql": "{% macro materialized_view_setup(backup_relation, intermediate_relation, pre_hooks) %}\n\n    -- backup_relation and intermediate_relation should not already exist in the database\n    -- it's possible these exist because of a previous run that exited unexpectedly\n    {% set preexisting_backup_relation = load_cached_relation(backup_relation) %}\n    {% set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) %}\n\n    -- drop the temp relations if they exist already in the database\n    {{ drop_relation_if_exists(preexisting_backup_relation) }}\n    {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n\n    {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.load_cached_relation",
+                    "macro.dbt.drop_relation_if_exists",
+                    "macro.dbt.run_hooks"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4963589,
+            "supported_languages": null
+        },
+        "macro.dbt.materialized_view_teardown": {
+            "name": "materialized_view_teardown",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/materialized_view.sql",
+            "original_file_path": "macros/materializations/models/materialized_view.sql",
+            "unique_id": "macro.dbt.materialized_view_teardown",
+            "macro_sql": "{% macro materialized_view_teardown(backup_relation, intermediate_relation, post_hooks) %}\n\n    -- drop the temp relations if they exist to leave the database clean for the next run\n    {{ drop_relation_if_exists(backup_relation) }}\n    {{ drop_relation_if_exists(intermediate_relation) }}\n\n    {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.drop_relation_if_exists",
+                    "macro.dbt.run_hooks"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.496583,
+            "supported_languages": null
+        },
+        "macro.dbt.materialized_view_get_build_sql": {
+            "name": "materialized_view_get_build_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/materialized_view.sql",
+            "original_file_path": "macros/materializations/models/materialized_view.sql",
+            "unique_id": "macro.dbt.materialized_view_get_build_sql",
+            "macro_sql": "{% macro materialized_view_get_build_sql(existing_relation, target_relation, backup_relation, intermediate_relation) %}\n\n    {% set full_refresh_mode = should_full_refresh() %}\n\n    -- determine the scenario we're in: create, full_refresh, alter, refresh data\n    {% if existing_relation is none %}\n        {% set build_sql = get_create_materialized_view_as_sql(target_relation, sql) %}\n    {% elif full_refresh_mode or not existing_relation.is_materialized_view %}\n        {% set build_sql = get_replace_sql(existing_relation, target_relation, sql) %}\n    {% else %}\n\n        -- get config options\n        {% set on_configuration_change = config.get('on_configuration_change') %}\n        {% set configuration_changes = get_materialized_view_configuration_changes(existing_relation, config) %}\n\n        {% if configuration_changes is none %}\n            {% set build_sql = refresh_materialized_view(target_relation) %}\n\n        {% elif on_configuration_change == 'apply' %}\n            {% set build_sql = get_alter_materialized_view_as_sql(target_relation, configuration_changes, sql, existing_relation, backup_relation, intermediate_relation) %}\n        {% elif on_configuration_change == 'continue' %}\n            {% set build_sql = '' %}\n            {{ exceptions.warn(\"Configuration changes were identified and `on_configuration_change` was set to `continue` for `\" ~ target_relation ~ \"`\") }}\n        {% elif on_configuration_change == 'fail' %}\n            {{ exceptions.raise_fail_fast_error(\"Configuration changes were identified and `on_configuration_change` was set to `fail` for `\" ~ target_relation ~ \"`\") }}\n\n        {% else %}\n            -- this only happens if the user provides a value other than `apply`, 'skip', 'fail'\n            {{ exceptions.raise_compiler_error(\"Unexpected configuration scenario\") }}\n\n        {% endif %}\n\n    {% endif %}\n\n    {% do return(build_sql) %}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.should_full_refresh",
+                    "macro.dbt.get_create_materialized_view_as_sql",
+                    "macro.dbt.get_replace_sql",
+                    "macro.dbt.get_materialized_view_configuration_changes",
+                    "macro.dbt.refresh_materialized_view",
+                    "macro.dbt.get_alter_materialized_view_as_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.497895,
+            "supported_languages": null
+        },
+        "macro.dbt.materialized_view_execute_no_op": {
+            "name": "materialized_view_execute_no_op",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/materialized_view.sql",
+            "original_file_path": "macros/materializations/models/materialized_view.sql",
+            "unique_id": "macro.dbt.materialized_view_execute_no_op",
+            "macro_sql": "{% macro materialized_view_execute_no_op(target_relation) %}\n    {% do store_raw_result(\n        name=\"main\",\n        message=\"skip \" ~ target_relation,\n        code=\"skip\",\n        rows_affected=\"-1\"\n    ) %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.4982002,
+            "supported_languages": null
+        },
+        "macro.dbt.materialized_view_execute_build_sql": {
+            "name": "materialized_view_execute_build_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/materialized_view.sql",
+            "original_file_path": "macros/materializations/models/materialized_view.sql",
+            "unique_id": "macro.dbt.materialized_view_execute_build_sql",
+            "macro_sql": "{% macro materialized_view_execute_build_sql(build_sql, existing_relation, target_relation, post_hooks) %}\n\n    -- `BEGIN` happens here:\n    {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n    {% set grant_config = config.get('grants') %}\n\n    {% call statement(name=\"main\") %}\n        {{ build_sql }}\n    {% endcall %}\n\n    {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}\n    {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n    {% do persist_docs(target_relation, model) %}\n\n    {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n    {{ adapter.commit() }}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.run_hooks",
+                    "macro.dbt.statement",
+                    "macro.dbt.should_revoke",
+                    "macro.dbt.apply_grants",
+                    "macro.dbt.persist_docs"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.498802,
+            "supported_languages": null
+        },
+        "macro.dbt.materialization_view_default": {
+            "name": "materialization_view_default",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/view.sql",
+            "original_file_path": "macros/materializations/models/view.sql",
+            "unique_id": "macro.dbt.materialization_view_default",
+            "macro_sql": "{%- materialization view, default -%}\n\n  {%- set existing_relation = load_cached_relation(this) -%}\n  {%- set target_relation = this.incorporate(type='view') -%}\n  {%- set intermediate_relation =  make_intermediate_relation(target_relation) -%}\n\n  -- the intermediate_relation should not already exist in the database; get_relation\n  -- will return None in that case. Otherwise, we get a relation that we can drop\n  -- later, before we try to use this name for the current operation\n  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}\n  /*\n     This relation (probably) doesn't exist yet. If it does exist, it's a leftover from\n     a previous run, and we're going to try to drop it immediately. At the end of this\n     materialization, we're going to rename the \"existing_relation\" to this identifier,\n     and then we're going to drop it. In order to make sure we run the correct one of:\n       - drop view ...\n       - drop table ...\n\n     We need to set the type of this relation to be the type of the existing_relation, if it exists,\n     or else \"view\" as a sane default if it does not. Note that if the existing_relation does not\n     exist, then there is nothing to move out of the way and subsequentally drop. In that case,\n     this relation will be effectively unused.\n  */\n  {%- set backup_relation_type = 'view' if existing_relation is none else existing_relation.type -%}\n  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}\n  -- as above, the backup_relation should not already exist\n  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}\n  -- grab current tables grants config for comparision later on\n  {% set grant_config = config.get('grants') %}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- drop the temp relations if they exist already in the database\n  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n  {{ drop_relation_if_exists(preexisting_backup_relation) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% call statement('main') -%}\n    {{ get_create_view_as_sql(intermediate_relation, sql) }}\n  {%- endcall %}\n\n  -- cleanup\n  -- move the existing view out of the way\n  {% if existing_relation is not none %}\n     /* Do the equivalent of rename_if_exists. 'existing_relation' could have been dropped\n        since the variable was first set. */\n    {% set existing_relation = load_cached_relation(existing_relation) %}\n    {% if existing_relation is not none %}\n        {{ adapter.rename_relation(existing_relation, backup_relation) }}\n    {% endif %}\n  {% endif %}\n  {{ adapter.rename_relation(intermediate_relation, target_relation) }}\n\n  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {{ adapter.commit() }}\n\n  {{ drop_relation_if_exists(backup_relation) }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{%- endmaterialization -%}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.load_cached_relation",
+                    "macro.dbt.make_intermediate_relation",
+                    "macro.dbt.make_backup_relation",
+                    "macro.dbt.run_hooks",
+                    "macro.dbt.drop_relation_if_exists",
+                    "macro.dbt.statement",
+                    "macro.dbt.get_create_view_as_sql",
+                    "macro.dbt.should_revoke",
+                    "macro.dbt.apply_grants",
+                    "macro.dbt.persist_docs"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.501663,
+            "supported_languages": [
+                "sql"
+            ]
+        },
+        "macro.dbt.materialization_table_default": {
+            "name": "materialization_table_default",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/table.sql",
+            "original_file_path": "macros/materializations/models/table.sql",
+            "unique_id": "macro.dbt.materialization_table_default",
+            "macro_sql": "{% materialization table, default %}\n\n  {%- set existing_relation = load_cached_relation(this) -%}\n  {%- set target_relation = this.incorporate(type='table') %}\n  {%- set intermediate_relation =  make_intermediate_relation(target_relation) -%}\n  -- the intermediate_relation should not already exist in the database; get_relation\n  -- will return None in that case. Otherwise, we get a relation that we can drop\n  -- later, before we try to use this name for the current operation\n  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}\n  /*\n      See ../view/view.sql for more information about this relation.\n  */\n  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}\n  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}\n  -- as above, the backup_relation should not already exist\n  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}\n  -- grab current tables grants config for comparision later on\n  {% set grant_config = config.get('grants') %}\n\n  -- drop the temp relations if they exist already in the database\n  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n  {{ drop_relation_if_exists(preexisting_backup_relation) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% call statement('main') -%}\n    {{ get_create_table_as_sql(False, intermediate_relation, sql) }}\n  {%- endcall %}\n\n  -- cleanup\n  {% if existing_relation is not none %}\n     /* Do the equivalent of rename_if_exists. 'existing_relation' could have been dropped\n        since the variable was first set. */\n    {% set existing_relation = load_cached_relation(existing_relation) %}\n    {% if existing_relation is not none %}\n        {{ adapter.rename_relation(existing_relation, backup_relation) }}\n    {% endif %}\n  {% endif %}\n\n  {{ adapter.rename_relation(intermediate_relation, target_relation) }}\n\n  {% do create_indexes(target_relation) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  -- `COMMIT` happens here\n  {{ adapter.commit() }}\n\n  -- finally, drop the existing/backup relation after the commit\n  {{ drop_relation_if_exists(backup_relation) }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n{% endmaterialization %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.load_cached_relation",
+                    "macro.dbt.make_intermediate_relation",
+                    "macro.dbt.make_backup_relation",
+                    "macro.dbt.drop_relation_if_exists",
+                    "macro.dbt.run_hooks",
+                    "macro.dbt.statement",
+                    "macro.dbt.get_create_table_as_sql",
+                    "macro.dbt.create_indexes",
+                    "macro.dbt.should_revoke",
+                    "macro.dbt.apply_grants",
+                    "macro.dbt.persist_docs"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5046,
+            "supported_languages": [
+                "sql"
+            ]
+        },
+        "macro.dbt.get_quoted_csv": {
+            "name": "get_quoted_csv",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/column_helpers.sql",
+            "original_file_path": "macros/materializations/models/incremental/column_helpers.sql",
+            "unique_id": "macro.dbt.get_quoted_csv",
+            "macro_sql": "{% macro get_quoted_csv(column_names) %}\n\n    {% set quoted = [] %}\n    {% for col in column_names -%}\n        {%- do quoted.append(adapter.quote(col)) -%}\n    {%- endfor %}\n\n    {%- set dest_cols_csv = quoted | join(', ') -%}\n    {{ return(dest_cols_csv) }}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.506144,
+            "supported_languages": null
+        },
+        "macro.dbt.diff_columns": {
+            "name": "diff_columns",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/column_helpers.sql",
+            "original_file_path": "macros/materializations/models/incremental/column_helpers.sql",
+            "unique_id": "macro.dbt.diff_columns",
+            "macro_sql": "{% macro diff_columns(source_columns, target_columns) %}\n\n  {% set result = [] %}\n  {% set source_names = source_columns | map(attribute = 'column') | list %}\n  {% set target_names = target_columns | map(attribute = 'column') | list %}\n\n   {# --check whether the name attribute exists in the target - this does not perform a data type check #}\n   {% for sc in source_columns %}\n     {% if sc.name not in target_names %}\n        {{ result.append(sc) }}\n     {% endif %}\n   {% endfor %}\n\n  {{ return(result) }}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5066829,
+            "supported_languages": null
+        },
+        "macro.dbt.diff_column_data_types": {
+            "name": "diff_column_data_types",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/column_helpers.sql",
+            "original_file_path": "macros/materializations/models/incremental/column_helpers.sql",
+            "unique_id": "macro.dbt.diff_column_data_types",
+            "macro_sql": "{% macro diff_column_data_types(source_columns, target_columns) %}\n\n  {% set result = [] %}\n  {% for sc in source_columns %}\n    {% set tc = target_columns | selectattr(\"name\", \"equalto\", sc.name) | list | first %}\n    {% if tc %}\n      {% if sc.data_type != tc.data_type and not sc.can_expand_to(other_column=tc) %}\n        {{ result.append( { 'column_name': tc.name, 'new_type': sc.data_type } ) }}\n      {% endif %}\n    {% endif %}\n  {% endfor %}\n\n  {{ return(result) }}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5073678,
+            "supported_languages": null
+        },
+        "macro.dbt.get_merge_update_columns": {
+            "name": "get_merge_update_columns",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/column_helpers.sql",
+            "original_file_path": "macros/materializations/models/incremental/column_helpers.sql",
+            "unique_id": "macro.dbt.get_merge_update_columns",
+            "macro_sql": "{% macro get_merge_update_columns(merge_update_columns, merge_exclude_columns, dest_columns) %}\n  {{ return(adapter.dispatch('get_merge_update_columns', 'dbt')(merge_update_columns, merge_exclude_columns, dest_columns)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_merge_update_columns"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.507602,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_merge_update_columns": {
+            "name": "default__get_merge_update_columns",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/column_helpers.sql",
+            "original_file_path": "macros/materializations/models/incremental/column_helpers.sql",
+            "unique_id": "macro.dbt.default__get_merge_update_columns",
+            "macro_sql": "{% macro default__get_merge_update_columns(merge_update_columns, merge_exclude_columns, dest_columns) %}\n  {%- set default_cols = dest_columns | map(attribute=\"quoted\") | list -%}\n\n  {%- if merge_update_columns and merge_exclude_columns -%}\n    {{ exceptions.raise_compiler_error(\n        'Model cannot specify merge_update_columns and merge_exclude_columns. Please update model to use only one config'\n    )}}\n  {%- elif merge_update_columns -%}\n    {%- set update_columns = merge_update_columns -%}\n  {%- elif merge_exclude_columns -%}\n    {%- set update_columns = [] -%}\n    {%- for column in dest_columns -%}\n      {% if column.column | lower not in merge_exclude_columns | map(\"lower\") | list %}\n        {%- do update_columns.append(column.quoted) -%}\n      {% endif %}\n    {%- endfor -%}\n  {%- else -%}\n    {%- set update_columns = default_cols -%}\n  {%- endif -%}\n\n  {{ return(update_columns) }}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5082371,
+            "supported_languages": null
+        },
+        "macro.dbt.get_merge_sql": {
+            "name": "get_merge_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/merge.sql",
+            "original_file_path": "macros/materializations/models/incremental/merge.sql",
+            "unique_id": "macro.dbt.get_merge_sql",
+            "macro_sql": "{% macro get_merge_sql(target, source, unique_key, dest_columns, incremental_predicates=none) -%}\n   -- back compat for old kwarg name\n  {% set incremental_predicates = kwargs.get('predicates', incremental_predicates) %}\n  {{ adapter.dispatch('get_merge_sql', 'dbt')(target, source, unique_key, dest_columns, incremental_predicates) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_merge_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.514847,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_merge_sql": {
+            "name": "default__get_merge_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/merge.sql",
+            "original_file_path": "macros/materializations/models/incremental/merge.sql",
+            "unique_id": "macro.dbt.default__get_merge_sql",
+            "macro_sql": "{% macro default__get_merge_sql(target, source, unique_key, dest_columns, incremental_predicates=none) -%}\n    {%- set predicates = [] if incremental_predicates is none else [] + incremental_predicates -%}\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n    {%- set merge_update_columns = config.get('merge_update_columns') -%}\n    {%- set merge_exclude_columns = config.get('merge_exclude_columns') -%}\n    {%- set update_columns = get_merge_update_columns(merge_update_columns, merge_exclude_columns, dest_columns) -%}\n    {%- set sql_header = config.get('sql_header', none) -%}\n\n    {% if unique_key %}\n        {% if unique_key is sequence and unique_key is not mapping and unique_key is not string %}\n            {% for key in unique_key %}\n                {% set this_key_match %}\n                    DBT_INTERNAL_SOURCE.{{ key }} = DBT_INTERNAL_DEST.{{ key }}\n                {% endset %}\n                {% do predicates.append(this_key_match) %}\n            {% endfor %}\n        {% else %}\n            {% set unique_key_match %}\n                DBT_INTERNAL_SOURCE.{{ unique_key }} = DBT_INTERNAL_DEST.{{ unique_key }}\n            {% endset %}\n            {% do predicates.append(unique_key_match) %}\n        {% endif %}\n    {% else %}\n        {% do predicates.append('FALSE') %}\n    {% endif %}\n\n    {{ sql_header if sql_header is not none }}\n\n    merge into {{ target }} as DBT_INTERNAL_DEST\n        using {{ source }} as DBT_INTERNAL_SOURCE\n        on {{\"(\" ~ predicates | join(\") and (\") ~ \")\"}}\n\n    {% if unique_key %}\n    when matched then update set\n        {% for column_name in update_columns -%}\n            {{ column_name }} = DBT_INTERNAL_SOURCE.{{ column_name }}\n            {%- if not loop.last %}, {%- endif %}\n        {%- endfor %}\n    {% endif %}\n\n    when not matched then insert\n        ({{ dest_cols_csv }})\n    values\n        ({{ dest_cols_csv }})\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_quoted_csv",
+                    "macro.dbt.get_merge_update_columns"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5165172,
+            "supported_languages": null
+        },
+        "macro.dbt.get_delete_insert_merge_sql": {
+            "name": "get_delete_insert_merge_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/merge.sql",
+            "original_file_path": "macros/materializations/models/incremental/merge.sql",
+            "unique_id": "macro.dbt.get_delete_insert_merge_sql",
+            "macro_sql": "{% macro get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates) -%}\n  {{ adapter.dispatch('get_delete_insert_merge_sql', 'dbt')(target, source, unique_key, dest_columns, incremental_predicates) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__get_delete_insert_merge_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.516791,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_delete_insert_merge_sql": {
+            "name": "default__get_delete_insert_merge_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/merge.sql",
+            "original_file_path": "macros/materializations/models/incremental/merge.sql",
+            "unique_id": "macro.dbt.default__get_delete_insert_merge_sql",
+            "macro_sql": "{% macro default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates) -%}\n\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n\n    {% if unique_key %}\n        {% if unique_key is sequence and unique_key is not string %}\n            delete from {{target }}\n            using {{ source }}\n            where (\n                {% for key in unique_key %}\n                    {{ source }}.{{ key }} = {{ target }}.{{ key }}\n                    {{ \"and \" if not loop.last}}\n                {% endfor %}\n                {% if incremental_predicates %}\n                    {% for predicate in incremental_predicates %}\n                        and {{ predicate }}\n                    {% endfor %}\n                {% endif %}\n            );\n        {% else %}\n            delete from {{ target }}\n            where (\n                {{ unique_key }}) in (\n                select ({{ unique_key }})\n                from {{ source }}\n            )\n            {%- if incremental_predicates %}\n                {% for predicate in incremental_predicates %}\n                    and {{ predicate }}\n                {% endfor %}\n            {%- endif -%};\n\n        {% endif %}\n    {% endif %}\n\n    insert into {{ target }} ({{ dest_cols_csv }})\n    (\n        select {{ dest_cols_csv }}\n        from {{ source }}\n    )\n\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_quoted_csv"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5176718,
+            "supported_languages": null
+        },
+        "macro.dbt.get_insert_overwrite_merge_sql": {
+            "name": "get_insert_overwrite_merge_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/merge.sql",
+            "original_file_path": "macros/materializations/models/incremental/merge.sql",
+            "unique_id": "macro.dbt.get_insert_overwrite_merge_sql",
+            "macro_sql": "{% macro get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header=false) -%}\n  {{ adapter.dispatch('get_insert_overwrite_merge_sql', 'dbt')(target, source, dest_columns, predicates, include_sql_header) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_insert_overwrite_merge_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.517919,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_insert_overwrite_merge_sql": {
+            "name": "default__get_insert_overwrite_merge_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/merge.sql",
+            "original_file_path": "macros/materializations/models/incremental/merge.sql",
+            "unique_id": "macro.dbt.default__get_insert_overwrite_merge_sql",
+            "macro_sql": "{% macro default__get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header) -%}\n    {#-- The only time include_sql_header is True: --#}\n    {#-- BigQuery + insert_overwrite strategy + \"static\" partitions config --#}\n    {#-- We should consider including the sql header at the materialization level instead --#}\n\n    {%- set predicates = [] if predicates is none else [] + predicates -%}\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n    {%- set sql_header = config.get('sql_header', none) -%}\n\n    {{ sql_header if sql_header is not none and include_sql_header }}\n\n    merge into {{ target }} as DBT_INTERNAL_DEST\n        using {{ source }} as DBT_INTERNAL_SOURCE\n        on FALSE\n\n    when not matched by source\n        {% if predicates %} and {{ predicates | join(' and ') }} {% endif %}\n        then delete\n\n    when not matched then insert\n        ({{ dest_cols_csv }})\n    values\n        ({{ dest_cols_csv }})\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_quoted_csv"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.518493,
+            "supported_languages": null
+        },
+        "macro.dbt.is_incremental": {
+            "name": "is_incremental",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/is_incremental.sql",
+            "original_file_path": "macros/materializations/models/incremental/is_incremental.sql",
+            "unique_id": "macro.dbt.is_incremental",
+            "macro_sql": "{% macro is_incremental() %}\n    {#-- do not run introspective queries in parsing #}\n    {% if not execute %}\n        {{ return(False) }}\n    {% else %}\n        {% set relation = adapter.get_relation(this.database, this.schema, this.table) %}\n        {{ return(relation is not none\n                  and relation.type == 'table'\n                  and model.config.materialized == 'incremental'\n                  and not should_full_refresh()) }}\n    {% endif %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.should_full_refresh"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.519082,
+            "supported_languages": null
+        },
+        "macro.dbt.get_incremental_append_sql": {
+            "name": "get_incremental_append_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/strategies.sql",
+            "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+            "unique_id": "macro.dbt.get_incremental_append_sql",
+            "macro_sql": "{% macro get_incremental_append_sql(arg_dict) %}\n\n  {{ return(adapter.dispatch('get_incremental_append_sql', 'dbt')(arg_dict)) }}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_incremental_append_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.519902,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_incremental_append_sql": {
+            "name": "default__get_incremental_append_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/strategies.sql",
+            "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+            "unique_id": "macro.dbt.default__get_incremental_append_sql",
+            "macro_sql": "{% macro default__get_incremental_append_sql(arg_dict) %}\n\n  {% do return(get_insert_into_sql(arg_dict[\"target_relation\"], arg_dict[\"temp_relation\"], arg_dict[\"dest_columns\"])) %}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_insert_into_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.520115,
+            "supported_languages": null
+        },
+        "macro.dbt.get_incremental_delete_insert_sql": {
+            "name": "get_incremental_delete_insert_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/strategies.sql",
+            "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+            "unique_id": "macro.dbt.get_incremental_delete_insert_sql",
+            "macro_sql": "{% macro get_incremental_delete_insert_sql(arg_dict) %}\n\n  {{ return(adapter.dispatch('get_incremental_delete_insert_sql', 'dbt')(arg_dict)) }}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_incremental_delete_insert_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.520279,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_incremental_delete_insert_sql": {
+            "name": "default__get_incremental_delete_insert_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/strategies.sql",
+            "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+            "unique_id": "macro.dbt.default__get_incremental_delete_insert_sql",
+            "macro_sql": "{% macro default__get_incremental_delete_insert_sql(arg_dict) %}\n\n  {% do return(get_delete_insert_merge_sql(arg_dict[\"target_relation\"], arg_dict[\"temp_relation\"], arg_dict[\"unique_key\"], arg_dict[\"dest_columns\"], arg_dict[\"incremental_predicates\"])) %}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_delete_insert_merge_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5205388,
+            "supported_languages": null
+        },
+        "macro.dbt.get_incremental_merge_sql": {
+            "name": "get_incremental_merge_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/strategies.sql",
+            "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+            "unique_id": "macro.dbt.get_incremental_merge_sql",
+            "macro_sql": "{% macro get_incremental_merge_sql(arg_dict) %}\n\n  {{ return(adapter.dispatch('get_incremental_merge_sql', 'dbt')(arg_dict)) }}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_incremental_merge_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5207071,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_incremental_merge_sql": {
+            "name": "default__get_incremental_merge_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/strategies.sql",
+            "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+            "unique_id": "macro.dbt.default__get_incremental_merge_sql",
+            "macro_sql": "{% macro default__get_incremental_merge_sql(arg_dict) %}\n\n  {% do return(get_merge_sql(arg_dict[\"target_relation\"], arg_dict[\"temp_relation\"], arg_dict[\"unique_key\"], arg_dict[\"dest_columns\"], arg_dict[\"incremental_predicates\"])) %}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_merge_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.520973,
+            "supported_languages": null
+        },
+        "macro.dbt.get_incremental_insert_overwrite_sql": {
+            "name": "get_incremental_insert_overwrite_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/strategies.sql",
+            "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+            "unique_id": "macro.dbt.get_incremental_insert_overwrite_sql",
+            "macro_sql": "{% macro get_incremental_insert_overwrite_sql(arg_dict) %}\n\n  {{ return(adapter.dispatch('get_incremental_insert_overwrite_sql', 'dbt')(arg_dict)) }}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_incremental_insert_overwrite_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.521295,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_incremental_insert_overwrite_sql": {
+            "name": "default__get_incremental_insert_overwrite_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/strategies.sql",
+            "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+            "unique_id": "macro.dbt.default__get_incremental_insert_overwrite_sql",
+            "macro_sql": "{% macro default__get_incremental_insert_overwrite_sql(arg_dict) %}\n\n  {% do return(get_insert_overwrite_merge_sql(arg_dict[\"target_relation\"], arg_dict[\"temp_relation\"], arg_dict[\"dest_columns\"], arg_dict[\"incremental_predicates\"])) %}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_insert_overwrite_merge_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.522431,
+            "supported_languages": null
+        },
+        "macro.dbt.get_incremental_default_sql": {
+            "name": "get_incremental_default_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/strategies.sql",
+            "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+            "unique_id": "macro.dbt.get_incremental_default_sql",
+            "macro_sql": "{% macro get_incremental_default_sql(arg_dict) %}\n\n  {{ return(adapter.dispatch('get_incremental_default_sql', 'dbt')(arg_dict)) }}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__get_incremental_default_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.523007,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_incremental_default_sql": {
+            "name": "default__get_incremental_default_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/strategies.sql",
+            "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+            "unique_id": "macro.dbt.default__get_incremental_default_sql",
+            "macro_sql": "{% macro default__get_incremental_default_sql(arg_dict) %}\n\n  {% do return(get_incremental_append_sql(arg_dict)) %}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_incremental_append_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.523458,
+            "supported_languages": null
+        },
+        "macro.dbt.get_insert_into_sql": {
+            "name": "get_insert_into_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/strategies.sql",
+            "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+            "unique_id": "macro.dbt.get_insert_into_sql",
+            "macro_sql": "{% macro get_insert_into_sql(target_relation, temp_relation, dest_columns) %}\n\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n\n    insert into {{ target_relation }} ({{ dest_cols_csv }})\n    (\n        select {{ dest_cols_csv }}\n        from {{ temp_relation }}\n    )\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_quoted_csv"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.523917,
+            "supported_languages": null
+        },
+        "macro.dbt.materialization_incremental_default": {
+            "name": "materialization_incremental_default",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/incremental.sql",
+            "original_file_path": "macros/materializations/models/incremental/incremental.sql",
+            "unique_id": "macro.dbt.materialization_incremental_default",
+            "macro_sql": "{% materialization incremental, default -%}\n\n  -- relations\n  {%- set existing_relation = load_cached_relation(this) -%}\n  {%- set target_relation = this.incorporate(type='table') -%}\n  {%- set temp_relation = make_temp_relation(target_relation)-%}\n  {%- set intermediate_relation = make_intermediate_relation(target_relation)-%}\n  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}\n  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}\n\n  -- configs\n  {%- set unique_key = config.get('unique_key') -%}\n  {%- set full_refresh_mode = (should_full_refresh()  or existing_relation.is_view) -%}\n  {%- set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') -%}\n\n  -- the temp_ and backup_ relations should not already exist in the database; get_relation\n  -- will return None in that case. Otherwise, we get a relation that we can drop\n  -- later, before we try to use this name for the current operation. This has to happen before\n  -- BEGIN, in a separate transaction\n  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation)-%}\n  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}\n   -- grab current tables grants config for comparision later on\n  {% set grant_config = config.get('grants') %}\n  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n  {{ drop_relation_if_exists(preexisting_backup_relation) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  {% set to_drop = [] %}\n\n  {% if existing_relation is none %}\n      {% set build_sql = get_create_table_as_sql(False, target_relation, sql) %}\n  {% elif full_refresh_mode %}\n      {% set build_sql = get_create_table_as_sql(False, intermediate_relation, sql) %}\n      {% set need_swap = true %}\n  {% else %}\n    {% do run_query(get_create_table_as_sql(True, temp_relation, sql)) %}\n    {% do adapter.expand_target_column_types(\n             from_relation=temp_relation,\n             to_relation=target_relation) %}\n    {#-- Process schema changes. Returns dict of changes if successful. Use source columns for upserting/merging --#}\n    {% set dest_columns = process_schema_changes(on_schema_change, temp_relation, existing_relation) %}\n    {% if not dest_columns %}\n      {% set dest_columns = adapter.get_columns_in_relation(existing_relation) %}\n    {% endif %}\n\n    {#-- Get the incremental_strategy, the macro to use for the strategy, and build the sql --#}\n    {% set incremental_strategy = config.get('incremental_strategy') or 'default' %}\n    {% set incremental_predicates = config.get('predicates', none) or config.get('incremental_predicates', none) %}\n    {% set strategy_sql_macro_func = adapter.get_incremental_strategy_macro(context, incremental_strategy) %}\n    {% set strategy_arg_dict = ({'target_relation': target_relation, 'temp_relation': temp_relation, 'unique_key': unique_key, 'dest_columns': dest_columns, 'incremental_predicates': incremental_predicates }) %}\n    {% set build_sql = strategy_sql_macro_func(strategy_arg_dict) %}\n\n  {% endif %}\n\n  {% call statement(\"main\") %}\n      {{ build_sql }}\n  {% endcall %}\n\n  {% if need_swap %}\n      {% do adapter.rename_relation(target_relation, backup_relation) %}\n      {% do adapter.rename_relation(intermediate_relation, target_relation) %}\n      {% do to_drop.append(backup_relation) %}\n  {% endif %}\n\n  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {% if existing_relation is none or existing_relation.is_view or should_full_refresh() %}\n    {% do create_indexes(target_relation) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  -- `COMMIT` happens here\n  {% do adapter.commit() %}\n\n  {% for rel in to_drop %}\n      {% do adapter.drop_relation(rel) %}\n  {% endfor %}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{%- endmaterialization %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.load_cached_relation",
+                    "macro.dbt.make_temp_relation",
+                    "macro.dbt.make_intermediate_relation",
+                    "macro.dbt.make_backup_relation",
+                    "macro.dbt.should_full_refresh",
+                    "macro.dbt.incremental_validate_on_schema_change",
+                    "macro.dbt.drop_relation_if_exists",
+                    "macro.dbt.run_hooks",
+                    "macro.dbt.get_create_table_as_sql",
+                    "macro.dbt.run_query",
+                    "macro.dbt.process_schema_changes",
+                    "macro.dbt.statement",
+                    "macro.dbt.should_revoke",
+                    "macro.dbt.apply_grants",
+                    "macro.dbt.persist_docs",
+                    "macro.dbt.create_indexes"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.528948,
+            "supported_languages": [
+                "sql"
+            ]
+        },
+        "macro.dbt.incremental_validate_on_schema_change": {
+            "name": "incremental_validate_on_schema_change",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/on_schema_change.sql",
+            "original_file_path": "macros/materializations/models/incremental/on_schema_change.sql",
+            "unique_id": "macro.dbt.incremental_validate_on_schema_change",
+            "macro_sql": "{% macro incremental_validate_on_schema_change(on_schema_change, default='ignore') %}\n\n   {% if on_schema_change not in ['sync_all_columns', 'append_new_columns', 'fail', 'ignore'] %}\n\n     {% set log_message = 'Invalid value for on_schema_change (%s) specified. Setting default value of %s.' % (on_schema_change, default) %}\n     {% do log(log_message) %}\n\n     {{ return(default) }}\n\n   {% else %}\n\n     {{ return(on_schema_change) }}\n\n   {% endif %}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.534081,
+            "supported_languages": null
+        },
+        "macro.dbt.check_for_schema_changes": {
+            "name": "check_for_schema_changes",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/on_schema_change.sql",
+            "original_file_path": "macros/materializations/models/incremental/on_schema_change.sql",
+            "unique_id": "macro.dbt.check_for_schema_changes",
+            "macro_sql": "{% macro check_for_schema_changes(source_relation, target_relation) %}\n\n  {% set schema_changed = False %}\n\n  {%- set source_columns = adapter.get_columns_in_relation(source_relation) -%}\n  {%- set target_columns = adapter.get_columns_in_relation(target_relation) -%}\n  {%- set source_not_in_target = diff_columns(source_columns, target_columns) -%}\n  {%- set target_not_in_source = diff_columns(target_columns, source_columns) -%}\n\n  {% set new_target_types = diff_column_data_types(source_columns, target_columns) %}\n\n  {% if source_not_in_target != [] %}\n    {% set schema_changed = True %}\n  {% elif target_not_in_source != [] or new_target_types != [] %}\n    {% set schema_changed = True %}\n  {% elif new_target_types != [] %}\n    {% set schema_changed = True %}\n  {% endif %}\n\n  {% set changes_dict = {\n    'schema_changed': schema_changed,\n    'source_not_in_target': source_not_in_target,\n    'target_not_in_source': target_not_in_source,\n    'source_columns': source_columns,\n    'target_columns': target_columns,\n    'new_target_types': new_target_types\n  } %}\n\n  {% set msg %}\n    In {{ target_relation }}:\n        Schema changed: {{ schema_changed }}\n        Source columns not in target: {{ source_not_in_target }}\n        Target columns not in source: {{ target_not_in_source }}\n        New column types: {{ new_target_types }}\n  {% endset %}\n\n  {% do log(msg) %}\n\n  {{ return(changes_dict) }}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.diff_columns",
+                    "macro.dbt.diff_column_data_types"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5354052,
+            "supported_languages": null
+        },
+        "macro.dbt.sync_column_schemas": {
+            "name": "sync_column_schemas",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/on_schema_change.sql",
+            "original_file_path": "macros/materializations/models/incremental/on_schema_change.sql",
+            "unique_id": "macro.dbt.sync_column_schemas",
+            "macro_sql": "{% macro sync_column_schemas(on_schema_change, target_relation, schema_changes_dict) %}\n\n  {%- set add_to_target_arr = schema_changes_dict['source_not_in_target'] -%}\n\n  {%- if on_schema_change == 'append_new_columns'-%}\n     {%- if add_to_target_arr | length > 0 -%}\n       {%- do alter_relation_add_remove_columns(target_relation, add_to_target_arr, none) -%}\n     {%- endif -%}\n\n  {% elif on_schema_change == 'sync_all_columns' %}\n     {%- set remove_from_target_arr = schema_changes_dict['target_not_in_source'] -%}\n     {%- set new_target_types = schema_changes_dict['new_target_types'] -%}\n\n     {% if add_to_target_arr | length > 0 or remove_from_target_arr | length > 0 %}\n       {%- do alter_relation_add_remove_columns(target_relation, add_to_target_arr, remove_from_target_arr) -%}\n     {% endif %}\n\n     {% if new_target_types != [] %}\n       {% for ntt in new_target_types %}\n         {% set column_name = ntt['column_name'] %}\n         {% set new_type = ntt['new_type'] %}\n         {% do alter_column_type(target_relation, column_name, new_type) %}\n       {% endfor %}\n     {% endif %}\n\n  {% endif %}\n\n  {% set schema_change_message %}\n    In {{ target_relation }}:\n        Schema change approach: {{ on_schema_change }}\n        Columns added: {{ add_to_target_arr }}\n        Columns removed: {{ remove_from_target_arr }}\n        Data types changed: {{ new_target_types }}\n  {% endset %}\n\n  {% do log(schema_change_message) %}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.alter_relation_add_remove_columns",
+                    "macro.dbt.alter_column_type"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.536468,
+            "supported_languages": null
+        },
+        "macro.dbt.process_schema_changes": {
+            "name": "process_schema_changes",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/incremental/on_schema_change.sql",
+            "original_file_path": "macros/materializations/models/incremental/on_schema_change.sql",
+            "unique_id": "macro.dbt.process_schema_changes",
+            "macro_sql": "{% macro process_schema_changes(on_schema_change, source_relation, target_relation) %}\n\n    {% if on_schema_change == 'ignore' %}\n\n     {{ return({}) }}\n\n    {% else %}\n\n      {% set schema_changes_dict = check_for_schema_changes(source_relation, target_relation) %}\n\n      {% if schema_changes_dict['schema_changed'] %}\n\n        {% if on_schema_change == 'fail' %}\n\n          {% set fail_msg %}\n              The source and target schemas on this incremental model are out of sync!\n              They can be reconciled in several ways:\n                - set the `on_schema_change` config to either append_new_columns or sync_all_columns, depending on your situation.\n                - Re-run the incremental model with `full_refresh: True` to update the target schema.\n                - update the schema manually and re-run the process.\n\n              Additional troubleshooting context:\n                 Source columns not in target: {{ schema_changes_dict['source_not_in_target'] }}\n                 Target columns not in source: {{ schema_changes_dict['target_not_in_source'] }}\n                 New column types: {{ schema_changes_dict['new_target_types'] }}\n          {% endset %}\n\n          {% do exceptions.raise_compiler_error(fail_msg) %}\n\n        {# -- unless we ignore, run the sync operation per the config #}\n        {% else %}\n\n          {% do sync_column_schemas(on_schema_change, target_relation, schema_changes_dict) %}\n\n        {% endif %}\n\n      {% endif %}\n\n      {{ return(schema_changes_dict['source_columns']) }}\n\n    {% endif %}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.check_for_schema_changes",
+                    "macro.dbt.sync_column_schemas"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.537212,
+            "supported_languages": null
+        },
+        "macro.dbt.can_clone_table": {
+            "name": "can_clone_table",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/clone/can_clone_table.sql",
+            "original_file_path": "macros/materializations/models/clone/can_clone_table.sql",
+            "unique_id": "macro.dbt.can_clone_table",
+            "macro_sql": "{% macro can_clone_table() %}\n    {{ return(adapter.dispatch('can_clone_table', 'dbt')()) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__can_clone_table"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.537436,
+            "supported_languages": null
+        },
+        "macro.dbt.default__can_clone_table": {
+            "name": "default__can_clone_table",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/clone/can_clone_table.sql",
+            "original_file_path": "macros/materializations/models/clone/can_clone_table.sql",
+            "unique_id": "macro.dbt.default__can_clone_table",
+            "macro_sql": "{% macro default__can_clone_table() %}\n    {{ return(False) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5375419,
+            "supported_languages": null
+        },
+        "macro.dbt.create_or_replace_clone": {
+            "name": "create_or_replace_clone",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/clone/create_or_replace_clone.sql",
+            "original_file_path": "macros/materializations/models/clone/create_or_replace_clone.sql",
+            "unique_id": "macro.dbt.create_or_replace_clone",
+            "macro_sql": "{% macro create_or_replace_clone(this_relation, defer_relation) %}\n    {{ return(adapter.dispatch('create_or_replace_clone', 'dbt')(this_relation, defer_relation)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__create_or_replace_clone"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.537806,
+            "supported_languages": null
+        },
+        "macro.dbt.default__create_or_replace_clone": {
+            "name": "default__create_or_replace_clone",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/clone/create_or_replace_clone.sql",
+            "original_file_path": "macros/materializations/models/clone/create_or_replace_clone.sql",
+            "unique_id": "macro.dbt.default__create_or_replace_clone",
+            "macro_sql": "{% macro default__create_or_replace_clone(this_relation, defer_relation) %}\n    create or replace table {{ this_relation }} clone {{ defer_relation }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5380218,
+            "supported_languages": null
+        },
+        "macro.dbt.materialization_clone_default": {
+            "name": "materialization_clone_default",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/models/clone/clone.sql",
+            "original_file_path": "macros/materializations/models/clone/clone.sql",
+            "unique_id": "macro.dbt.materialization_clone_default",
+            "macro_sql": "{%- materialization clone, default -%}\n\n  {%- set relations = {'relations': []} -%}\n\n  {%- if not defer_relation -%}\n      -- nothing to do\n      {{ log(\"No relation found in state manifest for \" ~ model.unique_id, info=True) }}\n      {{ return(relations) }}\n  {%- endif -%}\n\n  {%- set existing_relation = load_cached_relation(this) -%}\n\n  {%- if existing_relation and not flags.FULL_REFRESH -%}\n      -- noop!\n      {{ log(\"Relation \" ~ existing_relation ~ \" already exists\", info=True) }}\n      {{ return(relations) }}\n  {%- endif -%}\n\n  {%- set other_existing_relation = load_cached_relation(defer_relation) -%}\n\n  -- If this is a database that can do zero-copy cloning of tables, and the other relation is a table, then this will be a table\n  -- Otherwise, this will be a view\n\n  {% set can_clone_table = can_clone_table() %}\n\n  {%- if other_existing_relation and other_existing_relation.type == 'table' and can_clone_table -%}\n\n      {%- set target_relation = this.incorporate(type='table') -%}\n      {% if existing_relation is not none and not existing_relation.is_table %}\n        {{ log(\"Dropping relation \" ~ existing_relation ~ \" because it is of type \" ~ existing_relation.type) }}\n        {{ drop_relation_if_exists(existing_relation) }}\n      {% endif %}\n\n      -- as a general rule, data platforms that can clone tables can also do atomic 'create or replace'\n      {% call statement('main') %}\n          {% if target_relation and defer_relation and target_relation == defer_relation %}\n              {{ log(\"Target relation and defer relation are the same, skipping clone for relation: \" ~ target_relation) }}\n          {% else %}\n              {{ create_or_replace_clone(target_relation, defer_relation) }}\n          {% endif %}\n\n      {% endcall %}\n\n      {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}\n      {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n      {% do persist_docs(target_relation, model) %}\n\n      {{ return({'relations': [target_relation]}) }}\n\n  {%- else -%}\n\n      {%- set target_relation = this.incorporate(type='view') -%}\n\n      -- reuse the view materialization\n      -- TODO: support actual dispatch for materialization macros\n      -- Tracking ticket: https://github.com/dbt-labs/dbt-core/issues/7799\n      {% set search_name = \"materialization_view_\" ~ adapter.type() %}\n      {% if not search_name in context %}\n          {% set search_name = \"materialization_view_default\" %}\n      {% endif %}\n      {% set materialization_macro = context[search_name] %}\n      {% set relations = materialization_macro() %}\n      {{ return(relations) }}\n\n  {%- endif -%}\n\n{%- endmaterialization -%}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.load_cached_relation",
+                    "macro.dbt.can_clone_table",
+                    "macro.dbt.drop_relation_if_exists",
+                    "macro.dbt.statement",
+                    "macro.dbt.create_or_replace_clone",
+                    "macro.dbt.should_revoke",
+                    "macro.dbt.apply_grants",
+                    "macro.dbt.persist_docs"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5418,
+            "supported_languages": [
+                "sql"
+            ]
+        },
+        "macro.dbt.materialization_seed_default": {
+            "name": "materialization_seed_default",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/seeds/seed.sql",
+            "original_file_path": "macros/materializations/seeds/seed.sql",
+            "unique_id": "macro.dbt.materialization_seed_default",
+            "macro_sql": "{% materialization seed, default %}\n\n  {%- set identifier = model['alias'] -%}\n  {%- set full_refresh_mode = (should_full_refresh()) -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n\n  {%- set exists_as_table = (old_relation is not none and old_relation.is_table) -%}\n  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}\n\n  {%- set grant_config = config.get('grants') -%}\n  {%- set agate_table = load_agate_table() -%}\n  -- grab current tables grants config for comparison later on\n\n  {%- do store_result('agate_table', response='OK', agate_table=agate_table) -%}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% set create_table_sql = \"\" %}\n  {% if exists_as_view %}\n    {{ exceptions.raise_compiler_error(\"Cannot seed to '{}', it is a view\".format(old_relation)) }}\n  {% elif exists_as_table %}\n    {% set create_table_sql = reset_csv_table(model, full_refresh_mode, old_relation, agate_table) %}\n  {% else %}\n    {% set create_table_sql = create_csv_table(model, agate_table) %}\n  {% endif %}\n\n  {% set code = 'CREATE' if full_refresh_mode else 'INSERT' %}\n  {% set rows_affected = (agate_table.rows | length) %}\n  {% set sql = load_csv_rows(model, agate_table) %}\n\n  {% call noop_statement('main', code ~ ' ' ~ rows_affected, code, rows_affected) %}\n    {{ get_csv_sql(create_table_sql, sql) }};\n  {% endcall %}\n\n  {% set target_relation = this.incorporate(type='table') %}\n\n  {% set should_revoke = should_revoke(old_relation, full_refresh_mode) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {% if full_refresh_mode or not exists_as_table %}\n    {% do create_indexes(target_relation) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  -- `COMMIT` happens here\n  {{ adapter.commit() }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmaterialization %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.should_full_refresh",
+                    "macro.dbt.run_hooks",
+                    "macro.dbt.reset_csv_table",
+                    "macro.dbt.create_csv_table",
+                    "macro.dbt.load_csv_rows",
+                    "macro.dbt.noop_statement",
+                    "macro.dbt.get_csv_sql",
+                    "macro.dbt.should_revoke",
+                    "macro.dbt.apply_grants",
+                    "macro.dbt.persist_docs",
+                    "macro.dbt.create_indexes"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.544598,
+            "supported_languages": [
+                "sql"
+            ]
+        },
+        "macro.dbt.create_csv_table": {
+            "name": "create_csv_table",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/seeds/helpers.sql",
+            "original_file_path": "macros/materializations/seeds/helpers.sql",
+            "unique_id": "macro.dbt.create_csv_table",
+            "macro_sql": "{% macro create_csv_table(model, agate_table) -%}\n  {{ adapter.dispatch('create_csv_table', 'dbt')(model, agate_table) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__create_csv_table"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.551334,
+            "supported_languages": null
+        },
+        "macro.dbt.default__create_csv_table": {
+            "name": "default__create_csv_table",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/seeds/helpers.sql",
+            "original_file_path": "macros/materializations/seeds/helpers.sql",
+            "unique_id": "macro.dbt.default__create_csv_table",
+            "macro_sql": "{% macro default__create_csv_table(model, agate_table) %}\n  {%- set column_override = model['config'].get('column_types', {}) -%}\n  {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}\n\n  {% set sql %}\n    create table {{ this.render() }} (\n        {%- for col_name in agate_table.column_names -%}\n            {%- set inferred_type = adapter.convert_type(agate_table, loop.index0) -%}\n            {%- set type = column_override.get(col_name, inferred_type) -%}\n            {%- set column_name = (col_name | string) -%}\n            {{ adapter.quote_seed_column(column_name, quote_seed_column) }} {{ type }} {%- if not loop.last -%}, {%- endif -%}\n        {%- endfor -%}\n    )\n  {% endset %}\n\n  {% call statement('_') -%}\n    {{ sql }}\n  {%- endcall %}\n\n  {{ return(sql) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.552161,
+            "supported_languages": null
+        },
+        "macro.dbt.reset_csv_table": {
+            "name": "reset_csv_table",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/seeds/helpers.sql",
+            "original_file_path": "macros/materializations/seeds/helpers.sql",
+            "unique_id": "macro.dbt.reset_csv_table",
+            "macro_sql": "{% macro reset_csv_table(model, full_refresh, old_relation, agate_table) -%}\n  {{ adapter.dispatch('reset_csv_table', 'dbt')(model, full_refresh, old_relation, agate_table) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__reset_csv_table"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.552511,
+            "supported_languages": null
+        },
+        "macro.dbt.default__reset_csv_table": {
+            "name": "default__reset_csv_table",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/seeds/helpers.sql",
+            "original_file_path": "macros/materializations/seeds/helpers.sql",
+            "unique_id": "macro.dbt.default__reset_csv_table",
+            "macro_sql": "{% macro default__reset_csv_table(model, full_refresh, old_relation, agate_table) %}\n    {% set sql = \"\" %}\n    {% if full_refresh %}\n        {{ adapter.drop_relation(old_relation) }}\n        {% set sql = create_csv_table(model, agate_table) %}\n    {% else %}\n        {{ adapter.truncate_relation(old_relation) }}\n        {% set sql = \"truncate table \" ~ old_relation %}\n    {% endif %}\n\n    {{ return(sql) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.create_csv_table"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.553061,
+            "supported_languages": null
+        },
+        "macro.dbt.get_csv_sql": {
+            "name": "get_csv_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/seeds/helpers.sql",
+            "original_file_path": "macros/materializations/seeds/helpers.sql",
+            "unique_id": "macro.dbt.get_csv_sql",
+            "macro_sql": "{% macro get_csv_sql(create_or_truncate_sql, insert_sql) %}\n    {{ adapter.dispatch('get_csv_sql', 'dbt')(create_or_truncate_sql, insert_sql) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_csv_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5538182,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_csv_sql": {
+            "name": "default__get_csv_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/seeds/helpers.sql",
+            "original_file_path": "macros/materializations/seeds/helpers.sql",
+            "unique_id": "macro.dbt.default__get_csv_sql",
+            "macro_sql": "{% macro default__get_csv_sql(create_or_truncate_sql, insert_sql) %}\n    {{ create_or_truncate_sql }};\n    -- dbt seed --\n    {{ insert_sql }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.554225,
+            "supported_languages": null
+        },
+        "macro.dbt.get_binding_char": {
+            "name": "get_binding_char",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/seeds/helpers.sql",
+            "original_file_path": "macros/materializations/seeds/helpers.sql",
+            "unique_id": "macro.dbt.get_binding_char",
+            "macro_sql": "{% macro get_binding_char() -%}\n  {{ adapter.dispatch('get_binding_char', 'dbt')() }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__get_binding_char"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5546792,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_binding_char": {
+            "name": "default__get_binding_char",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/seeds/helpers.sql",
+            "original_file_path": "macros/materializations/seeds/helpers.sql",
+            "unique_id": "macro.dbt.default__get_binding_char",
+            "macro_sql": "{% macro default__get_binding_char() %}\n  {{ return('%s') }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.554869,
+            "supported_languages": null
+        },
+        "macro.dbt.get_batch_size": {
+            "name": "get_batch_size",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/seeds/helpers.sql",
+            "original_file_path": "macros/materializations/seeds/helpers.sql",
+            "unique_id": "macro.dbt.get_batch_size",
+            "macro_sql": "{% macro get_batch_size() -%}\n  {{ return(adapter.dispatch('get_batch_size', 'dbt')()) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__get_batch_size"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.555418,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_batch_size": {
+            "name": "default__get_batch_size",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/seeds/helpers.sql",
+            "original_file_path": "macros/materializations/seeds/helpers.sql",
+            "unique_id": "macro.dbt.default__get_batch_size",
+            "macro_sql": "{% macro default__get_batch_size() %}\n  {{ return(10000) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.555837,
+            "supported_languages": null
+        },
+        "macro.dbt.get_seed_column_quoted_csv": {
+            "name": "get_seed_column_quoted_csv",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/seeds/helpers.sql",
+            "original_file_path": "macros/materializations/seeds/helpers.sql",
+            "unique_id": "macro.dbt.get_seed_column_quoted_csv",
+            "macro_sql": "{% macro get_seed_column_quoted_csv(model, column_names) %}\n  {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}\n    {% set quoted = [] %}\n    {% for col in column_names -%}\n        {%- do quoted.append(adapter.quote_seed_column(col, quote_seed_column)) -%}\n    {%- endfor %}\n\n    {%- set dest_cols_csv = quoted | join(', ') -%}\n    {{ return(dest_cols_csv) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5563169,
+            "supported_languages": null
+        },
+        "macro.dbt.load_csv_rows": {
+            "name": "load_csv_rows",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/seeds/helpers.sql",
+            "original_file_path": "macros/materializations/seeds/helpers.sql",
+            "unique_id": "macro.dbt.load_csv_rows",
+            "macro_sql": "{% macro load_csv_rows(model, agate_table) -%}\n  {{ adapter.dispatch('load_csv_rows', 'dbt')(model, agate_table) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__load_csv_rows"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5564978,
+            "supported_languages": null
+        },
+        "macro.dbt.default__load_csv_rows": {
+            "name": "default__load_csv_rows",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/materializations/seeds/helpers.sql",
+            "original_file_path": "macros/materializations/seeds/helpers.sql",
+            "unique_id": "macro.dbt.default__load_csv_rows",
+            "macro_sql": "{% macro default__load_csv_rows(model, agate_table) %}\n\n  {% set batch_size = get_batch_size() %}\n\n  {% set cols_sql = get_seed_column_quoted_csv(model, agate_table.column_names) %}\n  {% set bindings = [] %}\n\n  {% set statements = [] %}\n\n  {% for chunk in agate_table.rows | batch(batch_size) %}\n      {% set bindings = [] %}\n\n      {% for row in chunk %}\n          {% do bindings.extend(row) %}\n      {% endfor %}\n\n      {% set sql %}\n          insert into {{ this.render() }} ({{ cols_sql }}) values\n          {% for row in chunk -%}\n              ({%- for column in agate_table.column_names -%}\n                  {{ get_binding_char() }}\n                  {%- if not loop.last%},{%- endif %}\n              {%- endfor -%})\n              {%- if not loop.last%},{%- endif %}\n          {%- endfor %}\n      {% endset %}\n\n      {% do adapter.add_query(sql, bindings=bindings, abridge_sql_log=True) %}\n\n      {% if loop.index0 == 0 %}\n          {% do statements.append(sql) %}\n      {% endif %}\n  {% endfor %}\n\n  {# Return SQL so we can render it out into the compiled files #}\n  {{ return(statements[0]) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_batch_size",
+                    "macro.dbt.get_seed_column_quoted_csv",
+                    "macro.dbt.get_binding_char"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.557733,
+            "supported_languages": null
+        },
+        "macro.dbt.generate_alias_name": {
+            "name": "generate_alias_name",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/get_custom_name/get_custom_alias.sql",
+            "original_file_path": "macros/get_custom_name/get_custom_alias.sql",
+            "unique_id": "macro.dbt.generate_alias_name",
+            "macro_sql": "{% macro generate_alias_name(custom_alias_name=none, node=none) -%}\n    {% do return(adapter.dispatch('generate_alias_name', 'dbt')(custom_alias_name, node)) %}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__generate_alias_name"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.558159,
+            "supported_languages": null
+        },
+        "macro.dbt.default__generate_alias_name": {
+            "name": "default__generate_alias_name",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/get_custom_name/get_custom_alias.sql",
+            "original_file_path": "macros/get_custom_name/get_custom_alias.sql",
+            "unique_id": "macro.dbt.default__generate_alias_name",
+            "macro_sql": "{% macro default__generate_alias_name(custom_alias_name=none, node=none) -%}\n\n    {%- if custom_alias_name -%}\n\n        {{ custom_alias_name | trim }}\n\n    {%- elif node.version -%}\n\n        {{ return(node.name ~ \"_v\" ~ (node.version | replace(\".\", \"_\"))) }}\n\n    {%- else -%}\n\n        {{ node.name }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.558507,
+            "supported_languages": null
+        },
+        "macro.dbt.generate_schema_name": {
+            "name": "generate_schema_name",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/get_custom_name/get_custom_schema.sql",
+            "original_file_path": "macros/get_custom_name/get_custom_schema.sql",
+            "unique_id": "macro.dbt.generate_schema_name",
+            "macro_sql": "{% macro generate_schema_name(custom_schema_name=none, node=none) -%}\n    {{ return(adapter.dispatch('generate_schema_name', 'dbt')(custom_schema_name, node)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__generate_schema_name"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.558992,
+            "supported_languages": null
+        },
+        "macro.dbt.default__generate_schema_name": {
+            "name": "default__generate_schema_name",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/get_custom_name/get_custom_schema.sql",
+            "original_file_path": "macros/get_custom_name/get_custom_schema.sql",
+            "unique_id": "macro.dbt.default__generate_schema_name",
+            "macro_sql": "{% macro default__generate_schema_name(custom_schema_name, node) -%}\n\n    {%- set default_schema = target.schema -%}\n    {%- if custom_schema_name is none -%}\n\n        {{ default_schema }}\n\n    {%- else -%}\n\n        {{ default_schema }}_{{ custom_schema_name | trim }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5593102,
+            "supported_languages": null
+        },
+        "macro.dbt.generate_schema_name_for_env": {
+            "name": "generate_schema_name_for_env",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/get_custom_name/get_custom_schema.sql",
+            "original_file_path": "macros/get_custom_name/get_custom_schema.sql",
+            "unique_id": "macro.dbt.generate_schema_name_for_env",
+            "macro_sql": "{% macro generate_schema_name_for_env(custom_schema_name, node) -%}\n\n    {%- set default_schema = target.schema -%}\n    {%- if target.name == 'prod' and custom_schema_name is not none -%}\n\n        {{ custom_schema_name | trim }}\n\n    {%- else -%}\n\n        {{ default_schema }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5596,
+            "supported_languages": null
+        },
+        "macro.dbt.generate_database_name": {
+            "name": "generate_database_name",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/get_custom_name/get_custom_database.sql",
+            "original_file_path": "macros/get_custom_name/get_custom_database.sql",
+            "unique_id": "macro.dbt.generate_database_name",
+            "macro_sql": "{% macro generate_database_name(custom_database_name=none, node=none) -%}\n    {% do return(adapter.dispatch('generate_database_name', 'dbt')(custom_database_name, node)) %}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__generate_database_name"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.55999,
+            "supported_languages": null
+        },
+        "macro.dbt.default__generate_database_name": {
+            "name": "default__generate_database_name",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/get_custom_name/get_custom_database.sql",
+            "original_file_path": "macros/get_custom_name/get_custom_database.sql",
+            "unique_id": "macro.dbt.default__generate_database_name",
+            "macro_sql": "{% macro default__generate_database_name(custom_database_name=none, node=none) -%}\n    {%- set default_database = target.database -%}\n    {%- if custom_database_name is none -%}\n\n        {{ default_database }}\n\n    {%- else -%}\n\n        {{ custom_database_name }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.560228,
+            "supported_languages": null
+        },
+        "macro.dbt.get_drop_sql": {
+            "name": "get_drop_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/drop.sql",
+            "original_file_path": "macros/relations/drop.sql",
+            "unique_id": "macro.dbt.get_drop_sql",
+            "macro_sql": "{%- macro get_drop_sql(relation) -%}\n    {{- log('Applying DROP to: ' ~ relation) -}}\n    {{- adapter.dispatch('get_drop_sql', 'dbt')(relation) -}}\n{%- endmacro -%}\n\n\n",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_drop_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.561318,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_drop_sql": {
+            "name": "default__get_drop_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/drop.sql",
+            "original_file_path": "macros/relations/drop.sql",
+            "unique_id": "macro.dbt.default__get_drop_sql",
+            "macro_sql": "{%- macro default__get_drop_sql(relation) -%}\n\n    {%- if relation.is_view -%}\n        {{ drop_view(relation) }}\n\n    {%- elif relation.is_table -%}\n        {{ drop_table(relation) }}\n\n    {%- elif relation.is_materialized_view -%}\n        {{ drop_materialized_view(relation) }}\n\n    {%- else -%}\n        drop {{ relation.type }} if exists {{ relation }} cascade\n\n    {%- endif -%}\n\n{%- endmacro -%}\n\n\n",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.drop_view",
+                    "macro.dbt.drop_table",
+                    "macro.dbt.drop_materialized_view"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5617652,
+            "supported_languages": null
+        },
+        "macro.dbt.drop_relation": {
+            "name": "drop_relation",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/drop.sql",
+            "original_file_path": "macros/relations/drop.sql",
+            "unique_id": "macro.dbt.drop_relation",
+            "macro_sql": "{% macro drop_relation(relation) -%}\n    {{ return(adapter.dispatch('drop_relation', 'dbt')(relation)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__drop_relation"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.561973,
+            "supported_languages": null
+        },
+        "macro.dbt.default__drop_relation": {
+            "name": "default__drop_relation",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/drop.sql",
+            "original_file_path": "macros/relations/drop.sql",
+            "unique_id": "macro.dbt.default__drop_relation",
+            "macro_sql": "{% macro default__drop_relation(relation) -%}\n    {% call statement('drop_relation', auto_begin=False) -%}\n        {{ get_drop_sql(relation) }}\n    {%- endcall %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement",
+                    "macro.dbt.get_drop_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5626612,
+            "supported_languages": null
+        },
+        "macro.dbt.drop_relation_if_exists": {
+            "name": "drop_relation_if_exists",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/drop.sql",
+            "original_file_path": "macros/relations/drop.sql",
+            "unique_id": "macro.dbt.drop_relation_if_exists",
+            "macro_sql": "{% macro drop_relation_if_exists(relation) %}\n  {% if relation is not none %}\n    {{ adapter.drop_relation(relation) }}\n  {% endif %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5631418,
+            "supported_languages": null
+        },
+        "macro.dbt.get_replace_sql": {
+            "name": "get_replace_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/replace.sql",
+            "original_file_path": "macros/relations/replace.sql",
+            "unique_id": "macro.dbt.get_replace_sql",
+            "macro_sql": "{% macro get_replace_sql(existing_relation, target_relation, sql) %}\n    {{- log('Applying REPLACE to: ' ~ existing_relation) -}}\n    {{- adapter.dispatch('get_replace_sql', 'dbt')(existing_relation, target_relation, sql) -}}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_replace_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.564019,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_replace_sql": {
+            "name": "default__get_replace_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/replace.sql",
+            "original_file_path": "macros/relations/replace.sql",
+            "unique_id": "macro.dbt.default__get_replace_sql",
+            "macro_sql": "{% macro default__get_replace_sql(existing_relation, target_relation, sql) %}\n\n    {# /* use a create or replace statement if possible */ #}\n\n    {% set is_replaceable = existing_relation.type == target_relation_type and existing_relation.can_be_replaced %}\n\n    {% if is_replaceable and existing_relation.is_view %}\n        {{ get_replace_view_sql(target_relation, sql) }}\n\n    {% elif is_replaceable and existing_relation.is_table %}\n        {{ get_replace_table_sql(target_relation, sql) }}\n\n    {% elif is_replaceable and existing_relation.is_materialized_view %}\n        {{ get_replace_materialized_view_sql(target_relation, sql) }}\n\n    {# /* a create or replace statement is not possible, so try to stage and/or backup to be safe */ #}\n\n    {# /* create target_relation as an intermediate relation, then swap it out with the existing one using a backup */ #}\n    {%- elif target_relation.can_be_renamed and existing_relation.can_be_renamed -%}\n        {{ get_create_intermediate_sql(target_relation, sql) }};\n        {{ get_create_backup_sql(existing_relation) }};\n        {{ get_rename_intermediate_sql(target_relation) }};\n        {{ get_drop_backup_sql(existing_relation) }}\n\n    {# /* create target_relation as an intermediate relation, then swap it out with the existing one without using a backup */ #}\n    {%- elif target_relation.can_be_renamed -%}\n        {{ get_create_intermediate_sql(target_relation, sql) }};\n        {{ get_drop_sql(existing_relation) }};\n        {{ get_rename_intermediate_sql(target_relation) }}\n\n    {# /* create target_relation in place by first backing up the existing relation */ #}\n    {%- elif existing_relation.can_be_renamed -%}\n        {{ get_create_backup_sql(existing_relation) }};\n        {{ get_create_sql(target_relation, sql) }};\n        {{ get_drop_backup_sql(existing_relation) }}\n\n    {# /* no renaming is allowed, so just drop and create */ #}\n    {%- else -%}\n        {{ get_drop_sql(existing_relation) }};\n        {{ get_create_sql(target_relation, sql) }}\n\n    {%- endif -%}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_replace_view_sql",
+                    "macro.dbt.get_replace_table_sql",
+                    "macro.dbt.get_replace_materialized_view_sql",
+                    "macro.dbt.get_create_intermediate_sql",
+                    "macro.dbt.get_create_backup_sql",
+                    "macro.dbt.get_rename_intermediate_sql",
+                    "macro.dbt.get_drop_backup_sql",
+                    "macro.dbt.get_drop_sql",
+                    "macro.dbt.get_create_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.566122,
+            "supported_languages": null
+        },
+        "macro.dbt.get_create_intermediate_sql": {
+            "name": "get_create_intermediate_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/create_intermediate.sql",
+            "original_file_path": "macros/relations/create_intermediate.sql",
+            "unique_id": "macro.dbt.get_create_intermediate_sql",
+            "macro_sql": "{%- macro get_create_intermediate_sql(relation, sql) -%}\n    {{- log('Applying CREATE INTERMEDIATE to: ' ~ relation) -}}\n    {{- adapter.dispatch('get_create_intermediate_sql', 'dbt')(relation, sql) -}}\n{%- endmacro -%}\n\n\n",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_create_intermediate_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.566592,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_create_intermediate_sql": {
+            "name": "default__get_create_intermediate_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/create_intermediate.sql",
+            "original_file_path": "macros/relations/create_intermediate.sql",
+            "unique_id": "macro.dbt.default__get_create_intermediate_sql",
+            "macro_sql": "{%- macro default__get_create_intermediate_sql(relation, sql) -%}\n\n    -- get the standard intermediate name\n    {% set intermediate_relation = make_intermediate_relation(relation) %}\n\n    -- drop any pre-existing intermediate\n    {{ get_drop_sql(intermediate_relation) }};\n\n    {{ get_create_sql(intermediate_relation, sql) }}\n\n{%- endmacro -%}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.make_intermediate_relation",
+                    "macro.dbt.get_drop_sql",
+                    "macro.dbt.get_create_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.566942,
+            "supported_languages": null
+        },
+        "macro.dbt.drop_schema_named": {
+            "name": "drop_schema_named",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/schema.sql",
+            "original_file_path": "macros/relations/schema.sql",
+            "unique_id": "macro.dbt.drop_schema_named",
+            "macro_sql": "{% macro drop_schema_named(schema_name) %}\n    {{ return(adapter.dispatch('drop_schema_named', 'dbt') (schema_name)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__drop_schema_named"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.56729,
+            "supported_languages": null
+        },
+        "macro.dbt.default__drop_schema_named": {
+            "name": "default__drop_schema_named",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/schema.sql",
+            "original_file_path": "macros/relations/schema.sql",
+            "unique_id": "macro.dbt.default__drop_schema_named",
+            "macro_sql": "{% macro default__drop_schema_named(schema_name) %}\n  {% set schema_relation = api.Relation.create(schema=schema_name) %}\n  {{ adapter.drop_schema(schema_relation) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.567498,
+            "supported_languages": null
+        },
+        "macro.dbt.get_drop_backup_sql": {
+            "name": "get_drop_backup_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/drop_backup.sql",
+            "original_file_path": "macros/relations/drop_backup.sql",
+            "unique_id": "macro.dbt.get_drop_backup_sql",
+            "macro_sql": "{%- macro get_drop_backup_sql(relation) -%}\n    {{- log('Applying DROP BACKUP to: ' ~ relation) -}}\n    {{- adapter.dispatch('get_drop_backup_sql', 'dbt')(relation) -}}\n{%- endmacro -%}\n\n\n",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_drop_backup_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.567807,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_drop_backup_sql": {
+            "name": "default__get_drop_backup_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/drop_backup.sql",
+            "original_file_path": "macros/relations/drop_backup.sql",
+            "unique_id": "macro.dbt.default__get_drop_backup_sql",
+            "macro_sql": "{%- macro default__get_drop_backup_sql(relation) -%}\n\n    -- get the standard backup name\n    {% set backup_relation = make_backup_relation(relation, relation.type) %}\n\n    {{ get_drop_sql(backup_relation) }}\n\n{%- endmacro -%}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.make_backup_relation",
+                    "macro.dbt.get_drop_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.568009,
+            "supported_languages": null
+        },
+        "macro.dbt.get_rename_sql": {
+            "name": "get_rename_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/rename.sql",
+            "original_file_path": "macros/relations/rename.sql",
+            "unique_id": "macro.dbt.get_rename_sql",
+            "macro_sql": "{%- macro get_rename_sql(relation, new_name) -%}\n    {{- log('Applying RENAME to: ' ~ relation) -}}\n    {{- adapter.dispatch('get_rename_sql', 'dbt')(relation, new_name) -}}\n{%- endmacro -%}\n\n\n",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_rename_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5687559,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_rename_sql": {
+            "name": "default__get_rename_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/rename.sql",
+            "original_file_path": "macros/relations/rename.sql",
+            "unique_id": "macro.dbt.default__get_rename_sql",
+            "macro_sql": "{%- macro default__get_rename_sql(relation, new_name) -%}\n\n    {%- if relation.is_view -%}\n        {{ get_rename_view_sql(relation, new_name) }}\n\n    {%- elif relation.is_table -%}\n        {{ get_rename_table_sql(relation, new_name) }}\n\n    {%- elif relation.is_materialized_view -%}\n        {{ get_rename_materialized_view_sql(relation, new_name) }}\n\n    {%- else -%}\n        {{- exceptions.raise_compiler_error(\"`get_rename_sql` has not been implemented for: \" ~ relation.type ) -}}\n\n    {%- endif -%}\n\n{%- endmacro -%}\n\n\n",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_rename_view_sql",
+                    "macro.dbt.get_rename_table_sql",
+                    "macro.dbt.get_rename_materialized_view_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.569163,
+            "supported_languages": null
+        },
+        "macro.dbt.rename_relation": {
+            "name": "rename_relation",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/rename.sql",
+            "original_file_path": "macros/relations/rename.sql",
+            "unique_id": "macro.dbt.rename_relation",
+            "macro_sql": "{% macro rename_relation(from_relation, to_relation) -%}\n  {{ return(adapter.dispatch('rename_relation', 'dbt')(from_relation, to_relation)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__rename_relation"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.569356,
+            "supported_languages": null
+        },
+        "macro.dbt.default__rename_relation": {
+            "name": "default__rename_relation",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/rename.sql",
+            "original_file_path": "macros/relations/rename.sql",
+            "unique_id": "macro.dbt.default__rename_relation",
+            "macro_sql": "{% macro default__rename_relation(from_relation, to_relation) -%}\n  {% set target_name = adapter.quote_as_configured(to_relation.identifier, 'identifier') %}\n  {% call statement('rename_relation') -%}\n    alter table {{ from_relation }} rename to {{ target_name }}\n  {%- endcall %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5696042,
+            "supported_languages": null
+        },
+        "macro.dbt.get_create_backup_sql": {
+            "name": "get_create_backup_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/create_backup.sql",
+            "original_file_path": "macros/relations/create_backup.sql",
+            "unique_id": "macro.dbt.get_create_backup_sql",
+            "macro_sql": "{%- macro get_create_backup_sql(relation) -%}\n    {{- log('Applying CREATE BACKUP to: ' ~ relation) -}}\n    {{- adapter.dispatch('get_create_backup_sql', 'dbt')(relation) -}}\n{%- endmacro -%}\n\n\n",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_create_backup_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.569935,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_create_backup_sql": {
+            "name": "default__get_create_backup_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/create_backup.sql",
+            "original_file_path": "macros/relations/create_backup.sql",
+            "unique_id": "macro.dbt.default__get_create_backup_sql",
+            "macro_sql": "{%- macro default__get_create_backup_sql(relation) -%}\n\n    -- get the standard backup name\n    {% set backup_relation = make_backup_relation(relation, relation.type) %}\n\n    -- drop any pre-existing backup\n    {{ get_drop_sql(backup_relation) }};\n\n    {{ get_rename_sql(relation, backup_relation.identifier) }}\n\n{%- endmacro -%}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.make_backup_relation",
+                    "macro.dbt.get_drop_sql",
+                    "macro.dbt.get_rename_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.570176,
+            "supported_languages": null
+        },
+        "macro.dbt.get_create_sql": {
+            "name": "get_create_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/create.sql",
+            "original_file_path": "macros/relations/create.sql",
+            "unique_id": "macro.dbt.get_create_sql",
+            "macro_sql": "{%- macro get_create_sql(relation, sql) -%}\n    {{- log('Applying CREATE to: ' ~ relation) -}}\n    {{- adapter.dispatch('get_create_sql', 'dbt')(relation, sql) -}}\n{%- endmacro -%}\n\n\n",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_create_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.570603,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_create_sql": {
+            "name": "default__get_create_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/create.sql",
+            "original_file_path": "macros/relations/create.sql",
+            "unique_id": "macro.dbt.default__get_create_sql",
+            "macro_sql": "{%- macro default__get_create_sql(relation, sql) -%}\n\n    {%- if relation.is_view -%}\n        {{ get_create_view_as_sql(relation, sql) }}\n\n    {%- elif relation.is_table -%}\n        {{ get_create_table_as_sql(False, relation, sql) }}\n\n    {%- elif relation.is_materialized_view -%}\n        {{ get_create_materialized_view_as_sql(relation, sql) }}\n\n    {%- else -%}\n        {{- exceptions.raise_compiler_error(\"`get_create_sql` has not been implemented for: \" ~ relation.type ) -}}\n\n    {%- endif -%}\n\n{%- endmacro -%}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_create_view_as_sql",
+                    "macro.dbt.get_create_table_as_sql",
+                    "macro.dbt.get_create_materialized_view_as_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.571,
+            "supported_languages": null
+        },
+        "macro.dbt.get_rename_intermediate_sql": {
+            "name": "get_rename_intermediate_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/rename_intermediate.sql",
+            "original_file_path": "macros/relations/rename_intermediate.sql",
+            "unique_id": "macro.dbt.get_rename_intermediate_sql",
+            "macro_sql": "{%- macro get_rename_intermediate_sql(relation) -%}\n    {{- log('Applying RENAME INTERMEDIATE to: ' ~ relation) -}}\n    {{- adapter.dispatch('get_rename_intermediate_sql', 'dbt')(relation) -}}\n{%- endmacro -%}\n\n\n",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_rename_intermediate_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.571303,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_rename_intermediate_sql": {
+            "name": "default__get_rename_intermediate_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/rename_intermediate.sql",
+            "original_file_path": "macros/relations/rename_intermediate.sql",
+            "unique_id": "macro.dbt.default__get_rename_intermediate_sql",
+            "macro_sql": "{%- macro default__get_rename_intermediate_sql(relation) -%}\n\n    -- get the standard intermediate name\n    {% set intermediate_relation = make_intermediate_relation(relation) %}\n\n    {{ get_rename_sql(intermediate_relation, relation.identifier) }}\n\n{%- endmacro -%}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.make_intermediate_relation",
+                    "macro.dbt.get_rename_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.57149,
+            "supported_languages": null
+        },
+        "macro.dbt.drop_materialized_view": {
+            "name": "drop_materialized_view",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/materialized_view/drop.sql",
+            "original_file_path": "macros/relations/materialized_view/drop.sql",
+            "unique_id": "macro.dbt.drop_materialized_view",
+            "macro_sql": "{% macro drop_materialized_view(relation) -%}\n    {{- adapter.dispatch('drop_materialized_view', 'dbt')(relation) -}}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__drop_materialized_view"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.571809,
+            "supported_languages": null
+        },
+        "macro.dbt.default__drop_materialized_view": {
+            "name": "default__drop_materialized_view",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/materialized_view/drop.sql",
+            "original_file_path": "macros/relations/materialized_view/drop.sql",
+            "unique_id": "macro.dbt.default__drop_materialized_view",
+            "macro_sql": "{% macro default__drop_materialized_view(relation) -%}\n    drop materialized view if exists {{ relation }} cascade\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.571914,
+            "supported_languages": null
+        },
+        "macro.dbt.get_replace_materialized_view_sql": {
+            "name": "get_replace_materialized_view_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/materialized_view/replace.sql",
+            "original_file_path": "macros/relations/materialized_view/replace.sql",
+            "unique_id": "macro.dbt.get_replace_materialized_view_sql",
+            "macro_sql": "{% macro get_replace_materialized_view_sql(relation, sql) %}\n    {{- adapter.dispatch('get_replace_materialized_view_sql', 'dbt')(relation, sql) -}}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_replace_materialized_view_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.572164,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_replace_materialized_view_sql": {
+            "name": "default__get_replace_materialized_view_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/materialized_view/replace.sql",
+            "original_file_path": "macros/relations/materialized_view/replace.sql",
+            "unique_id": "macro.dbt.default__get_replace_materialized_view_sql",
+            "macro_sql": "{% macro default__get_replace_materialized_view_sql(relation, sql) %}\n    {{ exceptions.raise_compiler_error(\n        \"`get_replace_materialized_view_sql` has not been implemented for this adapter.\"\n    ) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.572374,
+            "supported_languages": null
+        },
+        "macro.dbt.refresh_materialized_view": {
+            "name": "refresh_materialized_view",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/materialized_view/refresh.sql",
+            "original_file_path": "macros/relations/materialized_view/refresh.sql",
+            "unique_id": "macro.dbt.refresh_materialized_view",
+            "macro_sql": "{% macro refresh_materialized_view(relation) %}\n    {{- log('Applying REFRESH to: ' ~ relation) -}}\n    {{- adapter.dispatch('refresh_materialized_view', 'dbt')(relation) -}}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__refresh_materialized_view"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5726552,
+            "supported_languages": null
+        },
+        "macro.dbt.default__refresh_materialized_view": {
+            "name": "default__refresh_materialized_view",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/materialized_view/refresh.sql",
+            "original_file_path": "macros/relations/materialized_view/refresh.sql",
+            "unique_id": "macro.dbt.default__refresh_materialized_view",
+            "macro_sql": "{% macro default__refresh_materialized_view(relation) %}\n    {{ exceptions.raise_compiler_error(\"`refresh_materialized_view` has not been implemented for this adapter.\") }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.572781,
+            "supported_languages": null
+        },
+        "macro.dbt.get_rename_materialized_view_sql": {
+            "name": "get_rename_materialized_view_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/materialized_view/rename.sql",
+            "original_file_path": "macros/relations/materialized_view/rename.sql",
+            "unique_id": "macro.dbt.get_rename_materialized_view_sql",
+            "macro_sql": "{% macro get_rename_materialized_view_sql(relation, new_name) %}\n    {{- adapter.dispatch('get_rename_materialized_view_sql', 'dbt')(relation, new_name) -}}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_rename_materialized_view_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.573028,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_rename_materialized_view_sql": {
+            "name": "default__get_rename_materialized_view_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/materialized_view/rename.sql",
+            "original_file_path": "macros/relations/materialized_view/rename.sql",
+            "unique_id": "macro.dbt.default__get_rename_materialized_view_sql",
+            "macro_sql": "{% macro default__get_rename_materialized_view_sql(relation, new_name) %}\n    {{ exceptions.raise_compiler_error(\n        \"`get_rename_materialized_view_sql` has not been implemented for this adapter.\"\n    ) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.573157,
+            "supported_languages": null
+        },
+        "macro.dbt.get_alter_materialized_view_as_sql": {
+            "name": "get_alter_materialized_view_as_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/materialized_view/alter.sql",
+            "original_file_path": "macros/relations/materialized_view/alter.sql",
+            "unique_id": "macro.dbt.get_alter_materialized_view_as_sql",
+            "macro_sql": "{% macro get_alter_materialized_view_as_sql(\n    relation,\n    configuration_changes,\n    sql,\n    existing_relation,\n    backup_relation,\n    intermediate_relation\n) %}\n    {{- log('Applying ALTER to: ' ~ relation) -}}\n    {{- adapter.dispatch('get_alter_materialized_view_as_sql', 'dbt')(\n        relation,\n        configuration_changes,\n        sql,\n        existing_relation,\n        backup_relation,\n        intermediate_relation\n    ) -}}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_alter_materialized_view_as_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.574096,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_alter_materialized_view_as_sql": {
+            "name": "default__get_alter_materialized_view_as_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/materialized_view/alter.sql",
+            "original_file_path": "macros/relations/materialized_view/alter.sql",
+            "unique_id": "macro.dbt.default__get_alter_materialized_view_as_sql",
+            "macro_sql": "{% macro default__get_alter_materialized_view_as_sql(\n    relation,\n    configuration_changes,\n    sql,\n    existing_relation,\n    backup_relation,\n    intermediate_relation\n) %}\n    {{ exceptions.raise_compiler_error(\"Materialized views have not been implemented for this adapter.\") }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.574272,
+            "supported_languages": null
+        },
+        "macro.dbt.get_materialized_view_configuration_changes": {
+            "name": "get_materialized_view_configuration_changes",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/materialized_view/alter.sql",
+            "original_file_path": "macros/relations/materialized_view/alter.sql",
+            "unique_id": "macro.dbt.get_materialized_view_configuration_changes",
+            "macro_sql": "{% macro get_materialized_view_configuration_changes(existing_relation, new_config) %}\n    /* {#\n    It's recommended that configuration changes be formatted as follows:\n    {\"<change_category>\": [{\"action\": \"<name>\", \"context\": ...}]}\n\n    For example:\n    {\n        \"indexes\": [\n            {\"action\": \"drop\", \"context\": \"index_abc\"},\n            {\"action\": \"create\", \"context\": {\"columns\": [\"column_1\", \"column_2\"], \"type\": \"hash\", \"unique\": True}},\n        ],\n    }\n\n    Either way, `get_materialized_view_configuration_changes` needs to align with `get_alter_materialized_view_as_sql`.\n    #} */\n    {{- log('Determining configuration changes on: ' ~ existing_relation) -}}\n    {%- do return(adapter.dispatch('get_materialized_view_configuration_changes', 'dbt')(existing_relation, new_config)) -%}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_materialized_view_configuration_changes"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.574531,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_materialized_view_configuration_changes": {
+            "name": "default__get_materialized_view_configuration_changes",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/materialized_view/alter.sql",
+            "original_file_path": "macros/relations/materialized_view/alter.sql",
+            "unique_id": "macro.dbt.default__get_materialized_view_configuration_changes",
+            "macro_sql": "{% macro default__get_materialized_view_configuration_changes(existing_relation, new_config) %}\n    {{ exceptions.raise_compiler_error(\"Materialized views have not been implemented for this adapter.\") }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.574666,
+            "supported_languages": null
+        },
+        "macro.dbt.get_create_materialized_view_as_sql": {
+            "name": "get_create_materialized_view_as_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/materialized_view/create.sql",
+            "original_file_path": "macros/relations/materialized_view/create.sql",
+            "unique_id": "macro.dbt.get_create_materialized_view_as_sql",
+            "macro_sql": "{% macro get_create_materialized_view_as_sql(relation, sql) -%}\n    {{- adapter.dispatch('get_create_materialized_view_as_sql', 'dbt')(relation, sql) -}}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_create_materialized_view_as_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5749178,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_create_materialized_view_as_sql": {
+            "name": "default__get_create_materialized_view_as_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/materialized_view/create.sql",
+            "original_file_path": "macros/relations/materialized_view/create.sql",
+            "unique_id": "macro.dbt.default__get_create_materialized_view_as_sql",
+            "macro_sql": "{% macro default__get_create_materialized_view_as_sql(relation, sql) -%}\n    {{ exceptions.raise_compiler_error(\n        \"`get_create_materialized_view_as_sql` has not been implemented for this adapter.\"\n    ) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5750499,
+            "supported_languages": null
+        },
+        "macro.dbt.get_table_columns_and_constraints": {
+            "name": "get_table_columns_and_constraints",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/column/columns_spec_ddl.sql",
+            "original_file_path": "macros/relations/column/columns_spec_ddl.sql",
+            "unique_id": "macro.dbt.get_table_columns_and_constraints",
+            "macro_sql": "{%- macro get_table_columns_and_constraints() -%}\n  {{ adapter.dispatch('get_table_columns_and_constraints', 'dbt')() }}\n{%- endmacro -%}\n\n",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_table_columns_and_constraints"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.575975,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_table_columns_and_constraints": {
+            "name": "default__get_table_columns_and_constraints",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/column/columns_spec_ddl.sql",
+            "original_file_path": "macros/relations/column/columns_spec_ddl.sql",
+            "unique_id": "macro.dbt.default__get_table_columns_and_constraints",
+            "macro_sql": "{% macro default__get_table_columns_and_constraints() -%}\n  {{ return(table_columns_and_constraints()) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.table_columns_and_constraints"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.576086,
+            "supported_languages": null
+        },
+        "macro.dbt.table_columns_and_constraints": {
+            "name": "table_columns_and_constraints",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/column/columns_spec_ddl.sql",
+            "original_file_path": "macros/relations/column/columns_spec_ddl.sql",
+            "unique_id": "macro.dbt.table_columns_and_constraints",
+            "macro_sql": "{% macro table_columns_and_constraints() %}\n  {# loop through user_provided_columns to create DDL with data types and constraints #}\n    {%- set raw_column_constraints = adapter.render_raw_columns_constraints(raw_columns=model['columns']) -%}\n    {%- set raw_model_constraints = adapter.render_raw_model_constraints(raw_constraints=model['constraints']) -%}\n    (\n    {% for c in raw_column_constraints -%}\n      {{ c }}{{ \",\" if not loop.last or raw_model_constraints }}\n    {% endfor %}\n    {% for c in raw_model_constraints -%}\n        {{ c }}{{ \",\" if not loop.last }}\n    {% endfor -%}\n    )\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5765572,
+            "supported_languages": null
+        },
+        "macro.dbt.get_assert_columns_equivalent": {
+            "name": "get_assert_columns_equivalent",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/column/columns_spec_ddl.sql",
+            "original_file_path": "macros/relations/column/columns_spec_ddl.sql",
+            "unique_id": "macro.dbt.get_assert_columns_equivalent",
+            "macro_sql": "\n\n{%- macro get_assert_columns_equivalent(sql) -%}\n  {{ adapter.dispatch('get_assert_columns_equivalent', 'dbt')(sql) }}\n{%- endmacro -%}\n\n",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_assert_columns_equivalent"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.576898,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_assert_columns_equivalent": {
+            "name": "default__get_assert_columns_equivalent",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/column/columns_spec_ddl.sql",
+            "original_file_path": "macros/relations/column/columns_spec_ddl.sql",
+            "unique_id": "macro.dbt.default__get_assert_columns_equivalent",
+            "macro_sql": "{% macro default__get_assert_columns_equivalent(sql) -%}\n  {{ return(assert_columns_equivalent(sql)) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.assert_columns_equivalent"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.577066,
+            "supported_languages": null
+        },
+        "macro.dbt.assert_columns_equivalent": {
+            "name": "assert_columns_equivalent",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/column/columns_spec_ddl.sql",
+            "original_file_path": "macros/relations/column/columns_spec_ddl.sql",
+            "unique_id": "macro.dbt.assert_columns_equivalent",
+            "macro_sql": "{% macro assert_columns_equivalent(sql) %}\n\n  {#-- First ensure the user has defined 'columns' in yaml specification --#}\n  {%- set user_defined_columns = model['columns'] -%}\n  {%- if not user_defined_columns -%}\n      {{ exceptions.raise_contract_error([], []) }}\n  {%- endif -%}\n\n  {#-- Obtain the column schema provided by sql file. #}\n  {%- set sql_file_provided_columns = get_column_schema_from_query(sql, config.get('sql_header', none)) -%}\n  {#--Obtain the column schema provided by the schema file by generating an 'empty schema' query from the model's columns. #}\n  {%- set schema_file_provided_columns = get_column_schema_from_query(get_empty_schema_sql(user_defined_columns)) -%}\n\n  {#-- create dictionaries with name and formatted data type and strings for exception #}\n  {%- set sql_columns = format_columns(sql_file_provided_columns) -%}\n  {%- set yaml_columns = format_columns(schema_file_provided_columns)  -%}\n\n  {%- if sql_columns|length != yaml_columns|length -%}\n    {%- do exceptions.raise_contract_error(yaml_columns, sql_columns) -%}\n  {%- endif -%}\n\n  {%- for sql_col in sql_columns -%}\n    {%- set yaml_col = [] -%}\n    {%- for this_col in yaml_columns -%}\n      {%- if this_col['name'] == sql_col['name'] -%}\n        {%- do yaml_col.append(this_col) -%}\n        {%- break -%}\n      {%- endif -%}\n    {%- endfor -%}\n    {%- if not yaml_col -%}\n      {#-- Column with name not found in yaml #}\n      {%- do exceptions.raise_contract_error(yaml_columns, sql_columns) -%}\n    {%- endif -%}\n    {%- if sql_col['formatted'] != yaml_col[0]['formatted'] -%}\n      {#-- Column data types don't match #}\n      {%- do exceptions.raise_contract_error(yaml_columns, sql_columns) -%}\n    {%- endif -%}\n  {%- endfor -%}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_column_schema_from_query",
+                    "macro.dbt.get_empty_schema_sql",
+                    "macro.dbt.format_columns"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.578506,
+            "supported_languages": null
+        },
+        "macro.dbt.format_columns": {
+            "name": "format_columns",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/column/columns_spec_ddl.sql",
+            "original_file_path": "macros/relations/column/columns_spec_ddl.sql",
+            "unique_id": "macro.dbt.format_columns",
+            "macro_sql": "{% macro format_columns(columns) %}\n  {% set formatted_columns = [] %}\n  {% for column in columns %}\n    {%- set formatted_column = adapter.dispatch('format_column', 'dbt')(column) -%}\n    {%- do formatted_columns.append(formatted_column) -%}\n  {% endfor %}\n  {{ return(formatted_columns) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__format_column"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5790122,
+            "supported_languages": null
+        },
+        "macro.dbt.default__format_column": {
+            "name": "default__format_column",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/column/columns_spec_ddl.sql",
+            "original_file_path": "macros/relations/column/columns_spec_ddl.sql",
+            "unique_id": "macro.dbt.default__format_column",
+            "macro_sql": "{% macro default__format_column(column) -%}\n  {% set data_type = column.dtype %}\n  {% set formatted = column.column.lower() ~ \" \" ~ data_type %}\n  {{ return({'name': column.name, 'data_type': data_type, 'formatted': formatted}) }}\n{%- endmacro -%}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.579401,
+            "supported_languages": null
+        },
+        "macro.dbt.drop_table": {
+            "name": "drop_table",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/table/drop.sql",
+            "original_file_path": "macros/relations/table/drop.sql",
+            "unique_id": "macro.dbt.drop_table",
+            "macro_sql": "{% macro drop_table(relation) -%}\n    {{- adapter.dispatch('drop_table', 'dbt')(relation) -}}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__drop_table"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.579648,
+            "supported_languages": null
+        },
+        "macro.dbt.default__drop_table": {
+            "name": "default__drop_table",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/table/drop.sql",
+            "original_file_path": "macros/relations/table/drop.sql",
+            "unique_id": "macro.dbt.default__drop_table",
+            "macro_sql": "{% macro default__drop_table(relation) -%}\n    drop table if exists {{ relation }} cascade\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.579745,
+            "supported_languages": null
+        },
+        "macro.dbt.get_replace_table_sql": {
+            "name": "get_replace_table_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/table/replace.sql",
+            "original_file_path": "macros/relations/table/replace.sql",
+            "unique_id": "macro.dbt.get_replace_table_sql",
+            "macro_sql": "{% macro get_replace_table_sql(relation, sql) %}\n    {{- adapter.dispatch('get_replace_table_sql', 'dbt')(relation, sql) -}}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_replace_table_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.579995,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_replace_table_sql": {
+            "name": "default__get_replace_table_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/table/replace.sql",
+            "original_file_path": "macros/relations/table/replace.sql",
+            "unique_id": "macro.dbt.default__get_replace_table_sql",
+            "macro_sql": "{% macro default__get_replace_table_sql(relation, sql) %}\n    {{ exceptions.raise_compiler_error(\n        \"`get_replace_table_sql` has not been implemented for this adapter.\"\n    ) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5801332,
+            "supported_languages": null
+        },
+        "macro.dbt.get_rename_table_sql": {
+            "name": "get_rename_table_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/table/rename.sql",
+            "original_file_path": "macros/relations/table/rename.sql",
+            "unique_id": "macro.dbt.get_rename_table_sql",
+            "macro_sql": "{% macro get_rename_table_sql(relation, new_name) %}\n    {{- adapter.dispatch('get_rename_table_sql', 'dbt')(relation, new_name) -}}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_rename_table_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.580383,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_rename_table_sql": {
+            "name": "default__get_rename_table_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/table/rename.sql",
+            "original_file_path": "macros/relations/table/rename.sql",
+            "unique_id": "macro.dbt.default__get_rename_table_sql",
+            "macro_sql": "{% macro default__get_rename_table_sql(relation, new_name) %}\n    {{ exceptions.raise_compiler_error(\n        \"`get_rename_table_sql` has not been implemented for this adapter.\"\n    ) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.580514,
+            "supported_languages": null
+        },
+        "macro.dbt.get_create_table_as_sql": {
+            "name": "get_create_table_as_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/table/create.sql",
+            "original_file_path": "macros/relations/table/create.sql",
+            "unique_id": "macro.dbt.get_create_table_as_sql",
+            "macro_sql": "{% macro get_create_table_as_sql(temporary, relation, sql) -%}\n  {{ adapter.dispatch('get_create_table_as_sql', 'dbt')(temporary, relation, sql) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_create_table_as_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5813088,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_create_table_as_sql": {
+            "name": "default__get_create_table_as_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/table/create.sql",
+            "original_file_path": "macros/relations/table/create.sql",
+            "unique_id": "macro.dbt.default__get_create_table_as_sql",
+            "macro_sql": "{% macro default__get_create_table_as_sql(temporary, relation, sql) -%}\n  {{ return(create_table_as(temporary, relation, sql)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.create_table_as"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5814779,
+            "supported_languages": null
+        },
+        "macro.dbt.create_table_as": {
+            "name": "create_table_as",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/table/create.sql",
+            "original_file_path": "macros/relations/table/create.sql",
+            "unique_id": "macro.dbt.create_table_as",
+            "macro_sql": "{% macro create_table_as(temporary, relation, compiled_code, language='sql') -%}\n  {# backward compatibility for create_table_as that does not support language #}\n  {% if language == \"sql\" %}\n    {{ adapter.dispatch('create_table_as', 'dbt')(temporary, relation, compiled_code)}}\n  {% else %}\n    {{ adapter.dispatch('create_table_as', 'dbt')(temporary, relation, compiled_code, language) }}\n  {% endif %}\n\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__create_table_as"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5818748,
+            "supported_languages": null
+        },
+        "macro.dbt.default__create_table_as": {
+            "name": "default__create_table_as",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/table/create.sql",
+            "original_file_path": "macros/relations/table/create.sql",
+            "unique_id": "macro.dbt.default__create_table_as",
+            "macro_sql": "{% macro default__create_table_as(temporary, relation, sql) -%}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n\n  create {% if temporary: -%}temporary{%- endif %} table\n    {{ relation.include(database=(not temporary), schema=(not temporary)) }}\n  {% set contract_config = config.get('contract') %}\n  {% if contract_config.enforced and (not temporary) %}\n    {{ get_assert_columns_equivalent(sql) }}\n    {{ get_table_columns_and_constraints() }}\n    {%- set sql = get_select_subquery(sql) %}\n  {% endif %}\n  as (\n    {{ sql }}\n  );\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_assert_columns_equivalent",
+                    "macro.dbt.get_table_columns_and_constraints",
+                    "macro.dbt.get_select_subquery"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5825112,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_column_names": {
+            "name": "default__get_column_names",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/table/create.sql",
+            "original_file_path": "macros/relations/table/create.sql",
+            "unique_id": "macro.dbt.default__get_column_names",
+            "macro_sql": "{% macro default__get_column_names() %}\n  {#- loop through user_provided_columns to get column names -#}\n    {%- set user_provided_columns = model['columns'] -%}\n    {%- for i in user_provided_columns %}\n      {%- set col = user_provided_columns[i] -%}\n      {%- set col_name = adapter.quote(col['name']) if col.get('quote') else col['name'] -%}\n      {{ col_name }}{{ \", \" if not loop.last }}\n    {%- endfor -%}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.582929,
+            "supported_languages": null
+        },
+        "macro.dbt.get_select_subquery": {
+            "name": "get_select_subquery",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/table/create.sql",
+            "original_file_path": "macros/relations/table/create.sql",
+            "unique_id": "macro.dbt.get_select_subquery",
+            "macro_sql": "{% macro get_select_subquery(sql) %}\n  {{ return(adapter.dispatch('get_select_subquery', 'dbt')(sql)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_select_subquery"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5830982,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_select_subquery": {
+            "name": "default__get_select_subquery",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/table/create.sql",
+            "original_file_path": "macros/relations/table/create.sql",
+            "unique_id": "macro.dbt.default__get_select_subquery",
+            "macro_sql": "{% macro default__get_select_subquery(sql) %}\n    select {{ adapter.dispatch('get_column_names', 'dbt')() }}\n    from (\n        {{ sql }}\n    ) as model_subq\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.get_column_names",
+                    "macro.dbt.default__get_column_names"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5832698,
+            "supported_languages": null
+        },
+        "macro.dbt.drop_view": {
+            "name": "drop_view",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/view/drop.sql",
+            "original_file_path": "macros/relations/view/drop.sql",
+            "unique_id": "macro.dbt.drop_view",
+            "macro_sql": "{% macro drop_view(relation) -%}\n    {{- adapter.dispatch('drop_view', 'dbt')(relation) -}}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__drop_view"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5834901,
+            "supported_languages": null
+        },
+        "macro.dbt.default__drop_view": {
+            "name": "default__drop_view",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/view/drop.sql",
+            "original_file_path": "macros/relations/view/drop.sql",
+            "unique_id": "macro.dbt.default__drop_view",
+            "macro_sql": "{% macro default__drop_view(relation) -%}\n    drop view if exists {{ relation }} cascade\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.583584,
+            "supported_languages": null
+        },
+        "macro.dbt.get_replace_view_sql": {
+            "name": "get_replace_view_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/view/replace.sql",
+            "original_file_path": "macros/relations/view/replace.sql",
+            "unique_id": "macro.dbt.get_replace_view_sql",
+            "macro_sql": "{% macro get_replace_view_sql(relation, sql) %}\n    {{- adapter.dispatch('get_replace_view_sql', 'dbt')(relation, sql) -}}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_replace_view_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.584353,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_replace_view_sql": {
+            "name": "default__get_replace_view_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/view/replace.sql",
+            "original_file_path": "macros/relations/view/replace.sql",
+            "unique_id": "macro.dbt.default__get_replace_view_sql",
+            "macro_sql": "{% macro default__get_replace_view_sql(relation, sql) %}\n    {{ exceptions.raise_compiler_error(\n        \"`get_replace_view_sql` has not been implemented for this adapter.\"\n    ) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.584754,
+            "supported_languages": null
+        },
+        "macro.dbt.create_or_replace_view": {
+            "name": "create_or_replace_view",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/view/replace.sql",
+            "original_file_path": "macros/relations/view/replace.sql",
+            "unique_id": "macro.dbt.create_or_replace_view",
+            "macro_sql": "{% macro create_or_replace_view() %}\n  {%- set identifier = model['alias'] -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}\n\n  {%- set target_relation = api.Relation.create(\n      identifier=identifier, schema=schema, database=database,\n      type='view') -%}\n  {% set grant_config = config.get('grants') %}\n\n  {{ run_hooks(pre_hooks) }}\n\n  -- If there's a table with the same name and we weren't told to full refresh,\n  -- that's an error. If we were told to full refresh, drop it. This behavior differs\n  -- for Snowflake and BigQuery, so multiple dispatch is used.\n  {%- if old_relation is not none and old_relation.is_table -%}\n    {{ handle_existing_table(should_full_refresh(), old_relation) }}\n  {%- endif -%}\n\n  -- build model\n  {% call statement('main') -%}\n    {{ get_create_view_as_sql(target_relation, sql) }}\n  {%- endcall %}\n\n  {% set should_revoke = should_revoke(exists_as_view, full_refresh_mode=True) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {{ run_hooks(post_hooks) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.run_hooks",
+                    "macro.dbt.handle_existing_table",
+                    "macro.dbt.should_full_refresh",
+                    "macro.dbt.statement",
+                    "macro.dbt.get_create_view_as_sql",
+                    "macro.dbt.should_revoke",
+                    "macro.dbt.apply_grants"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.585983,
+            "supported_languages": null
+        },
+        "macro.dbt.handle_existing_table": {
+            "name": "handle_existing_table",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/view/replace.sql",
+            "original_file_path": "macros/relations/view/replace.sql",
+            "unique_id": "macro.dbt.handle_existing_table",
+            "macro_sql": "{% macro handle_existing_table(full_refresh, old_relation) %}\n    {{ adapter.dispatch('handle_existing_table', 'dbt')(full_refresh, old_relation) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__handle_existing_table"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.586167,
+            "supported_languages": null
+        },
+        "macro.dbt.default__handle_existing_table": {
+            "name": "default__handle_existing_table",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/view/replace.sql",
+            "original_file_path": "macros/relations/view/replace.sql",
+            "unique_id": "macro.dbt.default__handle_existing_table",
+            "macro_sql": "{% macro default__handle_existing_table(full_refresh, old_relation) %}\n    {{ log(\"Dropping relation \" ~ old_relation ~ \" because it is of type \" ~ old_relation.type) }}\n    {{ adapter.drop_relation(old_relation) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5863621,
+            "supported_languages": null
+        },
+        "macro.dbt.get_rename_view_sql": {
+            "name": "get_rename_view_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/view/rename.sql",
+            "original_file_path": "macros/relations/view/rename.sql",
+            "unique_id": "macro.dbt.get_rename_view_sql",
+            "macro_sql": "{% macro get_rename_view_sql(relation, new_name) %}\n    {{- adapter.dispatch('get_rename_view_sql', 'dbt')(relation, new_name) -}}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_rename_view_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.586609,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_rename_view_sql": {
+            "name": "default__get_rename_view_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/view/rename.sql",
+            "original_file_path": "macros/relations/view/rename.sql",
+            "unique_id": "macro.dbt.default__get_rename_view_sql",
+            "macro_sql": "{% macro default__get_rename_view_sql(relation, new_name) %}\n    {{ exceptions.raise_compiler_error(\n        \"`get_rename_view_sql` has not been implemented for this adapter.\"\n    ) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.586755,
+            "supported_languages": null
+        },
+        "macro.dbt.get_create_view_as_sql": {
+            "name": "get_create_view_as_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/view/create.sql",
+            "original_file_path": "macros/relations/view/create.sql",
+            "unique_id": "macro.dbt.get_create_view_as_sql",
+            "macro_sql": "{% macro get_create_view_as_sql(relation, sql) -%}\n  {{ adapter.dispatch('get_create_view_as_sql', 'dbt')(relation, sql) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_create_view_as_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.587469,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_create_view_as_sql": {
+            "name": "default__get_create_view_as_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/view/create.sql",
+            "original_file_path": "macros/relations/view/create.sql",
+            "unique_id": "macro.dbt.default__get_create_view_as_sql",
+            "macro_sql": "{% macro default__get_create_view_as_sql(relation, sql) -%}\n  {{ return(create_view_as(relation, sql)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.create_view_as"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.587637,
+            "supported_languages": null
+        },
+        "macro.dbt.create_view_as": {
+            "name": "create_view_as",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/view/create.sql",
+            "original_file_path": "macros/relations/view/create.sql",
+            "unique_id": "macro.dbt.create_view_as",
+            "macro_sql": "{% macro create_view_as(relation, sql) -%}\n  {{ adapter.dispatch('create_view_as', 'dbt')(relation, sql) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__create_view_as"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.587903,
+            "supported_languages": null
+        },
+        "macro.dbt.default__create_view_as": {
+            "name": "default__create_view_as",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/relations/view/create.sql",
+            "original_file_path": "macros/relations/view/create.sql",
+            "unique_id": "macro.dbt.default__create_view_as",
+            "macro_sql": "{% macro default__create_view_as(relation, sql) -%}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n  create view {{ relation }}\n    {% set contract_config = config.get('contract') %}\n    {% if contract_config.enforced %}\n      {{ get_assert_columns_equivalent(sql) }}\n    {%- endif %}\n  as (\n    {{ sql }}\n  );\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_assert_columns_equivalent"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.588358,
+            "supported_languages": null
+        },
+        "macro.dbt.default__test_relationships": {
+            "name": "default__test_relationships",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/generic_test_sql/relationships.sql",
+            "original_file_path": "macros/generic_test_sql/relationships.sql",
+            "unique_id": "macro.dbt.default__test_relationships",
+            "macro_sql": "{% macro default__test_relationships(model, column_name, to, field) %}\n\nwith child as (\n    select {{ column_name }} as from_field\n    from {{ model }}\n    where {{ column_name }} is not null\n),\n\nparent as (\n    select {{ field }} as to_field\n    from {{ to }}\n)\n\nselect\n    from_field\n\nfrom child\nleft join parent\n    on child.from_field = parent.to_field\n\nwhere parent.to_field is null\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5886998,
+            "supported_languages": null
+        },
+        "macro.dbt.default__test_not_null": {
+            "name": "default__test_not_null",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/generic_test_sql/not_null.sql",
+            "original_file_path": "macros/generic_test_sql/not_null.sql",
+            "unique_id": "macro.dbt.default__test_not_null",
+            "macro_sql": "{% macro default__test_not_null(model, column_name) %}\n\n{% set column_list = '*' if should_store_failures() else column_name %}\n\nselect {{ column_list }}\nfrom {{ model }}\nwhere {{ column_name }} is null\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.should_store_failures"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.588962,
+            "supported_languages": null
+        },
+        "macro.dbt.default__test_unique": {
+            "name": "default__test_unique",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/generic_test_sql/unique.sql",
+            "original_file_path": "macros/generic_test_sql/unique.sql",
+            "unique_id": "macro.dbt.default__test_unique",
+            "macro_sql": "{% macro default__test_unique(model, column_name) %}\n\nselect\n    {{ column_name }} as unique_field,\n    count(*) as n_records\n\nfrom {{ model }}\nwhere {{ column_name }} is not null\ngroup by {{ column_name }}\nhaving count(*) > 1\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.58918,
+            "supported_languages": null
+        },
+        "macro.dbt.default__test_accepted_values": {
+            "name": "default__test_accepted_values",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/generic_test_sql/accepted_values.sql",
+            "original_file_path": "macros/generic_test_sql/accepted_values.sql",
+            "unique_id": "macro.dbt.default__test_accepted_values",
+            "macro_sql": "{% macro default__test_accepted_values(model, column_name, values, quote=True) %}\n\nwith all_values as (\n\n    select\n        {{ column_name }} as value_field,\n        count(*) as n_records\n\n    from {{ model }}\n    group by {{ column_name }}\n\n)\n\nselect *\nfrom all_values\nwhere value_field not in (\n    {% for value in values -%}\n        {% if quote -%}\n        '{{ value }}'\n        {%- else -%}\n        {{ value }}\n        {%- endif -%}\n        {%- if not loop.last -%},{%- endif %}\n    {%- endfor %}\n)\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.589668,
+            "supported_languages": null
+        },
+        "macro.dbt.statement": {
+            "name": "statement",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/etc/statement.sql",
+            "original_file_path": "macros/etc/statement.sql",
+            "unique_id": "macro.dbt.statement",
+            "macro_sql": "\n{%- macro statement(name=None, fetch_result=False, auto_begin=True, language='sql') -%}\n  {%- if execute: -%}\n    {%- set compiled_code = caller() -%}\n\n    {%- if name == 'main' -%}\n      {{ log('Writing runtime {} for node \"{}\"'.format(language, model['unique_id'])) }}\n      {{ write(compiled_code) }}\n    {%- endif -%}\n    {%- if language == 'sql'-%}\n      {%- set res, table = adapter.execute(compiled_code, auto_begin=auto_begin, fetch=fetch_result) -%}\n    {%- elif language == 'python' -%}\n      {%- set res = submit_python_job(model, compiled_code) -%}\n      {#-- TODO: What should table be for python models? --#}\n      {%- set table = None -%}\n    {%- else -%}\n      {% do exceptions.raise_compiler_error(\"statement macro didn't get supported language\") %}\n    {%- endif -%}\n\n    {%- if name is not none -%}\n      {{ store_result(name, response=res, agate_table=table) }}\n    {%- endif -%}\n\n  {%- endif -%}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5913348,
+            "supported_languages": null
+        },
+        "macro.dbt.noop_statement": {
+            "name": "noop_statement",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/etc/statement.sql",
+            "original_file_path": "macros/etc/statement.sql",
+            "unique_id": "macro.dbt.noop_statement",
+            "macro_sql": "{% macro noop_statement(name=None, message=None, code=None, rows_affected=None, res=None) -%}\n  {%- set sql = caller() -%}\n\n  {%- if name == 'main' -%}\n    {{ log('Writing runtime SQL for node \"{}\"'.format(model['unique_id'])) }}\n    {{ write(sql) }}\n  {%- endif -%}\n\n  {%- if name is not none -%}\n    {{ store_raw_result(name, message=message, code=code, rows_affected=rows_affected, agate_table=res) }}\n  {%- endif -%}\n\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.592107,
+            "supported_languages": null
+        },
+        "macro.dbt.run_query": {
+            "name": "run_query",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/etc/statement.sql",
+            "original_file_path": "macros/etc/statement.sql",
+            "unique_id": "macro.dbt.run_query",
+            "macro_sql": "{% macro run_query(sql) %}\n  {% call statement(\"run_query_statement\", fetch_result=true, auto_begin=false) %}\n    {{ sql }}\n  {% endcall %}\n\n  {% do return(load_result(\"run_query_statement\").table) %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5923688,
+            "supported_languages": null
+        },
+        "macro.dbt.convert_datetime": {
+            "name": "convert_datetime",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/etc/datetime.sql",
+            "original_file_path": "macros/etc/datetime.sql",
+            "unique_id": "macro.dbt.convert_datetime",
+            "macro_sql": "{% macro convert_datetime(date_str, date_fmt) %}\n\n  {% set error_msg -%}\n      The provided partition date '{{ date_str }}' does not match the expected format '{{ date_fmt }}'\n  {%- endset %}\n\n  {% set res = try_or_compiler_error(error_msg, modules.datetime.datetime.strptime, date_str.strip(), date_fmt) %}\n  {{ return(res) }}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.594178,
+            "supported_languages": null
+        },
+        "macro.dbt.dates_in_range": {
+            "name": "dates_in_range",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/etc/datetime.sql",
+            "original_file_path": "macros/etc/datetime.sql",
+            "unique_id": "macro.dbt.dates_in_range",
+            "macro_sql": "{% macro dates_in_range(start_date_str, end_date_str=none, in_fmt=\"%Y%m%d\", out_fmt=\"%Y%m%d\") %}\n    {% set end_date_str = start_date_str if end_date_str is none else end_date_str %}\n\n    {% set start_date = convert_datetime(start_date_str, in_fmt) %}\n    {% set end_date = convert_datetime(end_date_str, in_fmt) %}\n\n    {% set day_count = (end_date - start_date).days %}\n    {% if day_count < 0 %}\n        {% set msg -%}\n            Partition start date is after the end date ({{ start_date }}, {{ end_date }})\n        {%- endset %}\n\n        {{ exceptions.raise_compiler_error(msg, model) }}\n    {% endif %}\n\n    {% set date_list = [] %}\n    {% for i in range(0, day_count + 1) %}\n        {% set the_date = (modules.datetime.timedelta(days=i) + start_date) %}\n        {% if not out_fmt %}\n            {% set _ = date_list.append(the_date) %}\n        {% else %}\n            {% set _ = date_list.append(the_date.strftime(out_fmt)) %}\n        {% endif %}\n    {% endfor %}\n\n    {{ return(date_list) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.convert_datetime"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.595413,
+            "supported_languages": null
+        },
+        "macro.dbt.partition_range": {
+            "name": "partition_range",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/etc/datetime.sql",
+            "original_file_path": "macros/etc/datetime.sql",
+            "unique_id": "macro.dbt.partition_range",
+            "macro_sql": "{% macro partition_range(raw_partition_date, date_fmt='%Y%m%d') %}\n    {% set partition_range = (raw_partition_date | string).split(\",\") %}\n\n    {% if (partition_range | length) == 1 %}\n      {% set start_date = partition_range[0] %}\n      {% set end_date = none %}\n    {% elif (partition_range | length) == 2 %}\n      {% set start_date = partition_range[0] %}\n      {% set end_date = partition_range[1] %}\n    {% else %}\n      {{ exceptions.raise_compiler_error(\"Invalid partition time. Expected format: {Start Date}[,{End Date}]. Got: \" ~ raw_partition_date) }}\n    {% endif %}\n\n    {{ return(dates_in_range(start_date, end_date, in_fmt=date_fmt)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.dates_in_range"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.596152,
+            "supported_languages": null
+        },
+        "macro.dbt.py_current_timestring": {
+            "name": "py_current_timestring",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/etc/datetime.sql",
+            "original_file_path": "macros/etc/datetime.sql",
+            "unique_id": "macro.dbt.py_current_timestring",
+            "macro_sql": "{% macro py_current_timestring() %}\n    {% set dt = modules.datetime.datetime.now() %}\n    {% do return(dt.strftime(\"%Y%m%d%H%M%S%f\")) %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5963662,
+            "supported_languages": null
+        },
+        "macro.dbt.except": {
+            "name": "except",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/except.sql",
+            "original_file_path": "macros/utils/except.sql",
+            "unique_id": "macro.dbt.except",
+            "macro_sql": "{% macro except() %}\n  {{ return(adapter.dispatch('except', 'dbt')()) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__except"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.596595,
+            "supported_languages": null
+        },
+        "macro.dbt.default__except": {
+            "name": "default__except",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/except.sql",
+            "original_file_path": "macros/utils/except.sql",
+            "unique_id": "macro.dbt.default__except",
+            "macro_sql": "{% macro default__except() %}\n\n    except\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.5966668,
+            "supported_languages": null
+        },
+        "macro.dbt.get_intervals_between": {
+            "name": "get_intervals_between",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/date_spine.sql",
+            "original_file_path": "macros/utils/date_spine.sql",
+            "unique_id": "macro.dbt.get_intervals_between",
+            "macro_sql": "{% macro get_intervals_between(start_date, end_date, datepart) -%}\n    {{ return(adapter.dispatch('get_intervals_between', 'dbt')(start_date, end_date, datepart)) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_intervals_between"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.597534,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_intervals_between": {
+            "name": "default__get_intervals_between",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/date_spine.sql",
+            "original_file_path": "macros/utils/date_spine.sql",
+            "unique_id": "macro.dbt.default__get_intervals_between",
+            "macro_sql": "{% macro default__get_intervals_between(start_date, end_date, datepart) -%}\n    {%- call statement('get_intervals_between', fetch_result=True) %}\n\n        select {{ dbt.datediff(start_date, end_date, datepart) }}\n\n    {%- endcall -%}\n\n    {%- set value_list = load_result('get_intervals_between') -%}\n\n    {%- if value_list and value_list['data'] -%}\n        {%- set values = value_list['data'] | map(attribute=0) | list %}\n        {{ return(values[0]) }}\n    {%- else -%}\n        {{ return(1) }}\n    {%- endif -%}\n\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement",
+                    "macro.dbt.datediff"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.598059,
+            "supported_languages": null
+        },
+        "macro.dbt.date_spine": {
+            "name": "date_spine",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/date_spine.sql",
+            "original_file_path": "macros/utils/date_spine.sql",
+            "unique_id": "macro.dbt.date_spine",
+            "macro_sql": "{% macro date_spine(datepart, start_date, end_date) %}\n    {{ return(adapter.dispatch('date_spine', 'dbt')(datepart, start_date, end_date)) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__date_spine"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.598263,
+            "supported_languages": null
+        },
+        "macro.dbt.default__date_spine": {
+            "name": "default__date_spine",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/date_spine.sql",
+            "original_file_path": "macros/utils/date_spine.sql",
+            "unique_id": "macro.dbt.default__date_spine",
+            "macro_sql": "{% macro default__date_spine(datepart, start_date, end_date) %}\n\n\n    {# call as follows:\n\n    date_spine(\n        \"day\",\n        \"to_date('01/01/2016', 'mm/dd/yyyy')\",\n        \"dbt.dateadd(week, 1, current_date)\"\n    ) #}\n\n\n    with rawdata as (\n\n        {{dbt.generate_series(\n            dbt.get_intervals_between(start_date, end_date, datepart)\n        )}}\n\n    ),\n\n    all_periods as (\n\n        select (\n            {{\n                dbt.dateadd(\n                    datepart,\n                    \"row_number() over (order by 1) - 1\",\n                    start_date\n                )\n            }}\n        ) as date_{{datepart}}\n        from rawdata\n\n    ),\n\n    filtered as (\n\n        select *\n        from all_periods\n        where date_{{datepart}} <= {{ end_date }}\n\n    )\n\n    select * from filtered\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.generate_series",
+                    "macro.dbt.get_intervals_between",
+                    "macro.dbt.dateadd"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.598598,
+            "supported_languages": null
+        },
+        "macro.dbt.date": {
+            "name": "date",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/date.sql",
+            "original_file_path": "macros/utils/date.sql",
+            "unique_id": "macro.dbt.date",
+            "macro_sql": "{% macro date(year, month, day) %}\n  {{ return(adapter.dispatch('date', 'dbt') (year, month, day)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__date"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.598995,
+            "supported_languages": null
+        },
+        "macro.dbt.default__date": {
+            "name": "default__date",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/date.sql",
+            "original_file_path": "macros/utils/date.sql",
+            "unique_id": "macro.dbt.default__date",
+            "macro_sql": "{% macro default__date(year, month, day) -%}\n    {%- set dt = modules.datetime.date(year, month, day) -%}\n    {%- set iso_8601_formatted_date = dt.strftime('%Y-%m-%d') -%}\n    to_date('{{ iso_8601_formatted_date }}', 'YYYY-MM-DD')\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.599257,
+            "supported_languages": null
+        },
+        "macro.dbt.replace": {
+            "name": "replace",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/replace.sql",
+            "original_file_path": "macros/utils/replace.sql",
+            "unique_id": "macro.dbt.replace",
+            "macro_sql": "{% macro replace(field, old_chars, new_chars) -%}\n    {{ return(adapter.dispatch('replace', 'dbt') (field, old_chars, new_chars)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__replace"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.599692,
+            "supported_languages": null
+        },
+        "macro.dbt.default__replace": {
+            "name": "default__replace",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/replace.sql",
+            "original_file_path": "macros/utils/replace.sql",
+            "unique_id": "macro.dbt.default__replace",
+            "macro_sql": "{% macro default__replace(field, old_chars, new_chars) %}\n\n    replace(\n        {{ field }},\n        {{ old_chars }},\n        {{ new_chars }}\n    )\n\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.599882,
+            "supported_languages": null
+        },
+        "macro.dbt.concat": {
+            "name": "concat",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/concat.sql",
+            "original_file_path": "macros/utils/concat.sql",
+            "unique_id": "macro.dbt.concat",
+            "macro_sql": "{% macro concat(fields) -%}\n  {{ return(adapter.dispatch('concat', 'dbt')(fields)) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__concat"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6001291,
+            "supported_languages": null
+        },
+        "macro.dbt.default__concat": {
+            "name": "default__concat",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/concat.sql",
+            "original_file_path": "macros/utils/concat.sql",
+            "unique_id": "macro.dbt.default__concat",
+            "macro_sql": "{% macro default__concat(fields) -%}\n    {{ fields|join(' || ') }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.600281,
+            "supported_languages": null
+        },
+        "macro.dbt.get_powers_of_two": {
+            "name": "get_powers_of_two",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/generate_series.sql",
+            "original_file_path": "macros/utils/generate_series.sql",
+            "unique_id": "macro.dbt.get_powers_of_two",
+            "macro_sql": "{% macro get_powers_of_two(upper_bound) %}\n    {{ return(adapter.dispatch('get_powers_of_two', 'dbt')(upper_bound)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_powers_of_two"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6011431,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_powers_of_two": {
+            "name": "default__get_powers_of_two",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/generate_series.sql",
+            "original_file_path": "macros/utils/generate_series.sql",
+            "unique_id": "macro.dbt.default__get_powers_of_two",
+            "macro_sql": "{% macro default__get_powers_of_two(upper_bound) %}\n\n    {% if upper_bound <= 0 %}\n    {{ exceptions.raise_compiler_error(\"upper bound must be positive\") }}\n    {% endif %}\n\n    {% for _ in range(1, 100) %}\n       {% if upper_bound <= 2 ** loop.index %}{{ return(loop.index) }}{% endif %}\n    {% endfor %}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.601634,
+            "supported_languages": null
+        },
+        "macro.dbt.generate_series": {
+            "name": "generate_series",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/generate_series.sql",
+            "original_file_path": "macros/utils/generate_series.sql",
+            "unique_id": "macro.dbt.generate_series",
+            "macro_sql": "{% macro generate_series(upper_bound) %}\n    {{ return(adapter.dispatch('generate_series', 'dbt')(upper_bound)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__generate_series"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.601803,
+            "supported_languages": null
+        },
+        "macro.dbt.default__generate_series": {
+            "name": "default__generate_series",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/generate_series.sql",
+            "original_file_path": "macros/utils/generate_series.sql",
+            "unique_id": "macro.dbt.default__generate_series",
+            "macro_sql": "{% macro default__generate_series(upper_bound) %}\n\n    {% set n = dbt.get_powers_of_two(upper_bound) %}\n\n    with p as (\n        select 0 as generated_number union all select 1\n    ), unioned as (\n\n    select\n\n    {% for i in range(n) %}\n    p{{i}}.generated_number * power(2, {{i}})\n    {% if not loop.last %} + {% endif %}\n    {% endfor %}\n    + 1\n    as generated_number\n\n    from\n\n    {% for i in range(n) %}\n    p as p{{i}}\n    {% if not loop.last %} cross join {% endif %}\n    {% endfor %}\n\n    )\n\n    select *\n    from unioned\n    where generated_number <= {{upper_bound}}\n    order by generated_number\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_powers_of_two"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.602241,
+            "supported_languages": null
+        },
+        "macro.dbt.length": {
+            "name": "length",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/length.sql",
+            "original_file_path": "macros/utils/length.sql",
+            "unique_id": "macro.dbt.length",
+            "macro_sql": "{% macro length(expression) -%}\n    {{ return(adapter.dispatch('length', 'dbt') (expression)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__length"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.602468,
+            "supported_languages": null
+        },
+        "macro.dbt.default__length": {
+            "name": "default__length",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/length.sql",
+            "original_file_path": "macros/utils/length.sql",
+            "unique_id": "macro.dbt.default__length",
+            "macro_sql": "{% macro default__length(expression) %}\n\n    length(\n        {{ expression }}\n    )\n\n{%- endmacro -%}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.602565,
+            "supported_languages": null
+        },
+        "macro.dbt.dateadd": {
+            "name": "dateadd",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/dateadd.sql",
+            "original_file_path": "macros/utils/dateadd.sql",
+            "unique_id": "macro.dbt.dateadd",
+            "macro_sql": "{% macro dateadd(datepart, interval, from_date_or_timestamp) %}\n  {{ return(adapter.dispatch('dateadd', 'dbt')(datepart, interval, from_date_or_timestamp)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__dateadd"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.602869,
+            "supported_languages": null
+        },
+        "macro.dbt.default__dateadd": {
+            "name": "default__dateadd",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/dateadd.sql",
+            "original_file_path": "macros/utils/dateadd.sql",
+            "unique_id": "macro.dbt.default__dateadd",
+            "macro_sql": "{% macro default__dateadd(datepart, interval, from_date_or_timestamp) %}\n\n    dateadd(\n        {{ datepart }},\n        {{ interval }},\n        {{ from_date_or_timestamp }}\n        )\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.60308,
+            "supported_languages": null
+        },
+        "macro.dbt.intersect": {
+            "name": "intersect",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/intersect.sql",
+            "original_file_path": "macros/utils/intersect.sql",
+            "unique_id": "macro.dbt.intersect",
+            "macro_sql": "{% macro intersect() %}\n  {{ return(adapter.dispatch('intersect', 'dbt')()) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__intersect"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.60331,
+            "supported_languages": null
+        },
+        "macro.dbt.default__intersect": {
+            "name": "default__intersect",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/intersect.sql",
+            "original_file_path": "macros/utils/intersect.sql",
+            "unique_id": "macro.dbt.default__intersect",
+            "macro_sql": "{% macro default__intersect() %}\n\n    intersect\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.603382,
+            "supported_languages": null
+        },
+        "macro.dbt.escape_single_quotes": {
+            "name": "escape_single_quotes",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/escape_single_quotes.sql",
+            "original_file_path": "macros/utils/escape_single_quotes.sql",
+            "unique_id": "macro.dbt.escape_single_quotes",
+            "macro_sql": "{% macro escape_single_quotes(expression) %}\n      {{ return(adapter.dispatch('escape_single_quotes', 'dbt') (expression)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__escape_single_quotes"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6036139,
+            "supported_languages": null
+        },
+        "macro.dbt.default__escape_single_quotes": {
+            "name": "default__escape_single_quotes",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/escape_single_quotes.sql",
+            "original_file_path": "macros/utils/escape_single_quotes.sql",
+            "unique_id": "macro.dbt.default__escape_single_quotes",
+            "macro_sql": "{% macro default__escape_single_quotes(expression) -%}\n{{ expression | replace(\"'\",\"''\") }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.603744,
+            "supported_languages": null
+        },
+        "macro.dbt.right": {
+            "name": "right",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/right.sql",
+            "original_file_path": "macros/utils/right.sql",
+            "unique_id": "macro.dbt.right",
+            "macro_sql": "{% macro right(string_text, length_expression) -%}\n    {{ return(adapter.dispatch('right', 'dbt') (string_text, length_expression)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__right"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.604049,
+            "supported_languages": null
+        },
+        "macro.dbt.default__right": {
+            "name": "default__right",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/right.sql",
+            "original_file_path": "macros/utils/right.sql",
+            "unique_id": "macro.dbt.default__right",
+            "macro_sql": "{% macro default__right(string_text, length_expression) %}\n\n    right(\n        {{ string_text }},\n        {{ length_expression }}\n    )\n\n{%- endmacro -%}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.604373,
+            "supported_languages": null
+        },
+        "macro.dbt.listagg": {
+            "name": "listagg",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/listagg.sql",
+            "original_file_path": "macros/utils/listagg.sql",
+            "unique_id": "macro.dbt.listagg",
+            "macro_sql": "{% macro listagg(measure, delimiter_text=\"','\", order_by_clause=none, limit_num=none) -%}\n    {{ return(adapter.dispatch('listagg', 'dbt') (measure, delimiter_text, order_by_clause, limit_num)) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__listagg"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.605271,
+            "supported_languages": null
+        },
+        "macro.dbt.default__listagg": {
+            "name": "default__listagg",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/listagg.sql",
+            "original_file_path": "macros/utils/listagg.sql",
+            "unique_id": "macro.dbt.default__listagg",
+            "macro_sql": "{% macro default__listagg(measure, delimiter_text, order_by_clause, limit_num) -%}\n\n    {% if limit_num -%}\n    array_to_string(\n        array_slice(\n            array_agg(\n                {{ measure }}\n            ){% if order_by_clause -%}\n            within group ({{ order_by_clause }})\n            {%- endif %}\n            ,0\n            ,{{ limit_num }}\n        ),\n        {{ delimiter_text }}\n        )\n    {%- else %}\n    listagg(\n        {{ measure }},\n        {{ delimiter_text }}\n        )\n        {% if order_by_clause -%}\n        within group ({{ order_by_clause }})\n        {%- endif %}\n    {%- endif %}\n\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.605628,
+            "supported_languages": null
+        },
+        "macro.dbt.datediff": {
+            "name": "datediff",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/datediff.sql",
+            "original_file_path": "macros/utils/datediff.sql",
+            "unique_id": "macro.dbt.datediff",
+            "macro_sql": "{% macro datediff(first_date, second_date, datepart) %}\n  {{ return(adapter.dispatch('datediff', 'dbt')(first_date, second_date, datepart)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__datediff"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6059341,
+            "supported_languages": null
+        },
+        "macro.dbt.default__datediff": {
+            "name": "default__datediff",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/datediff.sql",
+            "original_file_path": "macros/utils/datediff.sql",
+            "unique_id": "macro.dbt.default__datediff",
+            "macro_sql": "{% macro default__datediff(first_date, second_date, datepart) -%}\n\n    datediff(\n        {{ datepart }},\n        {{ first_date }},\n        {{ second_date }}\n        )\n\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.606266,
+            "supported_languages": null
+        },
+        "macro.dbt.safe_cast": {
+            "name": "safe_cast",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/safe_cast.sql",
+            "original_file_path": "macros/utils/safe_cast.sql",
+            "unique_id": "macro.dbt.safe_cast",
+            "macro_sql": "{% macro safe_cast(field, type) %}\n  {{ return(adapter.dispatch('safe_cast', 'dbt') (field, type)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__safe_cast"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.60669,
+            "supported_languages": null
+        },
+        "macro.dbt.default__safe_cast": {
+            "name": "default__safe_cast",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/safe_cast.sql",
+            "original_file_path": "macros/utils/safe_cast.sql",
+            "unique_id": "macro.dbt.default__safe_cast",
+            "macro_sql": "{% macro default__safe_cast(field, type) %}\n    {# most databases don't support this function yet\n    so we just need to use cast #}\n    cast({{field}} as {{type}})\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.607027,
+            "supported_languages": null
+        },
+        "macro.dbt.hash": {
+            "name": "hash",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/hash.sql",
+            "original_file_path": "macros/utils/hash.sql",
+            "unique_id": "macro.dbt.hash",
+            "macro_sql": "{% macro hash(field) -%}\n  {{ return(adapter.dispatch('hash', 'dbt') (field)) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__hash"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.607307,
+            "supported_languages": null
+        },
+        "macro.dbt.default__hash": {
+            "name": "default__hash",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/hash.sql",
+            "original_file_path": "macros/utils/hash.sql",
+            "unique_id": "macro.dbt.default__hash",
+            "macro_sql": "{% macro default__hash(field) -%}\n    md5(cast({{ field }} as {{ api.Column.translate_type('string') }}))\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.607462,
+            "supported_languages": null
+        },
+        "macro.dbt.cast_bool_to_text": {
+            "name": "cast_bool_to_text",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/cast_bool_to_text.sql",
+            "original_file_path": "macros/utils/cast_bool_to_text.sql",
+            "unique_id": "macro.dbt.cast_bool_to_text",
+            "macro_sql": "{% macro cast_bool_to_text(field) %}\n  {{ adapter.dispatch('cast_bool_to_text', 'dbt') (field) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__cast_bool_to_text"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6078038,
+            "supported_languages": null
+        },
+        "macro.dbt.default__cast_bool_to_text": {
+            "name": "default__cast_bool_to_text",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/cast_bool_to_text.sql",
+            "original_file_path": "macros/utils/cast_bool_to_text.sql",
+            "unique_id": "macro.dbt.default__cast_bool_to_text",
+            "macro_sql": "{% macro default__cast_bool_to_text(field) %}\n    cast({{ field }} as {{ api.Column.translate_type('string') }})\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6080132,
+            "supported_languages": null
+        },
+        "macro.dbt.cast": {
+            "name": "cast",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/cast.sql",
+            "original_file_path": "macros/utils/cast.sql",
+            "unique_id": "macro.dbt.cast",
+            "macro_sql": "{% macro cast(field, type) %}\n  {{ return(adapter.dispatch('cast', 'dbt') (field, type)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__cast"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6082869,
+            "supported_languages": null
+        },
+        "macro.dbt.default__cast": {
+            "name": "default__cast",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/cast.sql",
+            "original_file_path": "macros/utils/cast.sql",
+            "unique_id": "macro.dbt.default__cast",
+            "macro_sql": "{% macro default__cast(field, type) %}\n    cast({{field}} as {{type}})\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6084092,
+            "supported_languages": null
+        },
+        "macro.dbt.any_value": {
+            "name": "any_value",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/any_value.sql",
+            "original_file_path": "macros/utils/any_value.sql",
+            "unique_id": "macro.dbt.any_value",
+            "macro_sql": "{% macro any_value(expression) -%}\n    {{ return(adapter.dispatch('any_value', 'dbt') (expression)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__any_value"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.608633,
+            "supported_languages": null
+        },
+        "macro.dbt.default__any_value": {
+            "name": "default__any_value",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/any_value.sql",
+            "original_file_path": "macros/utils/any_value.sql",
+            "unique_id": "macro.dbt.default__any_value",
+            "macro_sql": "{% macro default__any_value(expression) -%}\n\n    any_value({{ expression }})\n\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.608732,
+            "supported_languages": null
+        },
+        "macro.dbt.position": {
+            "name": "position",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/position.sql",
+            "original_file_path": "macros/utils/position.sql",
+            "unique_id": "macro.dbt.position",
+            "macro_sql": "{% macro position(substring_text, string_text) -%}\n    {{ return(adapter.dispatch('position', 'dbt') (substring_text, string_text)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__position"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.608992,
+            "supported_languages": null
+        },
+        "macro.dbt.default__position": {
+            "name": "default__position",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/position.sql",
+            "original_file_path": "macros/utils/position.sql",
+            "unique_id": "macro.dbt.default__position",
+            "macro_sql": "{% macro default__position(substring_text, string_text) %}\n\n    position(\n        {{ substring_text }} in {{ string_text }}\n    )\n\n{%- endmacro -%}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.60912,
+            "supported_languages": null
+        },
+        "macro.dbt.string_literal": {
+            "name": "string_literal",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/literal.sql",
+            "original_file_path": "macros/utils/literal.sql",
+            "unique_id": "macro.dbt.string_literal",
+            "macro_sql": "{%- macro string_literal(value) -%}\n  {{ return(adapter.dispatch('string_literal', 'dbt') (value)) }}\n{%- endmacro -%}\n\n",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__string_literal"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.609399,
+            "supported_languages": null
+        },
+        "macro.dbt.default__string_literal": {
+            "name": "default__string_literal",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/literal.sql",
+            "original_file_path": "macros/utils/literal.sql",
+            "unique_id": "macro.dbt.default__string_literal",
+            "macro_sql": "{% macro default__string_literal(value) -%}\n    '{{ value }}'\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.609611,
+            "supported_languages": null
+        },
+        "macro.dbt.type_string": {
+            "name": "type_string",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/data_types.sql",
+            "original_file_path": "macros/utils/data_types.sql",
+            "unique_id": "macro.dbt.type_string",
+            "macro_sql": "\n\n{%- macro type_string() -%}\n  {{ return(adapter.dispatch('type_string', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__type_string"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.610694,
+            "supported_languages": null
+        },
+        "macro.dbt.default__type_string": {
+            "name": "default__type_string",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/data_types.sql",
+            "original_file_path": "macros/utils/data_types.sql",
+            "unique_id": "macro.dbt.default__type_string",
+            "macro_sql": "{% macro default__type_string() %}\n    {{ return(api.Column.translate_type(\"string\")) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.610843,
+            "supported_languages": null
+        },
+        "macro.dbt.type_timestamp": {
+            "name": "type_timestamp",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/data_types.sql",
+            "original_file_path": "macros/utils/data_types.sql",
+            "unique_id": "macro.dbt.type_timestamp",
+            "macro_sql": "\n\n{%- macro type_timestamp() -%}\n  {{ return(adapter.dispatch('type_timestamp', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__type_timestamp"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.611068,
+            "supported_languages": null
+        },
+        "macro.dbt.default__type_timestamp": {
+            "name": "default__type_timestamp",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/data_types.sql",
+            "original_file_path": "macros/utils/data_types.sql",
+            "unique_id": "macro.dbt.default__type_timestamp",
+            "macro_sql": "{% macro default__type_timestamp() %}\n    {{ return(api.Column.translate_type(\"timestamp\")) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6112902,
+            "supported_languages": null
+        },
+        "macro.dbt.type_float": {
+            "name": "type_float",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/data_types.sql",
+            "original_file_path": "macros/utils/data_types.sql",
+            "unique_id": "macro.dbt.type_float",
+            "macro_sql": "\n\n{%- macro type_float() -%}\n  {{ return(adapter.dispatch('type_float', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__type_float"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6115808,
+            "supported_languages": null
+        },
+        "macro.dbt.default__type_float": {
+            "name": "default__type_float",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/data_types.sql",
+            "original_file_path": "macros/utils/data_types.sql",
+            "unique_id": "macro.dbt.default__type_float",
+            "macro_sql": "{% macro default__type_float() %}\n    {{ return(api.Column.translate_type(\"float\")) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.611736,
+            "supported_languages": null
+        },
+        "macro.dbt.type_numeric": {
+            "name": "type_numeric",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/data_types.sql",
+            "original_file_path": "macros/utils/data_types.sql",
+            "unique_id": "macro.dbt.type_numeric",
+            "macro_sql": "\n\n{%- macro type_numeric() -%}\n  {{ return(adapter.dispatch('type_numeric', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__type_numeric"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.611878,
+            "supported_languages": null
+        },
+        "macro.dbt.default__type_numeric": {
+            "name": "default__type_numeric",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/data_types.sql",
+            "original_file_path": "macros/utils/data_types.sql",
+            "unique_id": "macro.dbt.default__type_numeric",
+            "macro_sql": "{% macro default__type_numeric() %}\n    {{ return(api.Column.numeric_type(\"numeric\", 28, 6)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.61204,
+            "supported_languages": null
+        },
+        "macro.dbt.type_bigint": {
+            "name": "type_bigint",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/data_types.sql",
+            "original_file_path": "macros/utils/data_types.sql",
+            "unique_id": "macro.dbt.type_bigint",
+            "macro_sql": "\n\n{%- macro type_bigint() -%}\n  {{ return(adapter.dispatch('type_bigint', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__type_bigint"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.612183,
+            "supported_languages": null
+        },
+        "macro.dbt.default__type_bigint": {
+            "name": "default__type_bigint",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/data_types.sql",
+            "original_file_path": "macros/utils/data_types.sql",
+            "unique_id": "macro.dbt.default__type_bigint",
+            "macro_sql": "{% macro default__type_bigint() %}\n    {{ return(api.Column.translate_type(\"bigint\")) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.612608,
+            "supported_languages": null
+        },
+        "macro.dbt.type_int": {
+            "name": "type_int",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/data_types.sql",
+            "original_file_path": "macros/utils/data_types.sql",
+            "unique_id": "macro.dbt.type_int",
+            "macro_sql": "\n\n{%- macro type_int() -%}\n  {{ return(adapter.dispatch('type_int', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__type_int"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6128159,
+            "supported_languages": null
+        },
+        "macro.dbt.default__type_int": {
+            "name": "default__type_int",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/data_types.sql",
+            "original_file_path": "macros/utils/data_types.sql",
+            "unique_id": "macro.dbt.default__type_int",
+            "macro_sql": "{%- macro default__type_int() -%}\n  {{ return(api.Column.translate_type(\"integer\")) }}\n{%- endmacro -%}\n\n",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.612986,
+            "supported_languages": null
+        },
+        "macro.dbt.type_boolean": {
+            "name": "type_boolean",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/data_types.sql",
+            "original_file_path": "macros/utils/data_types.sql",
+            "unique_id": "macro.dbt.type_boolean",
+            "macro_sql": "\n\n{%- macro type_boolean() -%}\n  {{ return(adapter.dispatch('type_boolean', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__type_boolean"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.613248,
+            "supported_languages": null
+        },
+        "macro.dbt.default__type_boolean": {
+            "name": "default__type_boolean",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/data_types.sql",
+            "original_file_path": "macros/utils/data_types.sql",
+            "unique_id": "macro.dbt.default__type_boolean",
+            "macro_sql": "{%- macro default__type_boolean() -%}\n  {{ return(api.Column.translate_type(\"boolean\")) }}\n{%- endmacro -%}\n\n",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6134121,
+            "supported_languages": null
+        },
+        "macro.dbt.array_concat": {
+            "name": "array_concat",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/array_concat.sql",
+            "original_file_path": "macros/utils/array_concat.sql",
+            "unique_id": "macro.dbt.array_concat",
+            "macro_sql": "{% macro array_concat(array_1, array_2) -%}\n  {{ return(adapter.dispatch('array_concat', 'dbt')(array_1, array_2)) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__array_concat"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.613683,
+            "supported_languages": null
+        },
+        "macro.dbt.default__array_concat": {
+            "name": "default__array_concat",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/array_concat.sql",
+            "original_file_path": "macros/utils/array_concat.sql",
+            "unique_id": "macro.dbt.default__array_concat",
+            "macro_sql": "{% macro default__array_concat(array_1, array_2) -%}\n    array_cat({{ array_1 }}, {{ array_2 }})\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.613804,
+            "supported_languages": null
+        },
+        "macro.dbt.bool_or": {
+            "name": "bool_or",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/bool_or.sql",
+            "original_file_path": "macros/utils/bool_or.sql",
+            "unique_id": "macro.dbt.bool_or",
+            "macro_sql": "{% macro bool_or(expression) -%}\n    {{ return(adapter.dispatch('bool_or', 'dbt') (expression)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__bool_or"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6140301,
+            "supported_languages": null
+        },
+        "macro.dbt.default__bool_or": {
+            "name": "default__bool_or",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/bool_or.sql",
+            "original_file_path": "macros/utils/bool_or.sql",
+            "unique_id": "macro.dbt.default__bool_or",
+            "macro_sql": "{% macro default__bool_or(expression) -%}\n\n    bool_or({{ expression }})\n\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.614128,
+            "supported_languages": null
+        },
+        "macro.dbt.last_day": {
+            "name": "last_day",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/last_day.sql",
+            "original_file_path": "macros/utils/last_day.sql",
+            "unique_id": "macro.dbt.last_day",
+            "macro_sql": "{% macro last_day(date, datepart) %}\n  {{ return(adapter.dispatch('last_day', 'dbt') (date, datepart)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__last_day"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.61443,
+            "supported_languages": null
+        },
+        "macro.dbt.default_last_day": {
+            "name": "default_last_day",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/last_day.sql",
+            "original_file_path": "macros/utils/last_day.sql",
+            "unique_id": "macro.dbt.default_last_day",
+            "macro_sql": "\n\n{%- macro default_last_day(date, datepart) -%}\n    cast(\n        {{dbt.dateadd('day', '-1',\n        dbt.dateadd(datepart, '1', dbt.date_trunc(datepart, date))\n        )}}\n        as date)\n{%- endmacro -%}\n\n",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.dateadd",
+                    "macro.dbt.date_trunc"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.614666,
+            "supported_languages": null
+        },
+        "macro.dbt.default__last_day": {
+            "name": "default__last_day",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/last_day.sql",
+            "original_file_path": "macros/utils/last_day.sql",
+            "unique_id": "macro.dbt.default__last_day",
+            "macro_sql": "{% macro default__last_day(date, datepart) -%}\n    {{dbt.default_last_day(date, datepart)}}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default_last_day"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.614798,
+            "supported_languages": null
+        },
+        "macro.dbt.split_part": {
+            "name": "split_part",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/split_part.sql",
+            "original_file_path": "macros/utils/split_part.sql",
+            "unique_id": "macro.dbt.split_part",
+            "macro_sql": "{% macro split_part(string_text, delimiter_text, part_number) %}\n  {{ return(adapter.dispatch('split_part', 'dbt') (string_text, delimiter_text, part_number)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__split_part"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6152692,
+            "supported_languages": null
+        },
+        "macro.dbt.default__split_part": {
+            "name": "default__split_part",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/split_part.sql",
+            "original_file_path": "macros/utils/split_part.sql",
+            "unique_id": "macro.dbt.default__split_part",
+            "macro_sql": "{% macro default__split_part(string_text, delimiter_text, part_number) %}\n\n    split_part(\n        {{ string_text }},\n        {{ delimiter_text }},\n        {{ part_number }}\n        )\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.615414,
+            "supported_languages": null
+        },
+        "macro.dbt._split_part_negative": {
+            "name": "_split_part_negative",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/split_part.sql",
+            "original_file_path": "macros/utils/split_part.sql",
+            "unique_id": "macro.dbt._split_part_negative",
+            "macro_sql": "{% macro _split_part_negative(string_text, delimiter_text, part_number) %}\n\n    split_part(\n        {{ string_text }},\n        {{ delimiter_text }},\n          length({{ string_text }})\n          - length(\n              replace({{ string_text }},  {{ delimiter_text }}, '')\n          ) + 2 + {{ part_number }}\n        )\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.615668,
+            "supported_languages": null
+        },
+        "macro.dbt.date_trunc": {
+            "name": "date_trunc",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/date_trunc.sql",
+            "original_file_path": "macros/utils/date_trunc.sql",
+            "unique_id": "macro.dbt.date_trunc",
+            "macro_sql": "{% macro date_trunc(datepart, date) -%}\n  {{ return(adapter.dispatch('date_trunc', 'dbt') (datepart, date)) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__date_trunc"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.616012,
+            "supported_languages": null
+        },
+        "macro.dbt.default__date_trunc": {
+            "name": "default__date_trunc",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/date_trunc.sql",
+            "original_file_path": "macros/utils/date_trunc.sql",
+            "unique_id": "macro.dbt.default__date_trunc",
+            "macro_sql": "{% macro default__date_trunc(datepart, date) -%}\n    date_trunc('{{datepart}}', {{date}})\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6161332,
+            "supported_languages": null
+        },
+        "macro.dbt.array_construct": {
+            "name": "array_construct",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/array_construct.sql",
+            "original_file_path": "macros/utils/array_construct.sql",
+            "unique_id": "macro.dbt.array_construct",
+            "macro_sql": "{% macro array_construct(inputs=[], data_type=api.Column.translate_type('integer')) -%}\n  {{ return(adapter.dispatch('array_construct', 'dbt')(inputs, data_type)) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__array_construct"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.616485,
+            "supported_languages": null
+        },
+        "macro.dbt.default__array_construct": {
+            "name": "default__array_construct",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/array_construct.sql",
+            "original_file_path": "macros/utils/array_construct.sql",
+            "unique_id": "macro.dbt.default__array_construct",
+            "macro_sql": "{% macro default__array_construct(inputs, data_type) -%}\n    {% if inputs|length > 0 %}\n    array[ {{ inputs|join(' , ') }} ]\n    {% else %}\n    array[]::{{data_type}}[]\n    {% endif %}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6167018,
+            "supported_languages": null
+        },
+        "macro.dbt.array_append": {
+            "name": "array_append",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/array_append.sql",
+            "original_file_path": "macros/utils/array_append.sql",
+            "unique_id": "macro.dbt.array_append",
+            "macro_sql": "{% macro array_append(array, new_element) -%}\n  {{ return(adapter.dispatch('array_append', 'dbt')(array, new_element)) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__array_append"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.616954,
+            "supported_languages": null
+        },
+        "macro.dbt.default__array_append": {
+            "name": "default__array_append",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/utils/array_append.sql",
+            "original_file_path": "macros/utils/array_append.sql",
+            "unique_id": "macro.dbt.default__array_append",
+            "macro_sql": "{% macro default__array_append(array, new_element) -%}\n    array_append({{ array }}, {{ new_element }})\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.617163,
+            "supported_languages": null
+        },
+        "macro.dbt.create_schema": {
+            "name": "create_schema",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/schema.sql",
+            "original_file_path": "macros/adapters/schema.sql",
+            "unique_id": "macro.dbt.create_schema",
+            "macro_sql": "{% macro create_schema(relation) -%}\n  {{ adapter.dispatch('create_schema', 'dbt')(relation) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__create_schema"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6174898,
+            "supported_languages": null
+        },
+        "macro.dbt.default__create_schema": {
+            "name": "default__create_schema",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/schema.sql",
+            "original_file_path": "macros/adapters/schema.sql",
+            "unique_id": "macro.dbt.default__create_schema",
+            "macro_sql": "{% macro default__create_schema(relation) -%}\n  {%- call statement('create_schema') -%}\n    create schema if not exists {{ relation.without_identifier() }}\n  {% endcall %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6176488,
+            "supported_languages": null
+        },
+        "macro.dbt.drop_schema": {
+            "name": "drop_schema",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/schema.sql",
+            "original_file_path": "macros/adapters/schema.sql",
+            "unique_id": "macro.dbt.drop_schema",
+            "macro_sql": "{% macro drop_schema(relation) -%}\n  {{ adapter.dispatch('drop_schema', 'dbt')(relation) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__drop_schema"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.617794,
+            "supported_languages": null
+        },
+        "macro.dbt.default__drop_schema": {
+            "name": "default__drop_schema",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/schema.sql",
+            "original_file_path": "macros/adapters/schema.sql",
+            "unique_id": "macro.dbt.default__drop_schema",
+            "macro_sql": "{% macro default__drop_schema(relation) -%}\n  {%- call statement('drop_schema') -%}\n    drop schema if exists {{ relation.without_identifier() }} cascade\n  {% endcall %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.617953,
+            "supported_languages": null
+        },
+        "macro.dbt.current_timestamp": {
+            "name": "current_timestamp",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/timestamps.sql",
+            "original_file_path": "macros/adapters/timestamps.sql",
+            "unique_id": "macro.dbt.current_timestamp",
+            "macro_sql": "{%- macro current_timestamp() -%}\n    {{ adapter.dispatch('current_timestamp', 'dbt')() }}\n{%- endmacro -%}\n\n",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__current_timestamp"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.618387,
+            "supported_languages": null
+        },
+        "macro.dbt.default__current_timestamp": {
+            "name": "default__current_timestamp",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/timestamps.sql",
+            "original_file_path": "macros/adapters/timestamps.sql",
+            "unique_id": "macro.dbt.default__current_timestamp",
+            "macro_sql": "{% macro default__current_timestamp() -%}\n  {{ exceptions.raise_not_implemented(\n    'current_timestamp macro not implemented for adapter ' + adapter.type()) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.61852,
+            "supported_languages": null
+        },
+        "macro.dbt.snapshot_get_time": {
+            "name": "snapshot_get_time",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/timestamps.sql",
+            "original_file_path": "macros/adapters/timestamps.sql",
+            "unique_id": "macro.dbt.snapshot_get_time",
+            "macro_sql": "\n\n{%- macro snapshot_get_time() -%}\n    {{ adapter.dispatch('snapshot_get_time', 'dbt')() }}\n{%- endmacro -%}\n\n",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__snapshot_get_time"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.618648,
+            "supported_languages": null
+        },
+        "macro.dbt.default__snapshot_get_time": {
+            "name": "default__snapshot_get_time",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/timestamps.sql",
+            "original_file_path": "macros/adapters/timestamps.sql",
+            "unique_id": "macro.dbt.default__snapshot_get_time",
+            "macro_sql": "{% macro default__snapshot_get_time() %}\n    {{ current_timestamp() }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.current_timestamp"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.618738,
+            "supported_languages": null
+        },
+        "macro.dbt.current_timestamp_backcompat": {
+            "name": "current_timestamp_backcompat",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/timestamps.sql",
+            "original_file_path": "macros/adapters/timestamps.sql",
+            "unique_id": "macro.dbt.current_timestamp_backcompat",
+            "macro_sql": "{% macro current_timestamp_backcompat() %}\n    {{ return(adapter.dispatch('current_timestamp_backcompat', 'dbt')()) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__current_timestamp_backcompat"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.618884,
+            "supported_languages": null
+        },
+        "macro.dbt.default__current_timestamp_backcompat": {
+            "name": "default__current_timestamp_backcompat",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/timestamps.sql",
+            "original_file_path": "macros/adapters/timestamps.sql",
+            "unique_id": "macro.dbt.default__current_timestamp_backcompat",
+            "macro_sql": "{% macro default__current_timestamp_backcompat() %}\n    current_timestamp::timestamp\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.618953,
+            "supported_languages": null
+        },
+        "macro.dbt.current_timestamp_in_utc_backcompat": {
+            "name": "current_timestamp_in_utc_backcompat",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/timestamps.sql",
+            "original_file_path": "macros/adapters/timestamps.sql",
+            "unique_id": "macro.dbt.current_timestamp_in_utc_backcompat",
+            "macro_sql": "{% macro current_timestamp_in_utc_backcompat() %}\n    {{ return(adapter.dispatch('current_timestamp_in_utc_backcompat', 'dbt')()) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__current_timestamp_in_utc_backcompat"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.619099,
+            "supported_languages": null
+        },
+        "macro.dbt.default__current_timestamp_in_utc_backcompat": {
+            "name": "default__current_timestamp_in_utc_backcompat",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/timestamps.sql",
+            "original_file_path": "macros/adapters/timestamps.sql",
+            "unique_id": "macro.dbt.default__current_timestamp_in_utc_backcompat",
+            "macro_sql": "{% macro default__current_timestamp_in_utc_backcompat() %}\n    {{ return(adapter.dispatch('current_timestamp_backcompat', 'dbt')()) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.current_timestamp_backcompat",
+                    "macro.dbt.default__current_timestamp_backcompat"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.619243,
+            "supported_languages": null
+        },
+        "macro.dbt.get_create_index_sql": {
+            "name": "get_create_index_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/indexes.sql",
+            "original_file_path": "macros/adapters/indexes.sql",
+            "unique_id": "macro.dbt.get_create_index_sql",
+            "macro_sql": "{% macro get_create_index_sql(relation, index_dict) -%}\n  {{ return(adapter.dispatch('get_create_index_sql', 'dbt')(relation, index_dict)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_create_index_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6200519,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_create_index_sql": {
+            "name": "default__get_create_index_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/indexes.sql",
+            "original_file_path": "macros/adapters/indexes.sql",
+            "unique_id": "macro.dbt.default__get_create_index_sql",
+            "macro_sql": "{% macro default__get_create_index_sql(relation, index_dict) -%}\n  {% do return(None) %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.620178,
+            "supported_languages": null
+        },
+        "macro.dbt.create_indexes": {
+            "name": "create_indexes",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/indexes.sql",
+            "original_file_path": "macros/adapters/indexes.sql",
+            "unique_id": "macro.dbt.create_indexes",
+            "macro_sql": "{% macro create_indexes(relation) -%}\n  {{ adapter.dispatch('create_indexes', 'dbt')(relation) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__create_indexes"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6203132,
+            "supported_languages": null
+        },
+        "macro.dbt.default__create_indexes": {
+            "name": "default__create_indexes",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/indexes.sql",
+            "original_file_path": "macros/adapters/indexes.sql",
+            "unique_id": "macro.dbt.default__create_indexes",
+            "macro_sql": "{% macro default__create_indexes(relation) -%}\n  {%- set _indexes = config.get('indexes', default=[]) -%}\n\n  {% for _index_dict in _indexes %}\n    {% set create_index_sql = get_create_index_sql(relation, _index_dict) %}\n    {% if create_index_sql %}\n      {% do run_query(create_index_sql) %}\n    {% endif %}\n  {% endfor %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_create_index_sql",
+                    "macro.dbt.run_query"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.620661,
+            "supported_languages": null
+        },
+        "macro.dbt.get_drop_index_sql": {
+            "name": "get_drop_index_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/indexes.sql",
+            "original_file_path": "macros/adapters/indexes.sql",
+            "unique_id": "macro.dbt.get_drop_index_sql",
+            "macro_sql": "{% macro get_drop_index_sql(relation, index_name) -%}\n    {{ adapter.dispatch('get_drop_index_sql', 'dbt')(relation, index_name) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_drop_index_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.620883,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_drop_index_sql": {
+            "name": "default__get_drop_index_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/indexes.sql",
+            "original_file_path": "macros/adapters/indexes.sql",
+            "unique_id": "macro.dbt.default__get_drop_index_sql",
+            "macro_sql": "{% macro default__get_drop_index_sql(relation, index_name) -%}\n    {{ exceptions.raise_compiler_error(\"`get_drop_index_sql has not been implemented for this adapter.\") }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.621006,
+            "supported_languages": null
+        },
+        "macro.dbt.get_show_indexes_sql": {
+            "name": "get_show_indexes_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/indexes.sql",
+            "original_file_path": "macros/adapters/indexes.sql",
+            "unique_id": "macro.dbt.get_show_indexes_sql",
+            "macro_sql": "{% macro get_show_indexes_sql(relation) -%}\n    {{ adapter.dispatch('get_show_indexes_sql', 'dbt')(relation) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_show_indexes_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.621143,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_show_indexes_sql": {
+            "name": "default__get_show_indexes_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/indexes.sql",
+            "original_file_path": "macros/adapters/indexes.sql",
+            "unique_id": "macro.dbt.default__get_show_indexes_sql",
+            "macro_sql": "{% macro default__get_show_indexes_sql(relation) -%}\n    {{ exceptions.raise_compiler_error(\"`get_show_indexes_sql has not been implemented for this adapter.\") }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.621253,
+            "supported_languages": null
+        },
+        "macro.dbt.make_intermediate_relation": {
+            "name": "make_intermediate_relation",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/relation.sql",
+            "original_file_path": "macros/adapters/relation.sql",
+            "unique_id": "macro.dbt.make_intermediate_relation",
+            "macro_sql": "{% macro make_intermediate_relation(base_relation, suffix='__dbt_tmp') %}\n  {{ return(adapter.dispatch('make_intermediate_relation', 'dbt')(base_relation, suffix)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__make_intermediate_relation"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.623536,
+            "supported_languages": null
+        },
+        "macro.dbt.default__make_intermediate_relation": {
+            "name": "default__make_intermediate_relation",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/relation.sql",
+            "original_file_path": "macros/adapters/relation.sql",
+            "unique_id": "macro.dbt.default__make_intermediate_relation",
+            "macro_sql": "{% macro default__make_intermediate_relation(base_relation, suffix) %}\n    {{ return(default__make_temp_relation(base_relation, suffix)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__make_temp_relation"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.623714,
+            "supported_languages": null
+        },
+        "macro.dbt.make_temp_relation": {
+            "name": "make_temp_relation",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/relation.sql",
+            "original_file_path": "macros/adapters/relation.sql",
+            "unique_id": "macro.dbt.make_temp_relation",
+            "macro_sql": "{% macro make_temp_relation(base_relation, suffix='__dbt_tmp') %}\n  {{ return(adapter.dispatch('make_temp_relation', 'dbt')(base_relation, suffix)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__make_temp_relation"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.624009,
+            "supported_languages": null
+        },
+        "macro.dbt.default__make_temp_relation": {
+            "name": "default__make_temp_relation",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/relation.sql",
+            "original_file_path": "macros/adapters/relation.sql",
+            "unique_id": "macro.dbt.default__make_temp_relation",
+            "macro_sql": "{% macro default__make_temp_relation(base_relation, suffix) %}\n    {%- set temp_identifier = base_relation.identifier ~ suffix -%}\n    {%- set temp_relation = base_relation.incorporate(\n                                path={\"identifier\": temp_identifier}) -%}\n\n    {{ return(temp_relation) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6242938,
+            "supported_languages": null
+        },
+        "macro.dbt.make_backup_relation": {
+            "name": "make_backup_relation",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/relation.sql",
+            "original_file_path": "macros/adapters/relation.sql",
+            "unique_id": "macro.dbt.make_backup_relation",
+            "macro_sql": "{% macro make_backup_relation(base_relation, backup_relation_type, suffix='__dbt_backup') %}\n    {{ return(adapter.dispatch('make_backup_relation', 'dbt')(base_relation, backup_relation_type, suffix)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__make_backup_relation"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6245818,
+            "supported_languages": null
+        },
+        "macro.dbt.default__make_backup_relation": {
+            "name": "default__make_backup_relation",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/relation.sql",
+            "original_file_path": "macros/adapters/relation.sql",
+            "unique_id": "macro.dbt.default__make_backup_relation",
+            "macro_sql": "{% macro default__make_backup_relation(base_relation, backup_relation_type, suffix) %}\n    {%- set backup_identifier = base_relation.identifier ~ suffix -%}\n    {%- set backup_relation = base_relation.incorporate(\n                                  path={\"identifier\": backup_identifier},\n                                  type=backup_relation_type\n    ) -%}\n    {{ return(backup_relation) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.624875,
+            "supported_languages": null
+        },
+        "macro.dbt.truncate_relation": {
+            "name": "truncate_relation",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/relation.sql",
+            "original_file_path": "macros/adapters/relation.sql",
+            "unique_id": "macro.dbt.truncate_relation",
+            "macro_sql": "{% macro truncate_relation(relation) -%}\n  {{ return(adapter.dispatch('truncate_relation', 'dbt')(relation)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__truncate_relation"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6251829,
+            "supported_languages": null
+        },
+        "macro.dbt.default__truncate_relation": {
+            "name": "default__truncate_relation",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/relation.sql",
+            "original_file_path": "macros/adapters/relation.sql",
+            "unique_id": "macro.dbt.default__truncate_relation",
+            "macro_sql": "{% macro default__truncate_relation(relation) -%}\n  {% call statement('truncate_relation') -%}\n    truncate table {{ relation }}\n  {%- endcall %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.625504,
+            "supported_languages": null
+        },
+        "macro.dbt.get_or_create_relation": {
+            "name": "get_or_create_relation",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/relation.sql",
+            "original_file_path": "macros/adapters/relation.sql",
+            "unique_id": "macro.dbt.get_or_create_relation",
+            "macro_sql": "{% macro get_or_create_relation(database, schema, identifier, type) -%}\n  {{ return(adapter.dispatch('get_or_create_relation', 'dbt')(database, schema, identifier, type)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_or_create_relation"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6259258,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_or_create_relation": {
+            "name": "default__get_or_create_relation",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/relation.sql",
+            "original_file_path": "macros/adapters/relation.sql",
+            "unique_id": "macro.dbt.default__get_or_create_relation",
+            "macro_sql": "{% macro default__get_or_create_relation(database, schema, identifier, type) %}\n  {%- set target_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) %}\n\n  {% if target_relation %}\n    {% do return([true, target_relation]) %}\n  {% endif %}\n\n  {%- set new_relation = api.Relation.create(\n      database=database,\n      schema=schema,\n      identifier=identifier,\n      type=type\n  ) -%}\n  {% do return([false, new_relation]) %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6266,
+            "supported_languages": null
+        },
+        "macro.dbt.load_cached_relation": {
+            "name": "load_cached_relation",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/relation.sql",
+            "original_file_path": "macros/adapters/relation.sql",
+            "unique_id": "macro.dbt.load_cached_relation",
+            "macro_sql": "{% macro load_cached_relation(relation) %}\n  {% do return(adapter.get_relation(\n    database=relation.database,\n    schema=relation.schema,\n    identifier=relation.identifier\n  )) -%}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.626827,
+            "supported_languages": null
+        },
+        "macro.dbt.load_relation": {
+            "name": "load_relation",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/relation.sql",
+            "original_file_path": "macros/adapters/relation.sql",
+            "unique_id": "macro.dbt.load_relation",
+            "macro_sql": "{% macro load_relation(relation) %}\n    {{ return(load_cached_relation(relation)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.load_cached_relation"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.627006,
+            "supported_languages": null
+        },
+        "macro.dbt.collect_freshness": {
+            "name": "collect_freshness",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/freshness.sql",
+            "original_file_path": "macros/adapters/freshness.sql",
+            "unique_id": "macro.dbt.collect_freshness",
+            "macro_sql": "{% macro collect_freshness(source, loaded_at_field, filter) %}\n  {{ return(adapter.dispatch('collect_freshness', 'dbt')(source, loaded_at_field, filter))}}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__collect_freshness"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.627537,
+            "supported_languages": null
+        },
+        "macro.dbt.default__collect_freshness": {
+            "name": "default__collect_freshness",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/freshness.sql",
+            "original_file_path": "macros/adapters/freshness.sql",
+            "unique_id": "macro.dbt.default__collect_freshness",
+            "macro_sql": "{% macro default__collect_freshness(source, loaded_at_field, filter) %}\n  {% call statement('collect_freshness', fetch_result=True, auto_begin=False) -%}\n    select\n      max({{ loaded_at_field }}) as max_loaded_at,\n      {{ current_timestamp() }} as snapshotted_at\n    from {{ source }}\n    {% if filter %}\n    where {{ filter }}\n    {% endif %}\n  {% endcall %}\n  {{ return(load_result('collect_freshness')) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement",
+                    "macro.dbt.current_timestamp"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6279008,
+            "supported_languages": null
+        },
+        "macro.dbt.validate_sql": {
+            "name": "validate_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/validate_sql.sql",
+            "original_file_path": "macros/adapters/validate_sql.sql",
+            "unique_id": "macro.dbt.validate_sql",
+            "macro_sql": "{% macro validate_sql(sql) -%}\n  {{ return(adapter.dispatch('validate_sql', 'dbt')(sql)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__validate_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.628159,
+            "supported_languages": null
+        },
+        "macro.dbt.default__validate_sql": {
+            "name": "default__validate_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/validate_sql.sql",
+            "original_file_path": "macros/adapters/validate_sql.sql",
+            "unique_id": "macro.dbt.default__validate_sql",
+            "macro_sql": "{% macro default__validate_sql(sql) -%}\n  {% call statement('validate_sql') -%}\n    explain {{ sql }}\n  {% endcall %}\n  {{ return(load_result('validate_sql')) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.628586,
+            "supported_languages": null
+        },
+        "macro.dbt.copy_grants": {
+            "name": "copy_grants",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/apply_grants.sql",
+            "original_file_path": "macros/adapters/apply_grants.sql",
+            "unique_id": "macro.dbt.copy_grants",
+            "macro_sql": "{% macro copy_grants() %}\n    {{ return(adapter.dispatch('copy_grants', 'dbt')()) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__copy_grants"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.630272,
+            "supported_languages": null
+        },
+        "macro.dbt.default__copy_grants": {
+            "name": "default__copy_grants",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/apply_grants.sql",
+            "original_file_path": "macros/adapters/apply_grants.sql",
+            "unique_id": "macro.dbt.default__copy_grants",
+            "macro_sql": "{% macro default__copy_grants() %}\n    {{ return(True) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.630375,
+            "supported_languages": null
+        },
+        "macro.dbt.support_multiple_grantees_per_dcl_statement": {
+            "name": "support_multiple_grantees_per_dcl_statement",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/apply_grants.sql",
+            "original_file_path": "macros/adapters/apply_grants.sql",
+            "unique_id": "macro.dbt.support_multiple_grantees_per_dcl_statement",
+            "macro_sql": "{% macro support_multiple_grantees_per_dcl_statement() %}\n    {{ return(adapter.dispatch('support_multiple_grantees_per_dcl_statement', 'dbt')()) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__support_multiple_grantees_per_dcl_statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6305249,
+            "supported_languages": null
+        },
+        "macro.dbt.default__support_multiple_grantees_per_dcl_statement": {
+            "name": "default__support_multiple_grantees_per_dcl_statement",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/apply_grants.sql",
+            "original_file_path": "macros/adapters/apply_grants.sql",
+            "unique_id": "macro.dbt.default__support_multiple_grantees_per_dcl_statement",
+            "macro_sql": "\n\n{%- macro default__support_multiple_grantees_per_dcl_statement() -%}\n    {{ return(True) }}\n{%- endmacro -%}\n\n\n",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.630635,
+            "supported_languages": null
+        },
+        "macro.dbt.should_revoke": {
+            "name": "should_revoke",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/apply_grants.sql",
+            "original_file_path": "macros/adapters/apply_grants.sql",
+            "unique_id": "macro.dbt.should_revoke",
+            "macro_sql": "{% macro should_revoke(existing_relation, full_refresh_mode=True) %}\n\n    {% if not existing_relation %}\n        {#-- The table doesn't already exist, so no grants to copy over --#}\n        {{ return(False) }}\n    {% elif full_refresh_mode %}\n        {#-- The object is being REPLACED -- whether grants are copied over depends on the value of user config --#}\n        {{ return(copy_grants()) }}\n    {% else %}\n        {#-- The table is being merged/upserted/inserted -- grants will be carried over --#}\n        {{ return(True) }}\n    {% endif %}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.copy_grants"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.631142,
+            "supported_languages": null
+        },
+        "macro.dbt.get_show_grant_sql": {
+            "name": "get_show_grant_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/apply_grants.sql",
+            "original_file_path": "macros/adapters/apply_grants.sql",
+            "unique_id": "macro.dbt.get_show_grant_sql",
+            "macro_sql": "{% macro get_show_grant_sql(relation) %}\n    {{ return(adapter.dispatch(\"get_show_grant_sql\", \"dbt\")(relation)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_show_grant_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.631454,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_show_grant_sql": {
+            "name": "default__get_show_grant_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/apply_grants.sql",
+            "original_file_path": "macros/adapters/apply_grants.sql",
+            "unique_id": "macro.dbt.default__get_show_grant_sql",
+            "macro_sql": "{% macro default__get_show_grant_sql(relation) %}\n    show grants on {{ relation }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.631595,
+            "supported_languages": null
+        },
+        "macro.dbt.get_grant_sql": {
+            "name": "get_grant_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/apply_grants.sql",
+            "original_file_path": "macros/adapters/apply_grants.sql",
+            "unique_id": "macro.dbt.get_grant_sql",
+            "macro_sql": "{% macro get_grant_sql(relation, privilege, grantees) %}\n    {{ return(adapter.dispatch('get_grant_sql', 'dbt')(relation, privilege, grantees)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_grant_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.631816,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_grant_sql": {
+            "name": "default__get_grant_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/apply_grants.sql",
+            "original_file_path": "macros/adapters/apply_grants.sql",
+            "unique_id": "macro.dbt.default__get_grant_sql",
+            "macro_sql": "\n\n{%- macro default__get_grant_sql(relation, privilege, grantees) -%}\n    grant {{ privilege }} on {{ relation }} to {{ grantees | join(', ') }}\n{%- endmacro -%}\n\n\n",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.632146,
+            "supported_languages": null
+        },
+        "macro.dbt.get_revoke_sql": {
+            "name": "get_revoke_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/apply_grants.sql",
+            "original_file_path": "macros/adapters/apply_grants.sql",
+            "unique_id": "macro.dbt.get_revoke_sql",
+            "macro_sql": "{% macro get_revoke_sql(relation, privilege, grantees) %}\n    {{ return(adapter.dispatch('get_revoke_sql', 'dbt')(relation, privilege, grantees)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_revoke_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.632417,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_revoke_sql": {
+            "name": "default__get_revoke_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/apply_grants.sql",
+            "original_file_path": "macros/adapters/apply_grants.sql",
+            "unique_id": "macro.dbt.default__get_revoke_sql",
+            "macro_sql": "\n\n{%- macro default__get_revoke_sql(relation, privilege, grantees) -%}\n    revoke {{ privilege }} on {{ relation }} from {{ grantees | join(', ') }}\n{%- endmacro -%}\n\n\n",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.632649,
+            "supported_languages": null
+        },
+        "macro.dbt.get_dcl_statement_list": {
+            "name": "get_dcl_statement_list",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/apply_grants.sql",
+            "original_file_path": "macros/adapters/apply_grants.sql",
+            "unique_id": "macro.dbt.get_dcl_statement_list",
+            "macro_sql": "{% macro get_dcl_statement_list(relation, grant_config, get_dcl_macro) %}\n    {{ return(adapter.dispatch('get_dcl_statement_list', 'dbt')(relation, grant_config, get_dcl_macro)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_dcl_statement_list"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.632864,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_dcl_statement_list": {
+            "name": "default__get_dcl_statement_list",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/apply_grants.sql",
+            "original_file_path": "macros/adapters/apply_grants.sql",
+            "unique_id": "macro.dbt.default__get_dcl_statement_list",
+            "macro_sql": "\n\n{%- macro default__get_dcl_statement_list(relation, grant_config, get_dcl_macro) -%}\n    {#\n      -- Unpack grant_config into specific privileges and the set of users who need them granted/revoked.\n      -- Depending on whether this database supports multiple grantees per statement, pass in the list of\n      -- all grantees per privilege, or (if not) template one statement per privilege-grantee pair.\n      -- `get_dcl_macro` will be either `get_grant_sql` or `get_revoke_sql`\n    #}\n    {%- set dcl_statements = [] -%}\n    {%- for privilege, grantees in grant_config.items() %}\n        {%- if support_multiple_grantees_per_dcl_statement() and grantees -%}\n          {%- set dcl = get_dcl_macro(relation, privilege, grantees) -%}\n          {%- do dcl_statements.append(dcl) -%}\n        {%- else -%}\n          {%- for grantee in grantees -%}\n              {% set dcl = get_dcl_macro(relation, privilege, [grantee]) %}\n              {%- do dcl_statements.append(dcl) -%}\n          {% endfor -%}\n        {%- endif -%}\n    {%- endfor -%}\n    {{ return(dcl_statements) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.support_multiple_grantees_per_dcl_statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.633584,
+            "supported_languages": null
+        },
+        "macro.dbt.call_dcl_statements": {
+            "name": "call_dcl_statements",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/apply_grants.sql",
+            "original_file_path": "macros/adapters/apply_grants.sql",
+            "unique_id": "macro.dbt.call_dcl_statements",
+            "macro_sql": "{% macro call_dcl_statements(dcl_statement_list) %}\n    {{ return(adapter.dispatch(\"call_dcl_statements\", \"dbt\")(dcl_statement_list)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__call_dcl_statements"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.633773,
+            "supported_languages": null
+        },
+        "macro.dbt.default__call_dcl_statements": {
+            "name": "default__call_dcl_statements",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/apply_grants.sql",
+            "original_file_path": "macros/adapters/apply_grants.sql",
+            "unique_id": "macro.dbt.default__call_dcl_statements",
+            "macro_sql": "{% macro default__call_dcl_statements(dcl_statement_list) %}\n    {#\n      -- By default, supply all grant + revoke statements in a single semicolon-separated block,\n      -- so that they're all processed together.\n\n      -- Some databases do not support this. Those adapters will need to override this macro\n      -- to run each statement individually.\n    #}\n    {% call statement('grants') %}\n        {% for dcl_statement in dcl_statement_list %}\n            {{ dcl_statement }};\n        {% endfor %}\n    {% endcall %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6339872,
+            "supported_languages": null
+        },
+        "macro.dbt.apply_grants": {
+            "name": "apply_grants",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/apply_grants.sql",
+            "original_file_path": "macros/adapters/apply_grants.sql",
+            "unique_id": "macro.dbt.apply_grants",
+            "macro_sql": "{% macro apply_grants(relation, grant_config, should_revoke) %}\n    {{ return(adapter.dispatch(\"apply_grants\", \"dbt\")(relation, grant_config, should_revoke)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__apply_grants"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6342359,
+            "supported_languages": null
+        },
+        "macro.dbt.default__apply_grants": {
+            "name": "default__apply_grants",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/apply_grants.sql",
+            "original_file_path": "macros/adapters/apply_grants.sql",
+            "unique_id": "macro.dbt.default__apply_grants",
+            "macro_sql": "{% macro default__apply_grants(relation, grant_config, should_revoke=True) %}\n    {#-- If grant_config is {} or None, this is a no-op --#}\n    {% if grant_config %}\n        {% if should_revoke %}\n            {#-- We think previous grants may have carried over --#}\n            {#-- Show current grants and calculate diffs --#}\n            {% set current_grants_table = run_query(get_show_grant_sql(relation)) %}\n            {% set current_grants_dict = adapter.standardize_grants_dict(current_grants_table) %}\n            {% set needs_granting = diff_of_two_dicts(grant_config, current_grants_dict) %}\n            {% set needs_revoking = diff_of_two_dicts(current_grants_dict, grant_config) %}\n            {% if not (needs_granting or needs_revoking) %}\n                {{ log('On ' ~ relation ~': All grants are in place, no revocation or granting needed.')}}\n            {% endif %}\n        {% else %}\n            {#-- We don't think there's any chance of previous grants having carried over. --#}\n            {#-- Jump straight to granting what the user has configured. --#}\n            {% set needs_revoking = {} %}\n            {% set needs_granting = grant_config %}\n        {% endif %}\n        {% if needs_granting or needs_revoking %}\n            {% set revoke_statement_list = get_dcl_statement_list(relation, needs_revoking, get_revoke_sql) %}\n            {% set grant_statement_list = get_dcl_statement_list(relation, needs_granting, get_grant_sql) %}\n            {% set dcl_statement_list = revoke_statement_list + grant_statement_list %}\n            {% if dcl_statement_list %}\n                {{ call_dcl_statements(dcl_statement_list) }}\n            {% endif %}\n        {% endif %}\n    {% endif %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.run_query",
+                    "macro.dbt.get_show_grant_sql",
+                    "macro.dbt.get_dcl_statement_list",
+                    "macro.dbt.call_dcl_statements"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.635697,
+            "supported_languages": null
+        },
+        "macro.dbt.get_show_sql": {
+            "name": "get_show_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/show.sql",
+            "original_file_path": "macros/adapters/show.sql",
+            "unique_id": "macro.dbt.get_show_sql",
+            "macro_sql": "{% macro get_show_sql(compiled_code, sql_header, limit) -%}\n  {%- if sql_header -%}\n  {{ sql_header }}\n  {%- endif -%}\n  {%- if limit is not none -%}\n  {{ get_limit_subquery_sql(compiled_code, limit) }}\n  {%- else -%}\n  {{ compiled_code }}\n  {%- endif -%}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_limit_subquery_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.636234,
+            "supported_languages": null
+        },
+        "macro.dbt.get_limit_subquery_sql": {
+            "name": "get_limit_subquery_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/show.sql",
+            "original_file_path": "macros/adapters/show.sql",
+            "unique_id": "macro.dbt.get_limit_subquery_sql",
+            "macro_sql": "{% macro get_limit_subquery_sql(sql, limit) %}\n  {{ adapter.dispatch('get_limit_subquery_sql', 'dbt')(sql, limit) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_limit_subquery_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6364129,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_limit_subquery_sql": {
+            "name": "default__get_limit_subquery_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/show.sql",
+            "original_file_path": "macros/adapters/show.sql",
+            "unique_id": "macro.dbt.default__get_limit_subquery_sql",
+            "macro_sql": "{% macro default__get_limit_subquery_sql(sql, limit) %}\n    select *\n    from (\n        {{ sql }}\n    ) as model_limit_subq\n    limit {{ limit }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.636543,
+            "supported_languages": null
+        },
+        "macro.dbt.alter_column_comment": {
+            "name": "alter_column_comment",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/persist_docs.sql",
+            "original_file_path": "macros/adapters/persist_docs.sql",
+            "unique_id": "macro.dbt.alter_column_comment",
+            "macro_sql": "{% macro alter_column_comment(relation, column_dict) -%}\n  {{ return(adapter.dispatch('alter_column_comment', 'dbt')(relation, column_dict)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__alter_column_comment"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.637163,
+            "supported_languages": null
+        },
+        "macro.dbt.default__alter_column_comment": {
+            "name": "default__alter_column_comment",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/persist_docs.sql",
+            "original_file_path": "macros/adapters/persist_docs.sql",
+            "unique_id": "macro.dbt.default__alter_column_comment",
+            "macro_sql": "{% macro default__alter_column_comment(relation, column_dict) -%}\n  {{ exceptions.raise_not_implemented(\n    'alter_column_comment macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6373188,
+            "supported_languages": null
+        },
+        "macro.dbt.alter_relation_comment": {
+            "name": "alter_relation_comment",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/persist_docs.sql",
+            "original_file_path": "macros/adapters/persist_docs.sql",
+            "unique_id": "macro.dbt.alter_relation_comment",
+            "macro_sql": "{% macro alter_relation_comment(relation, relation_comment) -%}\n  {{ return(adapter.dispatch('alter_relation_comment', 'dbt')(relation, relation_comment)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__alter_relation_comment"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.637505,
+            "supported_languages": null
+        },
+        "macro.dbt.default__alter_relation_comment": {
+            "name": "default__alter_relation_comment",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/persist_docs.sql",
+            "original_file_path": "macros/adapters/persist_docs.sql",
+            "unique_id": "macro.dbt.default__alter_relation_comment",
+            "macro_sql": "{% macro default__alter_relation_comment(relation, relation_comment) -%}\n  {{ exceptions.raise_not_implemented(\n    'alter_relation_comment macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.637656,
+            "supported_languages": null
+        },
+        "macro.dbt.persist_docs": {
+            "name": "persist_docs",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/persist_docs.sql",
+            "original_file_path": "macros/adapters/persist_docs.sql",
+            "unique_id": "macro.dbt.persist_docs",
+            "macro_sql": "{% macro persist_docs(relation, model, for_relation=true, for_columns=true) -%}\n  {{ return(adapter.dispatch('persist_docs', 'dbt')(relation, model, for_relation, for_columns)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__persist_docs"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6378949,
+            "supported_languages": null
+        },
+        "macro.dbt.default__persist_docs": {
+            "name": "default__persist_docs",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/persist_docs.sql",
+            "original_file_path": "macros/adapters/persist_docs.sql",
+            "unique_id": "macro.dbt.default__persist_docs",
+            "macro_sql": "{% macro default__persist_docs(relation, model, for_relation, for_columns) -%}\n  {% if for_relation and config.persist_relation_docs() and model.description %}\n    {% do run_query(alter_relation_comment(relation, model.description)) %}\n  {% endif %}\n\n  {% if for_columns and config.persist_column_docs() and model.columns %}\n    {% do run_query(alter_column_comment(relation, model.columns)) %}\n  {% endif %}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.run_query",
+                    "macro.dbt.alter_relation_comment",
+                    "macro.dbt.alter_column_comment"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.638315,
+            "supported_languages": null
+        },
+        "macro.dbt.get_catalog_relations": {
+            "name": "get_catalog_relations",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/metadata.sql",
+            "original_file_path": "macros/adapters/metadata.sql",
+            "unique_id": "macro.dbt.get_catalog_relations",
+            "macro_sql": "{% macro get_catalog_relations(information_schema, relations) -%}\n  {{ return(adapter.dispatch('get_catalog_relations', 'dbt')(information_schema, relations)) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_catalog_relations"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.641557,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_catalog_relations": {
+            "name": "default__get_catalog_relations",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/metadata.sql",
+            "original_file_path": "macros/adapters/metadata.sql",
+            "unique_id": "macro.dbt.default__get_catalog_relations",
+            "macro_sql": "{% macro default__get_catalog_relations(information_schema, relations) -%}\n  {% set typename = adapter.type() %}\n  {% set msg -%}\n    get_catalog_relations not implemented for {{ typename }}\n  {%- endset %}\n\n  {{ exceptions.raise_compiler_error(msg) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.641786,
+            "supported_languages": null
+        },
+        "macro.dbt.get_catalog": {
+            "name": "get_catalog",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/metadata.sql",
+            "original_file_path": "macros/adapters/metadata.sql",
+            "unique_id": "macro.dbt.get_catalog",
+            "macro_sql": "{% macro get_catalog(information_schema, schemas) -%}\n  {{ return(adapter.dispatch('get_catalog', 'dbt')(information_schema, schemas)) }}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__get_catalog"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.641964,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_catalog": {
+            "name": "default__get_catalog",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/metadata.sql",
+            "original_file_path": "macros/adapters/metadata.sql",
+            "unique_id": "macro.dbt.default__get_catalog",
+            "macro_sql": "{% macro default__get_catalog(information_schema, schemas) -%}\n\n  {% set typename = adapter.type() %}\n  {% set msg -%}\n    get_catalog not implemented for {{ typename }}\n  {%- endset %}\n\n  {{ exceptions.raise_compiler_error(msg) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6421819,
+            "supported_languages": null
+        },
+        "macro.dbt.information_schema_name": {
+            "name": "information_schema_name",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/metadata.sql",
+            "original_file_path": "macros/adapters/metadata.sql",
+            "unique_id": "macro.dbt.information_schema_name",
+            "macro_sql": "{% macro information_schema_name(database) %}\n  {{ return(adapter.dispatch('information_schema_name', 'dbt')(database)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__information_schema_name"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.642339,
+            "supported_languages": null
+        },
+        "macro.dbt.default__information_schema_name": {
+            "name": "default__information_schema_name",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/metadata.sql",
+            "original_file_path": "macros/adapters/metadata.sql",
+            "unique_id": "macro.dbt.default__information_schema_name",
+            "macro_sql": "{% macro default__information_schema_name(database) -%}\n  {%- if database -%}\n    {{ database }}.INFORMATION_SCHEMA\n  {%- else -%}\n    INFORMATION_SCHEMA\n  {%- endif -%}\n{%- endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.642478,
+            "supported_languages": null
+        },
+        "macro.dbt.list_schemas": {
+            "name": "list_schemas",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/metadata.sql",
+            "original_file_path": "macros/adapters/metadata.sql",
+            "unique_id": "macro.dbt.list_schemas",
+            "macro_sql": "{% macro list_schemas(database) -%}\n  {{ return(adapter.dispatch('list_schemas', 'dbt')(database)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__list_schemas"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.642636,
+            "supported_languages": null
+        },
+        "macro.dbt.default__list_schemas": {
+            "name": "default__list_schemas",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/metadata.sql",
+            "original_file_path": "macros/adapters/metadata.sql",
+            "unique_id": "macro.dbt.default__list_schemas",
+            "macro_sql": "{% macro default__list_schemas(database) -%}\n  {% set sql %}\n    select distinct schema_name\n    from {{ information_schema_name(database) }}.SCHEMATA\n    where catalog_name ilike '{{ database }}'\n  {% endset %}\n  {{ return(run_query(sql)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.information_schema_name",
+                    "macro.dbt.run_query"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6429498,
+            "supported_languages": null
+        },
+        "macro.dbt.check_schema_exists": {
+            "name": "check_schema_exists",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/metadata.sql",
+            "original_file_path": "macros/adapters/metadata.sql",
+            "unique_id": "macro.dbt.check_schema_exists",
+            "macro_sql": "{% macro check_schema_exists(information_schema, schema) -%}\n  {{ return(adapter.dispatch('check_schema_exists', 'dbt')(information_schema, schema)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__check_schema_exists"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.643213,
+            "supported_languages": null
+        },
+        "macro.dbt.default__check_schema_exists": {
+            "name": "default__check_schema_exists",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/metadata.sql",
+            "original_file_path": "macros/adapters/metadata.sql",
+            "unique_id": "macro.dbt.default__check_schema_exists",
+            "macro_sql": "{% macro default__check_schema_exists(information_schema, schema) -%}\n  {% set sql -%}\n        select count(*)\n        from {{ information_schema.replace(information_schema_view='SCHEMATA') }}\n        where catalog_name='{{ information_schema.database }}'\n          and schema_name='{{ schema }}'\n  {%- endset %}\n  {{ return(run_query(sql)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.replace",
+                    "macro.dbt.run_query"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.64348,
+            "supported_languages": null
+        },
+        "macro.dbt.list_relations_without_caching": {
+            "name": "list_relations_without_caching",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/metadata.sql",
+            "original_file_path": "macros/adapters/metadata.sql",
+            "unique_id": "macro.dbt.list_relations_without_caching",
+            "macro_sql": "{% macro list_relations_without_caching(schema_relation) %}\n  {{ return(adapter.dispatch('list_relations_without_caching', 'dbt')(schema_relation)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__list_relations_without_caching"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.643647,
+            "supported_languages": null
+        },
+        "macro.dbt.default__list_relations_without_caching": {
+            "name": "default__list_relations_without_caching",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/metadata.sql",
+            "original_file_path": "macros/adapters/metadata.sql",
+            "unique_id": "macro.dbt.default__list_relations_without_caching",
+            "macro_sql": "{% macro default__list_relations_without_caching(schema_relation) %}\n  {{ exceptions.raise_not_implemented(\n    'list_relations_without_caching macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.643786,
+            "supported_languages": null
+        },
+        "macro.dbt.get_catalog_for_single_relation": {
+            "name": "get_catalog_for_single_relation",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/metadata.sql",
+            "original_file_path": "macros/adapters/metadata.sql",
+            "unique_id": "macro.dbt.get_catalog_for_single_relation",
+            "macro_sql": "{% macro get_catalog_for_single_relation(relation) %}\n  {{ return(adapter.dispatch('get_catalog_for_single_relation', 'dbt')(relation)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_catalog_for_single_relation"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6439428,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_catalog_for_single_relation": {
+            "name": "default__get_catalog_for_single_relation",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/metadata.sql",
+            "original_file_path": "macros/adapters/metadata.sql",
+            "unique_id": "macro.dbt.default__get_catalog_for_single_relation",
+            "macro_sql": "{% macro default__get_catalog_for_single_relation(relation) %}\n  {{ exceptions.raise_not_implemented(\n    'get_catalog_for_single_relation macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.644087,
+            "supported_languages": null
+        },
+        "macro.dbt.get_relations": {
+            "name": "get_relations",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/metadata.sql",
+            "original_file_path": "macros/adapters/metadata.sql",
+            "unique_id": "macro.dbt.get_relations",
+            "macro_sql": "{% macro get_relations() %}\n  {{ return(adapter.dispatch('get_relations', 'dbt')()) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_relations"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.644233,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_relations": {
+            "name": "default__get_relations",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/metadata.sql",
+            "original_file_path": "macros/adapters/metadata.sql",
+            "unique_id": "macro.dbt.default__get_relations",
+            "macro_sql": "{% macro default__get_relations() %}\n  {{ exceptions.raise_not_implemented(\n    'get_relations macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6443672,
+            "supported_languages": null
+        },
+        "macro.dbt.get_relation_last_modified": {
+            "name": "get_relation_last_modified",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/metadata.sql",
+            "original_file_path": "macros/adapters/metadata.sql",
+            "unique_id": "macro.dbt.get_relation_last_modified",
+            "macro_sql": "{% macro get_relation_last_modified(information_schema, relations) %}\n  {{ return(adapter.dispatch('get_relation_last_modified', 'dbt')(information_schema, relations)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_relation_last_modified"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.644545,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_relation_last_modified": {
+            "name": "default__get_relation_last_modified",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/metadata.sql",
+            "original_file_path": "macros/adapters/metadata.sql",
+            "unique_id": "macro.dbt.default__get_relation_last_modified",
+            "macro_sql": "{% macro default__get_relation_last_modified(information_schema, relations) %}\n  {{ exceptions.raise_not_implemented(\n    'get_relation_last_modified macro not implemented for adapter ' + adapter.type()) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.644694,
+            "supported_languages": null
+        },
+        "macro.dbt.get_columns_in_relation": {
+            "name": "get_columns_in_relation",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/columns.sql",
+            "original_file_path": "macros/adapters/columns.sql",
+            "unique_id": "macro.dbt.get_columns_in_relation",
+            "macro_sql": "{% macro get_columns_in_relation(relation) -%}\n  {{ return(adapter.dispatch('get_columns_in_relation', 'dbt')(relation)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__get_columns_in_relation"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6467142,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_columns_in_relation": {
+            "name": "default__get_columns_in_relation",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/columns.sql",
+            "original_file_path": "macros/adapters/columns.sql",
+            "unique_id": "macro.dbt.default__get_columns_in_relation",
+            "macro_sql": "{% macro default__get_columns_in_relation(relation) -%}\n  {{ exceptions.raise_not_implemented(\n    'get_columns_in_relation macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6468558,
+            "supported_languages": null
+        },
+        "macro.dbt.sql_convert_columns_in_relation": {
+            "name": "sql_convert_columns_in_relation",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/columns.sql",
+            "original_file_path": "macros/adapters/columns.sql",
+            "unique_id": "macro.dbt.sql_convert_columns_in_relation",
+            "macro_sql": "{% macro sql_convert_columns_in_relation(table) -%}\n  {% set columns = [] %}\n  {% for row in table %}\n    {% do columns.append(api.Column(*row)) %}\n  {% endfor %}\n  {{ return(columns) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6472719,
+            "supported_languages": null
+        },
+        "macro.dbt.get_empty_subquery_sql": {
+            "name": "get_empty_subquery_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/columns.sql",
+            "original_file_path": "macros/adapters/columns.sql",
+            "unique_id": "macro.dbt.get_empty_subquery_sql",
+            "macro_sql": "{% macro get_empty_subquery_sql(select_sql, select_sql_header=none) -%}\n  {{ return(adapter.dispatch('get_empty_subquery_sql', 'dbt')(select_sql, select_sql_header)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_empty_subquery_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6476228,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_empty_subquery_sql": {
+            "name": "default__get_empty_subquery_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/columns.sql",
+            "original_file_path": "macros/adapters/columns.sql",
+            "unique_id": "macro.dbt.default__get_empty_subquery_sql",
+            "macro_sql": "{% macro default__get_empty_subquery_sql(select_sql, select_sql_header=none) %}\n    {%- if select_sql_header is not none -%}\n    {{ select_sql_header }}\n    {%- endif -%}\n    select * from (\n        {{ select_sql }}\n    ) as __dbt_sbq\n    where false\n    limit 0\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.647819,
+            "supported_languages": null
+        },
+        "macro.dbt.get_empty_schema_sql": {
+            "name": "get_empty_schema_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/columns.sql",
+            "original_file_path": "macros/adapters/columns.sql",
+            "unique_id": "macro.dbt.get_empty_schema_sql",
+            "macro_sql": "{% macro get_empty_schema_sql(columns) -%}\n  {{ return(adapter.dispatch('get_empty_schema_sql', 'dbt')(columns)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_empty_schema_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.647976,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_empty_schema_sql": {
+            "name": "default__get_empty_schema_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/columns.sql",
+            "original_file_path": "macros/adapters/columns.sql",
+            "unique_id": "macro.dbt.default__get_empty_schema_sql",
+            "macro_sql": "{% macro default__get_empty_schema_sql(columns) %}\n    {%- set col_err = [] -%}\n    {%- set col_naked_numeric = [] -%}\n    select\n    {% for i in columns %}\n      {%- set col = columns[i] -%}\n      {%- if col['data_type'] is not defined -%}\n        {%- do col_err.append(col['name']) -%}\n      {#-- If this column's type is just 'numeric' then it is missing precision/scale, raise a warning --#}\n      {%- elif col['data_type'].strip().lower() in ('numeric', 'decimal', 'number') -%}\n        {%- do col_naked_numeric.append(col['name']) -%}\n      {%- endif -%}\n      {% set col_name = adapter.quote(col['name']) if col.get('quote') else col['name'] %}\n      {{ cast('null', col['data_type']) }} as {{ col_name }}{{ \", \" if not loop.last }}\n    {%- endfor -%}\n    {%- if (col_err | length) > 0 -%}\n      {{ exceptions.column_type_missing(column_names=col_err) }}\n    {%- elif (col_naked_numeric | length) > 0 -%}\n      {{ exceptions.warn(\"Detected columns with numeric type and unspecified precision/scale, this can lead to unintended rounding: \" ~ col_naked_numeric ~ \"`\") }}\n    {%- endif -%}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.cast"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.649274,
+            "supported_languages": null
+        },
+        "macro.dbt.get_column_schema_from_query": {
+            "name": "get_column_schema_from_query",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/columns.sql",
+            "original_file_path": "macros/adapters/columns.sql",
+            "unique_id": "macro.dbt.get_column_schema_from_query",
+            "macro_sql": "{% macro get_column_schema_from_query(select_sql, select_sql_header=none) -%}\n    {% set columns = [] %}\n    {# -- Using an 'empty subquery' here to get the same schema as the given select_sql statement, without necessitating a data scan.#}\n    {% set sql = get_empty_subquery_sql(select_sql, select_sql_header) %}\n    {% set column_schema = adapter.get_column_schema_from_query(sql) %}\n    {{ return(column_schema) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.get_empty_subquery_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6496909,
+            "supported_languages": null
+        },
+        "macro.dbt.get_columns_in_query": {
+            "name": "get_columns_in_query",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/columns.sql",
+            "original_file_path": "macros/adapters/columns.sql",
+            "unique_id": "macro.dbt.get_columns_in_query",
+            "macro_sql": "{% macro get_columns_in_query(select_sql) -%}\n  {{ return(adapter.dispatch('get_columns_in_query', 'dbt')(select_sql)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__get_columns_in_query"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6498759,
+            "supported_languages": null
+        },
+        "macro.dbt.default__get_columns_in_query": {
+            "name": "default__get_columns_in_query",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/columns.sql",
+            "original_file_path": "macros/adapters/columns.sql",
+            "unique_id": "macro.dbt.default__get_columns_in_query",
+            "macro_sql": "{% macro default__get_columns_in_query(select_sql) %}\n    {% call statement('get_columns_in_query', fetch_result=True, auto_begin=False) -%}\n        {{ get_empty_subquery_sql(select_sql) }}\n    {% endcall %}\n    {{ return(load_result('get_columns_in_query').table.columns | map(attribute='name') | list) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement",
+                    "macro.dbt.get_empty_subquery_sql"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.65018,
+            "supported_languages": null
+        },
+        "macro.dbt.alter_column_type": {
+            "name": "alter_column_type",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/columns.sql",
+            "original_file_path": "macros/adapters/columns.sql",
+            "unique_id": "macro.dbt.alter_column_type",
+            "macro_sql": "{% macro alter_column_type(relation, column_name, new_column_type) -%}\n  {{ return(adapter.dispatch('alter_column_type', 'dbt')(relation, column_name, new_column_type)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__alter_column_type"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.650385,
+            "supported_languages": null
+        },
+        "macro.dbt.default__alter_column_type": {
+            "name": "default__alter_column_type",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/columns.sql",
+            "original_file_path": "macros/adapters/columns.sql",
+            "unique_id": "macro.dbt.default__alter_column_type",
+            "macro_sql": "{% macro default__alter_column_type(relation, column_name, new_column_type) -%}\n  {#\n    1. Create a new column (w/ temp name and correct type)\n    2. Copy data over to it\n    3. Drop the existing column (cascade!)\n    4. Rename the new column to existing column\n  #}\n  {%- set tmp_column = column_name + \"__dbt_alter\" -%}\n\n  {% call statement('alter_column_type') %}\n    alter table {{ relation }} add column {{ adapter.quote(tmp_column) }} {{ new_column_type }};\n    update {{ relation }} set {{ adapter.quote(tmp_column) }} = {{ adapter.quote(column_name) }};\n    alter table {{ relation }} drop column {{ adapter.quote(column_name) }} cascade;\n    alter table {{ relation }} rename column {{ adapter.quote(tmp_column) }} to {{ adapter.quote(column_name) }}\n  {% endcall %}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.statement"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.650893,
+            "supported_languages": null
+        },
+        "macro.dbt.alter_relation_add_remove_columns": {
+            "name": "alter_relation_add_remove_columns",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/columns.sql",
+            "original_file_path": "macros/adapters/columns.sql",
+            "unique_id": "macro.dbt.alter_relation_add_remove_columns",
+            "macro_sql": "{% macro alter_relation_add_remove_columns(relation, add_columns = none, remove_columns = none) -%}\n  {{ return(adapter.dispatch('alter_relation_add_remove_columns', 'dbt')(relation, add_columns, remove_columns)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_duckdb.duckdb__alter_relation_add_remove_columns"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.651119,
+            "supported_languages": null
+        },
+        "macro.dbt.default__alter_relation_add_remove_columns": {
+            "name": "default__alter_relation_add_remove_columns",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/adapters/columns.sql",
+            "original_file_path": "macros/adapters/columns.sql",
+            "unique_id": "macro.dbt.default__alter_relation_add_remove_columns",
+            "macro_sql": "{% macro default__alter_relation_add_remove_columns(relation, add_columns, remove_columns) %}\n\n  {% if add_columns is none %}\n    {% set add_columns = [] %}\n  {% endif %}\n  {% if remove_columns is none %}\n    {% set remove_columns = [] %}\n  {% endif %}\n\n  {% set sql -%}\n\n     alter {{ relation.type }} {{ relation }}\n\n            {% for column in add_columns %}\n               add column {{ column.name }} {{ column.data_type }}{{ ',' if not loop.last }}\n            {% endfor %}{{ ',' if add_columns and remove_columns }}\n\n            {% for column in remove_columns %}\n                drop column {{ column.name }}{{ ',' if not loop.last }}\n            {% endfor %}\n\n  {%- endset -%}\n\n  {% do run_query(sql) %}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.run_query"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.651943,
+            "supported_languages": null
+        },
+        "macro.dbt.get_fixture_sql": {
+            "name": "get_fixture_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/unit_test_sql/get_fixture_sql.sql",
+            "original_file_path": "macros/unit_test_sql/get_fixture_sql.sql",
+            "unique_id": "macro.dbt.get_fixture_sql",
+            "macro_sql": "{% macro get_fixture_sql(rows, column_name_to_data_types) %}\n-- Fixture for {{ model.name }}\n{% set default_row = {} %}\n\n{%- if not column_name_to_data_types -%}\n{#-- Use defer_relation IFF it is available in the manifest and 'this' is missing from the database --#}\n{%-   set this_or_defer_relation = defer_relation if (defer_relation and not load_relation(this)) else this -%}\n{%-   set columns_in_relation = adapter.get_columns_in_relation(this_or_defer_relation) -%}\n\n{%-   set column_name_to_data_types = {} -%}\n{%-   for column in columns_in_relation -%}\n{#-- This needs to be a case-insensitive comparison --#}\n{%-     do column_name_to_data_types.update({column.name|lower: column.data_type}) -%}\n{%-   endfor -%}\n{%- endif -%}\n\n{%- if not column_name_to_data_types -%}\n    {{ exceptions.raise_compiler_error(\"Not able to get columns for unit test '\" ~ model.name ~ \"' from relation \" ~ this ~ \" because the relation doesn't exist\") }}\n{%- endif -%}\n\n{%- for column_name, column_type in column_name_to_data_types.items() -%}\n    {%- do default_row.update({column_name: (safe_cast(\"null\", column_type) | trim )}) -%}\n{%- endfor -%}\n\n\n{%- for row in rows -%}\n{%-   set formatted_row = format_row(row, column_name_to_data_types) -%}\n{%-   set default_row_copy = default_row.copy() -%}\n{%-   do default_row_copy.update(formatted_row) -%}\nselect\n{%-   for column_name, column_value in default_row_copy.items() %} {{ column_value }} as {{ column_name }}{% if not loop.last -%}, {%- endif %}\n{%-   endfor %}\n{%-   if not loop.last %}\nunion all\n{%    endif %}\n{%- endfor -%}\n\n{%- if (rows | length) == 0 -%}\n    select\n    {%- for column_name, column_value in default_row.items() %} {{ column_value }} as {{ column_name }}{% if not loop.last -%},{%- endif %}\n    {%- endfor %}\n    limit 0\n{%- endif -%}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.load_relation",
+                    "macro.dbt.safe_cast",
+                    "macro.dbt.format_row"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.65484,
+            "supported_languages": null
+        },
+        "macro.dbt.get_expected_sql": {
+            "name": "get_expected_sql",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/unit_test_sql/get_fixture_sql.sql",
+            "original_file_path": "macros/unit_test_sql/get_fixture_sql.sql",
+            "unique_id": "macro.dbt.get_expected_sql",
+            "macro_sql": "{% macro get_expected_sql(rows, column_name_to_data_types) %}\n\n{%- if (rows | length) == 0 -%}\n    select * from dbt_internal_unit_test_actual\n    limit 0\n{%- else -%}\n{%- for row in rows -%}\n{%- set formatted_row = format_row(row, column_name_to_data_types) -%}\nselect\n{%- for column_name, column_value in formatted_row.items() %} {{ column_value }} as {{ column_name }}{% if not loop.last -%}, {%- endif %}\n{%- endfor %}\n{%- if not loop.last %}\nunion all\n{% endif %}\n{%- endfor -%}\n{%- endif -%}\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.format_row"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.655329,
+            "supported_languages": null
+        },
+        "macro.dbt.format_row": {
+            "name": "format_row",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/unit_test_sql/get_fixture_sql.sql",
+            "original_file_path": "macros/unit_test_sql/get_fixture_sql.sql",
+            "unique_id": "macro.dbt.format_row",
+            "macro_sql": "\n\n{%- macro format_row(row, column_name_to_data_types) -%}\n    {#-- generate case-insensitive formatted row --#}\n    {% set formatted_row = {} %}\n    {%- for column_name, column_value in row.items() -%}\n        {% set column_name = column_name|lower %}\n\n        {%- if column_name not in column_name_to_data_types %}\n            {#-- if user-provided row contains column name that relation does not contain, raise an error --#}\n            {% set fixture_name = \"expected output\" if model.resource_type == 'unit_test' else (\"'\" ~ model.name ~ \"'\") %}\n            {{ exceptions.raise_compiler_error(\n                \"Invalid column name: '\" ~ column_name ~ \"' in unit test fixture for \" ~ fixture_name ~ \".\"\n                \"\\nAccepted columns for \" ~ fixture_name ~ \" are: \" ~ (column_name_to_data_types.keys()|list)\n            ) }}\n        {%- endif -%}\n\n        {%- set column_type = column_name_to_data_types[column_name] %}\n\n        {#-- sanitize column_value: wrap yaml strings in quotes, apply cast --#}\n        {%- set column_value_clean = column_value -%}\n        {%- if column_value is string -%}\n            {%- set column_value_clean = dbt.string_literal(dbt.escape_single_quotes(column_value)) -%}\n        {%- elif column_value is none -%}\n            {%- set column_value_clean = 'null' -%}\n        {%- endif -%}\n\n        {%- set row_update = {column_name: safe_cast(column_value_clean, column_type) } -%}\n        {%- do formatted_row.update(row_update) -%}\n    {%- endfor -%}\n    {{ return(formatted_row) }}\n{%- endmacro -%}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.string_literal",
+                    "macro.dbt.escape_single_quotes",
+                    "macro.dbt.safe_cast"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.656342,
+            "supported_languages": null
+        },
+        "macro.dbt.resolve_model_name": {
+            "name": "resolve_model_name",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/python_model/python.sql",
+            "original_file_path": "macros/python_model/python.sql",
+            "unique_id": "macro.dbt.resolve_model_name",
+            "macro_sql": "{% macro resolve_model_name(input_model_name) %}\n    {{ return(adapter.dispatch('resolve_model_name', 'dbt')(input_model_name)) }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__resolve_model_name"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.657869,
+            "supported_languages": null
+        },
+        "macro.dbt.default__resolve_model_name": {
+            "name": "default__resolve_model_name",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/python_model/python.sql",
+            "original_file_path": "macros/python_model/python.sql",
+            "unique_id": "macro.dbt.default__resolve_model_name",
+            "macro_sql": "\n\n{%- macro default__resolve_model_name(input_model_name) -%}\n    {{  input_model_name | string | replace('\"', '\\\"') }}\n{%- endmacro -%}\n\n",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.658015,
+            "supported_languages": null
+        },
+        "macro.dbt.build_ref_function": {
+            "name": "build_ref_function",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/python_model/python.sql",
+            "original_file_path": "macros/python_model/python.sql",
+            "unique_id": "macro.dbt.build_ref_function",
+            "macro_sql": "{% macro build_ref_function(model) %}\n\n    {%- set ref_dict = {} -%}\n    {%- for _ref in model.refs -%}\n        {% set _ref_args = [_ref.get('package'), _ref['name']] if _ref.get('package') else [_ref['name'],] %}\n        {%- set resolved = ref(*_ref_args, v=_ref.get('version')) -%}\n        {%- if _ref.get('version') -%}\n            {% do _ref_args.extend([\"v\" ~ _ref['version']]) %}\n        {%- endif -%}\n       {%- do ref_dict.update({_ref_args | join('.'): resolve_model_name(resolved)}) -%}\n    {%- endfor -%}\n\ndef ref(*args, **kwargs):\n    refs = {{ ref_dict | tojson }}\n    key = '.'.join(args)\n    version = kwargs.get(\"v\") or kwargs.get(\"version\")\n    if version:\n        key += f\".v{version}\"\n    dbt_load_df_function = kwargs.get(\"dbt_load_df_function\")\n    return dbt_load_df_function(refs[key])\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.resolve_model_name"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.658728,
+            "supported_languages": null
+        },
+        "macro.dbt.build_source_function": {
+            "name": "build_source_function",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/python_model/python.sql",
+            "original_file_path": "macros/python_model/python.sql",
+            "unique_id": "macro.dbt.build_source_function",
+            "macro_sql": "{% macro build_source_function(model) %}\n\n    {%- set source_dict = {} -%}\n    {%- for _source in model.sources -%}\n        {%- set resolved = source(*_source) -%}\n        {%- do source_dict.update({_source | join('.'): resolve_model_name(resolved)}) -%}\n    {%- endfor -%}\n\ndef source(*args, dbt_load_df_function):\n    sources = {{ source_dict | tojson }}\n    key = '.'.join(args)\n    return dbt_load_df_function(sources[key])\n\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.resolve_model_name"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.659093,
+            "supported_languages": null
+        },
+        "macro.dbt.build_config_dict": {
+            "name": "build_config_dict",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/python_model/python.sql",
+            "original_file_path": "macros/python_model/python.sql",
+            "unique_id": "macro.dbt.build_config_dict",
+            "macro_sql": "{% macro build_config_dict(model) %}\n    {%- set config_dict = {} -%}\n    {% set config_dbt_used = zip(model.config.config_keys_used, model.config.config_keys_defaults) | list %}\n    {%- for key, default in config_dbt_used -%}\n        {# weird type testing with enum, would be much easier to write this logic in Python! #}\n        {%- if key == \"language\" -%}\n          {%- set value = \"python\" -%}\n        {%- endif -%}\n        {%- set value = model.config.get(key, default) -%}\n        {%- do config_dict.update({key: value}) -%}\n    {%- endfor -%}\nconfig_dict = {{ config_dict }}\n{% endmacro %}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6598551,
+            "supported_languages": null
+        },
+        "macro.dbt.py_script_postfix": {
+            "name": "py_script_postfix",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/python_model/python.sql",
+            "original_file_path": "macros/python_model/python.sql",
+            "unique_id": "macro.dbt.py_script_postfix",
+            "macro_sql": "{% macro py_script_postfix(model) %}\n# This part is user provided model code\n# you will need to copy the next section to run the code\n# COMMAND ----------\n# this part is dbt logic for get ref work, do not modify\n\n{{ build_ref_function(model ) }}\n{{ build_source_function(model ) }}\n{{ build_config_dict(model) }}\n\nclass config:\n    def __init__(self, *args, **kwargs):\n        pass\n\n    @staticmethod\n    def get(key, default=None):\n        return config_dict.get(key, default)\n\nclass this:\n    \"\"\"dbt.this() or dbt.this.identifier\"\"\"\n    database = \"{{ this.database }}\"\n    schema = \"{{ this.schema }}\"\n    identifier = \"{{ this.identifier }}\"\n    {% set this_relation_name = resolve_model_name(this) %}\n    def __repr__(self):\n        return '{{ this_relation_name  }}'\n\n\nclass dbtObj:\n    def __init__(self, load_df_function) -> None:\n        self.source = lambda *args: source(*args, dbt_load_df_function=load_df_function)\n        self.ref = lambda *args, **kwargs: ref(*args, **kwargs, dbt_load_df_function=load_df_function)\n        self.config = config\n        self.this = this()\n        self.is_incremental = {{ is_incremental() }}\n\n# COMMAND ----------\n{{py_script_comment()}}\n{% endmacro %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.build_ref_function",
+                    "macro.dbt.build_source_function",
+                    "macro.dbt.build_config_dict",
+                    "macro.dbt.resolve_model_name",
+                    "macro.dbt.is_incremental",
+                    "macro.dbt.py_script_comment"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.660442,
+            "supported_languages": null
+        },
+        "macro.dbt.py_script_comment": {
+            "name": "py_script_comment",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "macros/python_model/python.sql",
+            "original_file_path": "macros/python_model/python.sql",
+            "unique_id": "macro.dbt.py_script_comment",
+            "macro_sql": "{%macro py_script_comment()%}\n{%endmacro%}",
+            "depends_on": {
+                "macros": []
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.660533,
+            "supported_languages": null
+        },
+        "macro.dbt.test_unique": {
+            "name": "test_unique",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "tests/generic/builtin.sql",
+            "original_file_path": "tests/generic/builtin.sql",
+            "unique_id": "macro.dbt.test_unique",
+            "macro_sql": "{% test unique(model, column_name) %}\n    {% set macro = adapter.dispatch('test_unique', 'dbt') %}\n    {{ macro(model, column_name) }}\n{% endtest %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__test_unique"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.661011,
+            "supported_languages": null
+        },
+        "macro.dbt.test_not_null": {
+            "name": "test_not_null",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "tests/generic/builtin.sql",
+            "original_file_path": "tests/generic/builtin.sql",
+            "unique_id": "macro.dbt.test_not_null",
+            "macro_sql": "{% test not_null(model, column_name) %}\n    {% set macro = adapter.dispatch('test_not_null', 'dbt') %}\n    {{ macro(model, column_name) }}\n{% endtest %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__test_not_null"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6612248,
+            "supported_languages": null
+        },
+        "macro.dbt.test_accepted_values": {
+            "name": "test_accepted_values",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "tests/generic/builtin.sql",
+            "original_file_path": "tests/generic/builtin.sql",
+            "unique_id": "macro.dbt.test_accepted_values",
+            "macro_sql": "{% test accepted_values(model, column_name, values, quote=True) %}\n    {% set macro = adapter.dispatch('test_accepted_values', 'dbt') %}\n    {{ macro(model, column_name, values, quote) }}\n{% endtest %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__test_accepted_values"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.661505,
+            "supported_languages": null
+        },
+        "macro.dbt.test_relationships": {
+            "name": "test_relationships",
+            "resource_type": "macro",
+            "package_name": "dbt",
+            "path": "tests/generic/builtin.sql",
+            "original_file_path": "tests/generic/builtin.sql",
+            "unique_id": "macro.dbt.test_relationships",
+            "macro_sql": "{% test relationships(model, column_name, to, field) %}\n    {% set macro = adapter.dispatch('test_relationships', 'dbt') %}\n    {{ macro(model, column_name, to, field) }}\n{% endtest %}",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.default__test_relationships"
+                ]
+            },
+            "description": "",
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "arguments": [],
+            "created_at": 1720483775.6618419,
+            "supported_languages": null
+        }
+    },
+    "docs": {
+        "doc.jaffle_shop.__overview__": {
+            "name": "__overview__",
+            "resource_type": "doc",
+            "package_name": "jaffle_shop",
+            "path": "overview.md",
+            "original_file_path": "models/overview.md",
+            "unique_id": "doc.jaffle_shop.__overview__",
+            "block_contents": "## Data Documentation for Jaffle Shop\n\n`jaffle_shop` is a fictional ecommerce store.\n\nThis [dbt](https://www.getdbt.com/) project is for testing out code.\n\nThe source code can be found [here](https://github.com/clrcrl/jaffle_shop)."
+        },
+        "doc.jaffle_shop.orders_status": {
+            "name": "orders_status",
+            "resource_type": "doc",
+            "package_name": "jaffle_shop",
+            "path": "docs.md",
+            "original_file_path": "models/docs.md",
+            "unique_id": "doc.jaffle_shop.orders_status",
+            "block_contents": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |"
+        },
+        "doc.dbt.__overview__": {
+            "name": "__overview__",
+            "resource_type": "doc",
+            "package_name": "dbt",
+            "path": "overview.md",
+            "original_file_path": "docs/overview.md",
+            "unique_id": "doc.dbt.__overview__",
+            "block_contents": "### Welcome!\n\nWelcome to the auto-generated documentation for your dbt project!\n\n### Navigation\n\nYou can use the `Project` and `Database` navigation tabs on the left side of the window to explore the models\nin your project.\n\n#### Project Tab\nThe `Project` tab mirrors the directory structure of your dbt project. In this tab, you can see all of the\nmodels defined in your dbt project, as well as models imported from dbt packages.\n\n#### Database Tab\nThe `Database` tab also exposes your models, but in a format that looks more like a database explorer. This view\nshows relations (tables and views) grouped into database schemas. Note that ephemeral models are _not_ shown\nin this interface, as they do not exist in the database.\n\n### Graph Exploration\nYou can click the blue icon on the bottom-right corner of the page to view the lineage graph of your models.\n\nOn model pages, you'll see the immediate parents and children of the model you're exploring. By clicking the `Expand`\nbutton at the top-right of this lineage pane, you'll be able to see all of the models that are used to build,\nor are built from, the model you're exploring.\n\nOnce expanded, you'll be able to use the `--select` and `--exclude` model selection syntax to filter the\nmodels in the graph. For more information on model selection, check out the [dbt docs](https://docs.getdbt.com/docs/model-selection-syntax).\n\nNote that you can also right-click on models to interactively filter and explore the graph.\n\n---\n\n### More information\n\n- [What is dbt](https://docs.getdbt.com/docs/introduction)?\n- Read the [dbt viewpoint](https://docs.getdbt.com/docs/viewpoint)\n- [Installation](https://docs.getdbt.com/docs/installation)\n- Join the [dbt Community](https://www.getdbt.com/community/) for questions and discussion"
+        }
+    },
+    "exposures": {},
+    "metrics": {},
+    "groups": {},
+    "selectors": {},
+    "disabled": {},
+    "parent_map": {
+        "seed.jaffle_shop.raw_customers": [],
+        "seed.jaffle_shop.raw_orders": [],
+        "seed.jaffle_shop.raw_payments": [],
+        "model.jaffle_shop.orders": [
+            "model.jaffle_shop.stg_orders",
+            "model.jaffle_shop.stg_payments"
+        ],
+        "test.jaffle_shop.not_null_orders_order_id.cf6c17daed": [
+            "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.unique_orders_order_id.fed79b3a6e": [
+            "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.not_null_orders_customer_id.c5f02694af": [
+            "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2": [
+            "model.jaffle_shop.customers",
+            "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.accepted_values_orders_status__completed__placed__return_pending__returned__shipped.a015b8fc5d": [
+            "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59": [
+            "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625": [
+            "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49": [
+            "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a": [
+            "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.not_null_orders_amount.106140f9fd": [
+            "model.jaffle_shop.orders"
+        ],
+        "model.jaffle_shop.stg_customers": [
+            "seed.jaffle_shop.raw_customers"
+        ],
+        "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa": [
+            "model.jaffle_shop.stg_customers"
+        ],
+        "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada": [
+            "model.jaffle_shop.stg_customers"
+        ],
+        "model.jaffle_shop.stg_orders": [
+            "seed.jaffle_shop.raw_orders"
+        ],
+        "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64": [
+            "model.jaffle_shop.stg_orders"
+        ],
+        "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a": [
+            "model.jaffle_shop.stg_orders"
+        ],
+        "test.jaffle_shop.accepted_values_stg_orders_status__completed__placed__return_pending__returned__shipped.8adcbb5d61": [
+            "model.jaffle_shop.stg_orders"
+        ],
+        "model.jaffle_shop.stg_payments": [
+            "seed.jaffle_shop.raw_payments"
+        ],
+        "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075": [
+            "model.jaffle_shop.stg_payments"
+        ],
+        "test.jaffle_shop.unique_stg_payments_payment_id.3744510712": [
+            "model.jaffle_shop.stg_payments"
+        ],
+        "test.jaffle_shop.accepted_values_stg_payments_payment_method__bank_transfer__coupon__credit_card__gift_card.1ff927f246": [
+            "model.jaffle_shop.stg_payments"
+        ],
+        "model.jaffle_shop.customers": [
+            "model.jaffle_shop.stg_customers",
+            "model.jaffle_shop.stg_orders",
+            "model.jaffle_shop.stg_payments"
+        ],
+        "test.jaffle_shop.not_null_customers_customer_id.5c9bf9911d": [
+            "model.jaffle_shop.customers"
+        ],
+        "test.jaffle_shop.unique_customers_customer_id.c5af1ff4b1": [
+            "model.jaffle_shop.customers"
+        ]
+    },
+    "child_map": {
+        "seed.jaffle_shop.raw_customers": [
+            "model.jaffle_shop.stg_customers"
+        ],
+        "seed.jaffle_shop.raw_orders": [
+            "model.jaffle_shop.stg_orders"
+        ],
+        "seed.jaffle_shop.raw_payments": [
+            "model.jaffle_shop.stg_payments"
+        ],
+        "model.jaffle_shop.orders": [
+            "test.jaffle_shop.accepted_values_orders_status__completed__placed__return_pending__returned__shipped.a015b8fc5d",
+            "test.jaffle_shop.not_null_orders_amount.106140f9fd",
+            "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49",
+            "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625",
+            "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59",
+            "test.jaffle_shop.not_null_orders_customer_id.c5f02694af",
+            "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a",
+            "test.jaffle_shop.not_null_orders_order_id.cf6c17daed",
+            "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2",
+            "test.jaffle_shop.unique_orders_order_id.fed79b3a6e"
+        ],
+        "test.jaffle_shop.not_null_orders_order_id.cf6c17daed": [],
+        "test.jaffle_shop.unique_orders_order_id.fed79b3a6e": [],
+        "test.jaffle_shop.not_null_orders_customer_id.c5f02694af": [],
+        "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2": [],
+        "test.jaffle_shop.accepted_values_orders_status__completed__placed__return_pending__returned__shipped.a015b8fc5d": [],
+        "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59": [],
+        "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625": [],
+        "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49": [],
+        "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a": [],
+        "test.jaffle_shop.not_null_orders_amount.106140f9fd": [],
+        "model.jaffle_shop.stg_customers": [
+            "model.jaffle_shop.customers",
+            "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa",
+            "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada"
+        ],
+        "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa": [],
+        "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada": [],
+        "model.jaffle_shop.stg_orders": [
+            "model.jaffle_shop.customers",
+            "model.jaffle_shop.orders",
+            "test.jaffle_shop.accepted_values_stg_orders_status__completed__placed__return_pending__returned__shipped.8adcbb5d61",
+            "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64",
+            "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a"
+        ],
+        "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64": [],
+        "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a": [],
+        "test.jaffle_shop.accepted_values_stg_orders_status__completed__placed__return_pending__returned__shipped.8adcbb5d61": [],
+        "model.jaffle_shop.stg_payments": [
+            "model.jaffle_shop.customers",
+            "model.jaffle_shop.orders",
+            "test.jaffle_shop.accepted_values_stg_payments_payment_method__bank_transfer__coupon__credit_card__gift_card.1ff927f246",
+            "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075",
+            "test.jaffle_shop.unique_stg_payments_payment_id.3744510712"
+        ],
+        "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075": [],
+        "test.jaffle_shop.unique_stg_payments_payment_id.3744510712": [],
+        "test.jaffle_shop.accepted_values_stg_payments_payment_method__bank_transfer__coupon__credit_card__gift_card.1ff927f246": [],
+        "model.jaffle_shop.customers": [
+            "test.jaffle_shop.not_null_customers_customer_id.5c9bf9911d",
+            "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2",
+            "test.jaffle_shop.unique_customers_customer_id.c5af1ff4b1"
+        ],
+        "test.jaffle_shop.not_null_customers_customer_id.5c9bf9911d": [],
+        "test.jaffle_shop.unique_customers_customer_id.c5af1ff4b1": []
+    },
+    "group_map": {},
+    "saved_queries": {},
+    "semantic_models": {},
+    "unit_tests": {}
+}

--- a/tests/fixtures/dbt/import/manifest_jaffle_bigquery.json
+++ b/tests/fixtures/dbt/import/manifest_jaffle_bigquery.json
@@ -9,7 +9,7 @@
         "project_id": "06e5b98c2db46f8a72cc4f66410e9b3b",
         "user_id": "a9b24267-c9cb-49bb-ac4c-ae76c1eea8ee",
         "send_anonymous_usage_stats": true,
-        "adapter_type": "duckdb"
+        "adapter_type": "bigquery"
     },
     "nodes": {
         "seed.jaffle_shop.raw_customers": {
@@ -278,7 +278,7 @@
                     "name": "order_id",
                     "description": "This is a unique identifier for an order",
                     "meta": {},
-                    "data_type": "integer",
+                    "data_type": "INT64",
                     "constraints": [],
                     "quote": null,
                     "tags": []
@@ -287,7 +287,7 @@
                     "name": "customer_id",
                     "description": "Foreign key to the customers table",
                     "meta": {},
-                    "data_type": "integer",
+                    "data_type": "INT64",
                     "constraints": [],
                     "quote": null,
                     "tags": []
@@ -296,7 +296,7 @@
                     "name": "order_date",
                     "description": "Date (UTC) that the order was placed",
                     "meta": {},
-                    "data_type": "date",
+                    "data_type": "DATE",
                     "constraints": [],
                     "quote": null,
                     "tags": []
@@ -305,7 +305,7 @@
                     "name": "status",
                     "description": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |",
                     "meta": {},
-                    "data_type": "varchar",
+                    "data_type": "STRING",
                     "constraints": [],
                     "quote": null,
                     "tags": []
@@ -314,7 +314,7 @@
                     "name": "credit_card_amount",
                     "description": "Amount of the order (AUD) paid for by credit card",
                     "meta": {},
-                    "data_type": "double",
+                    "data_type": "FLOAT64",
                     "constraints": [],
                     "quote": null,
                     "tags": []
@@ -323,7 +323,7 @@
                     "name": "coupon_amount",
                     "description": "Amount of the order (AUD) paid for by coupon",
                     "meta": {},
-                    "data_type": "double",
+                    "data_type": "FLOAT64",
                     "constraints": [],
                     "quote": null,
                     "tags": []
@@ -332,7 +332,7 @@
                     "name": "bank_transfer_amount",
                     "description": "Amount of the order (AUD) paid for by bank transfer",
                     "meta": {},
-                    "data_type": "double",
+                    "data_type": "FLOAT64",
                     "constraints": [],
                     "quote": null,
                     "tags": []
@@ -341,7 +341,7 @@
                     "name": "gift_card_amount",
                     "description": "Amount of the order (AUD) paid for by gift card",
                     "meta": {},
-                    "data_type": "double",
+                    "data_type": "FLOAT64",
                     "constraints": [],
                     "quote": null,
                     "tags": []
@@ -350,7 +350,7 @@
                     "name": "amount",
                     "description": "Total amount (AUD) of the order",
                     "meta": {},
-                    "data_type": "double",
+                    "data_type": "FLOAT64",
                     "constraints": [],
                     "quote": null,
                     "tags": []
@@ -1354,7 +1354,7 @@
                     "name": "customer_id",
                     "description": "",
                     "meta": {},
-                    "data_type": "integer",
+                    "data_type": "INT64",
                     "constraints": [],
                     "quote": null,
                     "tags": []
@@ -1363,7 +1363,7 @@
                     "name": "first_name",
                     "description": "",
                     "meta": {},
-                    "data_type": "varchar",
+                    "data_type": "STRING",
                     "constraints": [],
                     "quote": null,
                     "tags": []
@@ -1372,7 +1372,7 @@
                     "name": "last_name",
                     "description": "",
                     "meta": {},
-                    "data_type": "varchar",
+                    "data_type": "STRING",
                     "constraints": [],
                     "quote": null,
                     "tags": []
@@ -1657,7 +1657,7 @@
                     "name": "order_id",
                     "description": "",
                     "meta": {},
-                    "data_type": "integer",
+                    "data_type": "INT64",
                     "constraints": [],
                     "quote": null,
                     "tags": []
@@ -1666,7 +1666,7 @@
                     "name": "customer_id",
                     "description": "",
                     "meta": {},
-                    "data_type": "integer",
+                    "data_type": "INT64",
                     "constraints": [],
                     "quote": null,
                     "tags": []
@@ -1675,7 +1675,7 @@
                     "name": "order_date",
                     "description": "",
                     "meta": {},
-                    "data_type": "date",
+                    "data_type": "DATE",
                     "constraints": [],
                     "quote": null,
                     "tags": []
@@ -1684,7 +1684,7 @@
                     "name": "status",
                     "description": "",
                     "meta": {},
-                    "data_type": "varchar",
+                    "data_type": "STRING",
                     "constraints": [],
                     "quote": null,
                     "tags": []
@@ -2067,7 +2067,7 @@
                     "name": "payment_id",
                     "description": "",
                     "meta": {},
-                    "data_type": "integer",
+                    "data_type": "INT64",
                     "constraints": [],
                     "quote": null,
                     "tags": []
@@ -2076,7 +2076,7 @@
                     "name": "order_id",
                     "description": "",
                     "meta": {},
-                    "data_type": "integer",
+                    "data_type": "INT64",
                     "constraints": [],
                     "quote": null,
                     "tags": []
@@ -2085,7 +2085,7 @@
                     "name": "payment_method",
                     "description": "",
                     "meta": {},
-                    "data_type": "varchar",
+                    "data_type": "STRING",
                     "constraints": [],
                     "quote": null,
                     "tags": []
@@ -2094,7 +2094,7 @@
                     "name": "amount",
                     "description": "",
                     "meta": {},
-                    "data_type": "double",
+                    "data_type": "FLOAT64",
                     "constraints": [],
                     "quote": null,
                     "tags": []
@@ -2475,7 +2475,7 @@
                     "name": "customer_id",
                     "description": "This is a unique identifier for a customer",
                     "meta": {},
-                    "data_type": "integer",
+                    "data_type": "INT64",
                     "constraints": [],
                     "quote": null,
                     "tags": []
@@ -2484,7 +2484,7 @@
                     "name": "first_name",
                     "description": "Customer's first name. PII.",
                     "meta": {},
-                    "data_type": "varchar",
+                    "data_type": "STRING",
                     "constraints": [],
                     "quote": null,
                     "tags": ["PII"]
@@ -2493,7 +2493,7 @@
                     "name": "last_name",
                     "description": "Customer's last name. PII.",
                     "meta": {},
-                    "data_type": "varchar",
+                    "data_type": "STRING",
                     "constraints": [],
                     "quote": null,
                     "tags": ["PII"]
@@ -2502,7 +2502,7 @@
                     "name": "first_order",
                     "description": "Date (UTC) of a customer's first order",
                     "meta": {},
-                    "data_type": "date",
+                    "data_type": "DATE",
                     "constraints": [],
                     "quote": null,
                     "tags": []
@@ -2511,7 +2511,7 @@
                     "name": "most_recent_order",
                     "description": "Date (UTC) of a customer's most recent order",
                     "meta": {},
-                    "data_type": "date",
+                    "data_type": "DATE",
                     "constraints": [],
                     "quote": null,
                     "tags": []
@@ -2520,7 +2520,7 @@
                     "name": "number_of_orders",
                     "description": "Count of the number of orders a customer has placed",
                     "meta": {},
-                    "data_type": "bigint",
+                    "data_type": "INT64",
                     "constraints": [],
                     "quote": null,
                     "tags": []
@@ -2529,7 +2529,7 @@
                     "name": "customer_lifetime_value",
                     "description": "",
                     "meta": {},
-                    "data_type": "double",
+                    "data_type": "FLOAT64",
                     "constraints": [],
                     "quote": null,
                     "tags": []

--- a/tests/test_export_dbt_sources.py
+++ b/tests/test_export_dbt_sources.py
@@ -42,9 +42,8 @@ sources:
         description: The orders model
         columns:
           - name: order_id
+            data_type: VARCHAR
             tests:
-              - dbt_expectations.dbt_expectations.expect_column_values_to_be_of_type:
-                  column_type: VARCHAR
               - not_null
               - unique
               - dbt_expectations.expect_column_value_lengths_to_be_between:
@@ -59,17 +58,15 @@ sources:
               - order_id
           - name: order_total
             description: The order_total field
+            data_type: NUMBER
             tests:
-              - dbt_expectations.dbt_expectations.expect_column_values_to_be_of_type:
-                  column_type: NUMBER
               - not_null
               - dbt_expectations.expect_column_values_to_be_between:
                    min_value: 0
                    max_value: 1000000
           - name: order_status
+            data_type: TEXT
             tests:
-              - dbt_expectations.dbt_expectations.expect_column_values_to_be_of_type:
-                  column_type: TEXT
               - not_null
               - accepted_values:
                   values:
@@ -115,7 +112,7 @@ sources:
               - order_id
           - name: order_total
             description: The order_total field
-            data_type: NUMERIC
+            data_type: INT64
             tests:
               - not_null
               - dbt_expectations.expect_column_values_to_be_between:

--- a/tests/test_export_dbt_sources.py
+++ b/tests/test_export_dbt_sources.py
@@ -17,19 +17,28 @@ def test_cli():
     assert result.exit_code == 0
 
 
+def test_cli_bigquery():
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["export", "./fixtures/dbt/export/datacontract.yaml", "--format", "dbt-sources", "--server", "production"]
+    )
+    print(result.stdout)
+    assert result.exit_code == 0
+
+
 def test_to_dbt_sources():
     data_contract = DataContractSpecification.from_file("fixtures/export/datacontract.yaml")
     expected_dbt_model = """
 version: 2
 sources:
   - name: orders-unit-test
-    description: The orders data contract  
+    description: The orders data contract
     database: my-database
-    schema: my-schema  
+    schema: my-schema
     meta:
       owner: checkout
     tables:
-      - name: orders 
+      - name: orders
         description: The orders model
         columns:
           - name: order_id
@@ -42,7 +51,7 @@ sources:
                   min_value: 8
                   max_value: 10
               - dbt_expectations.expect_column_values_to_match_regex:
-                  regex: ^B[0-9]+$      
+                  regex: ^B[0-9]+$
             meta:
               classification: sensitive
               pii: true
@@ -61,6 +70,60 @@ sources:
             tests:
               - dbt_expectations.dbt_expectations.expect_column_values_to_be_of_type:
                   column_type: TEXT
+              - not_null
+              - accepted_values:
+                  values:
+                    - 'pending'
+                    - 'shipped'
+                    - 'delivered'
+"""
+
+    result = to_dbt_sources_yaml(data_contract, "production")
+
+    assert yaml.safe_load(result) == yaml.safe_load(expected_dbt_model)
+
+
+def test_to_dbt_sources_bigquery():
+    data_contract = DataContractSpecification.from_file("./fixtures/dbt/export/datacontract.yaml")
+    expected_dbt_model = """
+version: 2
+sources:
+  - name: orders-unit-test
+    description: The orders data contract
+    database: my-database
+    schema: my-schema
+    meta:
+      owner: checkout
+    tables:
+      - name: orders
+        description: The orders model
+        columns:
+          - name: order_id
+            data_type: STRING
+            tests:
+              - not_null
+              - unique
+              - dbt_expectations.expect_column_value_lengths_to_be_between:
+                  min_value: 8
+                  max_value: 10
+              - dbt_expectations.expect_column_values_to_match_regex:
+                  regex: ^B[0-9]+$
+            meta:
+              classification: sensitive
+              pii: true
+            tags:
+              - order_id
+          - name: order_total
+            description: The order_total field
+            data_type: NUMERIC
+            tests:
+              - not_null
+              - dbt_expectations.expect_column_values_to_be_between:
+                   min_value: 0
+                   max_value: 1000000
+          - name: order_status
+            data_type: STRING
+            tests:
               - not_null
               - accepted_values:
                   values:


### PR DESCRIPTION
## Problem
When importing/exporting to/from dbt, the conversion of column types is not taken into account.

When using BigQuery as an adapter for dbt, running `datacontract import --format dbt ...` will generate the following yaml.

```yaml
dataContractSpecification: 1.1.0
id: my-data-contract-id
info:
  title: my_data_model
  version: 0.0.1
  dbt_version: 1.8.8
models:
  my_model:
    description: ''
    fields:
      product_id:
        type: STRING
      quantity:
        type: INT64
    tags: []
```


`STRING` and `INT64` are [not defined as valid data types](https://datacontract.com/#data-types). In fact, the following error occurs when you try to export the imported yaml(`datacontract export --format dbt-sources ...`).

```
DataContractException: Run operation failed: [lint] Check that data contract 
YAML is valid - None - failed - 
data.models.my_data_model.fields.product_id.type must be 
one of ['number', 'decimal', 'numeric', 'int', 'integer', 'long', 'bigint', 
'float', 'double', 'string', 'text', 'varchar', 'boolean', 'timestamp', 
'timestamp_tz', 'timestamp_ntz', 'date', 'array', 'map', 'object', 'record', 
'struct', 'bytes', 'null'] - datacontract
```

## Solution
When importing dbt's yaml into a contract and exporting a contract to dbt, the type conversion has been modified to take into account.

---

- [x] Tests pass
- [x] ruff format
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added
