### PR TITLE
feat: enumerate accepted values for --dialect and --sql-server-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1307,8 +1307,9 @@ steps:
 ╭─ SQL Options ────────────────────────────────────────────────────────────────────────────────────╮
 │ --sql-server-type        TEXT  [sql] The server type to determine the sql dialect. By default,   │
 │                                it uses 'auto' to automatically detect the sql dialect via the    │
-│                                specified servers in the data contract.                           │
-│                                [default: auto]                                                   │
+│                                specified servers in the data contract. Accepted values: auto,    │
+│                                snowflake, postgres, mysql, databricks, sqlserver, bigquery,      │
+│                                trino, oracle. [default: auto]                                    │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 
 ```
@@ -1657,10 +1658,10 @@ For more information about the Excel template structure, visit the [ODCS Excel T
 │    --source                                 TEXT                      The path to the file that  │
 │                                                                       should be imported.        │
 │                                                                       [default: None]            │
-│    --dialect                                TEXT                      The SQL dialect to use     │
-│                                                                       when importing SQL files,  │
-│                                                                       e.g., postgres, tsql,      │
-│                                                                       bigquery.                  │
+│    --dialect                                TEXT                      The SQL dialect.           │
+│                                                                       Accepted values: postgres, │
+│                                                                       tsql, bigquery, snowflake, │
+│                                                                       databricks, spark, duckdb. │
 │                                                                       [default: None]            │
 │    --glue-table                             TEXT                      List of table ids to       │
 │                                                                       import from the Glue       │

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -413,7 +413,9 @@ def import_(
     ] = None,
     dialect: Annotated[
         Optional[str],
-        typer.Option(help="The SQL dialect. Accepted values: postgres, tsql, bigquery, snowflake, databricks, spark, duckdb."),
+        typer.Option(
+            help="The SQL dialect. Accepted values: postgres, tsql, bigquery, snowflake, databricks, spark, duckdb."
+        ),
     ] = None,
     glue_table: Annotated[
         Optional[List[str]],

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -336,7 +336,7 @@ def export(
     sql_server_type: Annotated[
         Optional[str],
         typer.Option(
-            help="[sql] The server type to determine the sql dialect. By default, it uses 'auto' to automatically detect the sql dialect via the specified servers in the data contract.",
+            help="[sql] The server type to determine the sql dialect. By default, it uses 'auto' to automatically detect the sql dialect via the specified servers in the data contract. Accepted values: auto, snowflake, postgres, mysql, databricks, sqlserver, bigquery, trino, oracle.",
             rich_help_panel="SQL Options",
         ),
     ] = "auto",
@@ -413,7 +413,7 @@ def import_(
     ] = None,
     dialect: Annotated[
         Optional[str],
-        typer.Option(help="The SQL dialect to use when importing SQL files, e.g., postgres, tsql, bigquery."),
+        typer.Option(help="The SQL dialect. Accepted values: postgres, tsql, bigquery, snowflake, databricks, spark, duckdb."),
     ] = None,
     glue_table: Annotated[
         Optional[List[str]],


### PR DESCRIPTION
## Summary

- Updated `--dialect` help text to list all accepted values instead of "e.g., ..."
- Updated `--sql-server-type` help text to list all accepted values at the end

Closes #1150