### PR TITLE
Support numeric retention values with units in SodaCL export

### DIFF
--- a/tests/fixtures/sodacl/datacontract_numeric_retention.odcs.yaml
+++ b/tests/fixtures/sodacl/datacontract_numeric_retention.odcs.yaml
@@ -1,0 +1,23 @@
+kind: DataContract
+apiVersion: v3.1.0
+id: orders-numeric-retention-test
+name: Orders Numeric Retention Test
+version: 1.0.0
+status: active
+schema:
+- name: orders
+  description: test
+  properties:
+  - name: order_id
+    logicalType: string
+    physicalType: string
+    required: true
+  - name: processed_timestamp
+    logicalType: timestamp
+    physicalType: timestamp
+    required: true
+slaProperties:
+- property: retention
+  value: 3
+  unit: y
+  element: orders.processed_timestamp


### PR DESCRIPTION
## Description

This PR adds support for numeric retention values with units (ODCS style) in the SodaCL exporter. Previously, only ISO 8601 duration strings (e.g., "P1Y") were supported. Now the exporter can handle retention specifications like `value: 3, unit: y` and correctly convert them to seconds for SodaCL checks.

## Changes

- **New function `_retention_value_to_seconds()`**: Unified conversion function that handles both:
  - Numeric values with units (ODCS style): `value=3, unit="y"` → converts to seconds
  - ISO 8601 duration strings: `value="P1Y"` → parses to seconds
  - Supports units: y/year/years, m/month/months, d/day/days, h/hour/hours, min/minute/minutes, s/second/seconds

- **Updated `to_servicelevel_retention_check()`**: Refactored to use the new `_retention_value_to_seconds()` function instead of only parsing ISO 8601 strings

- **Test coverage**: Added comprehensive tests for:
  - Numeric retention values with various units
  - ISO 8601 duration string parsing
  - None value handling
  - Integration test with SodaCL export using numeric retention

- **Test fixture**: Added `datacontract_numeric_retention.odcs.yaml` demonstrating numeric retention specification

## Fixes

Resolves https://github.com/datacontract/datacontract-cli/issues/1033

## Checklist

- [x] Tests pass
- [ ] ruff format
- [ ] README.md updated (if relevant)
- [ ] CHANGELOG.md entry added

https://claude.ai/code/session_015KwAwrDQooVLRqMdAimGT6