### PR TITLE
fix: use actual materialization type for physicalType in dbt import

### DIFF
--- a/datacontract/imports/dbt_importer.py
+++ b/datacontract/imports/dbt_importer.py
@@ -127,7 +127,7 @@ def import_dbt_manifest(
 
         schema_obj = create_schema_object(
             name=node.name,
-            physical_type="table",
+            physical_type=node.config.materialized,
             description=node.description,
             properties=properties,
         )

--- a/tests/fixtures/dbt/import/expected/manifest_jaffle_bigquery.odcs.yaml
+++ b/tests/fixtures/dbt/import/expected/manifest_jaffle_bigquery.odcs.yaml
@@ -80,7 +80,7 @@ schema:
     logicalType: number
     required: true
 - name: stg_customers
-  physicalType: table
+  physicalType: view
   logicalType: object
   physicalName: stg_customers
   properties:
@@ -98,7 +98,7 @@ schema:
     physicalType: STRING
     logicalType: string
 - name: stg_orders
-  physicalType: table
+  physicalType: view
   logicalType: object
   physicalName: stg_orders
   properties:
@@ -119,7 +119,7 @@ schema:
     physicalType: STRING
     logicalType: string
 - name: stg_payments
-  physicalType: table
+  physicalType: view
   logicalType: object
   physicalName: stg_payments
   properties:

--- a/tests/fixtures/dbt/import/expected/manifest_jaffle_duckdb.odcs.yaml
+++ b/tests/fixtures/dbt/import/expected/manifest_jaffle_duckdb.odcs.yaml
@@ -80,7 +80,7 @@ schema:
     logicalType: number
     required: true
 - name: stg_customers
-  physicalType: table
+  physicalType: view
   logicalType: object
   physicalName: stg_customers
   properties:
@@ -98,7 +98,7 @@ schema:
     physicalType: varchar
     logicalType: string
 - name: stg_orders
-  physicalType: table
+  physicalType: view
   logicalType: object
   physicalName: stg_orders
   properties:
@@ -119,7 +119,7 @@ schema:
     physicalType: varchar
     logicalType: string
 - name: stg_payments
-  physicalType: table
+  physicalType: view
   logicalType: object
   physicalName: stg_payments
   properties:


### PR DESCRIPTION
## Summary
- When importing a dbt manifest, `physicalType` was hardcoded to `"table"` regardless of the model's actual materialization (e.g. `view`, `incremental`)
- Now reads `node.config.materialized` from the dbt manifest so views (and other materialization types) are correctly reflected in the generated ODCS contract
- Updated expected test fixtures: the three `stg_*` models in jaffle_shop are views, not tables

Closes #1111

## Test plan
- [x] All 8 existing `test_import_dbt.py` tests pass
- [x] Verified `stg_customers`, `stg_orders`, `stg_payments` now get `physicalType: view`
- [x] `orders` and `customers` still get `physicalType: table`

🤖 Generated with [Claude Code](https://claude.com/claude-code)