### PR TITLE
fix: remove unnecessary numpy dependency from databricks and kafka extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,6 @@ databricks = [
   "databricks-sql-connector>=3.7.0,<4.3.0",
   "databricks-sdk<0.103.0",
   "pyspark>=3.5.0,<5.0.0",
-  "numpy>=1.26.4,<3.0.0",
 ]
 
 iceberg = [
@@ -72,7 +71,6 @@ kafka = [
   "datacontract-cli[avro]",
   "soda-core-spark-df>=3.3.20,<3.6.0",
   "pyspark>=3.5.0,<5.0.0",
-  "numpy>=1.26.4,<3.0.0",
 ]
 
 mysql = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ databricks = [
   "databricks-sql-connector>=3.7.0,<4.3.0",
   "databricks-sdk<0.103.0",
   "pyspark>=3.5.0,<5.0.0",
-  "numpy>=1.26.4,<2.0.0",  # pyspark incompatible with numpy 2.0
+  "numpy>=1.26.4,<3.0.0",
 ]
 
 iceberg = [
@@ -72,7 +72,7 @@ kafka = [
   "datacontract-cli[avro]",
   "soda-core-spark-df>=3.3.20,<3.6.0",
   "pyspark>=3.5.0,<5.0.0",
-  "numpy>=1.26.4,<2.0.0",  # pyspark incompatible with numpy 2.0
+  "numpy>=1.26.4,<3.0.0",
 ]
 
 mysql = [

--- a/tests/test_export_spark.py
+++ b/tests/test_export_spark.py
@@ -1,6 +1,5 @@
 from datacontract_specification.model import DataContractSpecification
 from pyspark.sql import types
-from pyspark.testing import assertSchemaEqual
 from typer.testing import CliRunner
 
 from datacontract.cli import app
@@ -26,8 +25,8 @@ def test_to_spark_schema():
     result = to_spark_dict(data_contract)
 
     assert len(result) == 2
-    assertSchemaEqual(result.get("orders"), expected_dict.get("orders"))
-    assertSchemaEqual(result.get("customers"), expected_dict.get("customers"))
+    assert result.get("orders") == expected_dict.get("orders")
+    assert result.get("customers") == expected_dict.get("customers")
 
 
 expected_str = """orders = StructType([


### PR DESCRIPTION
## Summary

- Removes the explicit `numpy` dependency from `databricks` and `kafka` extras
- Fixes `test_export_spark.py` to avoid importing `pyspark.testing` (which is incompatible with numpy 2.x on PySpark 3.5.x)

## Context

The `numpy>=1.26.4,<2.0.0` constraint was added because `pyspark.testing` uses `np.NaN` (removed in numpy 2.0). However, the codebase never imports numpy directly — it was only listed to cap the version. Instead of relaxing the bound, we fixed the only affected test and removed the dependency entirely. Transitive dependencies (pyspark, pandas, etc.) pull in whatever numpy version they need on their own.

Closes #1131

## Test plan

- [x] Verified numpy 2.x + PySpark 3.5.x: all Spark tests pass after test fix
- [x] Verified numpy 2.x + PySpark 4.x: all Spark tests pass
- [x] Verified numpy 1.x + PySpark 3.5.x: unchanged behavior
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)