### PR TITLE
Make Markdown export compatible with XHTML by replacing `<br>` with `<br />`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Make Markdown export compatible with XHTML by replacing `<br>` with `<br />` (#1030)
+
 ## [0.11.4] - 2026-01-19
 
 ### Changed

--- a/datacontract/export/markdown_exporter.py
+++ b/datacontract/export/markdown_exporter.py
@@ -105,7 +105,7 @@ def obj_attributes_to_markdown(obj: BaseModel, excluded_fields: set = set(), is_
         return ""
     if is_in_table_cell:
         bullet_char = "•"
-        newline_char = "<br>"
+        newline_char = "<br />"
     else:
         bullet_char = "-"
         newline_char = "\n"
@@ -247,12 +247,12 @@ def description_to_markdown(description) -> str:
     if description is None:
         return "No description."
     if isinstance(description, str):
-        return description.replace("\n", "<br>")
+        return description.replace("\n", "<br />")
     # Handle Description object - use purpose as the primary description
     if hasattr(description, "purpose") and description.purpose:
-        return description.purpose.replace("\n", "<br>")
+        return description.purpose.replace("\n", "<br />")
     if hasattr(description, "usage") and description.usage:
-        return description.usage.replace("\n", "<br>")
+        return description.usage.replace("\n", "<br />")
     return "No description."
 
 
@@ -285,7 +285,7 @@ def array_of_dict_to_markdown(array: List[Dict[str, str]]) -> str:
         markdown_parts.append(
             "| "
             + " | ".join(
-                f"{str(element.get(header, ''))}".replace("\n", "<br>").replace("\t", TAB) for header in headers
+                f"{str(element.get(header, ''))}".replace("\n", "<br />").replace("\t", TAB) for header in headers
             )
             + " |"
         )
@@ -352,7 +352,7 @@ def extra_to_markdown(obj: BaseModel, is_in_table_cell: bool = False) -> str:
 
     bullet_char = "•"
     value_line_ending = "" if is_in_table_cell else "\n"
-    row_suffix = "<br>" if is_in_table_cell else ""
+    row_suffix = "<br />" if is_in_table_cell else ""
 
     def render_header(key: str) -> str:
         return f"{bullet_char} **{key}:** " if is_in_table_cell else f"\n### {key.capitalize()}\n"

--- a/datacontract/templates/partials/model_field.html
+++ b/datacontract/templates/partials/model_field.html
@@ -14,7 +14,7 @@
 {% endif %}
     <div class="py-2 text-sm">
       {% if field.title %}
-      <span>{{ field.title }}</span><br>
+      <span>{{ field.title }}</span><br />
       {% endif %}
       <span class="font-mono flex">{{ field_name }}{% if field.ref %} <a href="{{ field.ref }}">
         <svg title="Definition" class="mr-1.5 h-5 w-5 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="-0.75 -0.75 24 24"><defs></defs><path d="M3.046875 5.15625h16.40625s0.9375 0 0.9375 0.9375v10.3125s0 0.9375 -0.9375 0.9375H3.046875s-0.9375 0 -0.9375 -0.9375v-10.3125s0 -0.9375 0.9375 -0.9375" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path><path d="m12.568125 10.3125 4.6875 0" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path><path d="m12.568125 13.125 4.6875 0" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path><path d="M5.068124999999999 8.4375h4.6875v4.6875h-4.6875Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"></path></svg>

--- a/tests/fixtures/export/datacontract.html
+++ b/tests/fixtures/export/datacontract.html
@@ -1921,7 +1921,7 @@ video {
 
     <div class="py-2 text-sm">
       
-      <span>Order ID</span><br>
+      <span>Order ID</span><br />
       
       <span class="font-mono flex">order_id</span>
     </div>
@@ -2241,7 +2241,7 @@ FROM orders
 
     <div class="py-2 text-sm">
       
-      <span>Customer ID</span><br>
+      <span>Customer ID</span><br />
       
       <span class="font-mono flex">customer_id</span>
     </div>

--- a/tests/fixtures/markdown/export/expected.md
+++ b/tests/fixtures/markdown/export/expected.md
@@ -1,6 +1,6 @@
 # urn:datacontract:checkout:orders-latest
 ## Info
-*Successful customer orders in the webshop. <br>All orders since 2020-01-01. <br>Orders with their line items are in their current state (no history included).<br>*
+*Successful customer orders in the webshop. <br />All orders since 2020-01-01. <br />Orders with their line items are in their current state (no history included).<br />*
 - **name:** Orders Latest
 - **version:** 2.0.0
 - **team:** Checkout Team
@@ -26,8 +26,8 @@ Max data processing per day: 10 TiB
 ## Servers
 | Name | Type | Attributes |
 | ---- | ---- | ---------- |
-| production | s3 | *One folder per model. One file per day.*<br>• **environment:** prod<br>• **roles:** [{'role': 'analyst_us', 'description': 'Access to the data for US region'}, {'role': 'analyst_cn', 'description': 'Access to the data for China region'}]<br>• **delimiter:** new_line<br>• **format:** json<br>• **location:** s3://datacontract-example-orders-latest/v2/{model}/*.json |
-| development | s3 | *One folder per model. One file per day.*<br>• **environment:** dev<br>• **roles:** [{'role': 'analyst_us', 'description': 'Access to the data for US region'}, {'role': 'analyst_cn', 'description': 'Access to the data for China region'}]<br>• **delimiter:** new_line<br>• **format:** json<br>• **location:** s3://datacontract-example-orders-latest/v2/{model}/*.json |
+| production | s3 | *One folder per model. One file per day.*<br />• **environment:** prod<br />• **roles:** [{'role': 'analyst_us', 'description': 'Access to the data for US region'}, {'role': 'analyst_cn', 'description': 'Access to the data for China region'}]<br />• **delimiter:** new_line<br />• **format:** json<br />• **location:** s3://datacontract-example-orders-latest/v2/{model}/*.json |
+| development | s3 | *One folder per model. One file per day.*<br />• **environment:** dev<br />• **roles:** [{'role': 'analyst_us', 'description': 'Access to the data for US region'}, {'role': 'analyst_cn', 'description': 'Access to the data for China region'}]<br />• **delimiter:** new_line<br />• **format:** json<br />• **location:** s3://datacontract-example-orders-latest/v2/{model}/*.json |
 
 ## Schema
 ### orders
@@ -35,20 +35,20 @@ Max data processing per day: 10 TiB
 
 | Field | Type | Attributes |
 | ----- | ---- | ---------- |
-|  order_id | string | *An internal ID that identifies an order in the online shop.*<br>• **businessName:** Order ID<br>• **tags:** ['orders']<br>• **customProperties:** [{'property': 'pii', 'value': 'True'}]<br>• `primaryKey`<br>• **logicalTypeOptions:** {'format': 'uuid'}<br>• `required`<br>• `unique`<br>• **classification:** restricted<br>• **examples:** ['243c25e5-a081-43a9-aeab-6d5d5b6cb5e2'] |
-|  order_timestamp | timestamp | *The business timestamp in UTC when the order was successfully registered in the source system and the payment was successful.*<br>• **tags:** ['business-timestamp']<br>• `required`<br>• **examples:** ['2024-09-09T08:30:00Z'] |
-|  order_total | integer | *Total amount the smallest monetary unit (e.g., cents).*<br>• `required`<br>• **examples:** [9999] |
-|  customer_id | string | *Unique identifier for the customer.*<br>• **logicalTypeOptions:** {'minLength': 10, 'maxLength': 20} |
-|  customer_email_address | string | *The email address, as entered by the customer.*<br>• **customProperties:** [{'property': 'pii', 'value': 'True'}]<br>• **logicalTypeOptions:** {'format': 'email'}<br>• `required`<br>• **classification:** sensitive<br>• **transformSourceObjects:** ['com.example.service.checkout.checkout_db.orders.email_address']<br>• **quality:** [{'description': 'The email address is not verified and may be invalid.', 'type': 'text'}] |
-|  processed_timestamp | timestamp | *The timestamp when the record was processed by the data platform.*<br>• **customProperties:** [{'property': 'jsonType', 'value': 'string'}, {'property': 'jsonFormat', 'value': 'date-time'}]<br>• `required` |
+|  order_id | string | *An internal ID that identifies an order in the online shop.*<br />• **businessName:** Order ID<br />• **tags:** ['orders']<br />• **customProperties:** [{'property': 'pii', 'value': 'True'}]<br />• `primaryKey`<br />• **logicalTypeOptions:** {'format': 'uuid'}<br />• `required`<br />• `unique`<br />• **classification:** restricted<br />• **examples:** ['243c25e5-a081-43a9-aeab-6d5d5b6cb5e2'] |
+|  order_timestamp | timestamp | *The business timestamp in UTC when the order was successfully registered in the source system and the payment was successful.*<br />• **tags:** ['business-timestamp']<br />• `required`<br />• **examples:** ['2024-09-09T08:30:00Z'] |
+|  order_total | integer | *Total amount the smallest monetary unit (e.g., cents).*<br />• `required`<br />• **examples:** [9999] |
+|  customer_id | string | *Unique identifier for the customer.*<br />• **logicalTypeOptions:** {'minLength': 10, 'maxLength': 20} |
+|  customer_email_address | string | *The email address, as entered by the customer.*<br />• **customProperties:** [{'property': 'pii', 'value': 'True'}]<br />• **logicalTypeOptions:** {'format': 'email'}<br />• `required`<br />• **classification:** sensitive<br />• **transformSourceObjects:** ['com.example.service.checkout.checkout_db.orders.email_address']<br />• **quality:** [{'description': 'The email address is not verified and may be invalid.', 'type': 'text'}] |
+|  processed_timestamp | timestamp | *The timestamp when the record was processed by the data platform.*<br />• **customProperties:** [{'property': 'jsonType', 'value': 'string'}, {'property': 'jsonFormat', 'value': 'date-time'}]<br />• `required` |
 ### line_items
 *A single article that is part of an order.*
 
 | Field | Type | Attributes |
 | ----- | ---- | ---------- |
-|  line_item_id | string | *Primary key of the lines_item_id table*<br>• `primaryKey`<br>• **primaryKeyPosition:** 2<br>• `required` |
-|  order_id | string | *An internal ID that identifies an order in the online shop.*<br>• **businessName:** Order ID<br>• **tags:** ['orders']<br>• **customProperties:** [{'property': 'pii', 'value': 'True'}]<br>• `primaryKey`<br>• **primaryKeyPosition:** 1<br>• **logicalTypeOptions:** {'format': 'uuid'}<br>• **classification:** restricted<br>• **examples:** ['243c25e5-a081-43a9-aeab-6d5d5b6cb5e2']<br>• **relationships:** [{'type': 'foreignKey', 'to': 'orders.order_id'}] |
-|  sku | string | *The purchased article number*<br>• **businessName:** Stock Keeping Unit<br>• **tags:** ['inventory']<br>• **logicalTypeOptions:** {'pattern': '^[A-Za-z0-9]{8,14}$'}<br>• **examples:** ['96385074'] |
+|  line_item_id | string | *Primary key of the lines_item_id table*<br />• `primaryKey`<br />• **primaryKeyPosition:** 2<br />• `required` |
+|  order_id | string | *An internal ID that identifies an order in the online shop.*<br />• **businessName:** Order ID<br />• **tags:** ['orders']<br />• **customProperties:** [{'property': 'pii', 'value': 'True'}]<br />• `primaryKey`<br />• **primaryKeyPosition:** 1<br />• **logicalTypeOptions:** {'format': 'uuid'}<br />• **classification:** restricted<br />• **examples:** ['243c25e5-a081-43a9-aeab-6d5d5b6cb5e2']<br />• **relationships:** [{'type': 'foreignKey', 'to': 'orders.order_id'}] |
+|  sku | string | *The purchased article number*<br />• **businessName:** Stock Keeping Unit<br />• **tags:** ['inventory']<br />• **logicalTypeOptions:** {'pattern': '^[A-Za-z0-9]{8,14}$'}<br />• **examples:** ['96385074'] |
 
 ## SLA Properties
 | Property | Value | Unit |


### PR DESCRIPTION
Some Markdown converters are expecting XHTML format, and it is not working correctly with `<br>`. By replacing `<br>` with `<br />` it is working perfectly fine.

- [x] Tests pass
- [x] ruff format
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added
