### PR TITLE
Add support for Variant type

### DIFF
--- a/datacontract/export/odcs_v3_exporter.py
+++ b/datacontract/export/odcs_v3_exporter.py
@@ -202,6 +202,8 @@ def to_logical_type(type: str) -> str | None:
         return "array"
     if type.lower() in ["array"]:
         return "array"
+    if type.lower() in ["variant"]:
+        return "variant"
     if type.lower() in ["null"]:
         return None
     return None

--- a/datacontract/export/sql_type_converter.py
+++ b/datacontract/export/sql_type_converter.py
@@ -197,6 +197,8 @@ def convert_to_databricks(field: Field) -> None | str:
     if type.lower() in ["array"]:
         item_type = convert_to_databricks(field.items)
         return f"ARRAY<{item_type}>"
+    if type.lower() in ["variant"]:
+        return "VARIANT"
     return None
 
 

--- a/datacontract/imports/spark_importer.py
+++ b/datacontract/imports/spark_importer.py
@@ -154,5 +154,7 @@ def _data_type_from_spark(spark_type: types.DataType) -> str:
         return "null"
     elif isinstance(spark_type, types.VarcharType):
         return "varchar"
+    elif isinstance(spark_type, types.VariantType):
+        return "variant"
     else:
         raise ValueError(f"Unsupported Spark type: {spark_type}")


### PR DESCRIPTION
We are adding support for the variant type because its a new datatype which is currently in public preview:
https://docs.databricks.com/aws/en/sql/language-manual/data-types/variant-type

With these changes in the PR and adding the following two settings in the Databricks notebook or Python file Databricks variant types are completely supported and also deployable using DDLs created from data_contral.export("sql").

1. spark.conf.set("spark.databricks.delta.schema.typeCheck.enabled", "false")
2. from datacontract.model import data_contract_specification
data_contract_specification.DATACONTRACT_TYPES.append("variant")

When I create the contract with these setting above and changes to your code base below Variant types are stored in the ODCS Data Contract in the following way:

![image](https://github.com/user-attachments/assets/c67408e1-bd8f-4b98-8be2-7845be2da132)

When I generate the SQL DDLs to deploy into a Databricks Catalog.Schema they come out the following way:

![image](https://github.com/user-attachments/assets/c7369bf3-841c-4c71-bcf5-cf7580d26ae7)

This SQL DDL is deployable above in Databricks as long as the spark.conf() setting mentioned earlier is set.