### PR TITLE
Update convert_to_databricks sql converter

### DIFF
--- a/datacontract/export/sql_type_converter.py
+++ b/datacontract/export/sql_type_converter.py
@@ -158,8 +158,6 @@ def convert_to_dataframe(field: Field) -> None | str:
 # databricks data types:
 # https://docs.databricks.com/en/sql/language-manual/sql-ref-datatypes.html
 def convert_to_databricks(field: Field) -> None | str:
-    if field.config and "databricksType" in field.config:
-        return field.config["databricksType"]
     type = field.type
     if type is None:
         return None
@@ -197,6 +195,8 @@ def convert_to_databricks(field: Field) -> None | str:
     if type.lower() in ["array"]:
         item_type = convert_to_databricks(field.items)
         return f"ARRAY<{item_type}>"
+    if field.config and "databricksType" in field.config:
+        return field.config["databricksType"]
     return None
 
 


### PR DESCRIPTION
When creating a contract with servers of type "databricks", the field.config seems to get populated automatically with no way to control it. 

If the databricksType retains priority at the top of this conversion conditional, it causes problems with complex types like arrays and structs. Here is an example of output I got when using export("sql") on a databricks contract:

```
CREATE OR REPLACE TABLE flightstats_historical_old_dev_azr_westus.gold.baggage (
  baggage_id long,
  ticket_id long,
  baggage_type string
) COMMENT "";
CREATE OR REPLACE TABLE flightstats_historical_old_dev_azr_westus.gold.flights (
  flight_id long,
  airline string,
  flight_number string,
  origin string,
  destination string,
  departure_time timestamp,
  arrival_time timestamp,
  status string,
  ingestion_datetime timestamp,
  passengers array,
  flight_log struct
) COMMENT "";
```

This will fail with [[INCOMPLETE_TYPE_DEFINITION.ARRAY](https://docs.microsoft.com/azure/databricks/error-messages/incomplete-type-definition-error-class#array)] Incomplete complex type: The definition of "ARRAY" type is incomplete. You must provide an element type. For example: "ARRAY<INT>". SQLSTATE: 42K01

If i instead remove the config block recursively from each field and perform the export, I get the proper sql statement:

```
CREATE OR REPLACE TABLE flightstats_historical_old_dev_azr_westus.gold.baggage (
  baggage_id INT,
  ticket_id INT,
  baggage_type STRING
) COMMENT "";
CREATE OR REPLACE TABLE flightstats_historical_old_dev_azr_westus.gold.flights (
  flight_id INT,
  airline STRING,
  flight_number STRING,
  origin STRING,
  destination STRING,
  departure_time DATE,
  arrival_time DATE,
  status STRING,
  ingestion_datetime DATE,
  passengers ARRAY<STRUCT<passenger_id INT, seat_number STRING>>,
  flight_log STRUCT<blocks ARRAY<STRUCT<text STRING, title STRING, type STRING>>, column_additions ARRAY<STRING>, column_deletions ARRAY<STRING>, column_type_mismatches STRUCT<array_of_structs STRUCT<actual_type STRING, expected_type STRING>>, fail STRUCT<greaterThan DECIMAL, greaterThanOrEqual DECIMAL, lessThan DECIMAL>, missing_column_names ARRAY<STRING>, preferredChart STRING, present_column_names ARRAY<STRING>, value DECIMAL, valueLabel STRING, valueSeries STRUCT<values ARRAY<STRUCT<label STRING, outcome STRING, value INT>>>>
) COMMENT "";
```

I did not find any function arguments or any other mechanisms for circumventing this behavior. If there is a reason for placing the databricksType at the top of the condition, it would be nice if there was an argument we could pass to the export() method to change the behavior. 