### PR TITLE
datacontract test on azure csv file with spaces in column names, fix on  Parser Error: syntax error at or near 

### DIFF
--- a/datacontract/engines/soda/connections/duckdb_connection.py
+++ b/datacontract/engines/soda/connections/duckdb_connection.py
@@ -99,7 +99,7 @@ def create_view_with_schema_union(con, schema_obj: SchemaObject, model_path: str
             INTERSECT SELECT column_name
             FROM information_schema.columns
             WHERE table_name = '{model_name}'""").fetchall()
-        selected_columns = ", ".join([column[0] for column in intersecting_columns])
+        selected_columns = ", ".join([f'"{column[0]}"' for column in intersecting_columns])
 
         # Insert data into table by name, but only columns existing in contract and data
         insert_data_sql = f"""INSERT INTO {model_name} BY NAME


### PR DESCRIPTION
as `azure` csv file checks with columnName with spaces kind of #1053

- [ ] Tests pass
- [ ] ruff format
- [ ] README.md updated (if relevant)
- [ ] CHANGELOG.md entry added
<img width="1097" height="353" alt="image" src="https://github.com/user-attachments/assets/1c9c1f36-5c4d-42b3-bc39-87d2ec4c0537" />
