### PR TITLE
Fix KeyError on soda scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Modify the arguments to narrow down the import target with `--dbt-model` (#532)
-
+- SodaCL: Prevent `KeyError: 'fail'` from happening when testing with SodaCL
 
 ## [0.10.15] - 2024-10-26
 

--- a/datacontract/engines/soda/check_soda_execute.py
+++ b/datacontract/engines/soda/check_soda_execute.py
@@ -182,5 +182,5 @@ def update_reason(check, c):
                 check.reason = diagnostics_text_split[1].strip()
                 # print(check.reason)
             break  # Exit the loop once the desired block is found
-    if c["diagnostics"]["fail"] is not None:
+    if "fail" in c["diagnostics"]:
         check.reason = f"Got: {c['diagnostics']['value']} Expected: {c['diagnostics']['fail']}"


### PR DESCRIPTION
Better way to check if the key "fail" exists on the "diagnostics" object, so it won't throw this error:

```
if c["diagnostics"]["fail"] is not None:
       ~~~~~~~~~~~~~~~~^^^^^^^^
KeyError: 'fail'
ERROR:root:'fail
```

- [x] Tests pass
- [x] ruff format
- [ ] README.md updated (if relevant)
- [x] CHANGELOG.md entry added
