### PR TITLE
Extend Spark import and export for column descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The Spark importer and exporter now also exports the description of columns via the additional metadata of StructFields
+
+### Added
+
 - API `/test` endpoint now supports `publish_url` parameter to publish test results to a URL. (#853)
 
 ### Fixed

--- a/datacontract/export/spark_converter.py
+++ b/datacontract/export/spark_converter.py
@@ -1,3 +1,5 @@
+import json
+
 from pyspark.sql import types
 
 from datacontract.export.exporter import Exporter
@@ -104,7 +106,8 @@ def to_struct_field(field: Field, field_name: str) -> types.StructField:
         types.StructField: The corresponding Spark StructField.
     """
     data_type = to_spark_data_type(field)
-    return types.StructField(name=field_name, dataType=data_type, nullable=not field.required)
+    metadata = to_spark_metadata(field)
+    return types.StructField(name=field_name, dataType=data_type, nullable=not field.required, metadata=metadata)
 
 
 def to_spark_data_type(field: Field) -> types.DataType:
@@ -155,6 +158,24 @@ def to_spark_data_type(field: Field) -> types.DataType:
     return types.StringType()  # default if no condition is met
 
 
+def to_spark_metadata(field: Field) -> dict[str, str]:
+    """
+    Convert a field to a Spark metadata dictonary.
+
+    Args:
+        field (Field): The field to convert.
+
+    Returns:
+        dict: dictionary that can be supplied to Spark as metadata for a StructField
+    """
+
+    metadata = {}
+    if field.description:
+        metadata["comment"] = field.description
+
+    return metadata
+
+
 def print_schema(dtype: types.DataType) -> str:
     """
     Converts a PySpark DataType schema to its equivalent code representation.
@@ -192,7 +213,11 @@ def print_schema(dtype: types.DataType) -> str:
         name = f'"{column.name}"'
         data_type = indent(print_schema(column.dataType), 1)
         nullable = indent(f"{column.nullable}", 1)
-        return f"StructField({name},\n{data_type},\n{nullable}\n)"
+        if column.metadata:
+            metadata = indent(f"{json.dumps(column.metadata)}", 1)
+            return f"StructField({name},\n{data_type},\n{nullable},\n{metadata}\n)"
+        else:
+            return f"StructField({name},\n{data_type},\n{nullable}\n)"
 
     def format_struct_type(struct_type: types.StructType) -> str:
         """

--- a/tests/fixtures/spark/export/datacontract.yaml
+++ b/tests/fixtures/spark/export/datacontract.yaml
@@ -55,6 +55,7 @@ models:
         type: int
       name:
         type: string
+        description: First and last name of the customer
       metadata:
         type: map
         required: false

--- a/tests/fixtures/spark/import/users_datacontract_desc.yml
+++ b/tests/fixtures/spark/import/users_datacontract_desc.yml
@@ -16,6 +16,7 @@ models:
       name:
         type: string
         required: false
+        description: First and last name of the customer
       address:
         type: struct
         required: false

--- a/tests/fixtures/spark/import/users_datacontract_no_desc.yml
+++ b/tests/fixtures/spark/import/users_datacontract_no_desc.yml
@@ -15,6 +15,7 @@ models:
       name:
         type: string
         required: false
+        description: First and last name of the customer
       address:
         type: struct
         required: false

--- a/tests/test_export_spark.py
+++ b/tests/test_export_spark.py
@@ -92,7 +92,8 @@ customers = StructType([
     ),
     StructField("name",
         StringType(),
-        True
+        True,
+        {"comment": "First and last name of the customer"}
     ),
     StructField("metadata",
         MapType(
@@ -157,7 +158,7 @@ expected_dict = {
     "customers": types.StructType(
         [
             types.StructField("id", types.IntegerType(), True),
-            types.StructField("name", types.StringType(), True),
+            types.StructField("name", types.StringType(), True, {"comment": "First and last name of the customer"}),
             types.StructField(
                 "metadata",
                 types.MapType(

--- a/tests/test_import_spark.py
+++ b/tests/test_import_spark.py
@@ -71,7 +71,7 @@ def user_schema():
     return types.StructType(
         [
             types.StructField("id", types.StringType()),
-            types.StructField("name", types.StringType()),
+            types.StructField("name", types.StringType(), True, {"comment": "First and last name of the customer"}),
             types.StructField(
                 "address",
                 types.StructType(


### PR DESCRIPTION
As propsed in #868 this PR extends the Spark exporter to also add the description to the Spark StructFields.
I also added a test for the comments for the importer as this was not tested so far.

- [x] Tests pass
- [x] ruff format
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added
