### PR TITLE
When importing in dbt format, add the dbt `not_null` information as a datacontract `required` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- When importing in dbt format, add the dbt `not_null` information as a datacontract `required` field (#547)
 
 ### Changed
 - Type conversion when importing contracts into dbt and exporting contracts from dbt (#534)

--- a/datacontract/imports/dbt_importer.py
+++ b/datacontract/imports/dbt_importer.py
@@ -78,12 +78,18 @@ def import_dbt_manifest(
         dc_model = Model(
             description=model_contents.description,
             tags=model_contents.tags,
-            fields=create_fields(manifest, model_unique_id=model_contents.unique_id, columns=model_contents.columns, adapter_type=adapter_type),
+            fields=create_fields(
+                manifest,
+                model_unique_id=model_contents.unique_id,
+                columns=model_contents.columns,
+                adapter_type=adapter_type,
+            ),
         )
 
         data_contract_specification.models[model_contents.name] = dc_model
 
     return data_contract_specification
+
 
 def convert_data_type_by_adapter_type(data_type: str, adapter_type: str) -> str:
     if adapter_type == "bigquery":
@@ -91,11 +97,10 @@ def convert_data_type_by_adapter_type(data_type: str, adapter_type: str) -> str:
     return data_type
 
 
-def create_fields(manifest: Manifest, model_unique_id: str, columns: dict[str, ColumnInfo], adapter_type: str) -> dict[str, Field]:
-    fields = {
-        column.name: create_field(manifest, model_unique_id, column, adapter_type)
-        for column in columns.values()
-    }
+def create_fields(
+    manifest: Manifest, model_unique_id: str, columns: dict[str, ColumnInfo], adapter_type: str
+) -> dict[str, Field]:
+    fields = {column.name: create_field(manifest, model_unique_id, column, adapter_type) for column in columns.values()}
     return fields
 
 
@@ -119,18 +124,20 @@ def get_column_tests(manifest: Manifest, model_name: str, column_name: str) -> l
         if test_node.column_name != column_name:
             continue
 
-        column_tests.append({
-            "test_name": test_node.name,
-            "test_type": test_node.test_metadata.name,
-            "column": test_node.column_name,
-            "args": test_node.test_metadata.kwargs,
-        })
+        column_tests.append(
+            {
+                "test_name": test_node.name,
+                "test_type": test_node.test_metadata.name,
+                "column": test_node.column_name,
+                "args": test_node.test_metadata.kwargs,
+            }
+        )
     return column_tests
 
 
 def create_field(manifest: Manifest, model_unique_id: str, column: ColumnInfo, adapter_type: str) -> Field:
     column_type = convert_data_type_by_adapter_type(column.data_type, adapter_type) if column.data_type else ""
-    field =  Field(
+    field = Field(
         description=column.description,
         type=column_type,
         tags=column.tags,

--- a/datacontract/imports/dbt_importer.py
+++ b/datacontract/imports/dbt_importer.py
@@ -89,12 +89,18 @@ def convert_data_type_by_adapter_type(data_type: str, adapter_type: str) -> str:
 
 def create_fields(columns: dict[str, ColumnInfo], adapter_type: str) -> dict[str, Field]:
     fields = {
-        column.name: Field(
-            description=column.description,
-            type=convert_data_type_by_adapter_type(column.data_type, adapter_type) if column.data_type else "",
-            tags=column.tags,
-        )
+        column.name: create_field(column, adapter_type)
         for column in columns.values()
     }
 
     return fields
+
+
+def create_field(column: ColumnInfo, adapter_type: str) -> Field:
+    column_type = convert_data_type_by_adapter_type(column.data_type, adapter_type) if column.data_type else ""
+
+    return Field(
+        description=column.description,
+        type=column_type,
+        tags=column.tags,
+    )

--- a/datacontract/imports/dbt_importer.py
+++ b/datacontract/imports/dbt_importer.py
@@ -2,8 +2,8 @@ import json
 from typing import TypedDict
 
 from dbt.artifacts.resources.v1.components import ColumnInfo
-from dbt.contracts.graph.nodes import GenericTestNode
 from dbt.contracts.graph.manifest import Manifest
+from dbt.contracts.graph.nodes import GenericTestNode
 from dbt_common.contracts.constraints import ConstraintType
 
 from datacontract.imports.bigquery_importer import map_type_from_bigquery

--- a/datacontract/imports/dbt_importer.py
+++ b/datacontract/imports/dbt_importer.py
@@ -124,12 +124,14 @@ def get_column_tests(manifest: Manifest, model_name: str, column_name: str) -> l
         if test_node.column_name != column_name:
             continue
 
+        if test_node.config.where is not None:
+            continue
+
         column_tests.append(
             {
                 "test_name": test_node.name,
                 "test_type": test_node.test_metadata.name,
                 "column": test_node.column_name,
-                "args": test_node.test_metadata.kwargs,
             }
         )
     return column_tests

--- a/tests/test_import_dbt.py
+++ b/tests/test_import_dbt.py
@@ -84,9 +84,11 @@ models:
       order_id:
         type: integer
         description: This is a unique identifier for an order
+        required: true
       customer_id:
         type: integer
         description: Foreign key to the customers table
+        required: true
       order_date:
         type: date
         description: Date (UTC) that the order was placed
@@ -114,18 +116,23 @@ models:
       credit_card_amount:
         type: double
         description: Amount of the order (AUD) paid for by credit card
+        required: true
       coupon_amount:
         type: double
         description: Amount of the order (AUD) paid for by coupon
+        required: true
       bank_transfer_amount:
         type: double
         description: Amount of the order (AUD) paid for by bank transfer
+        required: true
       gift_card_amount:
         type: double
         description: Amount of the order (AUD) paid for by gift card
+        required: true
       amount:
         type: double
         description: Total amount (AUD) of the order
+        required: true
     tags: []
   stg_customers:
     description: ''
@@ -133,6 +140,7 @@ models:
       customer_id:
         type: integer
         description: ''
+        required: true
       first_name:
         type: varchar
         description: ''
@@ -146,6 +154,7 @@ models:
       order_id:
         type: integer
         description: ''
+        required: true
       customer_id:
         type: integer
         description: ''
@@ -162,6 +171,7 @@ models:
       payment_id:
         type: integer
         description: ''
+        required: true
       order_id:
         type: integer
         description: ''
@@ -179,6 +189,7 @@ models:
       customer_id:
         type: integer
         description: This is a unique identifier for a customer
+        required: true
       first_name:
         type: varchar
         description: Customer's first name. PII.
@@ -226,9 +237,11 @@ models:
       order_id:
         type: bigint
         description: This is a unique identifier for an order
+        required: true
       customer_id:
         type: bigint
         description: Foreign key to the customers table
+        required: true
       order_date:
         type: date
         description: Date (UTC) that the order was placed
@@ -256,18 +269,23 @@ models:
       credit_card_amount:
         type: double
         description: Amount of the order (AUD) paid for by credit card
+        required: true
       coupon_amount:
         type: double
         description: Amount of the order (AUD) paid for by coupon
+        required: true
       bank_transfer_amount:
         type: double
         description: Amount of the order (AUD) paid for by bank transfer
+        required: true
       gift_card_amount:
         type: double
         description: Amount of the order (AUD) paid for by gift card
+        required: true
       amount:
         type: double
         description: Total amount (AUD) of the order
+        required: true
     tags: []
   stg_customers:
     description: ''
@@ -275,6 +293,7 @@ models:
       customer_id:
         type: bigint
         description: ''
+        required: true
       first_name:
         type: string
         description: ''
@@ -288,6 +307,7 @@ models:
       order_id:
         type: bigint
         description: ''
+        required: true
       customer_id:
         type: bigint
         description: ''
@@ -304,6 +324,7 @@ models:
       payment_id:
         type: bigint
         description: ''
+        required: true
       order_id:
         type: bigint
         description: ''
@@ -321,6 +342,7 @@ models:
       customer_id:
         type: bigint
         description: This is a unique identifier for a customer
+        required: true
       first_name:
         type: string
         description: Customer's first name. PII.
@@ -390,6 +412,7 @@ models:
       customer_id:
         type: integer
         description: This is a unique identifier for a customer
+        required: true
       first_name:
         type: varchar
         description: Customer's first name. PII.


### PR DESCRIPTION
partially resolve https://github.com/datacontract/datacontract-cli/issues/542

dbt can describe `not_null` information as `constraints` or `data_tests`.

However, this information is lost when `datacontract import --format dbt` is executed. This pull request improves this information to be reflected as the `required` field of the data contract.

- [x] Tests pass
- [x] ruff format
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added
