### PR TITLE
feat: add --checks option to test command to filter check categories (#678)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- Added `--checks` option to `test` command to selectively run check categories: `schema`, `quality`, `servicelevel` (#678)
 - Added `--schema-name` option to `test` command to test a specific schema instead of all schemas (#1079 @kelsoufi-sanofi)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -376,6 +376,16 @@ $ datacontract changelog v1.odcs.yaml v2.odcs.yaml
 │                                                                 `production`, or `all` for all   │
 │                                                                 servers (default).               │
 │                                                                 [default: all]                   │
+│ --schema-name                                          TEXT     The name of the schema to test,  │
+│                                                                 e.g., `orders`, or `all` for     │
+│                                                                 all schemas (default).           │
+│                                                                 [default: all]                   │
+│ --checks                                               TEXT     Comma-separated list of check    │
+│                                                                 categories to run. Available     │
+│                                                                 categories: schema, quality,     │
+│                                                                 servicelevel, custom. Omit to    │
+│                                                                 enable all.                      │
+│                                                                 [default: None]                  │
 │ --publish-test-results    --no-publish-test-results             Deprecated. Use publish          │
 │                                                                 parameter. Publish the results   │
 │                                                                 after the test                   │

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -181,6 +181,14 @@ def test(
         ),
     ] = None,
     output_format: Annotated[OutputFormat, typer.Option(help="The target format for the test results.")] = None,
+    checks: Annotated[
+        str,
+        typer.Option(
+            help="Comma-separated list of check categories to run. "
+            "Available categories: schema, quality, servicelevel, custom. "
+            "Omit to enable all."
+        ),
+    ] = None,
     logs: Annotated[bool, typer.Option(help="Print logs")] = False,
     ssl_verification: Annotated[
         bool,
@@ -193,6 +201,20 @@ def test(
     """
     enable_debug_logging(debug)
 
+    valid_categories = {"schema", "quality", "servicelevel", "custom"}
+    check_categories = None
+    if checks is not None:
+        check_categories = {c.strip() for c in checks.split(",") if c.strip()}
+        if not check_categories:
+            console.print("[red]Empty --checks specified.[/red]")
+            console.print(f"Available categories: {', '.join(sorted(valid_categories))}")
+            raise typer.Exit(code=1)
+        invalid = check_categories - valid_categories
+        if invalid:
+            console.print(f"[red]Invalid --checks specified: {', '.join(sorted(invalid))}[/red]")
+            console.print(f"Available categories: {', '.join(sorted(valid_categories))}")
+            raise typer.Exit(code=1)
+
     console.print(f"Testing {location}")
     if server == "all":
         server = None
@@ -204,6 +226,7 @@ def test(
         server=server,
         schema_name=schema_name,
         ssl_verification=ssl_verification,
+        check_categories=check_categories,
     ).test()
     if logs:
         _print_logs(run)

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -35,6 +35,7 @@ class DataContract:
         ssl_verification: bool = True,
         publish_test_results: bool = False,
         all_errors: bool = False,
+        check_categories: set[str] | None = None,
     ):
         self._data_contract_file = data_contract_file
         self._data_contract_str = data_contract_str
@@ -49,6 +50,7 @@ class DataContract:
         self._inline_definitions = inline_definitions
         self._ssl_verification = ssl_verification
         self._all_errors = all_errors
+        self._check_categories = check_categories
 
     @classmethod
     def init(cls, template: typing.Optional[str], schema: typing.Optional[str] = None) -> OpenDataContractStandard:
@@ -123,7 +125,13 @@ class DataContract:
             )
 
             execute_data_contract_test(
-                data_contract, run, self._server, self._spark, self._duckdb_connection, schema_name=self._schema_name
+                data_contract,
+                run,
+                self._server,
+                self._spark,
+                self._duckdb_connection,
+                schema_name=self._schema_name,
+                check_categories=self._check_categories,
             )
 
         except DataContractException as e:

--- a/datacontract/engines/data_contract_test.py
+++ b/datacontract/engines/data_contract_test.py
@@ -65,6 +65,8 @@ def execute_data_contract_test(
     checks = create_checks(data_contract, server, schema_name=schema_name)
     if check_categories is not None:
         checks = [c for c in checks if c.category in check_categories]
+        if not checks:
+            run.log_warn(f"No checks found for categories: {', '.join(sorted(check_categories))}")
     run.checks.extend(checks)
 
     # TODO check server is supported type for nicer error messages
@@ -72,7 +74,7 @@ def execute_data_contract_test(
     if server.format == "json" and server.type != "kafka":
         if check_categories is None or "schema" in check_categories:
             check_jsonschema(run, data_contract, server, schema_name=schema_name)
-    check_soda_execute(run, data_contract, server, spark, duckdb_connection, schema_name=schema_name)
+    check_soda_execute(run, data_contract, server, spark, duckdb_connection, schema_name=schema_name, check_categories=check_categories)
 
 
 def get_server(data_contract: OpenDataContractStandard, server_name: str = None) -> Server | None:

--- a/datacontract/engines/data_contract_test.py
+++ b/datacontract/engines/data_contract_test.py
@@ -28,6 +28,7 @@ def execute_data_contract_test(
     spark: "SparkSession" = None,
     duckdb_connection: "DuckDBPyConnection" = None,
     schema_name: str = "all",
+    check_categories: set[str] | None = None,
 ):
     if data_contract.schema_ is None or len(data_contract.schema_) == 0:
         raise DataContractException(
@@ -61,13 +62,18 @@ def execute_data_contract_test(
     if server.type == "api":
         server = process_api_response(run, server)
 
-    run.checks.extend(create_checks(data_contract, server, schema_name=schema_name))
+    checks = create_checks(data_contract, server, schema_name=schema_name)
+    if check_categories is not None:
+        checks = [c for c in checks if c.category in check_categories]
+    run.checks.extend(checks)
 
     # TODO check server is supported type for nicer error messages
     # TODO check server credentials are complete for nicer error messages
     if server.format == "json" and server.type != "kafka":
-        check_jsonschema(run, data_contract, server, schema_name=schema_name)
-    check_soda_execute(run, data_contract, server, spark, duckdb_connection, schema_name=schema_name)
+        if check_categories is None or "schema" in check_categories:
+            check_jsonschema(run, data_contract, server, schema_name=schema_name)
+    if check_categories is None or any(c in check_categories for c in ("schema", "quality", "servicelevel", "custom")):
+        check_soda_execute(run, data_contract, server, spark, duckdb_connection, schema_name=schema_name)
 
 
 def get_server(data_contract: OpenDataContractStandard, server_name: str = None) -> Server | None:

--- a/datacontract/engines/data_contract_test.py
+++ b/datacontract/engines/data_contract_test.py
@@ -72,8 +72,7 @@ def execute_data_contract_test(
     if server.format == "json" and server.type != "kafka":
         if check_categories is None or "schema" in check_categories:
             check_jsonschema(run, data_contract, server, schema_name=schema_name)
-    if check_categories is None or any(c in check_categories for c in ("schema", "quality", "servicelevel", "custom")):
-        check_soda_execute(run, data_contract, server, spark, duckdb_connection, schema_name=schema_name)
+    check_soda_execute(run, data_contract, server, spark, duckdb_connection, schema_name=schema_name)
 
 
 def get_server(data_contract: OpenDataContractStandard, server_name: str = None) -> Server | None:

--- a/datacontract/engines/data_contract_test.py
+++ b/datacontract/engines/data_contract_test.py
@@ -74,7 +74,9 @@ def execute_data_contract_test(
     if server.format == "json" and server.type != "kafka":
         if check_categories is None or "schema" in check_categories:
             check_jsonschema(run, data_contract, server, schema_name=schema_name)
-    check_soda_execute(run, data_contract, server, spark, duckdb_connection, schema_name=schema_name, check_categories=check_categories)
+    check_soda_execute(
+        run, data_contract, server, spark, duckdb_connection, schema_name=schema_name, check_categories=check_categories
+    )
 
 
 def get_server(data_contract: OpenDataContractStandard, server_name: str = None) -> Server | None:

--- a/datacontract/engines/soda/check_soda_execute.py
+++ b/datacontract/engines/soda/check_soda_execute.py
@@ -32,6 +32,7 @@ def check_soda_execute(
     spark: "SparkSession" = None,
     duckdb_connection: "DuckDBPyConnection" = None,
     schema_name: str = "all",
+    check_categories: set[str] | None = None,
 ):
     from soda.common.config_helper import ConfigHelper
 
@@ -165,6 +166,8 @@ def check_soda_execute(
         name = scan_result.get("name")
         check = get_check(run, scan_result)
         if check is None:
+            if check_categories is not None and "custom" not in check_categories:
+                continue
             check = Check(
                 id=str(uuid.uuid4()),
                 category="custom",

--- a/tests/test_test_checks_filter.py
+++ b/tests/test_test_checks_filter.py
@@ -1,0 +1,86 @@
+from typer.testing import CliRunner
+
+from datacontract.cli import app
+from datacontract.data_contract import DataContract
+
+runner = CliRunner()
+
+
+def test_checks_schema_only():
+    data_contract = DataContract(
+        data_contract_file="fixtures/parquet/datacontract.yaml",
+        check_categories=["schema"],
+    )
+    run = data_contract.test()
+    print(run.pretty())
+    assert run.result == "passed"
+    assert all(check.category == "schema" for check in run.checks)
+    assert len(run.checks) > 0
+
+
+def test_checks_quality_only_no_quality_checks_defined():
+    data_contract = DataContract(
+        data_contract_file="fixtures/parquet/datacontract.yaml",
+        check_categories=["quality"],
+    )
+    run = data_contract.test()
+    print(run.pretty())
+    # No quality checks defined in parquet fixture, so no checks should run
+    assert len(run.checks) == 0
+
+
+def test_checks_all_categories_same_as_default():
+    run_all = DataContract(
+        data_contract_file="fixtures/parquet/datacontract.yaml",
+    ).test()
+
+    run_explicit = DataContract(
+        data_contract_file="fixtures/parquet/datacontract.yaml",
+        check_categories=["schema", "quality", "servicelevel", "custom"],
+    ).test()
+
+    assert len(run_all.checks) == len(run_explicit.checks)
+    assert run_all.result == run_explicit.result
+
+
+def test_checks_cli_option():
+    result = runner.invoke(
+        app,
+        ["test", "--checks", "schema", "./fixtures/parquet/datacontract.yaml"],
+    )
+    assert result.exit_code == 0
+
+
+def test_checks_cli_invalid_category():
+    result = runner.invoke(
+        app,
+        ["test", "--checks", "invalid", "./fixtures/parquet/datacontract.yaml"],
+    )
+    assert result.exit_code == 1
+    assert "Invalid --checks specified" in result.stdout
+
+
+def test_checks_cli_empty_category():
+    result = runner.invoke(
+        app,
+        ["test", "--checks", "", "./fixtures/parquet/datacontract.yaml"],
+    )
+    assert result.exit_code == 1
+    assert "Empty --checks specified" in result.stdout
+    assert "Available" in result.stdout
+
+
+def test_checks_cli_multiple_categories():
+    result = runner.invoke(
+        app,
+        ["test", "--checks", "schema,quality", "./fixtures/parquet/datacontract.yaml"],
+    )
+    assert result.exit_code == 0
+
+
+def test_checks_cli_spaces_after_comma():
+    result = runner.invoke(
+        app,
+        ["test", "--checks", "schema, quality", "./fixtures/parquet/datacontract.yaml"],
+    )
+    assert result.exit_code == 0

--- a/tests/test_test_checks_filter.py
+++ b/tests/test_test_checks_filter.py
@@ -9,7 +9,7 @@ runner = CliRunner()
 def test_checks_schema_only():
     data_contract = DataContract(
         data_contract_file="fixtures/parquet/datacontract.yaml",
-        check_categories=["schema"],
+        check_categories={"schema"},
     )
     run = data_contract.test()
     print(run.pretty())
@@ -21,7 +21,7 @@ def test_checks_schema_only():
 def test_checks_quality_only_no_quality_checks_defined():
     data_contract = DataContract(
         data_contract_file="fixtures/parquet/datacontract.yaml",
-        check_categories=["quality"],
+        check_categories={"quality"},
     )
     run = data_contract.test()
     print(run.pretty())
@@ -36,7 +36,7 @@ def test_checks_all_categories_same_as_default():
 
     run_explicit = DataContract(
         data_contract_file="fixtures/parquet/datacontract.yaml",
-        check_categories=["schema", "quality", "servicelevel", "custom"],
+        check_categories={"schema", "quality", "servicelevel", "custom"},
     ).test()
 
     assert len(run_all.checks) == len(run_explicit.checks)


### PR DESCRIPTION
## Summary

- Adds `--checks` option to `datacontract test` to selectively run check categories
- Available categories: `schema`, `quality`, `servicelevel`, `custom`
- Omitting the option runs all categories (default behaviour unchanged)
- Invalid or empty `--checks` values exit with a helpful error message

## Usage

```bash
# Only run schema checks
datacontract test --checks schema datacontract.yaml

# Run schema and quality checks
datacontract test --checks schema,quality datacontract.yaml
```

## Test plan

- [x] `test_checks_schema_only` — only schema-category checks returned
- [x] `test_checks_quality_only_no_quality_checks_defined` — empty result when no quality checks defined
- [x] `test_checks_all_categories_same_as_default` — explicit full list matches default behaviour
- [x] `test_checks_cli_option` — CLI option accepted
- [x] `test_checks_cli_invalid_category` — exits with error on unknown category
- [x] `test_checks_cli_empty_category` — exits with error on empty value
- [x] `test_checks_cli_multiple_categories` — comma-separated list works
- [x] `test_checks_cli_spaces_after_comma` — spaces around commas handled

Closes #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)