### PR TITLE
Change behaviour of DBT constraints vs data tests when no model type specified on contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Fixed DBT export behaviour of constraints to default to data tests when no model type is specified in the datacontract model
+
 ## [0.10.25] - 2025-05-07
 
 ### Added

--- a/datacontract/export/dbt_converter.py
+++ b/datacontract/export/dbt_converter.py
@@ -9,7 +9,7 @@ from datacontract.model.data_contract_specification import DataContractSpecifica
 
 class DbtExporter(Exporter):
     def export(self, data_contract, model, server, sql_server_type, export_args) -> dict:
-        return to_dbt_models_yaml(data_contract, server, export_args)
+        return to_dbt_models_yaml(data_contract, server)
 
 
 class DbtSourceExporter(Exporter):
@@ -27,9 +27,7 @@ class DbtStageExporter(Exporter):
         )
 
 
-def to_dbt_models_yaml(
-    data_contract_spec: DataContractSpecification, server: str = None, export_args: dict = None
-) -> str:
+def to_dbt_models_yaml(data_contract_spec: DataContractSpecification, server: str = None) -> str:
     dbt = {
         "version": 2,
         "models": [],

--- a/tests/fixtures/export/datacontract_no_model_type.yaml
+++ b/tests/fixtures/export/datacontract_no_model_type.yaml
@@ -1,0 +1,91 @@
+dataContractSpecification: 1.1.0
+id: orders-unit-test
+info:
+  title: Orders Unit Test
+  version: 1.0.0
+  status: active
+  owner: checkout
+  description: The orders data contract
+  contact:
+    email: team-orders@example.com
+    url: https://wiki.example.com/teams/checkout
+  otherField: otherValue
+terms:
+  usage: This data contract serves to demo datacontract CLI export.
+  limitations: Not intended to use in production
+  billing: free
+  noticePeriod: P3M
+servers:
+  production:
+    type: snowflake
+    environment: production
+    account: my-account
+    database: my-database
+    schema: my-schema
+    roles:
+      - name: analyst_us
+        description: Access to the data for US region
+models:
+  orders:
+    title: Webshop Orders
+    description: The orders model
+    primaryKey:
+    - order_id
+    - order_status
+    customModelProperty1: customModelProperty1Value
+    fields:
+      order_id:
+        title: Order ID
+        type: varchar
+        unique: true
+        required: true
+        minLength: 8
+        maxLength: 10
+        pii: true
+        classification: sensitive
+        tags:
+          - order_id
+        pattern: ^B[0-9]+$
+        examples:
+          - B12345678
+          - B12345679
+        customFieldProperty1: customFieldProperty1Value
+      order_total:
+        type: bigint
+        required: true
+        description: The order_total field
+        minimum: 0
+        maximum: 1000000
+        quality:
+          - type: sql
+            description: 95% of all order total values are expected to be between 10 and 499 EUR.
+            query: |
+              SELECT quantile_cont(order_total, 0.95) AS percentile_95
+              FROM orders
+            mustBeBetween: [1000, 49900]
+      order_status:
+        type: text
+        required: true
+        enum:
+          - pending
+          - shipped
+          - delivered
+    quality:
+      - type: sql
+        description: Row Count
+        query: |
+          SELECT COUNT(*) AS row_count
+          FROM orders
+        mustBeGreaterThan: 1000
+definitions:
+  customer_id:
+    title: Customer ID
+    type: string
+    format: uuid
+    description: Unique identifier for the customer.
+    examples:
+      - acbd1a47-9dca-4cb8-893e-87aa0aa0f243
+      - 5742637f-bb8b-4f0c-8ed1-afb1a91300a9
+    tags:
+      - features
+      - pii


### PR DESCRIPTION
- [x] Tests pass
- [x] ruff format
- [ ] README.md updated (if relevant)
- [x] CHANGELOG.md entry added

The [default DBT behaviour is to materialize models as views](https://docs.getdbt.com/docs/build/materializations#:~:text=By%20default%2C%20dbt%20models%20are%20materialized%20as%20%22views%22.) which do not support `constraints`, only `data tests`.

However, we don't want to assume a default DBT model type if none is specified in the contract and so the DBT exporter defaults to the more permissive `data tests` rather than `constraints`, and does not include the `models[].config.materialized` key in the DBT output.

This has *no* impact on data contracts that specify the `model.type` in the model object.