### PR TITLE
Make sure that column types are not inferred to VARCHAR

### DIFF
--- a/tests/fixtures/schema-evolution/cities-version-3.csv
+++ b/tests/fixtures/schema-evolution/cities-version-3.csv
@@ -1,0 +1,3 @@
+city_id,name,population
+c5193fd1-6b9b-4abc-81c5-ddb30a52d8f6,Babylon,
+cdcc7194-8f4d-40a8-84bb-92b32e0fb684,Tokyo,

--- a/tests/test_test_schema_evolution.py
+++ b/tests/test_test_schema_evolution.py
@@ -9,7 +9,6 @@ def test_csv_optional_field_missing_from_old_data():
 
     run = data_contract.test()
 
-    print(run)
     assert run.result == "passed"
     assert all(check.result == "passed" for check in run.checks)
 
@@ -21,7 +20,6 @@ def test_csv_optional_field_present_in_new_data():
 
     run = data_contract.test()
 
-    print(run)
     assert run.result == "passed"
     assert all(check.result == "passed" for check in run.checks)
 
@@ -32,7 +30,6 @@ def test_data_from_historical_and_current_schema_csv_mixed():
 
     run = data_contract.test()
 
-    print(run)
     assert run.result == "passed"
     assert all(check.result == "passed" for check in run.checks)
 
@@ -43,7 +40,6 @@ def test_csv_optional_field_with_invalid_values():
 
     run = data_contract.test()
 
-    print(run)
     assert run.result == "failed"
     # Should have at least one failed check for constraint violation
     assert any(check.result == "failed" for check in run.checks)
@@ -55,7 +51,6 @@ def test_csv_required_field_missing_fails():
 
     run = data_contract.test()
 
-    print(run)
     assert run.result == "failed"
 
 
@@ -70,7 +65,6 @@ def test_parquet_optional_field_missing_from_old_data():
 
     run = data_contract.test()
 
-    print(run)
     assert run.result == "passed"
     assert all(check.result == "passed" for check in run.checks)
 
@@ -82,7 +76,6 @@ def test_parquet_optional_field_present_in_new_data():
 
     run = data_contract.test()
 
-    print(run)
     assert run.result == "passed"
     assert all(check.result == "passed" for check in run.checks)
 
@@ -93,7 +86,6 @@ def test_data_from_historical_and_current_schema_parquet_mixed():
 
     run = data_contract.test()
 
-    print(run)
     assert run.result == "passed"
     assert all(check.result == "passed" for check in run.checks)
 
@@ -104,7 +96,6 @@ def test_parquet_optional_field_with_invalid_values():
 
     run = data_contract.test()
 
-    print(run)
     assert run.result == "failed"
     # Should have at least one failed check for constraint violation
     assert any(check.result == "failed" for check in run.checks)
@@ -116,5 +107,4 @@ def test_parquet_required_field_missing_fails():
 
     run = data_contract.test()
 
-    print(run)
     assert run.result == "failed"


### PR DESCRIPTION
The `UNION BY NAME` approach introduced as a fix for issue #977 led to the problem that if one of the files contained only empty values for an optional column, that column would be inferred to be of type `VARCHAR` by DuckDB.

The solution is to create the empty table with strict types based on the data contract and then insert the data into the table in a separate step, taking only into account those columns that exist in both the data contract and the data, which might be missing newly introduced columns or still have columns that have been removed from the contract by now.

I have not added a CHANGELOG.md because this is actually an amendmend of the solution to #977 which has not been released yet.

- [x] Tests pass
- [x] ruff format
- [ ] README.md updated (if relevant)
- [ ] CHANGELOG.md entry added
