### PR TITLE
Add data contract version number to index.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- `datacontract catalog [OPTIONS]`: Added version to contract cards in `index.html` of the catalog (enabled search by version)
 
 ### Fixed
 

--- a/datacontract/templates/index.html
+++ b/datacontract/templates/index.html
@@ -80,6 +80,7 @@
                   data-search="{{
     contract.spec.info.title|lower|e }} {{
     contract.spec.info.owner|lower|e if contract.spec.info.owner else '' }} {{
+    contract.spec.info.version|lower|e if contract.spec.info.version else '' }} {{
     contract.spec.info.description|lower|e }} {%
     for model_name, model in contract.spec.models.items() %}
       {{ model.description|lower|e }} {%
@@ -94,6 +95,7 @@
                       <div class="flex items-center space-x-3">
                         <h3 class="truncate text-sm font-medium text-gray-900">{{contract.spec.info.title}}</h3>
                       </div>
+                      <p class="mt-1 text-sm text-gray-400">{{ contract.spec.info.version }}</p>
                       <div class="flex flex-wrap mt-1 text-sm text-gray-500 gap-1">
                         {% if contract.spec.info.owner %}
                         <div class="flex items-center text-sm text-gray-500">


### PR DESCRIPTION
The `index.html`, created with `datacontract catalog`, did not show data contract versions.  
However, it might happen that the same contract is versioned and there would be no way do distinguish each version based on the information presented on the data contract cards in the catalog's index.

This PR:
- adds a version number below contract title
- adds a version number to `data-search` attribute (to enable search by version)

--- 
- [x] Tests pass
- [x] ruff format
- [ ] ~~README.md updated (if relevant)~~
- [x] CHANGELOG.md entry added
