### PR TITLE
fix: Soda Exporter did not correctly pass server object to create_checks function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `datacontract import --format spark`: Added support for spark importer table level comments (#761)
 
+### Fixed
+
+- `datacontract export --format sodacl`: Fix resolving server when using `--server` flag (#768)
+
 ## [0.10.26] - 2025-05-16
 
 ### Changed

--- a/datacontract/export/sodacl_converter.py
+++ b/datacontract/export/sodacl_converter.py
@@ -2,12 +2,12 @@ import yaml
 
 from datacontract.engines.data_contract_checks import create_checks
 from datacontract.export.exporter import Exporter
+from datacontract.model.data_contract_specification import DataContractSpecification, Server
 from datacontract.model.run import Run
-from datacontract.engines.data_contract_test import get_server
 
 
 class SodaExporter(Exporter):
-    def export(self, data_contract, model, server, sql_server_type, export_args) -> dict:
+    def export(self, data_contract, model, server, sql_server_type, export_args) -> str:
         run = Run.create_run()
         server = get_server(data_contract, server)
         run.checks.extend(create_checks(data_contract, server))
@@ -30,3 +30,9 @@ def to_sodacl_yaml(run: Run) -> str:
             else:
                 sodacl_dict[key] = value
     return yaml.dump(sodacl_dict)
+
+
+def get_server(data_contract_specification: DataContractSpecification, server_name: str = None) -> Server | None:
+    if server_name is None:
+        return None
+    return data_contract_specification.servers.get(server_name)

--- a/datacontract/export/sodacl_converter.py
+++ b/datacontract/export/sodacl_converter.py
@@ -8,6 +8,7 @@ from datacontract.model.run import Run
 class SodaExporter(Exporter):
     def export(self, data_contract, model, server, sql_server_type, export_args) -> dict:
         run = Run.create_run()
+        server = get_server(data_contract, server)
         run.checks.extend(create_checks(data_contract, server))
         return to_sodacl_yaml(run)
 

--- a/datacontract/export/sodacl_converter.py
+++ b/datacontract/export/sodacl_converter.py
@@ -3,6 +3,7 @@ import yaml
 from datacontract.engines.data_contract_checks import create_checks
 from datacontract.export.exporter import Exporter
 from datacontract.model.run import Run
+from datacontract.engines.data_contract_test import get_server
 
 
 class SodaExporter(Exporter):


### PR DESCRIPTION
The soda exporter create_checks function expects to receive a server object but only receives a server_name string.
This fix adds in a step to get the server object from the data contract using the get_server function from the data_contract_test module.

Example:
If you run the exporter like so 'datacontract export .\src\\datacontract.yaml --format sodacl --server dev'  with a data contract like:
```

dataContractSpecification: 1.1.0
id: my-data-contract-id
info:
  title: Transactions
  version: 1.0.0
  description: Transactions from datahub since 2020-01-01

servers:
  dev:
    type: databricks
    catalog: core_dev
    schema: silver

models:
  initial_data:
    type: table
    description: Initial data for testing
    fields:
      id:
        type: integer
        description: ID of the person
      name:
        type: string
        description: Name of the person
        config:
          databricksType: decimal(10, 2)
      added_timestamp:
        type: timestamp
        description: Timestamp when the data was added

```

I would expect this to work but it fails with 'AttributeError: 'str' object has no attribute 'type'.
![image](https://github.com/user-attachments/assets/600c93a5-5e74-463d-995c-7714db87775d)


- [ ] Tests pass
- [ ] ruff format
- [ ] README.md updated (if relevant)
- [ ] CHANGELOG.md entry added
