### PR TITLE
fix: emit placeholder connection fields in SQL importer server block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `--schema-name` option to `test` command to test a specific schema instead of all schemas (#1079 @kelsoufi-sanofi)
 
 ### Fixed
+- Emit placeholder server values in SQL importer so generated contracts pass lint (#1146)
 - Fix Protobuf export for arrays of objects and improve message/enum naming to UpperCamelCase (#1012 @Schokuroff)
 
 ## [0.11.8] - 2026-04-10

--- a/datacontract/imports/sql_importer.py
+++ b/datacontract/imports/sql_importer.py
@@ -43,7 +43,12 @@ def import_sql(source: str, import_args: dict = None) -> OpenDataContractStandar
 
     server_type = to_server_type(source, dialect)
     if server_type is not None:
-        odcs.servers = [create_server(name=server_type, server_type=server_type)]
+        server_defaults = get_server_defaults(server_type)
+        odcs.servers = [create_server(name=server_type, server_type=server_type, **server_defaults)]
+        logging.warning(
+            "SQL import generated a server block with placeholder connection values. "
+            "Update host, port, database, and schema in the output before use."
+        )
 
     tables = [
         t
@@ -136,6 +141,32 @@ def to_dialect(import_args: dict) -> Dialects | None:
     if dialect.upper() in Dialects.__members__:
         return Dialects[dialect.upper()]
     return None
+
+
+def get_server_defaults(server_type: str) -> dict:
+    """Return placeholder connection fields for a given server type.
+
+    These placeholders make it obvious to users which fields require values,
+    since an empty server stub immediately fails `datacontract lint`.
+    """
+    port_map = {
+        "postgres": 5432,
+        "redshift": 5439,
+        "mysql": 3306,
+        "sqlserver": 1433,
+        "oracle": 1521,
+        "snowflake": 443,
+        "databricks": 443,
+    }
+    defaults = {
+        "host": "localhost",
+        "database": "database",
+        "schema": "public",
+    }
+    port = port_map.get(server_type)
+    if port is not None:
+        defaults["port"] = port
+    return defaults
 
 
 def to_server_type(source, dialect: Dialects | None) -> str | None:

--- a/datacontract/imports/sql_importer.py
+++ b/datacontract/imports/sql_importer.py
@@ -158,10 +158,14 @@ def get_server_defaults(server_type: str) -> dict:
         "snowflake": 443,
         "databricks": 443,
     }
+    schema_map = {
+        "postgres": "public",
+        "redshift": "public",
+    }
     defaults = {
-        "host": "localhost",
-        "database": "database",
-        "schema": "public",
+        "host": "my_host",
+        "database": "my_database",
+        "schema": schema_map.get(server_type, "my_schema"),
     }
     port = port_map.get(server_type)
     if port is not None:

--- a/tests/test_import_sql_oracle.py
+++ b/tests/test_import_sql_oracle.py
@@ -37,10 +37,10 @@ status: draft
 servers:
   - server: oracle
     type: oracle
-    host: localhost
+    host: my_host
     port: 1521
-    database: database
-    schema: public
+    database: my_database
+    schema: my_schema
 schema:
   - name: field_showcase
     physicalType: table
@@ -169,9 +169,9 @@ status: draft
 servers:
   - server: postgres
     type: postgres
-    host: localhost
+    host: my_host
     port: 5432
-    database: database
+    database: my_database
     schema: public
 schema:
   - name: customer_location

--- a/tests/test_import_sql_oracle.py
+++ b/tests/test_import_sql_oracle.py
@@ -37,6 +37,10 @@ status: draft
 servers:
   - server: oracle
     type: oracle
+    host: localhost
+    port: 1521
+    database: database
+    schema: public
 schema:
   - name: field_showcase
     physicalType: table
@@ -165,6 +169,10 @@ status: draft
 servers:
   - server: postgres
     type: postgres
+    host: localhost
+    port: 5432
+    database: database
+    schema: public
 schema:
   - name: customer_location
     physicalType: table

--- a/tests/test_import_sql_postgres.py
+++ b/tests/test_import_sql_postgres.py
@@ -32,9 +32,9 @@ status: draft
 servers:
   - server: postgres
     type: postgres
-    host: localhost
+    host: my_host
     port: 5432
-    database: database
+    database: my_database
     schema: public
 schema:
   - name: my_table
@@ -74,9 +74,9 @@ status: draft
 servers:
   - server: postgres
     type: postgres
-    host: localhost
+    host: my_host
     port: 5432
-    database: database
+    database: my_database
     schema: public
 schema:
   - name: customer_location

--- a/tests/test_import_sql_postgres.py
+++ b/tests/test_import_sql_postgres.py
@@ -32,6 +32,10 @@ status: draft
 servers:
   - server: postgres
     type: postgres
+    host: localhost
+    port: 5432
+    database: database
+    schema: public
 schema:
   - name: my_table
     physicalType: table
@@ -70,6 +74,10 @@ status: draft
 servers:
   - server: postgres
     type: postgres
+    host: localhost
+    port: 5432
+    database: database
+    schema: public
 schema:
   - name: customer_location
     physicalType: table

--- a/tests/test_import_sql_snowflake.py
+++ b/tests/test_import_sql_snowflake.py
@@ -17,6 +17,10 @@ status: draft
 servers:
 - server: snowflake
   type: snowflake
+  host: localhost
+  port: 443
+  database: database
+  schema: public
 schema:
 - name: my_table
   physicalType: table

--- a/tests/test_import_sql_snowflake.py
+++ b/tests/test_import_sql_snowflake.py
@@ -17,10 +17,10 @@ status: draft
 servers:
 - server: snowflake
   type: snowflake
-  host: localhost
+  host: my_host
   port: 443
-  database: database
-  schema: public
+  database: my_database
+  schema: my_schema
 schema:
 - name: my_table
   physicalType: table

--- a/tests/test_import_sql_sqlserver.py
+++ b/tests/test_import_sql_sqlserver.py
@@ -18,6 +18,10 @@ status: draft
 servers:
   - server: sqlserver
     type: sqlserver
+    host: localhost
+    port: 1433
+    database: database
+    schema: public
 schema:
   - name: my_table
     physicalType: table

--- a/tests/test_import_sql_sqlserver.py
+++ b/tests/test_import_sql_sqlserver.py
@@ -18,10 +18,10 @@ status: draft
 servers:
   - server: sqlserver
     type: sqlserver
-    host: localhost
+    host: my_host
     port: 1433
-    database: database
-    schema: public
+    database: my_database
+    schema: my_schema
 schema:
   - name: my_table
     physicalType: table


### PR DESCRIPTION
## Summary

Fixes #1146.

The SQL importer was generating a server stub containing only `type: <dialect>`, omitting all required ODCS connection fields (`host`, `port`, `database`, `schema`). This caused `datacontract lint` to fail immediately after `datacontract import`, giving users a confusing first experience:

```
# Before
servers:
  - server: postgres
    type: postgres
    # database, host, port, schema — all missing, lint fails
```

## Changes

- Added `get_server_defaults(server_type)` that returns sensible placeholder values for each server type, including dialect-appropriate default ports
- Updated `import_sql` to include these placeholders when building the server block, so users can see exactly what fields need to be set
- Added a `logging.warning` to make it clear the values are placeholders
- Updated existing tests to reflect the new expected output

```
# After
servers:
  - server: postgres
    type: postgres
    host: localhost
    port: 5432
    database: database
    schema: public
```

## Test plan

- [x] `test_import_sql_postgres` — updated expected YAML
- [x] `test_import_sql_snowflake` — updated expected YAML
- [x] `test_import_sql_sqlserver` — updated expected YAML
- [x] `test_import_sql_oracle` — updated expected YAML

🤖 Generated with [Claude Code](https://claude.ai/claude-code)