### PR TITLE
Add DBT sql dialect column data types with support for optional --server flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `datacontract test --output-format junit --output TEST-datacontract.xml` Export CLI test results
   to a file, in a standard format (e.g. JUnit) to improve CI/CD experience (#650)
+- `dbt` & `dbt-sources` export formats now support the optional `--server` flag to adapt the DBT column `data_type` to specific SQL dialects
 
 ### Changed
 
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Unicode Encode Error when exporting data contract YAML to HTML
   (#652)
+- Fix multiline descriptions in the DBT export functionality
 
 ## [0.10.22] - 2025-02-20
 

--- a/README.md
+++ b/README.md
@@ -949,6 +949,12 @@ The export function converts the logical data types of the datacontract into the
 if a server is selected via the `--server` option (based on the `type` of that server). If no server is selected, the
 logical data types are exported.
 
+#### DBT & DBT-SOURCES
+
+The export funciton converts the datacontract to dbt models in YAML format, with support for SQL dialects.
+If a server is selected via the `--server` option (based on the `type` of that server) then the DBT column `data_types` match the expected data types of the server.
+If no server is selected, then it defaults to `snowflake`.
+
 #### Spark
 
 The export function converts the data contract specification into a StructType Spark schema. The returned value is a Python code picture of the model schemas.


### PR DESCRIPTION
- [x] Tests pass
- [x] ruff format
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added

## Changes

-  `dbt` & `dbt-sources` export formats now support the optional `--server` flag to adapt the DBT column `data_type` to specific SQL dialects
- Fix multiline descriptions in the DBT export functionality


Motivation behind this PR is that we use DBT and BigQuery as part of ETL pipelines, but when exporting datacontracts into DBT yaml formats, the column `data_types` didn't match those expected in Bigquery.

The DBT exporter now relies on the `server`/`adapter_type` being passed down to the `_to_column()` function to correctly determine the column data type.