### PR TITLE
fix : odcs excel export Error filling properties 

### DIFF
--- a/datacontract/export/excel_exporter.py
+++ b/datacontract/export/excel_exporter.py
@@ -283,7 +283,7 @@ def fill_single_property_template(
     sheet: Worksheet, row_index: int, prefix: str, property: SchemaProperty, header_map: dict
 ) -> int:
     """Fill a single property row using the template's column structure"""
-    property_name = f"{prefix}{"." + property.name if property.name else ""}" if prefix else property.name
+    property_name = f"{prefix}{'.' + property.name if property.name else ''}" if prefix else property.name
 
     # Helper function to set cell value by header name
     def set_by_header(header_name: str, value: Any):
@@ -404,7 +404,7 @@ def fill_properties_quality(
         if not property.name:
             continue
 
-        full_property_name = f"{prefix}{"." + property.name if property.name else ""}" if prefix else property.name
+        full_property_name = f"{prefix}{'.' + property.name if property.name else ''}" if prefix else property.name
 
         # Add quality attributes for this property
         if property.quality:

--- a/datacontract/export/excel_exporter.py
+++ b/datacontract/export/excel_exporter.py
@@ -307,7 +307,7 @@ def fill_single_property_template(
     set_by_header("Classification", property.classification)
     set_by_header("Tags", ",".join(property.tags) if property.tags else "")
     set_by_header(
-        "Example(s)", ",".join(property.examples) if property.examples else ""
+        "Example(s)", ",".join(map(str, property.examples)) if property.examples else ""
     )  # Note: using "Example(s)" as in template
     set_by_header("Encrypted Name", property.encryptedName)
     set_by_header(

--- a/datacontract/export/excel_exporter.py
+++ b/datacontract/export/excel_exporter.py
@@ -283,7 +283,7 @@ def fill_single_property_template(
     sheet: Worksheet, row_index: int, prefix: str, property: SchemaProperty, header_map: dict
 ) -> int:
     """Fill a single property row using the template's column structure"""
-    property_name = f"{prefix}.{property.name}" if prefix else property.name
+    property_name = f"{prefix}{"." + property.name if property.name else ""}" if prefix else property.name
 
     # Helper function to set cell value by header name
     def set_by_header(header_name: str, value: Any):
@@ -404,7 +404,7 @@ def fill_properties_quality(
         if not property.name:
             continue
 
-        full_property_name = f"{prefix}.{property.name}" if prefix else property.name
+        full_property_name = f"{prefix}{"." + property.name if property.name else ""}" if prefix else property.name
 
         # Add quality attributes for this property
         if property.quality:


### PR DESCRIPTION
`WARNING:datacontract.export.excel_exporter:Error filling properties: sequence item 0: expected str instance, int found
Written result to excel.xlsx`

When the examples is an array of int the warning raise and stop the rendering

adding a map(str, property.examples) solve the ",".join() python statement

",".join(map(str, property.examples))

```yaml
...
- name: exclusionType
      busninessName: exclusionType
      logicalType: string
      physicalType: string
      required: true
      unique: false
      examples:
        - "subCategory"
    - name: exclusionCode
      busninessName: exclusionCode
      logicalType: integer
      physicalType: bigint
      required: true
      unique: false
      examples:
        - 624002
```

fix the property name `None` presentation with nested properties
before
<img width="665" height="263" alt="image" src="https://github.com/user-attachments/assets/528f2483-49d1-46cc-b133-1500ce20f5dc" />

after
<img width="665" height="386" alt="image" src="https://github.com/user-attachments/assets/b5fc03be-535c-4403-99cb-d0a91e7afde8" />


- [ ] Tests pass
- [ ] ruff format
- [ ] README.md updated (if relevant)
- [ ] CHANGELOG.md entry added
