### PR TITLE
Lower pyspark version requirement to 3.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ databricks = [
   "soda-core-spark[databricks]>=3.3.20,<3.6.0",
   "databricks-sql-connector>=3.7.0,<4.3.0",
   "databricks-sdk<0.74.0",
-  "pyspark>=3.5.5,<5.0.0",
+  "pyspark>=3.5.0,<5.0.0",
 ]
 
 iceberg = [
@@ -71,7 +71,7 @@ iceberg = [
 kafka = [
   "datacontract-cli[avro]",
   "soda-core-spark-df>=3.3.20,<3.6.0",
-  "pyspark>=3.5.5,<5.0.0",
+  "pyspark>=3.5.0,<5.0.0",
 ]
 
 postgres = [


### PR DESCRIPTION
to be able to use datacontract-cli within Databricks runtime 15.4 , the min pyspark version should match. Since Databricks runtime ships with pyspark 3.5.0, it would be great if datacontract-cli also supports this as lowest number.....if it doesn't break stuff elsewhere 🤞

- [ ] Tests pass
- [ ] ruff format
- [ ] README.md updated (if relevant)
- [ ] CHANGELOG.md entry added
