### PR TITLE
fix Soda test quote_field_name for Azure CSV file with schema[].properties[].name with space in it

### DIFF
--- a/datacontract/engines/data_contract_checks.py
+++ b/datacontract/engines/data_contract_checks.py
@@ -72,7 +72,7 @@ def to_schema_checks(schema_object: SchemaObject, server: Server) -> List[Check]
 
     type1 = server.type if server and server.type else None
     config = QuotingConfig(
-        quote_field_name=type1 in ["postgres", "sqlserver"],
+        quote_field_name=type1 in ["postgres", "sqlserver", "azure"],
         quote_model_name=type1 in ["postgres", "sqlserver"],
         quote_model_name_with_backticks=type1 == "bigquery",
     )


### PR DESCRIPTION
- [ ] Tests pass
- [ ] ruff format
- [ ] README.md updated (if relevant)
- [ ] CHANGELOG.md entry added

fix the #1024 force the quote_field_name property config on azure (storage account csv file

```
 QuotingConfig(
        quote_field_name=type1 in ["postgres", "sqlserver", "azure"],
        quote_model_name=type1 in ["postgres", "sqlserver"],
        quote_model_name_with_backticks=type1 == "bigquery",
    )
``` 