### PR TITLE
feat(736): backticks for bigquery quality checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Escape single quotes in string values for SodaCL checks (#1090)
+- Escape BigQuery field and model names with backticks for SodaCL checks (#736)
 - Fixed catalog export SpecView not having a tags property for the index.html template (#1059)
 
 ### Added

--- a/datacontract/engines/data_contract_checks.py
+++ b/datacontract/engines/data_contract_checks.py
@@ -97,7 +97,7 @@ def to_schema_checks(schema_object: SchemaObject, server: Server) -> List[Check]
     type1 = server.type if server and server.type else None
     config = QuotingConfig(
         quote_field_name=type1 in ["postgres", "sqlserver", "snowflake", "azure", "s3", "gcs", "local"],
-        quote_field_name_with_backticks=type1 in ["databricks"],
+        quote_field_name_with_backticks=type1 in ["databricks", "bigquery"],
         quote_model_name=type1 in ["postgres", "sqlserver", "snowflake", "azure", "s3", "gcs", "local"],
         quote_model_name_with_backticks=type1 == "bigquery",
     )

--- a/tests/fixtures/bigquery/datacontract_with_quality_rules.odcs.yaml
+++ b/tests/fixtures/bigquery/datacontract_with_quality_rules.odcs.yaml
@@ -1,0 +1,25 @@
+# nonk8s
+# $schema: http://github.com/bitol-io/open-data-contract-standard/blob/main/schema/odcs-json-schema-latest.json
+---
+kind: DataContract
+apiVersion: v3.1.0
+id: bigquery_table_with_quality_rules
+version: 0.0.1
+status: draft
+servers:
+- server: my-dataproduct/bigquery
+  type: bigquery
+  dataset: datacontract_cli
+  project: datameshexample-product
+schema:
+- name: test_table
+  physicalType: TABLE
+  logicalType: object
+  properties:
+  - name: field_with_quality_rules
+    physicalType: STRING
+    logicalType: string
+    quality:
+      - type: library
+        metric: duplicateValues
+        mustBe: 0

--- a/tests/test_data_contract_checks.py
+++ b/tests/test_data_contract_checks.py
@@ -1,6 +1,7 @@
 import yaml
 from open_data_contract_standard.model import DataQuality, Server
 
+from datacontract.data_contract import DataContract
 from datacontract.engines.data_contract_checks import (
     QuotingConfig,
     _escape_sql_string_values,
@@ -13,6 +14,7 @@ from datacontract.engines.data_contract_checks import (
     check_property_type,
     check_property_unique,
     prepare_query,
+    to_schema_checks,
 )
 
 
@@ -225,6 +227,20 @@ def test_check_property_is_present_duckdb_hyphenated_model_name():
     checks = impl['checks for "test-1"']
     schema_check = checks[0]["schema"]
     assert schema_check["fail"]["when required column missing"] == ["name"]
+
+
+def test_field_and_model_names_have_backticks_in_quality_bigquery():
+    """Test that field and model names are encapsulated with backticks for BigQuery servers in quality checks"""
+    data_contract = DataContract(data_contract_file="fixtures/bigquery/datacontract_with_quality_rules.odcs.yaml")
+    checks = to_schema_checks(
+        schema_object=data_contract.get_data_contract().schema_[0],
+        server=Server(type="bigquery"),
+    )
+    quality_check = [check for check in checks if check.category == "quality"][0]
+    impl = yaml.safe_load(quality_check.implementation)
+    checks = impl["checks for `test_table`"]
+    check_name = checks[0]["duplicate_count(`field_with_quality_rules`) = 0"]["name"]
+    assert "test_table__field_with_quality_rules__field_duplicate_values" == check_name
 
 
 # --- Tests for single-quote escaping in SodaCL checks (issue #980) ---


### PR DESCRIPTION
This PR address issue #736. I found that table (model) names were already escaped with backticks, so the issue as described was already resolved. However, field names were not yet escaped. Since BigQuery has many reserved keywords, the safest strategy is to just escape all field names.

- [x] Tests pass
- [x] ruff format
- [ ] README.md updated (if relevant)
- [x] CHANGELOG.md entry added
