### PR TITLE
Correct name of session token YAML key to match Soda expectations for…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Athena: Now correctly uses the (optional) AWS session token specified in the `DATACONTRACT_S3_SESSION_TOKEN' environment variable when testing contracts (#934)
 
 ## [0.10.37] - 2025-11-03
 

--- a/datacontract/engines/soda/connections/athena.py
+++ b/datacontract/engines/soda/connections/athena.py
@@ -71,7 +71,7 @@ def to_athena_soda_configuration(server):
         data_source["catalog"] = server.catalog
 
     if s3_session_token:
-        data_source["aws_session_token"] = s3_session_token
+        data_source["session_token"] = s3_session_token
 
     soda_configuration = {f"data_source {server.type}": data_source}
 


### PR DESCRIPTION
As discussed in issue (#934), datacontract-cli does not currently pass AWS session tokens specified in the `DATACONTRACT_S3_SESSION_TOKEN` environment variable through to Soda, due to use of an incorrect YAML key.  This prevents the use of `datacontract test` against Athena in situations where IAM is defined such that these tokens are required - resulting in `The security token included in the request is invalid` errors.

The fix is extremely simple, and just involves renaming the incorrect `aws_session_token` key to `session_token`, as expected by Soda.  I have verified this against my own AWS Athena environment and confirmed the session token is now correctly passed through and tests may be run.

- [ ] Tests pass
- [x] ruff format
- [ ] README.md updated (if relevant)
- [x] CHANGELOG.md entry added
