### PR TITLE
fix: BigQuery test command failure for fields with FLOAT or BOOLEAN types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restrict DuckDB dependency to < 1.4.0 (#972)
 - Fixed schema evolution support for optional fields in CSV and Parquet formats. Optional fields marked with `required: false` are no longer incorrectly treated as required during validation, enabling proper schema evolution where optional fields can be added to contracts without breaking validation of historical data files (#977)
 - Fixed decimals in pydantic model export. Fields marked with `type: decimal` will be mapped to `decimal.Decimal` instead of `float`.
+- Fix BigQuery test failure for fields with FLOAT or BOOLEAN types by mapping them to equivalent types (BOOL and FLOAT64)
 
 ## [0.11.2] - 2025-12-15
 

--- a/datacontract/export/bigquery_exporter.py
+++ b/datacontract/export/bigquery_exporter.py
@@ -113,8 +113,8 @@ def map_type_to_bigquery(prop: SchemaProperty) -> str:
     # If physicalType is already a BigQuery type, return it directly
     if prop.physicalType:
         bq_types = {
-            "STRING", "BYTES", "INT64", "INTEGER", "FLOAT64", "FLOAT", "NUMERIC",
-            "BIGNUMERIC", "BOOL", "BOOLEAN", "TIMESTAMP", "DATE", "TIME", "DATETIME",
+            "STRING", "BYTES", "INT64", "INTEGER", "FLOAT64", "NUMERIC",
+            "BIGNUMERIC", "BOOL", "TIMESTAMP", "DATE", "TIME", "DATETIME",
             "GEOGRAPHY", "JSON", "RECORD", "STRUCT", "ARRAY"
         }
         if prop.physicalType.upper() in bq_types or prop.physicalType.upper().startswith(("STRUCT<", "ARRAY<", "RANGE<")):


### PR DESCRIPTION
fix BigQuery test failure for fields with FLOAT or BOOLEAN types by mapping them to equivalent types (BOOL and FLOAT64)
This pull request fixes #1002 

- [x] Tests pass
- [x] ruff format
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added
