### PR TITLE
added support for map logical type since it was missing

### DIFF
--- a/datacontract/export/odcs_v3_exporter.py
+++ b/datacontract/export/odcs_v3_exporter.py
@@ -197,14 +197,10 @@ def to_logical_type(type: str) -> str | None:
         return "integer"
     if type.lower() in ["boolean"]:
         return "boolean"
-    if type.lower() in ["object", "record", "struct"]:
+    if type.lower() in ["object", "record", "struct", "map", "variant"]:
         return "object"
     if type.lower() in ["bytes", "array"]:
         return "array"
-    if type.lower() in ["map"]:
-        return "map"
-    if type.lower() in ["variant"]:
-        return "variant"
     if type.lower() in ["null"]:
         return None
     return None


### PR DESCRIPTION
The map logical type was missing for fields which have a map datatype.  The physical type was there.  Without the logic type added the Map<key, val> was not written correctly in the data contract.

Testing was done with map field which looks like the following:
<img width="987" height="382" alt="image" src="https://github.com/user-attachments/assets/b4b7a796-3cd7-4716-9b76-547f675e7607" />

This is the fix we implemented:
<img width="841" height="735" alt="image" src="https://github.com/user-attachments/assets/53b9efbc-1353-4652-9b6f-b078ed126ab8" />


- [ ] Tests pass
- [ ] ruff format
- [ ] README.md updated (if relevant)
- [ ] CHANGELOG.md entry added
