### PR TITLE
Include custom quality rules in great expectations export

### DIFF
--- a/datacontract/export/great_expectations_converter.py
+++ b/datacontract/export/great_expectations_converter.py
@@ -19,6 +19,7 @@ from datacontract.export.spark_converter import to_spark_data_type
 from datacontract.export.sql_type_converter import convert_to_sql_type
 from datacontract.model.data_contract_specification import (
     DataContractSpecification,
+    DeprecatedQuality,
     Field,
     Quality,
 )
@@ -91,8 +92,14 @@ def to_great_expectations(
             model_key=model_key, contract_version=data_contract_spec.info.version
         )
     model_value = data_contract_spec.models.get(model_key)
-    quality_checks = get_quality_checks(data_contract_spec.quality)
+
+    # Support for Deprecated Quality
+    quality_checks = get_deprecated_quality_checks(data_contract_spec.quality)
+
+    expectations.extend(get_quality_checks(model_value.quality))
+
     expectations.extend(model_to_expectations(model_value.fields, engine, sql_server_type))
+
     expectations.extend(checks_to_expectations(quality_checks, model_key))
     model_expectation_suite = to_suite(expectations, expectation_suite_name)
 
@@ -135,6 +142,8 @@ def model_to_expectations(fields: Dict[str, Field], engine: str | None, sql_serv
     add_column_order_exp(fields, expectations)
     for field_name, field in fields.items():
         add_field_expectations(field_name, field, expectations, engine, sql_server_type)
+        expectations.extend(get_quality_checks(field.quality, field_name))
+        # Add field quality here
     return expectations
 
 
@@ -173,6 +182,8 @@ def add_field_expectations(
         expectations.append(to_column_length_exp(field_name, field.minLength, field.maxLength))
     if field.minimum is not None or field.maximum is not None:
         expectations.append(to_column_min_max_exp(field_name, field.minimum, field.maximum))
+    if field.enum is not None and len(field.enum) != 0:
+        expectations.append(to_column_enum_exp(field_name, field.enum))
 
     return expectations
 
@@ -266,7 +277,24 @@ def to_column_min_max_exp(field_name, minimum, maximum) -> Dict[str, Any]:
     }
 
 
-def get_quality_checks(quality: Quality) -> Dict[str, Any]:
+def to_column_enum_exp(field_name, enum_list: List[str]) -> Dict[str, Any]:
+    """Creates a expect_column_values_to_be_in_set expectation.
+
+    Args:
+        field_name (str): The name of the field.
+        enum_list (Set[str]): enum list of value.
+
+    Returns:
+        Dict[str, Any]: Column value in set expectation.
+    """
+    return {
+        "expectation_type": "expect_column_values_to_be_in_set",
+        "kwargs": {"column": field_name, "value_set": enum_list},
+        "meta": {},
+    }
+
+
+def get_deprecated_quality_checks(quality: DeprecatedQuality) -> Dict[str, Any]:
     """Retrieves quality checks defined in a data contract.
 
     Args:
@@ -285,6 +313,26 @@ def get_quality_checks(quality: Quality) -> Dict[str, Any]:
         quality_specification = yaml.safe_load(quality.specification)
     else:
         quality_specification = quality.specification
+    return quality_specification
+
+
+def get_quality_checks(qualities: List[Quality], field_name: str | None = None) -> List[Dict[str, Any]]:
+    """Retrieves quality checks defined in a data contract.
+
+    Args:
+        qualities (List[Quality]): List of quality object from the model specification.
+        field_name (str | None): field name if the quality list is attached to a specific field
+
+    Returns:
+        Dict[str, Any]: Dictionary of quality checks.
+    """
+    quality_specification = []
+    for quality in qualities:
+        if quality is not None and quality.engine is not None and quality.engine.lower() == "great-expectations":
+            ge_expectation = quality.implementation
+            if field_name is not None:
+                ge_expectation["column"] = field_name
+            quality_specification.append(ge_expectation)
     return quality_specification
 
 

--- a/datacontract/export/great_expectations_converter.py
+++ b/datacontract/export/great_expectations_converter.py
@@ -143,7 +143,6 @@ def model_to_expectations(fields: Dict[str, Field], engine: str | None, sql_serv
     for field_name, field in fields.items():
         add_field_expectations(field_name, field, expectations, engine, sql_server_type)
         expectations.extend(get_quality_checks(field.quality, field_name))
-        # Add field quality here
     return expectations
 
 

--- a/tests/fixtures/great-expectations/datacontract_quality_column.yaml
+++ b/tests/fixtures/great-expectations/datacontract_quality_column.yaml
@@ -1,0 +1,35 @@
+dataContractSpecification: 1.1.0
+id: my-data-contract-id
+info:
+  title: Orders Unit Test
+  version: 1.1.1
+  owner: checkout
+  description: The orders data contract
+  contact:
+    email: team-orders@example.com
+    url: https://wiki.example.com/teams/checkout
+models:
+  orders:
+    description: test
+    fields:
+      id:
+        description: Unique identifier for each alert.
+        type: string
+        required: true
+        primaryKey: true
+        unique: true
+      type:
+        description: The type of alert that has fired.
+        type: string
+        required: true
+        enum: [ "A", "B", "C", "D", "E" ]
+        quality:
+          - type: custom
+            engine: great-expectations
+            description: "Accepted Values for type"
+            implementation:
+              expectation_type: expect_column_value_lengths_to_equal
+              kwargs:
+                value: 1
+              meta:
+                notes: "Ensures that column length is 1."

--- a/tests/fixtures/great-expectations/datacontract_quality_yaml.yaml
+++ b/tests/fixtures/great-expectations/datacontract_quality_yaml.yaml
@@ -16,9 +16,6 @@ models:
       order_id:
         type: string
         required: true
-      processed_timestamp:
-        type: timestamp
-        required: true
     quality:
       - type: custom
         engine: great-expectations

--- a/tests/fixtures/great-expectations/datacontract_quality_yaml.yaml
+++ b/tests/fixtures/great-expectations/datacontract_quality_yaml.yaml
@@ -1,0 +1,29 @@
+dataContractSpecification: 0.9.1
+id: my-data-contract-id
+
+info:
+  title: Orders Unit Test
+  version: 1.0.0
+  owner: checkout
+  description: The orders data contract
+  contact:
+    email: team-orders@example.com
+    url: https://wiki.example.com/teams/checkout
+models:
+  orders:
+    description: test
+    fields:
+      order_id:
+        type: string
+        required: true
+      processed_timestamp:
+        type: timestamp
+        required: true
+    quality:
+      - type: custom
+        engine: great-expectations
+        implementation:
+          expectation_type: expect_table_row_count_to_be_between
+          kwargs:
+            min_value: 10
+          meta: {}

--- a/tests/test_export_great_expectations.py
+++ b/tests/test_export_great_expectations.py
@@ -136,6 +136,28 @@ def expected_json_suite() -> Dict[str, Any]:
 
 
 @pytest.fixture
+def expected_json_suite_table_quality() -> Dict[str, Any]:
+    return {
+        "data_asset_type": "null",
+        "expectation_suite_name": "orders.1.0.0",
+        "expectations": [
+            {"expectation_type": "expect_table_row_count_to_be_between", "kwargs": {"min_value": 10}, "meta": {}},
+            {
+                "expectation_type": "expect_table_columns_to_match_ordered_list",
+                "kwargs": {"column_list": ["order_id"]},
+                "meta": {},
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_of_type",
+                "kwargs": {"column": "order_id", "type_": "string"},
+                "meta": {},
+            },
+        ],
+        "meta": {},
+    }
+
+
+@pytest.fixture
 def expected_json_suite_with_enum() -> Dict[str, Any]:
     return {
         "data_asset_type": "null",
@@ -665,13 +687,13 @@ def test_to_great_expectation_missing_quality_json_file():
 
 def test_to_great_expectation_quality_yaml(
     data_contract_great_expectations_quality_yaml: DataContractSpecification,
-    expected_json_suite: Dict[str, Any],
+    expected_json_suite_table_quality: Dict[str, Any],
 ):
     """
     Test with Quality definition in a model quality list
     """
     result = to_great_expectations(data_contract_great_expectations_quality_yaml, "orders")
-    assert result == json.dumps(expected_json_suite, indent=2)
+    assert result == json.dumps(expected_json_suite_table_quality, indent=2)
 
 
 def test_to_great_expectation_quality_column(

--- a/tests/test_export_great_expectations.py
+++ b/tests/test_export_great_expectations.py
@@ -89,6 +89,22 @@ def data_contract_great_expectations_quality_file() -> DataContractSpecification
 
 
 @pytest.fixture
+def data_contract_great_expectations_quality_yaml() -> DataContractSpecification:
+    return resolve.resolve_data_contract_from_location(
+        "./fixtures/great-expectations/datacontract_quality_yaml.yaml",
+        inline_quality=True,
+    )
+
+
+@pytest.fixture
+def data_contract_great_expectations_quality_column() -> DataContractSpecification:
+    return resolve.resolve_data_contract_from_location(
+        "./fixtures/great-expectations/datacontract_quality_column.yaml",
+        inline_quality=True,
+    )
+
+
+@pytest.fixture
 def expected_json_suite() -> Dict[str, Any]:
     return {
         "data_asset_type": "null",
@@ -113,6 +129,44 @@ def expected_json_suite() -> Dict[str, Any]:
                 "expectation_type": "expect_table_row_count_to_be_between",
                 "kwargs": {"min_value": 10},
                 "meta": {},
+            },
+        ],
+        "meta": {},
+    }
+
+
+@pytest.fixture
+def expected_json_suite_with_enum() -> Dict[str, Any]:
+    return {
+        "data_asset_type": "null",
+        "expectation_suite_name": "orders.1.1.1",
+        "expectations": [
+            {
+                "expectation_type": "expect_table_columns_to_match_ordered_list",
+                "kwargs": {"column_list": ["id", "type"]},
+                "meta": {},
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_of_type",
+                "kwargs": {"column": "id", "type_": "string"},
+                "meta": {},
+            },
+            {"expectation_type": "expect_column_values_to_be_unique", "kwargs": {"column": "id"}, "meta": {}},
+            {
+                "expectation_type": "expect_column_values_to_be_of_type",
+                "kwargs": {"column": "type", "type_": "string"},
+                "meta": {},
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_in_set",
+                "kwargs": {"column": "type", "value_set": ["A", "B", "C", "D", "E"]},
+                "meta": {},
+            },
+            {
+                "expectation_type": "expect_column_value_lengths_to_equal",
+                "kwargs": {"value": 1},
+                "meta": {"notes": "Ensures that column length is 1."},
+                "column": "type",
             },
         ],
         "meta": {},
@@ -288,6 +342,11 @@ def test_to_great_expectation(data_contract_basic: DataContractSpecification):
             {
                 "expectation_type": "expect_column_values_to_be_of_type",
                 "kwargs": {"column": "order_status", "type_": "text"},
+                "meta": {},
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_in_set",
+                "kwargs": {"column": "order_status", "value_set": ["pending", "shipped", "delivered"]},
                 "meta": {},
             },
         ],
@@ -602,3 +661,25 @@ def test_to_great_expectation_missing_quality_json_file():
         assert False
     except DataContractException as dataContractException:
         assert dataContractException.reason == "Cannot resolve reference ./fixtures/great-expectations/missing.json"
+
+
+def test_to_great_expectation_quality_yaml(
+    data_contract_great_expectations_quality_yaml: DataContractSpecification,
+    expected_json_suite: Dict[str, Any],
+):
+    """
+    Test with Quality definition in a model quality list
+    """
+    result = to_great_expectations(data_contract_great_expectations_quality_yaml, "orders")
+    assert result == json.dumps(expected_json_suite, indent=2)
+
+
+def test_to_great_expectation_quality_column(
+    data_contract_great_expectations_quality_column: DataContractSpecification,
+    expected_json_suite_with_enum: Dict[str, Any],
+):
+    """
+    Test with quality definition in a field quality list
+    """
+    result = to_great_expectations(data_contract_great_expectations_quality_column, "orders")
+    assert result == json.dumps(expected_json_suite_with_enum, indent=2)


### PR DESCRIPTION
In Great Expectations export function, add:
- support for generating expect_column_values_to_be_in_set based on enum field specification
- support for model quality custom definition
- support for field quality custom definition