### PR TITLE
nit: Rename dbt's `tests` to `data_tests`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Type conversion when importing contracts into dbt and exporting contracts from dbt (#534)
 - Ensure 'name' is the first column when exporting in dbt format, considering column attributes (#541)
+- Rename dbt's `tests` to `data_tests` (#548)
 
 ### Fixed
 - Modify the arguments to narrow down the import target with `--dbt-model` (#532)

--- a/datacontract/export/dbt_converter.py
+++ b/datacontract/export/dbt_converter.py
@@ -144,10 +144,12 @@ def _to_column(field_name: str, field: Field, supports_constraints: bool, adapte
     column = {"name": field_name}
     adapter_type = adapter_type or "snowflake"
     dbt_type = convert_to_sql_type(field, adapter_type)
+
+    column["data_tests"] = []
     if dbt_type is not None:
         column["data_type"] = dbt_type
     else:
-        column.setdefault("data_tests", []).append(
+        column["data_tests"].append(
             {"dbt_expectations.dbt_expectations.expect_column_values_to_be_of_type": {"column_type": dbt_type}}
         )
     if field.description is not None:
@@ -156,21 +158,21 @@ def _to_column(field_name: str, field: Field, supports_constraints: bool, adapte
         if supports_constraints:
             column.setdefault("constraints", []).append({"type": "not_null"})
         else:
-            column.setdefault("data_tests", []).append("not_null")
+            column["data_tests"].append("not_null")
     if field.unique:
         if supports_constraints:
             column.setdefault("constraints", []).append({"type": "unique"})
         else:
-            column.setdefault("data_tests", []).append("unique")
+            column["data_tests"].append("unique")
     if field.enum is not None and len(field.enum) > 0:
-        column.setdefault("data_tests", []).append({"accepted_values": {"values": field.enum}})
+        column["data_tests"].append({"accepted_values": {"values": field.enum}})
     if field.minLength is not None or field.maxLength is not None:
         length_test = {}
         if field.minLength is not None:
             length_test["min_value"] = field.minLength
         if field.maxLength is not None:
             length_test["max_value"] = field.maxLength
-        column.setdefault("data_tests", []).append(
+        column["data_tests"].append(
             {"dbt_expectations.expect_column_value_lengths_to_be_between": length_test}
         )
     if field.pii is not None:
@@ -181,7 +183,7 @@ def _to_column(field_name: str, field: Field, supports_constraints: bool, adapte
         column.setdefault("tags", []).extend(field.tags)
     if field.pattern is not None:
         # Beware, the data contract pattern is a regex, not a like pattern
-        column.setdefault("data_tests", []).append(
+        column["data_tests"].append(
             {"dbt_expectations.expect_column_values_to_match_regex": {"regex": field.pattern}}
         )
     if (
@@ -195,7 +197,7 @@ def _to_column(field_name: str, field: Field, supports_constraints: bool, adapte
             range_test["min_value"] = field.minimum
         if field.maximum is not None:
             range_test["max_value"] = field.maximum
-        column.setdefault("data_tests", []).append({"dbt_expectations.expect_column_values_to_be_between": range_test})
+        column["data_tests"].append({"dbt_expectations.expect_column_values_to_be_between": range_test})
     elif (
         field.exclusiveMinimum is not None
         or field.exclusiveMaximum is not None
@@ -208,18 +210,18 @@ def _to_column(field_name: str, field: Field, supports_constraints: bool, adapte
         if field.exclusiveMaximum is not None:
             range_test["max_value"] = field.exclusiveMaximum
         range_test["strictly"] = True
-        column.setdefault("data_tests", []).append({"dbt_expectations.expect_column_values_to_be_between": range_test})
+        column["data_tests"].append({"dbt_expectations.expect_column_values_to_be_between": range_test})
     else:
         if field.minimum is not None:
-            column.setdefault("data_tests", []).append(
+            column["data_tests"].append(
                 {"dbt_expectations.expect_column_values_to_be_between": {"min_value": field.minimum}}
             )
         if field.maximum is not None:
-            column.setdefault("data_tests", []).append(
+            column["data_tests"].append(
                 {"dbt_expectations.expect_column_values_to_be_between": {"max_value": field.maximum}}
             )
         if field.exclusiveMinimum is not None:
-            column.setdefault("data_tests", []).append(
+            column["data_tests"].append(
                 {
                     "dbt_expectations.expect_column_values_to_be_between": {
                         "min_value": field.exclusiveMinimum,
@@ -228,7 +230,7 @@ def _to_column(field_name: str, field: Field, supports_constraints: bool, adapte
                 }
             )
         if field.exclusiveMaximum is not None:
-            column.setdefault("data_tests", []).append(
+            column["data_tests"].append(
                 {
                     "dbt_expectations.expect_column_values_to_be_between": {
                         "max_value": field.exclusiveMaximum,
@@ -236,6 +238,9 @@ def _to_column(field_name: str, field: Field, supports_constraints: bool, adapte
                     }
                 }
             )
+
+        if not column["data_tests"]:
+            column.pop("data_tests")
 
     # TODO: all constraints
     return column

--- a/datacontract/export/dbt_converter.py
+++ b/datacontract/export/dbt_converter.py
@@ -147,7 +147,7 @@ def _to_column(field_name: str, field: Field, supports_constraints: bool, adapte
     if dbt_type is not None:
         column["data_type"] = dbt_type
     else:
-        column.setdefault("tests", []).append(
+        column.setdefault("data_tests", []).append(
             {"dbt_expectations.dbt_expectations.expect_column_values_to_be_of_type": {"column_type": dbt_type}}
         )
     if field.description is not None:
@@ -156,21 +156,21 @@ def _to_column(field_name: str, field: Field, supports_constraints: bool, adapte
         if supports_constraints:
             column.setdefault("constraints", []).append({"type": "not_null"})
         else:
-            column.setdefault("tests", []).append("not_null")
+            column.setdefault("data_tests", []).append("not_null")
     if field.unique:
         if supports_constraints:
             column.setdefault("constraints", []).append({"type": "unique"})
         else:
-            column.setdefault("tests", []).append("unique")
+            column.setdefault("data_tests", []).append("unique")
     if field.enum is not None and len(field.enum) > 0:
-        column.setdefault("tests", []).append({"accepted_values": {"values": field.enum}})
+        column.setdefault("data_tests", []).append({"accepted_values": {"values": field.enum}})
     if field.minLength is not None or field.maxLength is not None:
         length_test = {}
         if field.minLength is not None:
             length_test["min_value"] = field.minLength
         if field.maxLength is not None:
             length_test["max_value"] = field.maxLength
-        column.setdefault("tests", []).append(
+        column.setdefault("data_tests", []).append(
             {"dbt_expectations.expect_column_value_lengths_to_be_between": length_test}
         )
     if field.pii is not None:
@@ -181,7 +181,7 @@ def _to_column(field_name: str, field: Field, supports_constraints: bool, adapte
         column.setdefault("tags", []).extend(field.tags)
     if field.pattern is not None:
         # Beware, the data contract pattern is a regex, not a like pattern
-        column.setdefault("tests", []).append(
+        column.setdefault("data_tests", []).append(
             {"dbt_expectations.expect_column_values_to_match_regex": {"regex": field.pattern}}
         )
     if (
@@ -195,7 +195,7 @@ def _to_column(field_name: str, field: Field, supports_constraints: bool, adapte
             range_test["min_value"] = field.minimum
         if field.maximum is not None:
             range_test["max_value"] = field.maximum
-        column.setdefault("tests", []).append({"dbt_expectations.expect_column_values_to_be_between": range_test})
+        column.setdefault("data_tests", []).append({"dbt_expectations.expect_column_values_to_be_between": range_test})
     elif (
         field.exclusiveMinimum is not None
         or field.exclusiveMaximum is not None
@@ -208,18 +208,18 @@ def _to_column(field_name: str, field: Field, supports_constraints: bool, adapte
         if field.exclusiveMaximum is not None:
             range_test["max_value"] = field.exclusiveMaximum
         range_test["strictly"] = True
-        column.setdefault("tests", []).append({"dbt_expectations.expect_column_values_to_be_between": range_test})
+        column.setdefault("data_tests", []).append({"dbt_expectations.expect_column_values_to_be_between": range_test})
     else:
         if field.minimum is not None:
-            column.setdefault("tests", []).append(
+            column.setdefault("data_tests", []).append(
                 {"dbt_expectations.expect_column_values_to_be_between": {"min_value": field.minimum}}
             )
         if field.maximum is not None:
-            column.setdefault("tests", []).append(
+            column.setdefault("data_tests", []).append(
                 {"dbt_expectations.expect_column_values_to_be_between": {"max_value": field.maximum}}
             )
         if field.exclusiveMinimum is not None:
-            column.setdefault("tests", []).append(
+            column.setdefault("data_tests", []).append(
                 {
                     "dbt_expectations.expect_column_values_to_be_between": {
                         "min_value": field.exclusiveMinimum,
@@ -228,7 +228,7 @@ def _to_column(field_name: str, field: Field, supports_constraints: bool, adapte
                 }
             )
         if field.exclusiveMaximum is not None:
-            column.setdefault("tests", []).append(
+            column.setdefault("data_tests", []).append(
                 {
                     "dbt_expectations.expect_column_values_to_be_between": {
                         "max_value": field.exclusiveMaximum,

--- a/tests/test_export_dbt_models.py
+++ b/tests/test_export_dbt_models.py
@@ -22,7 +22,7 @@ def test_to_dbt_models():
     expected_dbt_model = """
 version: 2
 models:
-  - name: orders    
+  - name: orders
     config:
       meta:
         owner: checkout
@@ -37,12 +37,12 @@ models:
         constraints:
           - type: not_null
           - type: unique
-        tests:
+        data_tests:
           - dbt_expectations.expect_column_value_lengths_to_be_between:
               min_value: 8
               max_value: 10
           - dbt_expectations.expect_column_values_to_match_regex:
-              regex: ^B[0-9]+$      
+              regex: ^B[0-9]+$
         meta:
           classification: sensitive
           pii: true
@@ -51,9 +51,9 @@ models:
       - name: order_total
         data_type: NUMBER
         constraints:
-          - type: not_null    
+          - type: not_null
         description: The order_total field
-        tests:
+        data_tests:
           - dbt_expectations.expect_column_values_to_be_between:
                min_value: 0
                max_value: 1000000
@@ -61,7 +61,7 @@ models:
         data_type: TEXT
         constraints:
           - type: not_null
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 - 'pending'

--- a/tests/test_export_dbt_sources.py
+++ b/tests/test_export_dbt_sources.py
@@ -43,7 +43,7 @@ sources:
         columns:
           - name: order_id
             data_type: VARCHAR
-            tests:
+            data_tests:
               - not_null
               - unique
               - dbt_expectations.expect_column_value_lengths_to_be_between:
@@ -59,14 +59,14 @@ sources:
           - name: order_total
             description: The order_total field
             data_type: NUMBER
-            tests:
+            data_tests:
               - not_null
               - dbt_expectations.expect_column_values_to_be_between:
                    min_value: 0
                    max_value: 1000000
           - name: order_status
             data_type: TEXT
-            tests:
+            data_tests:
               - not_null
               - accepted_values:
                   values:
@@ -97,7 +97,7 @@ sources:
         columns:
           - name: order_id
             data_type: STRING
-            tests:
+            data_tests:
               - not_null
               - unique
               - dbt_expectations.expect_column_value_lengths_to_be_between:
@@ -113,14 +113,14 @@ sources:
           - name: order_total
             description: The order_total field
             data_type: INT64
-            tests:
+            data_tests:
               - not_null
               - dbt_expectations.expect_column_values_to_be_between:
                    min_value: 0
                    max_value: 1000000
           - name: order_status
             data_type: STRING
-            tests:
+            data_tests:
               - not_null
               - accepted_values:
                   values:


### PR DESCRIPTION
From dbt v1.8, `tests` are now called `data tests` to disambiguate from unit tests. Since it is now recommended to use `data_tests`, we will modify the export to dbt format to use `data_tests`.

- [x] Tests pass
- [x] ruff format
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added
