### PR TITLE
Define `primaryKey` and `examples` for model to follow the changes in datacontract-specification v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Define primaryKey and examples for model to follow the changes in datacontract-specification v1.1.0 (#559)
 
 ## [0.10.16] - 2024-12-19
 

--- a/datacontract/model/data_contract_specification.py
+++ b/datacontract/model/data_contract_specification.py
@@ -186,6 +186,8 @@ class Model(pyd.BaseModel):
     title: Optional[str] = None
     fields: Dict[str, Field] = {}
     quality: List[Quality] | None = []
+    primaryKey: List[str] | None = []
+    examples: List[Any] | None = None
     config: Dict[str, Any] = None
     tags: List[str] | None = None
 


### PR DESCRIPTION
In datacontract-specification v1.1.0, the model-level `primaryKey` and `examples` were added to the fields.

- https://github.com/datacontract/datacontract-specification/pull/95
- https://datacontract.com/#model-object

However, the addition of model-level `primaryKey` and `examples` was not reflected in the implementation of datacontract-cli, so we added it.

---

This pull request is mainly for https://github.com/datacontract/datacontract-cli/pull/562, but since defining `primaryKey` and `examples` is a topic that goes beyond dbt-style imports, I've split it out into this pull request.

- [x] Tests pass
- [x] ruff format
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added
