### PR TITLE
chore: exclude entire .claude/ directory in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -329,7 +329,9 @@ fabric.properties
 
 # Generated test files
 **/.tmp
-/.claude/settings.local.json
+
+# Claude Code
+.claude/
 
 # Auto Claude data directory
 .auto-claude/


### PR DESCRIPTION
## Summary
- Previously only `/.claude/settings.local.json` was ignored, leaving other Claude Code files (cache, skills) untracked but visible
- Now the entire `.claude/` directory is excluded, matching the pattern used for `.auto-claude/`

## Test plan
- [x] Verified with `git check-ignore -v .claude/` that the directory is properly excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)