### PR TITLE
Ensure 'name' is the first column when exporting in dbt format, considering column attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Type conversion when importing contracts into dbt and exporting contracts from dbt (#534)
+- Ensure 'name' is the first column when exporting in dbt format, considering column attributes (#541)
 
 ### Fixed
 - Modify the arguments to narrow down the import target with `--dbt-model` (#532)

--- a/datacontract/export/dbt_converter.py
+++ b/datacontract/export/dbt_converter.py
@@ -135,14 +135,13 @@ def _supports_constraints(model_type):
 def _to_columns(fields: Dict[str, Field], supports_constraints: bool, adapter_type: Optional[str]) -> list:
     columns = []
     for field_name, field in fields.items():
-        column = _to_column(field, supports_constraints, adapter_type)
-        column["name"] = field_name
+        column = _to_column(field_name, field, supports_constraints, adapter_type)
         columns.append(column)
     return columns
 
 
-def _to_column(field: Field, supports_constraints: bool, adapter_type: Optional[str]) -> dict:
-    column = {}
+def _to_column(field_name: str, field: Field, supports_constraints: bool, adapter_type: Optional[str]) -> dict:
+    column = {"name": field_name}
     adapter_type = adapter_type or "snowflake"
     dbt_type = convert_to_sql_type(field, adapter_type)
     if dbt_type is not None:


### PR DESCRIPTION
Currently, exporting in dbt format will output the following yaml(`datacontract export --format dbt-sources --output datacontract.yml input.yml`).

```yaml
version: 2
sources:
- name: my-data-contract-id
  tables:
  - name: my_product
    description: product table
    columns:
    - data_type: STRING
      description: product id
      tests:
        - not_null
        - unique
      meta:
        ...
      name: product_id
```

This yaml is valid as dbt yaml, but the column name is the last of the column attributes. Since the column name is the first attribute we want to see, this pull request modifies the column name so that it is the first of the column attributes.

- [x] Tests pass
- [x] ruff format
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added
