### PR TITLE
fix: Primary and example fields have been deprecated in Data Contract Specification v1.1.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When importing in dbt format, add the dbt unique information as a datacontract unique field (#558)
 
 ### Changed
+- fix: Primary and example fields have been deprecated in Data Contract Specification v1.1.0 (#561)
 
 ## [0.10.16] - 2024-12-19
 

--- a/datacontract/model/data_contract_specification.py
+++ b/datacontract/model/data_contract_specification.py
@@ -146,7 +146,10 @@ class Field(pyd.BaseModel):
     type: str = None
     format: str = None
     required: bool = None
-    primary: bool = None
+    primary: bool = pyd.Field(
+        default=None,
+        deprecated="Removed in Data Contract Specification v1.1.0. Use " "primaryKey instead.",
+    )
     primaryKey: bool = None
     unique: bool | None = None
     references: str = None
@@ -169,7 +172,10 @@ class Field(pyd.BaseModel):
     values: "Field" = None
     precision: int = None
     scale: int = None
-    example: str = None
+    example: str = pyd.Field(
+        default=None,
+        deprecated="Removed in Data Contract Specification v1.1.0. Use " "examples instead.",
+    )
     examples: List[Any] | None = None
     quality: List[Quality] | None = []
     config: Dict[str, Any] | None = None


### PR DESCRIPTION
Almost same as https://github.com/datacontract/datacontract-cli/pull/559 (ref: https://github.com/datacontract/datacontract-specification/commit/59cebdb4c1f716ff0b83c36d99d230f2526fb0f2#diff-895e6ef6de060fb42770fde8770b906e6528e0f01434be7dbb55a2c4e3cbefd1R568).

- [x] Tests pass
- [x] ruff format
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added
