### PR TITLE
docs: remove duplicate 'excel' import option from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1537,7 +1537,6 @@ Available import options:
 | `spark`            | Import from Spark StructTypes, Variant        | ✅       |
 | `sql`              | Import from SQL DDL                           | ✅       |
 | `unity`            | Import from Databricks Unity Catalog          | partial |
-| `excel`            | Import from ODCS Excel Template               | ✅       |
 | Missing something? | Please create an issue on GitHub              | TBD     |
 
 


### PR DESCRIPTION
`excel` as an option appears twice under the import options in the README.

I removed the latter row and kept the one that's in the right position by alphabetical order (line 1531).

- [ ] Tests pass
- [ ] ruff format
- [x] README.md updated (if relevant)
- [ ] CHANGELOG.md entry added
