### PR TITLE
ref: expose the `data_contract_file` variable

### DIFF
--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -46,7 +46,7 @@ class DataContract:
         inline_quality: bool = True,
         ssl_verification: bool = True,
     ):
-        self._data_contract_file = data_contract_file
+        self.data_contract_file = data_contract_file
         self._data_contract_str = data_contract_str
         self._data_contract = data_contract
         self._schema_location = schema_location
@@ -80,7 +80,7 @@ class DataContract:
         try:
             run.log_info("Linting data contract")
             data_contract = resolve.resolve_data_contract(
-                self._data_contract_file,
+                self.data_contract_file,
                 self._data_contract_str,
                 self._data_contract,
                 self._schema_location,
@@ -142,7 +142,7 @@ class DataContract:
         try:
             run.log_info("Testing data contract")
             data_contract = resolve.resolve_data_contract(
-                self._data_contract_file,
+                self.data_contract_file,
                 self._data_contract_str,
                 self._data_contract,
                 self._schema_location,
@@ -200,7 +200,7 @@ class DataContract:
             info_breaking_changes(
                 old_info=old.info,
                 new_info=new.info,
-                new_path=other._data_contract_file,
+                new_path=other.data_contract_file,
                 include_severities=include_severities,
             )
         )
@@ -209,7 +209,7 @@ class DataContract:
             terms_breaking_changes(
                 old_terms=old.terms,
                 new_terms=new.terms,
-                new_path=other._data_contract_file,
+                new_path=other.data_contract_file,
                 include_severities=include_severities,
             )
         )
@@ -218,7 +218,7 @@ class DataContract:
             quality_breaking_changes(
                 old_quality=old.quality,
                 new_quality=new.quality,
-                new_path=other._data_contract_file,
+                new_path=other.data_contract_file,
                 include_severities=include_severities,
             )
         )
@@ -227,7 +227,7 @@ class DataContract:
             models_breaking_changes(
                 old_models=old.models,
                 new_models=new.models,
-                new_path=other._data_contract_file,
+                new_path=other.data_contract_file,
                 include_severities=include_severities,
             )
         )
@@ -236,7 +236,7 @@ class DataContract:
 
     def get_data_contract_specification(self) -> DataContractSpecification:
         return resolve.resolve_data_contract(
-            data_contract_location=self._data_contract_file,
+            data_contract_location=self.data_contract_file,
             data_contract_str=self._data_contract_str,
             data_contract=self._data_contract,
             schema_location=self._schema_location,
@@ -246,7 +246,7 @@ class DataContract:
 
     def export(self, export_format: ExportFormat, model: str = "all", sql_server_type: str = "auto", **kwargs) -> str:
         data_contract = resolve.resolve_data_contract(
-            self._data_contract_file,
+            self.data_contract_file,
             self._data_contract_str,
             self._data_contract,
             schema_location=self._schema_location,

--- a/datacontract/imports/avro_importer.py
+++ b/datacontract/imports/avro_importer.py
@@ -55,7 +55,7 @@ def import_avro(data_contract_specification: DataContractSpecification, source: 
             engine="datacontract",
             original_exception=e,
         )
-  # type record is being used for both the table and the object types in data contract
+    # type record is being used for both the table and the object types in data contract
     # -> CONSTRAINT: one table per .avsc input, all nested records are interpreted as objects
     fields = import_record_fields(avro_schema.fields)
 
@@ -92,19 +92,19 @@ def handle_config_avro_custom_properties(field: avro.schema.Field, imported_fiel
 
 
 LOGICAL_TYPE_MAPPING = {
-     "decimal": "decimal",
-     "date": "date",
-     "time-millis": "time",
-     "time-micros": "time",
-     "timestamp-millis": "timestamp_tz",
-     "timestamp-micros": "timestamp_tz",
-     "local-timestamp-micros": "timestamp_ntz",
-     "local-timestamp-millis": "timestamp_ntz",
-     "duration": "string",
-     "uuid": "string",
- }
-    
-  
+    "decimal": "decimal",
+    "date": "date",
+    "time-millis": "time",
+    "time-micros": "time",
+    "timestamp-millis": "timestamp_tz",
+    "timestamp-micros": "timestamp_tz",
+    "local-timestamp-micros": "timestamp_ntz",
+    "local-timestamp-millis": "timestamp_ntz",
+    "duration": "string",
+    "uuid": "string",
+}
+
+
 def import_record_fields(record_fields: List[avro.schema.Field]) -> Dict[str, Field]:
     """
     Import Avro record fields and convert them to data contract fields.
@@ -150,15 +150,15 @@ def import_record_fields(record_fields: List[avro.schema.Field]) -> Dict[str, Fi
             if not imported_field.config:
                 imported_field.config = {}
             imported_field.config["avroType"] = "enum"
-        else:  
-             logical_type = field.type.get_prop("logicalType")
-             if logical_type in LOGICAL_TYPE_MAPPING:
-                 imported_field.type = LOGICAL_TYPE_MAPPING[logical_type]
-                 if logical_type == "decimal":
-                     imported_field.precision = field.type.precision
-                     imported_field.scale = field.type.scale
-             else:
-                 imported_field.type = map_type_from_avro(field.type.type)
+        else:
+            logical_type = field.type.get_prop("logicalType")
+            if logical_type in LOGICAL_TYPE_MAPPING:
+                imported_field.type = LOGICAL_TYPE_MAPPING[logical_type]
+                if logical_type == "decimal":
+                    imported_field.precision = field.type.precision
+                    imported_field.scale = field.type.scale
+            else:
+                imported_field.type = map_type_from_avro(field.type.type)
         imported_fields[field.name] = imported_field
 
     return imported_fields

--- a/datacontract/imports/protobuf_importer.py
+++ b/datacontract/imports/protobuf_importer.py
@@ -238,7 +238,6 @@ def import_protobuf(
             os.remove(descriptor_file)
 
 
-
 class ProtoBufImporter(Importer):
     def __init__(self, name):
         # 'name' is passed by the importer factory.
@@ -263,4 +262,3 @@ class ProtoBufImporter(Importer):
         """
         # Wrap the source in a list because import_protobuf expects a list of sources.
         return import_protobuf(data_contract_specification, [source], import_args)
-


### PR DESCRIPTION
- [ ] Tests pass
- [X] ruff format
- [ ] README.md updated (if relevant)
- [ ] CHANGELOG.md entry added

I suggest exposing the `data_contract_file` variable from the `DataContract`-object so that it can be indirectly exposed and used for other purposes. An alternative approach for this is to add some `getter`-functions to be able to fetch this information from the `DataContract`-object.

Open for any inputs or further suggestions 😄 