### PR TITLE
fix: s3 url style path

### DIFF
--- a/datacontract/engines/soda/connections/duckdb_connection.py
+++ b/datacontract/engines/soda/connections/duckdb_connection.py
@@ -132,10 +132,10 @@ def setup_s3_connection(con, server):
     use_ssl = "true"
     url_style = "vhost"
     if server.endpointUrl is not None:
+        url_style = "path"
         s3_endpoint = server.endpointUrl.removeprefix("http://").removeprefix("https://")
         if server.endpointUrl.startswith("http://"):
             use_ssl = "false"
-            url_style = "path"
 
     if s3_access_key_id is not None:
         if s3_session_token is not None:


### PR DESCRIPTION
the s3 url style "path" should not be bound to an endpoint starting with "http://". local min.io could be protected with ssl/tls as well.

- [ ] Tests pass
- [ ] ruff format
- [ ] README.md updated (if relevant)
- [ ] CHANGELOG.md entry added
