### PR TITLE
fix bug on junit test result

### DIFF
--- a/datacontract/output/junit_test_results.py
+++ b/datacontract/output/junit_test_results.py
@@ -56,19 +56,19 @@ def write_junit_test_results(run: Run, console, output_path: Path):
                 type=check.category if check.category else "General",
             )
             error.text = to_failure_text(check)
-        elif check.result is ResultEnum.warning:
+        elif check.result == ResultEnum.warning:
             skipped = ET.SubElement(
                 testcase,
                 "skipped",
                 message=check.reason if check.reason else "Warning",
                 type=check.category if check.category else "General",
             )
-            skipped.skipped = to_failure_text(check)
+            skipped.text = to_failure_text(check)
         else:
             ET.SubElement(
                 testcase,
                 "skipped",
-                message=check.reason if check.reason else "None",
+                message=check.reason if check.reason else "Skipped",
                 type=check.category if check.category else "General",
             )
 


### PR DESCRIPTION
fix incorrect syntax on handling warning test report.
Issue created in: https://github.com/datacontract/datacontract-cli/issues/833

- [x] Tests pass
- [ ] ruff format
- [ ] README.md updated (if relevant)
- [ ] CHANGELOG.md entry added