### PR TITLE
Complex Types Fix When Exporting to SQL and 'databricksType' is Defined

### DIFF
--- a/datacontract/export/odcs_v3_exporter.py
+++ b/datacontract/export/odcs_v3_exporter.py
@@ -202,6 +202,8 @@ def to_logical_type(type: str) -> str | None:
         return "array"
     if type.lower() in ["array"]:
         return "array"
+    if type.lower() in ["variant"]:
+        return "variant"
     if type.lower() in ["null"]:
         return None
     return None

--- a/datacontract/export/odcs_v3_exporter.py
+++ b/datacontract/export/odcs_v3_exporter.py
@@ -249,7 +249,7 @@ def to_property(field_name: str, field: Field) -> SchemaProperty:
 
     if field.type is not None:
         property.logicalType = to_logical_type(field.type)
-        property.physicalType = to_physical_type(field.config)
+        property.physicalType = to_physical_type(field.config) or field.type
 
     if field.description is not None:
         property.description = field.description

--- a/datacontract/export/sql_type_converter.py
+++ b/datacontract/export/sql_type_converter.py
@@ -197,6 +197,8 @@ def convert_to_databricks(field: Field) -> None | str:
     if type.lower() in ["array"]:
         item_type = convert_to_databricks(field.items)
         return f"ARRAY<{item_type}>"
+    if type.lower() in ["variant"]:
+        return "VARIANT"
     return None
 
 

--- a/datacontract/export/sql_type_converter.py
+++ b/datacontract/export/sql_type_converter.py
@@ -158,9 +158,9 @@ def convert_to_dataframe(field: Field) -> None | str:
 # databricks data types:
 # https://docs.databricks.com/en/sql/language-manual/sql-ref-datatypes.html
 def convert_to_databricks(field: Field) -> None | str:
-    if field.config and "databricksType" in field.config:
-        return field.config["databricksType"]
     type = field.type
+    if field.config and "databricksType" in field.config and type.lower() not in ["array", "object", "record", "struct"]:
+        return field.config["databricksType"]
     if type is None:
         return None
     if type.lower() in ["string", "varchar", "text"]:

--- a/datacontract/imports/spark_importer.py
+++ b/datacontract/imports/spark_importer.py
@@ -154,5 +154,7 @@ def _data_type_from_spark(spark_type: types.DataType) -> str:
         return "null"
     elif isinstance(spark_type, types.VarcharType):
         return "varchar"
+    elif isinstance(spark_type, types.VariantType):
+        return "variant"
     else:
         raise ValueError(f"Unsupported Spark type: {spark_type}")

--- a/tests/test_export_odcs_v3.py
+++ b/tests/test_export_odcs_v3.py
@@ -39,8 +39,8 @@ schema:
     properties:
       - name: order_id
         businessName: Order ID
-        physicalType: varchar
         logicalType: string
+        physicalType: varchar
         logicalTypeOptions:
             minLength: 8
             maxLength: 10
@@ -59,8 +59,8 @@ schema:
         - property: pii
           value: true
       - name: order_total
-        physicalType: bigint
         logicalType: integer
+        physicalType: bigint
         logicalTypeOptions:
             minimum: 0
             maximum: 1000000
@@ -74,8 +74,8 @@ schema:
               FROM orders
             mustBeBetween: [1000, 49900]
       - name: order_status
-        physicalType: text
         logicalType: string
+        physicalType: text
         required: true
     quality:
     - type: sql

--- a/tests/test_export_odcs_v3.py
+++ b/tests/test_export_odcs_v3.py
@@ -39,6 +39,7 @@ schema:
     properties:
       - name: order_id
         businessName: Order ID
+        physicalType: varchar
         logicalType: string
         logicalTypeOptions:
             minLength: 8
@@ -58,6 +59,7 @@ schema:
         - property: pii
           value: true
       - name: order_total
+        physicalType: bigint
         logicalType: integer
         logicalTypeOptions:
             minimum: 0
@@ -72,6 +74,7 @@ schema:
               FROM orders
             mustBeBetween: [1000, 49900]
       - name: order_status
+        physicalType: text
         logicalType: string
         required: true
     quality:


### PR DESCRIPTION
These changes add physical type back into the ODCS contract, and allow us to capture the full complex nested datatype (e.g. array, object, record, struct) --> 

![image](https://github.com/user-attachments/assets/14294858-2d15-466f-9a21-365c16e0e6c2)

With these changes here is what this sql block above translates into the ODCS Data Contract prior to being converted to sql DDL:

![image](https://github.com/user-attachments/assets/5aa4b69b-6448-4884-9668-497a922ff2d4)

![image](https://github.com/user-attachments/assets/626edceb-15b0-444b-8f3b-006e580c2c53)


