### PR TITLE
Fixing the options for importing and exporting to standard output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Modify the arguments to narrow down the import target with `--dbt-model` (#532)
 - SodaCL: Prevent `KeyError: 'fail'` from happening when testing with SodaCL
+- Fixing the options for importing and exporting to standard output (#544)
 
 ## [0.10.15] - 2024-10-26
 

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -221,7 +221,7 @@ def export(
     )
     # Don't interpret console markup in output.
     if output is None:
-        console.print(result, markup=False)
+        console.print(result, markup=False, soft_wrap=True)
     else:
         with output.open("w") as f:
             f.write(result)
@@ -298,7 +298,7 @@ def import_(
         iceberg_table=iceberg_table,
     )
     if output is None:
-        console.print(result.to_yaml())
+        console.print(result.to_yaml(), markup=False, soft_wrap=True)
     else:
         with output.open("w") as f:
             f.write(result.to_yaml())


### PR DESCRIPTION
When executing the import and export subcommands, if `--output` is not specified, the data contract yaml will be output to standard output.

However, when outputting yaml to standard output, since [rich.console](https://rich.readthedocs.io/en/stable/console.html) is used, long descriptions in the yaml may be truncated. This is troublesome because when using file redirection, invalid yaml may be output. This is especially true if you are using a tool like [yq](https://github.com/mikefarah/yq).

Therefore, this pull request adds an option to avoid this.

- [x] Tests pass
- [x] ruff format
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added
