### PR TITLE
fix: populate database and schema values for bigquery in exported dbt sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Modify the arguments to narrow down the import target with `--dbt-model` (#532)
 - SodaCL: Prevent `KeyError: 'fail'` from happening when testing with SodaCL
+- fix: populate database and schema values for bigquery in exported dbt sources (#543)
 
 ## [0.10.15] - 2024-10-26
 

--- a/datacontract/export/dbt_converter.py
+++ b/datacontract/export/dbt_converter.py
@@ -72,8 +72,12 @@ def to_dbt_sources_yaml(data_contract_spec: DataContractSpecification, server: s
     adapter_type = None
     if found_server is not None:
         adapter_type = found_server.type
-        source["database"] = found_server.database
-        source["schema"] = found_server.schema_
+        if adapter_type == "bigquery":
+            source["database"] = found_server.project
+            source["schema"] = found_server.dataset
+        else:
+            source["database"] = found_server.database
+            source["schema"] = found_server.schema_
 
     for model_key, model_value in data_contract_spec.models.items():
         dbt_model = _to_dbt_source_table(model_key, model_value, adapter_type)

--- a/datacontract/export/dbt_converter.py
+++ b/datacontract/export/dbt_converter.py
@@ -59,7 +59,7 @@ def to_dbt_staging_sql(data_contract_spec: DataContractSpecification, model_name
 
 
 def to_dbt_sources_yaml(data_contract_spec: DataContractSpecification, server: str = None):
-    source = {"name": data_contract_spec.id, "tables": []}
+    source = {"name": data_contract_spec.id}
     dbt = {
         "version": 2,
         "sources": [source],
@@ -79,6 +79,7 @@ def to_dbt_sources_yaml(data_contract_spec: DataContractSpecification, server: s
             source["database"] = found_server.database
             source["schema"] = found_server.schema_
 
+    source["tables"] = []
     for model_key, model_value in data_contract_spec.models.items():
         dbt_model = _to_dbt_source_table(model_key, model_value, adapter_type)
         source["tables"].append(dbt_model)

--- a/tests/fixtures/dbt/export/datacontract.yaml
+++ b/tests/fixtures/dbt/export/datacontract.yaml
@@ -20,8 +20,8 @@ servers:
     type: bigquery
     environment: production
     account: my-account
-    database: my-database
-    schema: my-schema
+    project: my-database
+    dataset: my-schema
     roles:
       - name: analyst_us
         description: Access to the data for US region


### PR DESCRIPTION
## Problem

Run the following command on the following yaml file:

```
datacontract export --format dbt-sources --output out.yml datacontract.yaml --server production
```

```yaml
dataContractSpecification: 1.1.0
id: my_contract
info:
  title: my_models
  version: 0.0.1
  dbt_version: 1.8.8
models:
  my_model:
    ...
servers:
  production:
    type: bigquery
    project: my-project
    dataset: my_dataset
```

This will result in a yaml file being generated with null database and schema values. Ideally, the BigQuery project name and dataset name should be entered here.

```yaml
version: 2
sources:
- name: my_models
  tables:
  - name: my_model
    ...
  database: null
  schema: null
```

## Solution
In the case of BigQuery, we added conditions so that project corresponds to database and dataset corresponds to schema.

---

- [x] Tests pass
- [x] ruff format
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added
