### PR TITLE
Add ADC/WIF and impersonation support for BigQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,10 +521,11 @@ servers:
 
 #### BigQuery
 
-We support authentication to BigQuery using Service Account Key. The used Service Account should include the roles:
+We support authentication to BigQuery using Service Account Key or Application Default Credentials (ADC). ADC supports Workload Identity Federation (WIF), GCE metadata server, and `gcloud auth application-default login`. The used Service Account should include the roles:
 * BigQuery Job User
 * BigQuery Data Viewer
 
+When no `DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH` is set, the CLI falls back to ADC/WIF automatically via Soda's `use_context_auth`.
 
 ##### Example
 
@@ -545,7 +546,8 @@ models:
 
 | Environment Variable                         | Example                   | Description                                             |
 |----------------------------------------------|---------------------------|---------------------------------------------------------|
-| `DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH` | `~/service-access-key.json` | Service Access key as saved on key creation by BigQuery. If this environment variable isn't set, the cli tries to use `GOOGLE_APPLICATION_CREDENTIALS` as a fallback, so if you have that set for using their Python library anyway, it should work seamlessly. |
+| `DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH` | `~/service-access-key.json` | Service Account key JSON file. If not set, ADC/WIF is used automatically. |
+| `DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT` | `sa@project.iam.gserviceaccount.com` | Optional. Service account to impersonate. Works with both key file and ADC auth. |
 
 
 #### Azure

--- a/datacontract/engines/soda/connections/bigquery.py
+++ b/datacontract/engines/soda/connections/bigquery.py
@@ -5,23 +5,20 @@ import yaml
 
 # https://docs.soda.io/soda/connect-bigquery.html#authentication-methods
 def to_bigquery_soda_configuration(server):
-    # with service account key, using an external json file
-
-    # check for our own environment variable first
-    account_info = os.getenv("DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH")
-    if account_info is None:
-        # but as a fallback look for the default google one
-        account_info = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
-
-    soda_configuration = {
-        f"data_source {server.type}": {
-            "type": "bigquery",
-            "account_info_json_path": account_info,
-            "auth_scopes": ["https://www.googleapis.com/auth/bigquery"],
-            "project_id": server.project,
-            "dataset": server.dataset,
-        }
+    data_source = {
+        "type": "bigquery",
+        "project_id": server.project,
+        "dataset": server.dataset,
     }
 
-    soda_configuration_str = yaml.dump(soda_configuration)
+    if "DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH" in os.environ:
+        data_source["account_info_json_path"] = os.environ["DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH"]
+        data_source["auth_scopes"] = ["https://www.googleapis.com/auth/bigquery"]
+    else:
+        data_source["use_context_auth"] = True
+
+    if "DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT" in os.environ:
+        data_source["impersonation_account"] = os.environ["DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT"]
+
+    soda_configuration_str = yaml.dump({f"data_source {server.type}": data_source})
     return soda_configuration_str

--- a/tests/test_bigquery_soda_connection.py
+++ b/tests/test_bigquery_soda_connection.py
@@ -1,0 +1,61 @@
+from unittest.mock import MagicMock
+
+import yaml
+
+from datacontract.engines.soda.connections.bigquery import to_bigquery_soda_configuration
+
+
+def _make_server(type_="bigquery", project="my-project", dataset="my_dataset"):
+    server = MagicMock()
+    server.type = type_
+    server.project = project
+    server.dataset = dataset
+    return server
+
+
+def test_key_file_set(monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH", "/path/to/key.json")
+    monkeypatch.delenv("DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT", raising=False)
+    result = yaml.safe_load(to_bigquery_soda_configuration(_make_server()))
+    ds = result["data_source bigquery"]
+    assert ds["account_info_json_path"] == "/path/to/key.json"
+    assert ds["auth_scopes"] == ["https://www.googleapis.com/auth/bigquery"]
+    assert "use_context_auth" not in ds
+
+
+def test_no_key_file_uses_context_auth(monkeypatch):
+    monkeypatch.delenv("DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH", raising=False)
+    monkeypatch.delenv("DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT", raising=False)
+    result = yaml.safe_load(to_bigquery_soda_configuration(_make_server()))
+    ds = result["data_source bigquery"]
+    assert ds["use_context_auth"] is True
+    assert "account_info_json_path" not in ds
+    assert "auth_scopes" not in ds
+
+
+def test_impersonation_only(monkeypatch):
+    monkeypatch.delenv("DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH", raising=False)
+    monkeypatch.setenv("DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT", "sa@project.iam.gserviceaccount.com")
+    result = yaml.safe_load(to_bigquery_soda_configuration(_make_server()))
+    ds = result["data_source bigquery"]
+    assert ds["impersonation_account"] == "sa@project.iam.gserviceaccount.com"
+    assert ds["use_context_auth"] is True
+
+
+def test_key_file_and_impersonation(monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH", "/path/to/key.json")
+    monkeypatch.setenv("DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT", "sa@project.iam.gserviceaccount.com")
+    result = yaml.safe_load(to_bigquery_soda_configuration(_make_server()))
+    ds = result["data_source bigquery"]
+    assert ds["account_info_json_path"] == "/path/to/key.json"
+    assert ds["impersonation_account"] == "sa@project.iam.gserviceaccount.com"
+
+
+def test_adc_and_impersonation(monkeypatch):
+    monkeypatch.delenv("DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH", raising=False)
+    monkeypatch.setenv("DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT", "sa@project.iam.gserviceaccount.com")
+    result = yaml.safe_load(to_bigquery_soda_configuration(_make_server()))
+    ds = result["data_source bigquery"]
+    assert ds["use_context_auth"] is True
+    assert ds["impersonation_account"] == "sa@project.iam.gserviceaccount.com"
+    assert "account_info_json_path" not in ds


### PR DESCRIPTION
## Summary
- Fall back to Soda's `use_context_auth` when no `DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH` is set, enabling ADC/WIF, GCE metadata server, and `gcloud auth application-default login`
- Remove `GOOGLE_APPLICATION_CREDENTIALS` fallback (ADC handles this natively)
- Add `DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT` env var for service account impersonation (works with both key file and ADC auth)

## Test plan
- [x] 5 unit tests covering all auth combinations (key file, ADC, impersonation, both combos)
- [x] Verify existing BigQuery integration tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)