### PR TITLE
Adding new enum members should not be breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - datacontract export --format html: The composite primary key is now shown. (#591)
 - datacontract export --format html: now examples are rendered in the model and definition (#497)
 - datacontract export --format sql: Create arrays and struct for Databricks (#467)
+- Adding new members to enums without removing existing ones is no longer a breaking change
 
 ### Fixed
 - datacontract lint: Linter 'Field references existing field' too many values to unpack (expected

--- a/datacontract/breaking/breaking.py
+++ b/datacontract/breaking/breaking.py
@@ -493,8 +493,12 @@ def field_breaking_changes(
                 rule_name = f"field_{_camel_to_snake(field_definition_field)}_removed"
                 description = "removed field property"
             elif sorted(old_value) != sorted(new_value):
-                rule_name = f"field_{_camel_to_snake(field_definition_field)}_updated"
                 description = f"changed from `{old_value}` to `{new_value}`"
+                if field_definition_field == "enum" and all(item in new_value for item in old_value):
+                    # new_value contains all items in old_value, therefore only new members added to enum
+                    rule_name = "field_enum_members_added"
+                else:
+                    rule_name = f"field_{_camel_to_snake(field_definition_field)}_updated"
 
         # logic for normal fields
         elif old_value is None and new_value is not None:

--- a/datacontract/breaking/breaking_rules.py
+++ b/datacontract/breaking/breaking_rules.py
@@ -95,6 +95,7 @@ class BreakingRules:
     field_enum_added = Severity.WARNING
     field_enum_removed = Severity.INFO
     field_enum_updated = Severity.ERROR
+    field_enum_members_added = Severity.INFO
 
     field_tags_added = Severity.INFO
     field_tags_removed = Severity.INFO

--- a/tests/test_breaking.py
+++ b/tests/test_breaking.py
@@ -161,9 +161,32 @@ def test_fields_updated():
     output = result.stdout
 
     assert result.exit_code == 1
-    assert "18 breaking changes: 15 error, 3 warning\n" in output
+    assert "17 breaking changes: 14 error, 3 warning\n" in output
     assert "field_description_updated" not in output
     assert "field_tags_updated" not in output
+    assert "field_enum_updated" not in output
+    assert "field_enum_members_added" not in output
+
+
+def test_enum_values_removed():
+    result = runner.invoke(
+        app,
+        [
+            "breaking",
+            "./fixtures/breaking/datacontract-fields-v3.yaml",
+            "./fixtures/breaking/datacontract-fields-v2.yaml",
+        ],
+    )
+
+    output = result.stdout
+
+    assert result.exit_code == 1
+    assert (
+        r"""error   [field_enum_updated] at ./fixtures/breaking/datacontract-fields-v2.yaml
+        in models.my_table.fields.field_enum.enum
+            changed from `['one', 'two']` to `['one']`"""
+        in output
+    )
 
 
 def test_definition_added():

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -494,7 +494,7 @@ def test_fields_updated():
     )
     output = result.stdout
     assert result.exit_code == 0
-    assert "21 changes: 15 error, 3 warning, 3 info\n" in output
+    assert "21 changes: 14 error, 3 warning, 4 info\n" in output
     assert (
         r"""error   [field_type_updated] at ./fixtures/breaking/datacontract-fields-v3.yaml
         in models.my_table.fields.field_type.type
@@ -606,7 +606,8 @@ def test_fields_updated():
         in output
     )
     assert (
-        r"""error   [field_enum_updated] at ./fixtures/breaking/datacontract-fields-v3.yaml
+        r"""info    [field_enum_members_added] at 
+./fixtures/breaking/datacontract-fields-v3.yaml
         in models.my_table.fields.field_enum.enum
             changed from `['one']` to `['one', 'two']`"""
         in output


### PR DESCRIPTION
Adding new members to enums without removing existing members should not be a breaking change. This PR adds a new `field_enum_members_added` breaking change rule with severity `info` - i.e. not breaking.

- [x] Tests pass
- [x] ruff format
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added
