### PR TITLE
Resolve FastAPI deprecation warning for example fields

### DIFF
--- a/datacontract/api.py
+++ b/datacontract/api.py
@@ -162,7 +162,7 @@ async def test(
     server: Annotated[
         str | None,
         Query(
-            example="production",
+            examples=["production"],
             description="The server name to test. Optional, if there is only one server.",
         ),
     ] = None,
@@ -191,7 +191,7 @@ async def lint(
     schema: Annotated[
         str | None,
         Query(
-            example="https://datacontract.com/datacontract.schema.json",
+            examples=["https://datacontract.com/datacontract.schema.json"],
             description="The schema to use for validation. This must be a URL.",
         ),
     ] = None,
@@ -220,7 +220,7 @@ def export(
     server: Annotated[
         str | None,
         Query(
-            example="production",
+            examples=["production"],
             description="The server name to export. Optional, if there is only one server.",
         ),
     ] = None,


### PR DESCRIPTION
# PR Summary
This small PR resolves deprecation warnings for the `example` parameter in FastAPI's `Query` object, replacing it with the recommended `examples` parameter. These warnings were visible in the [CI logs](https://www.google.com/url?sa=E&q=https%3A%2F%2Fgithub.com%2Fdatacontract%2Fdatacontract-cli%2Factions%2Fruns%2F14550437258%2Fjob%2F40820964851%23step%3A7%3A102):
```python
datacontract/api.py:164
  /home/runner/work/datacontract-cli/datacontract-cli/datacontract/api.py:164: DeprecationWarning: `example` has been deprecated, please use `examples` instead
    Query(

datacontract/api.py:193
  /home/runner/work/datacontract-cli/datacontract-cli/datacontract/api.py:193: DeprecationWarning: `example` has been deprecated, please use `examples` instead
    Query(

datacontract/api.py:222
  /home/runner/work/datacontract-cli/datacontract-cli/datacontract/api.py:222: DeprecationWarning: `example` has been deprecated, please use `examples` instead
    Query(
```


- [x] Tests pass
- [x] ruff format
- [ ] README.md updated (if relevant)
- [ ] CHANGELOG.md entry added

