### PR TITLE
Fix markdown servers rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improved regex for extracting Azure storage account names from URLs with containerName@storageAccountName format (#848)
 - JSON Schema Check: Add globbing support for local JSON files
-
+- Fixed server section rendering for markdown exporter
 
 ## [0.10.34] - 2025-08-06
 

--- a/datacontract/export/markdown_converter.py
+++ b/datacontract/export/markdown_converter.py
@@ -82,7 +82,7 @@ def obj_attributes_to_markdown(obj: BaseModel, excluded_fields: set = set(), is_
         if value
     ]
     description = f"*{description_to_markdown(description_value)}*"
-    extra = [extra_to_markdown(obj)] if obj.model_extra else []
+    extra = [extra_to_markdown(obj, is_in_table_cell)] if obj.model_extra else []
     return newline_char.join([description] + attributes + extra)
 
 
@@ -293,19 +293,30 @@ def dict_to_markdown(dictionary: Dict[str, str]) -> str:
     return "\n".join(markdown_parts) + "\n"
 
 
-def extra_to_markdown(obj: BaseModel) -> str:
+def extra_to_markdown(obj: BaseModel, is_in_table_cell: bool = False) -> str:
     """
     Convert the extra attributes of a data contract to Markdown format.
     Args:
         obj (BaseModel): The data contract object containing extra attributes.
+        is_in_table_cell (bool): Whether the extra attributes are in a table cell.
     Returns:
         str: A Markdown formatted string representing the extra attributes of the data contract.
     """
     markdown_part = ""
     extra = obj.model_extra
+
+    bullet_char = "•"
+    new_line_char = "\n" if not is_in_table_cell else ""
+    new_line_in_tab = "<br>"
     if extra:
         for key_extra, value_extra in extra.items():
-            markdown_part += f"\n### {key_extra.capitalize()}\n"
+            if not value_extra:
+                continue
+            if is_in_table_cell:
+                markdown_part += f"{bullet_char} **{key_extra}:** "
+            else:
+                markdown_part += f"\n### {key_extra.capitalize()}\n"
+
             if isinstance(value_extra, list) and len(value_extra):
                 if isinstance(value_extra[0], dict):
                     markdown_part += array_of_dict_to_markdown(value_extra)
@@ -314,5 +325,8 @@ def extra_to_markdown(obj: BaseModel) -> str:
             elif isinstance(value_extra, dict):
                 markdown_part += dict_to_markdown(value_extra)
             else:
-                markdown_part += f"{str(value_extra)}\n"
+                markdown_part += f"{str(value_extra)}{new_line_char}"
+
+            if is_in_table_cell:
+                markdown_part += new_line_in_tab
     return markdown_part

--- a/tests/fixtures/markdown/export/datacontract.yaml
+++ b/tests/fixtures/markdown/export/datacontract.yaml
@@ -24,6 +24,18 @@ servers:
         description: Access to the data for US region
       - name: analyst_cn
         description: Access to the data for China region
+  development:
+    type: s3
+    environment: dev
+    location: s3://datacontract-example-orders-latest/v2/{model}/*.json
+    format: json
+    delimiter: new_line
+    description: "One folder per model. One file per day."
+    roles:
+      - name: analyst_us
+        description: Access to the data for US region
+      - name: analyst_cn
+        description: Access to the data for China region
 terms:
   usage: |
     Data can be used for reports, analytics and machine learning use cases.

--- a/tests/fixtures/markdown/export/expected.md
+++ b/tests/fixtures/markdown/export/expected.md
@@ -10,6 +10,7 @@
 | Name | Type | Attributes |
 | ---- | ---- | ---------- |
 | production | s3 | *One folder per model. One file per day.*<br>• **environment:** prod<br>• **format:** json<br>• **delimiter:** new_line<br>• **location:** s3://datacontract-example-orders-latest/v2/{model}/*.json<br>• **roles:** [{'name': 'analyst_us', 'description': 'Access to the data for US region'}, {'name': 'analyst_cn', 'description': 'Access to the data for China region'}] |
+| development | s3 | *One folder per model. One file per day.*<br>• **environment:** dev<br>• **format:** json<br>• **delimiter:** new_line<br>• **location:** s3://datacontract-example-orders-latest/v2/{model}/*.json<br>• **roles:** [{'name': 'analyst_us', 'description': 'Access to the data for US region'}, {'name': 'analyst_cn', 'description': 'Access to the data for China region'}] |
 
 ## Terms
 *No description.*


### PR DESCRIPTION
The `extra_to_markdown` function was not supported in cell rendering, which caused the staging directory from extra to be rendered as a Markdown section and broke the servers' table.

- [ ] Tests pass
- [ ] ruff format
- [ ] README.md updated (if relevant)
- [ ] CHANGELOG.md entry added
