### PR TITLE
Fix Snowflake quoted identifiers (#797)

### DIFF
--- a/datacontract/engines/data_contract_checks.py
+++ b/datacontract/engines/data_contract_checks.py
@@ -84,9 +84,9 @@ def to_schema_checks(schema_object: SchemaObject, server: Server) -> List[Check]
 
     type1 = server.type if server and server.type else None
     config = QuotingConfig(
-        quote_field_name=type1 in ["postgres", "sqlserver", "azure"],
+        quote_field_name=type1 in ["postgres", "sqlserver", "azure", "snowflake"],
         quote_field_name_with_backticks=type1 in ["databricks"],
-        quote_model_name=type1 in ["postgres", "sqlserver"],
+        quote_model_name=type1 in ["postgres", "sqlserver", "snowflake"],
         quote_model_name_with_backticks=type1 == "bigquery",
     )
     quoting_config = config


### PR DESCRIPTION
## Summary
- Add Snowflake to the list of databases that use double-quote quoting for field and model names in soda-core checks
- Fixes `invalid identifier` errors when Snowflake tables use quoted lowercase column names

## Test plan
- [x] Reproduced bug on main: `invalid identifier 'NAME'` with quoted lowercase columns
- [x] Verified fix: all 12 checks pass on the fix branch
- [x] All 17 unit tests pass

Closes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)