### PR TITLE
Fix: Valid Field Constraints for date/integer/number

### DIFF
--- a/datacontract/lint/linters/valid_constraints_linter.py
+++ b/datacontract/lint/linters/valid_constraints_linter.py
@@ -17,7 +17,7 @@ class ValidFieldConstraintsLinter(Linter):
 
     valid_types_for_constraint = {
         "pattern": set(["string", "text", "varchar"]),
-        "format": set(["string", "text", "varchar"]),
+        "format": set(["string", "text", "varchar", "date", "integer", "number"]),
         "minLength": set(["string", "text", "varchar"]),
         "maxLength": set(["string", "text", "varchar"]),
         "minimum": set(["int", "integer", "number", "decimal", "numeric", "long", "bigint", "float", "double"]),

--- a/tests/fixtures/lint/datacontract_valid_field_constraints.yaml
+++ b/tests/fixtures/lint/datacontract_valid_field_constraints.yaml
@@ -1,0 +1,16 @@
+dataContractSpecification: 1.2.0
+id: my-data-contract-id
+info:
+  title: "My Data Contract"
+  version: 0.0.1
+models:
+  orders:
+    type: table
+    fields:
+      event_date:
+        type: date
+      amount:
+        type: number
+      id:
+        type: integer
+        required: true

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -72,3 +72,12 @@ def test_lint_with_references():
     run = data_contract.lint()
 
     assert run.result == "passed"
+
+
+def test_lint_valid_field_constraints():
+    data_contract_file = "fixtures/lint/datacontract_valid_field_constraints.yaml"
+    data_contract = DataContract(data_contract_file=data_contract_file)
+
+    run = data_contract.lint()
+    
+    assert run.result == "passed"


### PR DESCRIPTION
Fixes [#890](https://github.com/datacontract/datacontract-cli/issues/890).

**Cause**: The linter only allows 'format' constraint on logicalType `string`; whereas in [ODCS docs](https://bitol-io.github.io/open-data-contract-standard/v3.0.2/#logical-type-options), 'format' is also applicable to  logicalType `date`, `integer`, and `number`.

**Fix**: Extend valid_types_for_constraint for format to include date, number, integer.

- [ ] Tests pass
- [ ] ruff format
- [ ] README.md updated (if relevant)
- [ ] CHANGELOG.md entry added
