### PR TITLE
Allow datacontract import to be run offline

### DIFF
--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -284,6 +284,18 @@ def import_(
         Optional[str],
         typer.Option(help="Table name to assign to the model created from the Iceberg schema."),
     ] = None,
+    template: Annotated[
+        Optional[str],
+        typer.Option(
+            help="The location (url or path) of the Data Contract Specification Template"
+        ),
+    ] = None,
+    schema: Annotated[
+        str,
+        typer.Option(
+            help="The location (url or path) of the Data Contract Specification JSON Schema"
+        ),
+    ] = DEFAULT_DATA_CONTRACT_SCHEMA_URL,
 ):
     """
     Create a data contract from the given source location. Saves to file specified by `output` option if present, otherwise prints to stdout.
@@ -291,6 +303,8 @@ def import_(
     result = DataContract().import_from_source(
         format=format,
         source=source,
+        template=template,
+        schema=schema,
         glue_table=glue_table,
         bigquery_table=bigquery_table,
         bigquery_project=bigquery_project,

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -37,6 +37,7 @@ from datacontract.model.data_contract_specification import DataContractSpecifica
 from datacontract.model.exceptions import DataContractException
 from datacontract.model.run import Check, Run
 
+DEFAULT_DATA_CONTRACT_TEMPLATE_URL = "https://datacontract.com/datacontract.init.yaml"
 
 class DataContract:
     def __init__(
@@ -75,8 +76,10 @@ class DataContract:
         }
 
     @classmethod
-    def init(cls, template: str = "https://datacontract.com/datacontract.init.yaml") -> DataContractSpecification:
-        return resolve.resolve_data_contract(data_contract_location=template)
+    def init(cls, template: str = DEFAULT_DATA_CONTRACT_TEMPLATE_URL, schema: typing.Optional[str] = None) -> DataContractSpecification:
+        return resolve.resolve_data_contract(
+            data_contract_location=template, schema_location=schema
+        )
 
     def lint(self, enabled_linters: typing.Union[str, set[str]] = "all") -> Run:
         """Lint the data contract by deserializing the contract and checking the schema, as well as calling the configured linters.
@@ -347,10 +350,12 @@ class DataContract:
         )
 
     def import_from_source(
-        self, format: str, source: typing.Optional[str] = None, **kwargs
+        self, format: str, source: typing.Optional[str] = None, template: typing.Optional[str] = None, schema: typing.Optional[str] = None, **kwargs
     ) -> DataContractSpecification:
-        data_contract_specification_initial = DataContract.init()
+        template = DEFAULT_DATA_CONTRACT_TEMPLATE_URL if template is None else template
+        data_contract_specification_initial = DataContract.init(template=template, schema=schema)
 
         return importer_factory.create(format).import_source(
             data_contract_specification=data_contract_specification_initial, source=source, import_args=kwargs
         )
+


### PR DESCRIPTION
Right now, schema and template are always downloaded from the default URLs, which might not be accessible in a restricted environment.
Add --schema and --template parameters to datacontract import.
- [ ] Tests pass
- [ ] ruff format
- [ ] README.md updated (if relevant)
- [ ] CHANGELOG.md entry added
