### PR TITLE
fix(resolve): extract ref paths prior to parsing definitions

### DIFF
--- a/datacontract/lint/resolve.py
+++ b/datacontract/lint/resolve.py
@@ -125,11 +125,24 @@ def _resolve_definition_ref(ref, spec) -> Definition:
         path = path.replace("file://", "")
         definition_str = _fetch_file(path)
         definition_dict = _to_yaml(definition_str)
+        if definition_path:
+            path_parts = [part for part in definition_path.split("/") if part != ""]
+            for path_part in path_parts:
+                definition_dict = definition_dict.get(path_part, None)
+                if not definition_dict:
+                    raise DataContractException(
+                        type="lint",
+                        result="failed",
+                        name="Check that data contract YAML is valid",
+                        reason=f"Cannot resolve definition {definition_path}, {path_part} not found",
+                        engine="datacontract",
+                    )
+        # this assumes that definitions_dict is a definitions dict, however,
+        # all we know is that it is a file!
         definition = Definition(**definition_dict)
-        if definition_path is not None:
-            return _find_by_path_in_definition(definition_path, definition)
-        else:
-            return definition
+        # if definition_path is not None:
+        #     definition = _find_by_path_in_definition(definition_path, definition)
+        return definition
     elif ref.startswith("#"):
         logging.info(f"Resolving definition local path {path}")
 

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -169,3 +169,39 @@ def test_resolve_data_contract_complex_definition_file():
             inline_definitions=True,
         )
         assert datacontract.models["orders"].fields["order_id"].type == "int"
+
+def test_resolve_data_contract_relative_refrence():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # create temp file with content
+        with open(f"{temp_dir}/order.yaml", "w") as temp_file:
+            temp_file.write("""
+definitions:
+  order_id:
+    title: order id
+    type: text
+    examples:
+      - O1234
+    pii: True
+    classification: restricted
+    tags:
+      - policy
+            """)
+            temp_file.flush()
+            print(temp_file.name)
+
+        datacontract = resolve_data_contract(
+            data_contract_str=f"""
+        dataContractSpecification: 1.1.0
+        id: my-id
+        info:
+          title: My Title
+          version: 1.0.0
+        models:
+          orders:
+            fields:
+              order_id:
+                $ref: "file://{temp_dir}/order.yaml#/definitions/order_id"
+        """,
+            inline_definitions=True,
+        )
+        assert datacontract.models["orders"].fields["order_id"].type == "text"


### PR DESCRIPTION
fixes #664

- [] Tests pass
- [ ] ruff format
- [ ] README.md updated (if relevant)
- [ ] CHANGELOG.md entry added
