### PR TITLE
Fix format of data-caterer YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - datacontract lint: Linter 'Field references existing field' too many values to unpack (expected
   2) (#586)
 - datacontract test (Azure): Error querying delta tables from azure storage. (#458)
+- datacontract export --format data-caterer: Use `fields` instead of `schema`
+- datacontract export --format data-caterer: Use `options` instead of `generator.options`
+- datacontract export --format data-caterer: Capture array type length option and inner data type
 
 ## [0.10.18] - 2024-01-18
 

--- a/README.md
+++ b/README.md
@@ -950,20 +950,6 @@ To specify custom Avro properties in your data contract, you can define them wit
 
 >NOTE: At this moment, we just support [logicalType](https://avro.apache.org/docs/1.11.0/spec.html#Logical+Types) and [default](https://avro.apache.org/docs/1.11.0/spec.htm)
 
-#### Data Caterer
-
-The export function converts the data contract to a data generation task in YAML format that can be 
-ingested by [Data Caterer](https://github.com/data-catering/data-caterer). This gives you the 
-ability to generate production-like data in any environment based off your data contract.
-
-```shell
-datacontract export datacontract.yaml --format data-caterer --model orders
-```
-
-You can further customise the way data is generated via adding 
-[additional metadata in the YAML](https://data.catering/setup/generator/data-generator/) 
-to suit your needs.
-
 #### Example Configuration
 
 ```yaml
@@ -993,6 +979,20 @@ models:
   - **config**: Section to specify custom Avro properties.
     - **avroLogicalType**: Specifies the logical type of the field in Avro. In this example, it is `local-timestamp-micros`.
     - **avroDefault**: Specifies the default value for the field in Avro. In this example, it is 1672534861000000 which corresponds to ` 2023-01-01 01:01:01 UTC`.
+
+#### Data Caterer
+
+The export function converts the data contract to a data generation task in YAML format that can be
+ingested by [Data Caterer](https://github.com/data-catering/data-caterer). This gives you the
+ability to generate production-like data in any environment based off your data contract.
+
+```shell
+datacontract export datacontract.yaml --format data-caterer --model orders
+```
+
+You can further customise the way data is generated via adding
+[additional metadata in the YAML](https://data.catering/setup/generator/data-generator/)
+to suit your needs.
 
 #### Iceberg
 

--- a/tests/fixtures/data-caterer/export/datacontract_nested.yaml
+++ b/tests/fixtures/data-caterer/export/datacontract_nested.yaml
@@ -36,6 +36,7 @@ models:
         maxLength: 10
         pii: true
         classification: sensitive
+        primaryKey: true
         tags:
           - order_id
         pattern: ^B[0-9]+$
@@ -45,6 +46,28 @@ models:
         description: The order_total field
         minimum: 0
         maximum: 1000000
+      amount:
+        type: double
+      customer_id:
+        type: integer
+      customer_id_int:
+        type: int
+      customer_id_long:
+        type: long
+      customer_id_float:
+        type: float
+      customer_id_number:
+        type: number
+      customer_id_numeric:
+        type: numeric
+      created_date:
+        type: date
+      created_ts:
+        type: timestamp
+      created_ts_tz:
+        type: timestamp_tz
+      created_ts_ntz:
+        type: timestamp_ntz
       order_status:
         type: text
         required: true
@@ -59,3 +82,11 @@ models:
             type: string
           city:
             type: string
+      tags:
+        type: array
+        items:
+          type: string
+      tags_int:
+        type: array
+        items:
+          type: integer

--- a/tests/test_export_data_caterer.py
+++ b/tests/test_export_data_caterer.py
@@ -47,37 +47,64 @@ steps:
   type: json
   options:
     path: {path}
-  schema:
+  fields:
   - name: order_id
     type: string
-    generator:
-      options:
-        isUnique: true
-        minLength: 8
-        maxLength: 10
-        regex: ^B[0-9]+$
+    options:
+      isUnique: true
+      minLen: 8
+      maxLen: 10
+      regex: ^B[0-9]+$
+      isPrimaryKey: true
   - name: order_total
     type: decimal
-    generator:
-      options:
-        min: 0
-        max: 1000000
+    options:
+      min: 0
+      max: 1000000
+  - name: amount
+    type: double
+  - name: customer_id
+    type: integer
+  - name: customer_id_int
+    type: integer
+  - name: customer_id_long
+    type: long
+  - name: customer_id_float
+    type: float
+  - name: customer_id_number
+    type: double
+  - name: customer_id_numeric
+    type: double
+  - name: created_date
+    type: date
+  - name: created_ts
+    type: timestamp
+  - name: created_ts_tz
+    type: timestamp
+  - name: created_ts_ntz
+    type: timestamp
   - name: order_status
     type: string
-    generator:
-      options:
-        oneOf:
-        - pending
-        - shipped
-        - delivered
+    options:
+      oneOf:
+      - pending
+      - shipped
+      - delivered
   - name: address
     type: struct
-    schema:
-      fields:
-      - name: street
-        type: string
-      - name: city
-        type: string
+    fields:
+    - name: street
+      type: string
+    - name: city
+      type: string
+  - name: tags
+    type: array
+    options:
+      arrayType: string
+  - name: tags_int
+    type: array
+    options:
+      arrayType: integer
 """
 
 


### PR DESCRIPTION
- use `fields` instead of `schema`
- use `options` instead of `generator.options`

- [x] Tests pass
- [x] ruff format
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added
