### PR TITLE
feat: use Typer subcommands for import/export (#1134, #1155)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Test datacontract init
         run: datacontract init new-datacontract.yaml
       - name: Test datacontract export
-        run: datacontract export --format sql tests/fixtures/export/datacontract.odcs.yaml
+        run: datacontract export sql tests/fixtures/export/datacontract.odcs.yaml
       - name: Install dependencies with duckdb
         run: |
           pip install -e '.[duckdb]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.12.0]
+## Unreleased
 - **Breaking**: the `dbt` export format was renamed to `dbt-models` (to differentiate from other dbt export formats)
 - **Breaking**: Several changes in the CLI syntax (#1134, #1155):
 
-  | Commands                                        | Old syntax                       | New syntax                             |
-    |-------------------------------------------------|----------------------------------|----------------------------------------|
+  | Commands affected                               | Old syntax                       | New syntax                             |
+  |-------------------------------------------------|----------------------------------|----------------------------------------|
   | `export`, `import`                              | `--format <FORMAT> <OPTIONS>`    | `<FORMAT> <OPTIONS>` (drop `--format`) |
   | `lint`, `test`, `ci`, `publish`, `catalog`      | `--schema <PATH>`                | `--odcs-schema <PATH>`                 |
   | `export rdf`                                    | `--rdf-base <URI>`               | `--base <URI>`                         |
@@ -28,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   | `import spark`                                  | `--source <NAMES>`               | `--tables <NAMES>`                     |
   | `import`                                        | `--template`                     | dropped (was a no-op)                  |
 
-## Unreleased
 
 ### Added
 - Added `--checks` option to `test` command to selectively run check categories: `schema`, `quality`, `servicelevel` (#678)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0]
+- **Breaking**: the `dbt` export format was renamed to `dbt-models` (to differentiate from other dbt export formats)
+- **Breaking**: Several changes in the CLI syntax (#1134, #1155):
+
+  | Commands                                        | Old syntax                       | New syntax                             |
+    |-------------------------------------------------|----------------------------------|----------------------------------------|
+  | `export`, `import`                              | `--format <FORMAT> <OPTIONS>`    | `<FORMAT> <OPTIONS>` (drop `--format`) |
+  | `lint`, `test`, `ci`, `publish`, `catalog`      | `--schema <PATH>`                | `--odcs-schema <PATH>`                 |
+  | `export rdf`                                    | `--rdf-base <URI>`               | `--base <URI>`                         |
+  | `export sql`, `sql-query`, `great-expectations` | `--sql-server-type <TYPE>`       | `--server-type <TYPE>`                 |
+  | `import dbt`                                    | `--dbt-model <NAME>`             | `--model <NAME>`                       |
+  | `import dbml`                                   | `--dbml-schema <NAME>`           | `--schema <NAME>`                      |
+  | `import dbml`                                   | `--dbml-table <NAME>`            | `--table <NAME>`                       |
+  | `import glue`                                   | `--source <NAME>`                | `--database <NAME>`                    |
+  | `import glue`                                   | `--glue-table <NAME>`            | `--table <NAME>`                       |
+  | `import bigquery`                               | `--bigquery-project <NAME>`      | `--project <NAME>`                     |
+  | `import bigquery`                               | `--bigquery-dataset <NAME>`      | `--dataset <NAME>`                     |
+  | `import bigquery`                               | `--bigquery-table <NAME>`        | `--table <NAME>`                       |
+  | `import unity`                                  | `--unity-table-full-name <NAME>` | `--table <NAME>`                       |
+  | `import iceberg`                                | `--iceberg-table <NAME>`         | `--table <NAME>`                       |
+  | `import spark`                                  | `--source <NAMES>`               | `--tables <NAMES>`                     |
+  | `import`                                        | `--template`                     | dropped (was a no-op)                  |
+
 ## Unreleased
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,10 +85,10 @@ datacontract lint datacontract.yaml
 datacontract test datacontract.yaml
 
 # Export a data contract to a different format
-datacontract export --format html datacontract.yaml --output datacontract.html
+datacontract export html datacontract.yaml --output datacontract.html
 
 # Import from a different format
-datacontract import --format sql --source my-ddl.sql --dialect postgres --output datacontract.yaml
+datacontract import sql --source my-ddl.sql --dialect postgres --output datacontract.yaml
 
 # Show a changelog between two data contracts
 datacontract changelog datacontract-v1.yaml datacontract-v2.yaml

--- a/README.md
+++ b/README.md
@@ -1704,6 +1704,7 @@ For more information about the Excel template structure, visit the [ODCS Excel T
 │                                      file).                                                      │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options for glue ───────────────────────────────────────────────────────────────────────────────╮
+│ --database                     TEXT  Name of the AWS Glue database.                              │
 │ --table                        TEXT  List of table ids to import from the Glue Database (repeat  │
 │                                      for multiple table ids, leave empty for all tables in the   │
 │                                      dataset).                                                   │
@@ -1718,13 +1719,17 @@ For more information about the Excel template structure, visit the [ODCS Excel T
 ╭─ Options for unity ──────────────────────────────────────────────────────────────────────────────╮
 │ --table                        TEXT  Full name of a table in the Unity Catalog                   │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options for spark ──────────────────────────────────────────────────────────────────────────────╮
+│ --tables                       TEXT  Comma-separated list of Spark table names to import from    │
+│                                      the current Spark session.                                  │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options for iceberg ────────────────────────────────────────────────────────────────────────────╮
 │ --table                        TEXT  Table name to assign to the model created from the Iceberg  │
 │                                      schema.                                                     │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
-Run `datacontract import <format> --help` to see the format-specific options (e.g. `datacontract export sql --help`). If you are missing a format, please [create an issue on GitHub](https://github.com/datacontract/datacontract-cli/issues).
+Run `datacontract import <format> --help` to see the format-specific options (e.g. `datacontract import sql --help`). If you are missing a format, please [create an issue on GitHub](https://github.com/datacontract/datacontract-cli/issues).
 
 #### Examples
 ```bash
@@ -1828,12 +1833,12 @@ Examples:
 
 ```bash
 # Example import from AWS Glue with specifying the tables to import
-datacontract import glue --source <database_name> --table <table_name_1> --table <table_name_2> --table <table_name_3>
+datacontract import glue --database <database_name> --table <table_name_1> --table <table_name_2> --table <table_name_3>
 ```
 
 ```bash
 # Example import from AWS Glue importing all tables in the database
-datacontract import glue --source <database_name>
+datacontract import glue --database <database_name>
 ```
 
 </details>
@@ -1841,11 +1846,11 @@ datacontract import glue --source <database_name>
 <details markdown="1">
 <summary><strong>Spark</strong></summary>
 
-Importing from Spark table or view these must be created or accessible in the Spark context. Specify tables list in `source` parameter.  If the `source` tables are registered as tables in Databricks, and they have a table-level descriptions they will also be added to the Data Contract Specification.
+Importing from Spark table or view these must be created or accessible in the Spark context. Specify tables list in the `--tables` option. If the tables are registered in Databricks and have a table-level description, it will also be added to the Data Contract Specification.
 
 ```bash
 # Example: Import Spark table(s) from Spark context
-datacontract import spark --source "users,orders"
+datacontract import spark --tables "users,orders"
 ```
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Commands
 │                             [default: datacontract.yaml]                     │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --schema                         TEXT          The location (url or path) of │
+│ --json-schema                    TEXT          The location (url or path) of │
 │                                                the ODCS JSON Schema          │
 │ --output                         PATH          Specify the file path where   │
 │                                                the test results should be    │
@@ -364,52 +364,70 @@ $ datacontract changelog v1.odcs.yaml v2.odcs.yaml
 │   location      [LOCATION]  The location (url or path) of the data contract yaml.                │
 │                             [default: datacontract.yaml]                                         │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
-│ --schema                                               TEXT     The location (url or path) of    │
-│                                                                 the ODCS JSON Schema             │
-│                                                                 [default: None]                  │
-│ --server                                               TEXT     The server configuration to run  │
-│                                                                 the schema and quality tests.    │
-│                                                                 Use the key of the server object │
-│                                                                 in the data contract yaml file   │
-│                                                                 to refer to a server, e.g.,      │
-│                                                                 `production`, or `all` for all   │
-│                                                                 servers (default).               │
-│                                                                 [default: all]                   │
-│ --schema-name                                          TEXT     The name of the schema to test,  │
-│                                                                 e.g., `orders`, or `all` for     │
-│                                                                 all schemas (default).           │
-│                                                                 [default: all]                   │
-│ --checks                                               TEXT     Comma-separated list of check    │
-│                                                                 categories to run. Available     │
-│                                                                 categories: schema, quality,     │
-│                                                                 servicelevel, custom. Omit to    │
-│                                                                 enable all.                      │
-│                                                                 [default: None]                  │
-│ --publish-test-results    --no-publish-test-results             Deprecated. Use publish          │
-│                                                                 parameter. Publish the results   │
-│                                                                 after the test                   │
-│                                                                 [default:                        │
-│                                                                 no-publish-test-results]         │
-│ --publish                                              TEXT     The url to publish the results   │
-│                                                                 after the test.                  │
-│                                                                 [default: None]                  │
-│ --output                                               PATH     Specify the file path where the  │
-│                                                                 test results should be written   │
-│                                                                 to (e.g.,                        │
-│                                                                 './test-results/TEST-datacontra… │
-│                                                                 [default: None]                  │
-│ --output-format                                        [junit]  The target format for the test   │
-│                                                                 results.                         │
-│                                                                 [default: None]                  │
-│ --logs                    --no-logs                             Print logs [default: no-logs]    │
-│ --ssl-verification        --no-ssl-verification                 SSL verification when publishing │
-│                                                                 the data contract.               │
-│                                                                 [default: ssl-verification]      │
-│ --debug                   --no-debug                            Enable debug logging             │
-│                                                                 [default: no-debug]              │
-│ --help                                                          Show this message and exit.      │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json-schema                              TEXT          The location (url   │
+│                                                          or path) of the     │
+│                                                          ODCS JSON Schema    │
+│ --server                                   TEXT          The server          │
+│                                                          configuration to    │
+│                                                          run the schema and  │
+│                                                          quality tests. Use  │
+│                                                          the key of the      │
+│                                                          server object in    │
+│                                                          the data contract   │
+│                                                          yaml file to refer  │
+│                                                          to a server, e.g.,  │
+│                                                          `production`, or    │
+│                                                          `all` for all       │
+│                                                          servers (default).  │
+│                                                          [default: all]      │
+│ --schema-name                              TEXT          Which model to      │
+│                                                          test, e.g.,         │
+│                                                          `orders`, or `all`  │
+│                                                          for all models      │
+│                                                          (default). Distinct │
+│                                                          from --json-schema, │
+│                                                          which is the ODCS   │
+│                                                          validation schema.  │
+│                                                          [default: all]      │
+│ --publish-test-re…    --no-publish-tes…                  Deprecated. Use     │
+│                                                          publish parameter.  │
+│                                                          Publish the results │
+│                                                          after the test      │
+│                                                          [default:           │
+│                                                          no-publish-test-re… │
+│ --publish                                  TEXT          The url to publish  │
+│                                                          the results after   │
+│                                                          the test.           │
+│ --output                                   PATH          Specify the file    │
+│                                                          path where the test │
+│                                                          results should be   │
+│                                                          written to (e.g.,   │
+│                                                          './test-results/TE… │
+│ --output-format                            [json|junit]  The target format   │
+│                                                          for the test        │
+│                                                          results.            │
+│ --checks                                   TEXT          Comma-separated     │
+│                                                          list of check       │
+│                                                          categories to run.  │
+│                                                          Available           │
+│                                                          categories: schema, │
+│                                                          quality,            │
+│                                                          servicelevel,       │
+│                                                          custom. Omit to     │
+│                                                          enable all.         │
+│ --logs                --no-logs                          Print logs          │
+│                                                          [default: no-logs]  │
+│ --ssl-verification    --no-ssl-verific…                  SSL verification    │
+│                                                          when publishing the │
+│                                                          data contract.      │
+│                                                          [default:           │
+│                                                          ssl-verification]   │
+│ --debug               --no-debug                         Enable debug        │
+│                                                          logging             │
+│ --help                                                   Show this message   │
+│                                                          and exit.           │
+╰──────────────────────────────────────────────────────────────────────────────╯
 
 ```
 
@@ -1131,53 +1149,59 @@ models:
 │                                  contract yaml file(s).                      │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --schema                                   TEXT          The location (url   │
-│                                                          or path) of the     │
-│                                                          ODCS JSON Schema    │
-│ --server                                   TEXT          The server          │
-│                                                          configuration to    │
-│                                                          run the schema and  │
-│                                                          quality tests. Use  │
-│                                                          the key of the      │
-│                                                          server object in    │
-│                                                          the data contract   │
-│                                                          yaml file to refer  │
-│                                                          to a server, e.g.,  │
-│                                                          `production`, or    │
-│                                                          `all` for all       │
-│                                                          servers (default).  │
-│                                                          [default: all]      │
-│ --publish                                  TEXT          The url to publish  │
-│                                                          the results after   │
-│                                                          the test.           │
-│ --output                                   PATH          Specify the file    │
-│                                                          path where the test │
-│                                                          results should be   │
-│                                                          written to (e.g.,   │
-│                                                          './test-results/TE… │
-│ --output-format                            [json|junit]  The target format   │
-│                                                          for the test        │
-│                                                          results.            │
-│ --logs                --no-logs                          Print logs          │
-│                                                          [default: no-logs]  │
-│ --json                --no-json                          Print test results  │
-│                                                          as JSON to stdout.  │
-│                                                          [default: no-json]  │
-│ --fail-on                                  TEXT          Minimum severity    │
-│                                                          that causes a       │
-│                                                          non-zero exit code: │
-│                                                          'warning', 'error', │
-│                                                          or 'never'.         │
-│                                                          [default: error]    │
-│ --ssl-verification    --no-ssl-verific…                  SSL verification    │
-│                                                          when publishing the │
-│                                                          data contract.      │
-│                                                          [default:           │
-│                                                          ssl-verification]   │
-│ --debug               --no-debug                         Enable debug        │
-│                                                          logging             │
-│ --help                                                   Show this message   │
-│                                                          and exit.           │
+│ --json-schema                            TEXT              The location (url │
+│                                                            or path) of the   │
+│                                                            ODCS JSON Schema  │
+│ --server                                 TEXT              The server        │
+│                                                            configuration to  │
+│                                                            run the schema    │
+│                                                            and quality       │
+│                                                            tests. Use the    │
+│                                                            key of the server │
+│                                                            object in the     │
+│                                                            data contract     │
+│                                                            yaml file to      │
+│                                                            refer to a        │
+│                                                            server, e.g.,     │
+│                                                            `production`, or  │
+│                                                            `all` for all     │
+│                                                            servers           │
+│                                                            (default).        │
+│                                                            [default: all]    │
+│ --publish                                TEXT              The url to        │
+│                                                            publish the       │
+│                                                            results after the │
+│                                                            test.             │
+│ --output                                 PATH              Specify the file  │
+│                                                            path where the    │
+│                                                            test results      │
+│                                                            should be written │
+│                                                            to (e.g.,         │
+│                                                            './test-results/… │
+│ --output-format                          [json|junit]      The target format │
+│                                                            for the test      │
+│                                                            results.          │
+│ --logs               --no-logs                             Print logs        │
+│                                                            [default:         │
+│                                                            no-logs]          │
+│ --json                                                     Print test        │
+│                                                            results as JSON   │
+│                                                            to stdout.        │
+│ --fail-on                                [warning|error|n  Minimum severity  │
+│                                          ever]             that causes a     │
+│                                                            non-zero exit     │
+│                                                            code.             │
+│                                                            [default: error]  │
+│ --ssl-verificati…    --no-ssl-verifi…                      SSL verification  │
+│                                                            when publishing   │
+│                                                            the data          │
+│                                                            contract.         │
+│                                                            [default:         │
+│                                                            ssl-verification] │
+│ --debug              --no-debug                            Enable debug      │
+│                                                            logging           │
+│ --help                                                     Show this message │
+│                                                            and exit.         │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 
 ```
@@ -1262,63 +1286,47 @@ steps:
 
 ### export
 ```
-                                                                                                    
- Usage: datacontract export FORMAT [OPTIONS] [LOCATION]                                              
-                                                                                                    
- Convert data contract to a specific format. Saves to file specified by `output` option if present, 
- otherwise prints to stdout.                                                                        
-                                                                                                    
- FORMAT is a subcommand: jsonschema, pydantic-model, sodacl, dbt-models, dbt-sources,              
- dbt-staging-sql, odcs, rdf, avro, protobuf, great-expectations, avro-idl, sql, sql-query,        
- mermaid, html, go, bigquery, dbml, spark, sqlalchemy, data-caterer, dcs, markdown, iceberg,       
- custom, excel, dqx                                                                                
-                                                                                                    
-╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────╮
-│   location      [LOCATION]  The location (url or path) of the data contract yaml.                │
-│                             [default: datacontract.yaml]                                         │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
-│    --output                       PATH                            Specify the file path where    │
-│                                                                   the exported data will be      │
-│                                                                   saved. If no path is provided, │
-│                                                                   the output will be printed to  │
-│                                                                   stdout.                        │
-│                                                                   [default: None]                │
-│    --server                       TEXT                            The server name to export.     │
-│                                                                   [default: None]                │
-│    --schema-name                  TEXT                            The name of the schema to      │
-│                                                                   export, e.g., `orders`, or     │
-│                                                                   `all` for all schemas          │
-│                                                                   (default).                     │
-│                                                                   [default: all]                 │
-│    --schema                       TEXT                            The location (url or path) of  │
-│                                                                   the ODCS JSON Schema           │
-│                                                                   [default: None]                │
-│    --engine                       TEXT                            [engine] The engine used for   │
-│                                                                   great expection run.           │
-│                                                                   [default: None]                │
-│    --template                     PATH                            The file path or URL of a      │
-│                                                                   template. For Excel format:    │
-│                                                                   path/URL to custom Excel       │
-│                                                                   template. For custom format:   │
-│                                                                   path to Jinja template.        │
-│                                                                   [default: None]                │
-│    --base                         TEXT                            [rdf] The base URI used to     │
-│                                                                   generate the RDF graph.        │
-│                                                                   [default: None]                │
-│    --server-type                  TEXT                            [sql] The server type to       │
-│                                                                   determine the sql dialect.     │
-│                                                                   Accepted values: auto,         │
-│                                                                   snowflake, postgres, mysql,    │
-│                                                                   databricks, sqlserver,         │
-│                                                                   bigquery, trino, oracle.       │
-│                                                                   [default: auto]                │
-│    --debug          --no-debug                                    Enable debug logging           │
-│                                                                   [default: no-debug]            │
-│    --help                                                         Show this message and exit.    │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+ Usage: datacontract export [OPTIONS] COMMAND [ARGS]...                         
+                                                                                
+ Convert a data contract to a target format.                                    
+                                                                                
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ sql                 Export a data contract to SQL DDL.                       │
+│ sql-query           Export a data contract to a SQL query.                   │
+│ dbt-models          Export a data contract to dbt model schema YAML.         │
+│ dbt-sources         Export a data contract to dbt sources YAML.              │
+│ dbt-staging-sql     Export a data contract to a dbt staging SQL file.        │
+│ avro                Export a data contract to Avro schema.                   │
+│ avro-idl            Export a data contract to Avro IDL.                      │
+│ jsonschema          Export a data contract to JSON Schema.                   │
+│ pydantic-model      Export a data contract to a Pydantic model.              │
+│ protobuf            Export a data contract to Protobuf schema.               │
+│ odcs                Export a data contract to ODCS format.                   │
+│ rdf                 Export a data contract to RDF.                           │
+│ html                Export a data contract to HTML.                          │
+│ markdown            Export a data contract to Markdown.                      │
+│ mermaid             Export a data contract to Mermaid diagram.               │
+│ bigquery            Export a data contract to BigQuery schema.               │
+│ dbml                Export a data contract to DBML.                          │
+│ go                  Export a data contract to Go structs.                    │
+│ spark               Export a data contract to Spark schema.                  │
+│ sqlalchemy          Export a data contract to SQLAlchemy models.             │
+│ iceberg             Export a data contract to Iceberg schema.                │
+│ sodacl              Export a data contract to SodaCL checks.                 │
+│ great-expectations  Export a data contract to Great Expectations suite.      │
+│ data-caterer        Export a data contract to Data Caterer format.           │
+│ dcs                 Export a data contract to DCS format.                    │
+│ dqx                 Export a data contract to DQX format.                    │
+│ excel               Export a data contract to Excel.                         │
+│ custom              Export a data contract using a custom Jinja template.    │
+╰──────────────────────────────────────────────────────────────────────────────╯
 
 ```
+
+Each format is a subcommand with its own options. Run `datacontract export <format> --help` to see the format-specific options (e.g. `datacontract export sql --help`).
 
 ```bash
 # Example export data contract as HTML
@@ -1642,75 +1650,35 @@ For more information about the Excel template structure, visit the [ODCS Excel T
 
 ### import
 ```
-                                                                                                    
- Usage: datacontract import FORMAT [OPTIONS]                                                        
-                                                                                                    
- Create a data contract from the given source location. Saves to file specified by `output` option  
- if present, otherwise prints to stdout.                                                            
-                                                                                                    
- FORMAT is a subcommand: sql, avro, dbt, dbml, glue, jsonschema, json, bigquery, odcs, unity,      
- spark, iceberg, parquet, csv, protobuf, excel                                                     
-                                                                                                    
-╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
-│    --output                                 PATH                      Specify the file path      │
-│                                                                       where the Data Contract    │
-│                                                                       will be saved. If no path  │
-│                                                                       is provided, the output    │
-│                                                                       will be printed to stdout. │
-│                                                                       [default: None]            │
-│    --source                                 TEXT                      The path to the file that  │
-│                                                                       should be imported.        │
-│                                                                       [default: None]            │
-│    --dialect                                TEXT                      The SQL dialect.           │
-│                                                                       Accepted values: postgres, │
-│                                                                       tsql, bigquery, snowflake, │
-│                                                                       databricks, spark, duckdb. │
-│                                                                       [default: None]            │
-│    --table                                  TEXT                      List of table ids/names to │
-│                                                                       import (repeat for         │
-│                                                                       multiple, leave empty for  │
-│                                                                       all tables in the          │
-│                                                                       dataset). Used by glue,    │
-│                                                                       bigquery, dbml, iceberg,   │
-│                                                                       unity.                     │
-│                                                                       [default: None]            │
-│    --project                                TEXT                      The bigquery project id.   │
-│                                                                       [default: None]            │
-│    --dataset                                TEXT                      The bigquery dataset id.   │
-│                                                                       [default: None]            │
-│    --model                                  TEXT                      List of models names to    │
-│                                                                       import from the dbt        │
-│                                                                       manifest file (repeat for  │
-│                                                                       multiple models names,     │
-│                                                                       leave empty for all models │
-│                                                                       in the dataset).           │
-│                                                                       [default: None]            │
-│    --schema                                 TEXT                      List of schema names to    │
-│                                                                       import from the DBML file  │
-│                                                                       (repeat for multiple       │
-│                                                                       schema names, leave empty  │
-│                                                                       for all tables in the      │
-│                                                                       file). Also: the location  │
-│                                                                       (url or path) of the ODCS  │
-│                                                                       JSON Schema.               │
-│                                                                       [default: None]            │
-│    --template                               TEXT                      The location (url or path) │
-│                                                                       of the ODCS template       │
-│                                                                       [default: None]            │
-│    --owner                                  TEXT                      The owner or team          │
-│                                                                       responsible for managing   │
-│                                                                       the data contract.         │
-│                                                                       [default: None]            │
-│    --id                                     TEXT                      The identifier for the the │
-│                                                                       data contract.             │
-│                                                                       [default: None]            │
-│    --debug                    --no-debug                              Enable debug logging       │
-│                                                                       [default: no-debug]        │
-│    --help                                                             Show this message and      │
-│                                                                       exit.                      │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+ Usage: datacontract import [OPTIONS] COMMAND [ARGS]...                         
+                                                                                
+ Create a data contract from a source format.                                   
+                                                                                
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ sql         Import a data contract from a SQL DDL file.                      │
+│ avro        Import a data contract from an Avro schema file.                 │
+│ dbt         Import a data contract from a dbt manifest file.                 │
+│ dbml        Import a data contract from a DBML file.                         │
+│ glue        Import a data contract from AWS Glue.                            │
+│ bigquery    Import a data contract from BigQuery.                            │
+│ unity       Import a data contract from Databricks Unity Catalog.            │
+│ jsonschema  Import a data contract from a JSON Schema file.                  │
+│ json        Import a data contract from a JSON file.                         │
+│ odcs        Import a data contract from an ODCS file.                        │
+│ parquet     Import a data contract from a Parquet file.                      │
+│ csv         Import a data contract from a CSV file.                          │
+│ protobuf    Import a data contract from a Protobuf schema file.              │
+│ spark       Import a data contract from a Spark schema.                      │
+│ iceberg     Import a data contract from an Iceberg schema.                   │
+│ excel       Import a data contract from an Excel file.                       │
+╰──────────────────────────────────────────────────────────────────────────────╯
 
 ```
+
+Each format is a subcommand with its own options. Run `datacontract import <format> --help` to see the format-specific options (e.g. `datacontract import sql --help`).
 
 Example:
 ```bash
@@ -1932,7 +1900,7 @@ datacontract import protobuf --source "test.proto"
 │                                 catalog. Applies recursively to any subfolders.                  │
 │                                 [default: *.yaml]                                                │
 │ --output                  TEXT  Output directory for the catalog html files. [default: catalog/] │
-│ --schema                  TEXT  The location (url or path) of the ODCS JSON Schema               │
+│ --json-schema             TEXT  The location (url or path) of the ODCS JSON Schema               │
 │                                 [default: None]                                                  │
 │ --debug     --no-debug          Enable debug logging [default: no-debug]                         │
 │ --help                          Show this message and exit.                                      │
@@ -1963,7 +1931,7 @@ datacontract catalog --files "*.odcs.yaml"
 │                             [default: datacontract.yaml]                                         │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
-│ --schema                                       TEXT  The location (url or path) of the ODCS JSON │
+│ --json-schema                                  TEXT  The location (url or path) of the ODCS JSON │
 │                                                      Schema                                      │
 │                                                      [default: None]                             │
 │ --ssl-verification    --no-ssl-verification          SSL verification when publishing the data   │

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Commands
 │                             [default: datacontract.yaml]                                         │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
-│ --json-schema                    TEXT          The location (url or path) of the ODCS JSON       │
+│ --odcs-schema                    TEXT          The location (url or path) of the ODCS JSON       │
 │                                                Schema                                            │
 │ --output                         PATH          Specify the file path where the test results      │
 │                                                should be written to (e.g.,                       │
@@ -356,7 +356,7 @@ $ datacontract changelog v1.odcs.yaml v2.odcs.yaml
 │                             [default: datacontract.yaml]                                         │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
-│ --json-schema                                          TEXT          The location (url or path)  │
+│ --odcs-schema                                          TEXT          The location (url or path)  │
 │                                                                      of the ODCS JSON Schema     │
 │ --server                                               TEXT          The server configuration to │
 │                                                                      run the schema and quality  │
@@ -1119,7 +1119,7 @@ models:
 │                                  file(s).                                                        │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
-│ --json-schema                                  TEXT                   The location (url or path) │
+│ --odcs-schema                                  TEXT                   The location (url or path) │
 │                                                                       of the ODCS JSON Schema    │
 │ --server                                       TEXT                   The server configuration   │
 │                                                                       to run the schema and      │
@@ -1285,7 +1285,7 @@ steps:
 │ --schema-name                  TEXT  Which schema to export, e.g., `orders`, or `all` for all    │
 │                                      schemas (default).                                          │
 │                                      [default: all]                                              │
-│ --json-schema                  TEXT  The location (url or path) of the ODCS JSON Schema          │
+│ --odcs-schema                  TEXT  The location (url or path) of the ODCS JSON Schema          │
 │ --debug          --no-debug          Enable debug logging                                        │
 │ --help                               Show a command-specific help message and exit.              │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
@@ -1679,7 +1679,7 @@ For more information about the Excel template structure, visit the [ODCS Excel T
 │ --output                       PATH  Specify the file path where the Data Contract will be       │
 │                                      saved. If no path is provided, the output will be printed   │
 │                                      to stdout.                                                  │
-│ --json-schema                  TEXT  The location (url or path) of the ODCS JSON Schema          │
+│ --odcs-schema                  TEXT  The location (url or path) of the ODCS JSON Schema          │
 │ --template                     TEXT  The location (url or path) of the ODCS template             │
 │ --owner                        TEXT  The owner or team responsible for managing the data         │
 │                                      contract.                                                   │
@@ -1956,7 +1956,7 @@ datacontract import protobuf --source "test.proto"
 │                                      [default: *.yaml]                                           │
 │ --output                       TEXT  Output directory for the catalog html files.                │
 │                                      [default: catalog/]                                         │
-│ --json-schema                  TEXT  The location (url or path) of the ODCS JSON Schema          │
+│ --odcs-schema                  TEXT  The location (url or path) of the ODCS JSON Schema          │
 │ --debug          --no-debug          Enable debug logging                                        │
 │ --help                               Show this message and exit.                                 │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
@@ -1985,7 +1985,7 @@ datacontract catalog --files "*.odcs.yaml"
 │                             [default: datacontract.yaml]                                         │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
-│ --json-schema                                  TEXT  The location (url or path) of the ODCS JSON │
+│ --odcs-schema                                  TEXT  The location (url or path) of the ODCS JSON │
 │                                                      Schema                                      │
 │ --ssl-verification    --no-ssl-verification          SSL verification when publishing the data   │
 │                                                      contract.                                   │

--- a/README.md
+++ b/README.md
@@ -1335,6 +1335,12 @@ The `export` function converts a given data contract into a SQL data definition 
 datacontract export sql datacontract.yaml --output output.sql
 ```
 
+The SQL dialect is determined from the `servers` block in the data contract (e.g. `type: postgres`, `type: snowflake`). Alternatively, pass it explicitly:
+
+```shell
+datacontract export sql datacontract.yaml --server-type postgres --output output.sql
+```
+
 If using Databricks, and an error is thrown when trying to deploy the SQL DDLs with `variant` columns set the following properties.
 
 ```shell
@@ -1347,7 +1353,7 @@ The `export` function transforms a specified data contract into a comprehensive 
 If the contract includes multiple models, you need to specify the names of the schema/models you wish to export.
 
 ```shell
-datacontract export great-expectations datacontract.yaml --model orders
+datacontract export great-expectations datacontract.yaml --schema-name orders
 ```
 
 The export creates a list of expectations by utilizing:
@@ -1460,7 +1466,7 @@ ingested by [Data Caterer](https://github.com/data-catering/data-caterer). This 
 ability to generate production-like data in any environment based off your data contract.
 
 ```shell
-datacontract export data-caterer datacontract.yaml --model orders
+datacontract export data-caterer datacontract.yaml --schema-name orders
 ```
 
 You can further customise the way data is generated via adding
@@ -1471,11 +1477,11 @@ to suit your needs.
 
 Exports to an [Iceberg Table Json Schema Definition](https://iceberg.apache.org/spec/#appendix-c-json-serialization).
 
-This export only supports a single model export at a time because Iceberg's schema definition is for a single table and the exporter maps 1 model to 1 table, use the `--model` flag
+This export only supports a single model export at a time because Iceberg's schema definition is for a single table and the exporter maps 1 model to 1 table, use the `--schema-name` flag
 to limit your contract export to a single model.
 
 ```bash
- $ datacontract export iceberg --model orders https://datacontract.com/examples/orders-latest/datacontract.yaml --output /tmp/orders_iceberg.json
+ $ datacontract export iceberg --schema-name orders https://datacontract.com/examples/orders-latest/datacontract.yaml --output /tmp/orders_iceberg.json
  
  $ cat /tmp/orders_iceberg.json | jq '.'
 {
@@ -1535,19 +1541,21 @@ datacontract export custom --template template.txt datacontract.yaml
 
 ##### Jinja templates & variables
 
-You can directly use the Data Contract Specification as template variables.
+You can directly use the ODCS (Open Data Contract Standard) object as a template variable. `data_contract` is an `OpenDataContractStandard` instance; top-level fields include `name`, `id`, `version`, `schema_` (the list of schemas), `servers`, `team`, etc.
 
 {% raw %}
 ```shell
 $ cat template.txt
-title: {{ data_contract.info.title }}
-models:
-{%- for model_name, model in data_contract.models.items() %}
-  - name: {{ model.name }}
+title: {{ data_contract.name }}
+schemas:
+{%- for schema in data_contract.schema_ %}
+  - name: {{ schema.name }}
 {%- endfor %}
 
 $ datacontract export custom --template template.txt datacontract.yaml
 title: Orders Latest
+schemas:
+  - name: orders
 ```
 {% endraw %}
 

--- a/README.md
+++ b/README.md
@@ -1239,8 +1239,7 @@ steps:
 
 
 ### export
-```
-                                                                                                    
+```                                                                                              
  Usage: datacontract export [OPTIONS] COMMAND [ARGS]...                                             
                                                                                                     
  Convert a data contract to a target format.                                                        
@@ -1316,47 +1315,16 @@ steps:
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
-Each format is a subcommand with its own options. Run `datacontract export <format> --help` to see the format-specific options (e.g. `datacontract export sql --help`).
+Run `datacontract export <format> --help` to see the format-specific options (e.g. `datacontract export sql --help`). If you are missing a format, please [create an issue on GitHub](https://github.com/datacontract/datacontract-cli/issues).
 
+#### Examples
 ```bash
 # Example export data contract as HTML
 datacontract export html --output datacontract.html
 ```
 
-Available export options:
-
-| Type                 | Description                                             | Status  |
-|----------------------|---------------------------------------------------------|---------|
-| `html`               | Export to HTML                                          | ✅       |
-| `jsonschema`         | Export to JSON Schema                                   | ✅       |
-| `odcs`               | Export to Open Data Contract Standard (ODCS) V3         | ✅       |
-| `sodacl`             | Export to SodaCL quality checks in YAML format          | ✅       |
-| `dbt-models`         | Export to dbt models in YAML format                     | ✅       |
-| `dbt-sources`        | Export to dbt sources in YAML format                    | ✅       |
-| `dbt-staging-sql`    | Export to dbt staging SQL models                        | ✅       |
-| `rdf`                | Export data contract to RDF representation in N3 format | ✅       |
-| `avro`               | Export to AVRO models                                   | ✅       |
-| `protobuf`           | Export to Protobuf                                      | ✅       |
-| `terraform`          | Export to terraform resources                           | ✅       |
-| `sql`                | Export to SQL DDL                                       | ✅       |
-| `sql-query`          | Export to SQL Query                                     | ✅       |
-| `great-expectations` | Export to Great Expectations Suites in JSON Format      | ✅       |
-| `bigquery`           | Export to BigQuery Schemas                              | ✅       |
-| `go`                 | Export to Go types                                      | ✅       |
-| `pydantic-model`     | Export to pydantic models                               | ✅       |
-| `DBML`               | Export to a DBML Diagram description                    | ✅       |
-| `spark`              | Export to a Spark StructType                            | ✅       |
-| `sqlalchemy`         | Export to SQLAlchemy Models                             | ✅       |
-| `data-caterer`       | Export to Data Caterer in YAML format                   | ✅       |
-| `dcs`                | Export to Data Contract Specification in YAML format    | ✅       |
-| `markdown`           | Export to Markdown                                      | ✅       |
-| `iceberg`            | Export to an Iceberg JSON Schema Definition             | partial |
-| `excel`              | Export to ODCS Excel Template                           | ✅       |
-| `custom`             | Export to Custom format with Jinja                      | ✅       |
-| `dqx`                | Export to DQX in YAML format                            | ✅       |
-| Missing something?   | Please create an issue on GitHub                        | TBD     |
-
-#### SQL
+<details markdown="1">
+<summary><strong>SQL</strong></summary>
 
 The `export` function converts a given data contract into a SQL data definition language (DDL).
 
@@ -1376,7 +1344,10 @@ If using Databricks, and an error is thrown when trying to deploy the SQL DDLs w
 spark.conf.set(“spark.databricks.delta.schema.typeCheck.enabled”, “false”)
 ```
 
-#### Great Expectations
+</details>
+
+<details markdown="1">
+<summary><strong>Great Expectations</strong></summary>
 
 The `export` function transforms a specified data contract into a comprehensive Great Expectations JSON suite.
 If the contract includes multiple models, you need to specify the names of the schema/models you wish to export.
@@ -1405,7 +1376,10 @@ To further customize the export, the following optional arguments are available:
 
   Providing `sql_server_type` ensures that the appropriate SQL dialect and connection settings are applied during the expectation validation.
 
-#### RDF
+</details>
+
+<details markdown="1">
+<summary><strong>RDF</strong></summary>
 
 The `export` function converts a given data contract into a RDF representation. You have the option to
 add a base_url which will be used as the default prefix to resolve relative IRIs inside the document.
@@ -1429,24 +1403,36 @@ Having the data contract inside an RDF Graph gives us access the following use c
 - Apply graph algorithms on multiple data contracts (Find similar data contracts, find "gatekeeper"
 data products, find the true domain owner of a field attribute)
 
-#### DBML
+</details>
+
+<details markdown="1">
+<summary><strong>DBML</strong></summary>
 
 The export function converts the logical data types of the datacontract into the specific ones of a concrete Database
 if a server is selected via the `--server` option (based on the `type` of that server). If no server is selected, the
 logical data types are exported.
 
-#### DBT & DBT-SOURCES
+</details>
+
+<details markdown="1">
+<summary><strong>DBT & DBT-SOURCES</strong></summary>
 
 The export function converts the datacontract to dbt models in YAML format, with support for SQL dialects.
 If a server is selected via the `--server` option (based on the `type` of that server) then the DBT column `data_types` match the expected data types of the server.
 If no server is selected, then it defaults to `snowflake`.
 
-#### Spark
+</details>
+
+<details markdown="1">
+<summary><strong>Spark</strong></summary>
 
 The export function converts the data contract specification into a StructType Spark schema. The returned value is a Python code picture of the model schemas.
 Spark DataFrame schema is defined as StructType. For more details about Spark Data Types please see [the spark documentation](https://spark.apache.org/docs/latest/sql-ref-datatypes.html)
 
-#### Avro
+</details>
+
+<details markdown="1">
+<summary><strong>Avro</strong></summary>
 
 The export function converts the data contract specification into an avro schema. It supports specifying custom avro properties for logicalTypes and default values.
 
@@ -1458,7 +1444,7 @@ To specify custom Avro properties in your data contract, you can define them wit
 
 >NOTE: At this moment, we just support [logicalType](https://avro.apache.org/docs/1.11.0/spec.html#Logical+Types) and [default](https://avro.apache.org/docs/1.11.0/spec.htm)
 
-#### Example Configuration
+##### Example Configuration
 
 ```yaml
 models:
@@ -1474,7 +1460,7 @@ models:
           avroDefault: 1672534861000000
 ```
 
-#### Explanation
+##### Explanation
 
 - **models**: The top-level key that contains different models (tables or objects) in your data contract.
 - **orders**: A specific model name. Replace this with the name of your model.
@@ -1488,7 +1474,10 @@ models:
     - **avroLogicalType**: Specifies the logical type of the field in Avro. In this example, it is `local-timestamp-micros`.
     - **avroDefault**: Specifies the default value for the field in Avro. In this example, it is 1672534861000000 which corresponds to ` 2023-01-01 01:01:01 UTC`.
 
-#### Data Caterer
+</details>
+
+<details markdown="1">
+<summary><strong>Data Caterer</strong></summary>
 
 The export function converts the data contract to a data generation task in YAML format that can be
 ingested by [Data Caterer](https://github.com/data-catering/data-caterer). This gives you the
@@ -1502,7 +1491,10 @@ You can further customise the way data is generated via adding
 [additional metadata in the YAML](https://data.catering/setup/generator/data-generator/)
 to suit your needs.
 
-#### Iceberg
+</details>
+
+<details markdown="1">
+<summary><strong>Iceberg</strong></summary>
 
 Exports to an [Iceberg Table Json Schema Definition](https://iceberg.apache.org/spec/#appendix-c-json-serialization).
 
@@ -1560,7 +1552,10 @@ to limit your contract export to a single model.
 }
 ```
 
-#### Custom
+</details>
+
+<details markdown="1">
+<summary><strong>Custom</strong></summary>
 
 The export function converts the data contract specification into the custom format with Jinja. You can specify the path to a Jinja template with the `--template` argument, allowing you to output files in any format.
 
@@ -1630,7 +1625,10 @@ Below is an example of a dbt staging layer that converts a field of `type: times
   ```
   {% endraw %}
 
-#### ODCS Excel Template
+</details>
+
+<details markdown="1">
+<summary><strong>ODCS Excel Template</strong></summary>
 
 The `export` function converts a data contract into an ODCS (Open Data Contract Standard) Excel template. This creates a user-friendly Excel spreadsheet that can be used for authoring, sharing, and managing data contracts using the familiar Excel interface.
 
@@ -1645,6 +1643,8 @@ The Excel format enables:
 - **Round-trip conversion**: Import Excel templates back to YAML data contracts
 
 For more information about the Excel template structure, visit the [ODCS Excel Template repository](https://github.com/datacontract/open-data-contract-standard-excel-template).
+
+</details>
 
 ### import
 ```
@@ -1723,41 +1723,19 @@ For more information about the Excel template structure, visit the [ODCS Excel T
 │ --table                        TEXT  Table name to assign to the model created from the Iceberg  │
 │                                      schema.                                                     │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-
 ```
 
-Each format is a subcommand with its own options. Run `datacontract import <format> --help` to see the format-specific options (e.g. `datacontract import sql --help`).
+Run `datacontract import <format> --help` to see the format-specific options (e.g. `datacontract export sql --help`). If you are missing a format, please [create an issue on GitHub](https://github.com/datacontract/datacontract-cli/issues).
 
-Example:
+#### Examples
 ```bash
 # Example import from SQL DDL
 datacontract import sql --source my_ddl.sql --dialect postgres
 # To save to file
 datacontract import sql --source my_ddl.sql --dialect postgres --output datacontract.yaml
 ```
-
-Available import options:
-
-| Type               | Description                                   | Status  |
-|--------------------|-----------------------------------------------|---------|
-| `avro`             | Import from AVRO schemas                      | ✅       |
-| `bigquery`         | Import from BigQuery Schemas                  | ✅       |
-| `csv`              | Import from CSV File                          | ✅       |
-| `dbml`             | Import from DBML models                       | ✅       |
-| `dbt`              | Import from dbt models                        | ✅       |
-| `excel`            | Import from ODCS Excel Template               | ✅       |
-| `glue`             | Import from AWS Glue DataCatalog              | ✅       |
-| `iceberg`          | Import from an Iceberg JSON Schema Definition | partial |
-| `jsonschema`       | Import from JSON Schemas                      | ✅       |
-| `parquet`          | Import from Parquet File Metadata             | ✅       |
-| `protobuf`         | Import from Protobuf schemas                  | ✅       |
-| `spark`            | Import from Spark StructTypes, Variant        | ✅       |
-| `sql`              | Import from SQL DDL                           | ✅       |
-| `unity`            | Import from Databricks Unity Catalog          | partial |
-| Missing something? | Please create an issue on GitHub              | TBD     |
-
-
-#### BigQuery
+<details markdown="1">
+<summary><strong>BigQuery</strong></summary>
 
 BigQuery data can either be imported off of JSON Files generated from the table descriptions or directly from the Bigquery API. In case you want to use JSON Files, specify the `source` parameter with a path to the JSON File.
 
@@ -1782,7 +1760,11 @@ datacontract import bigquery --project <project_id> --dataset <dataset_id> --tab
 datacontract import bigquery --project <project_id> --dataset <dataset_id>
 ```
 
-#### Unity Catalog
+</details>
+
+<details markdown="1">
+<summary><strong>Unity Catalog</strong></summary>
+
 ```bash
 # Example import from a Unity Catalog JSON file
 datacontract import unity --source my_unity_table.json
@@ -1801,7 +1783,10 @@ export DATACONTRACT_DATABRICKS_PROFILE="my-profile"
 datacontract import unity --table <table_full_name>
 ```
 
-#### dbt
+</details>
+
+<details markdown="1">
+<summary><strong>dbt</strong></summary>
 
 Importing from dbt manifest file.
 You may give the `--model` parameter to enumerate the tables that should be imported. If no tables are given, _all_ available tables of the database will be imported.
@@ -1818,7 +1803,10 @@ datacontract import dbt --source <manifest_path> --model <model_name_1> --model 
 datacontract import dbt --source <manifest_path>
 ```
 
-#### Excel
+</details>
+
+<details markdown="1">
+<summary><strong>Excel</strong></summary>
 
 Importing from [ODCS Excel Template](https://github.com/datacontract/open-data-contract-standard-excel-template).
 
@@ -1829,7 +1817,10 @@ Examples:
 datacontract import excel --source odcs.xlsx
 ```
 
-#### Glue
+</details>
+
+<details markdown="1">
+<summary><strong>Glue</strong></summary>
 
 Importing from Glue reads the necessary Data directly off of the AWS API.
 You may give the `--table` parameter to enumerate the tables that should be imported. If no tables are given, _all_ available tables of the database will be imported.
@@ -1846,7 +1837,10 @@ datacontract import glue --source <database_name> --table <table_name_1> --table
 datacontract import glue --source <database_name>
 ```
 
-#### Spark
+</details>
+
+<details markdown="1">
+<summary><strong>Spark</strong></summary>
 
 Importing from Spark table or view these must be created or accessible in the Spark context. Specify tables list in `source` parameter.  If the `source` tables are registered as tables in Databricks, and they have a table-level descriptions they will also be added to the Data Contract Specification.
 
@@ -1873,7 +1867,10 @@ DataContract.import_from_source("spark", "users", dataframe = df_user, descripti
 DataContract.import_from_source(format = "spark", source = "users", dataframe = df_user, description = "description")
 ```
 
-#### DBML
+</details>
+
+<details markdown="1">
+<summary><strong>DBML</strong></summary>
 
 Importing from DBML Documents.
 **NOTE:** Since DBML does _not_ have strict requirements on the types of columns, this import _may_ create non-valid datacontracts, as not all types of fields can be properly mapped. In this case you will have to adapt the generated document manually.
@@ -1904,7 +1901,10 @@ datacontract import dbml --source <file_path> --table <table_name_1> --table <ta
 datacontract import dbml --source <file_path> --table <table_name_1> --schema <schema_1>
 ```
 
-#### Iceberg
+</details>
+
+<details markdown="1">
+<summary><strong>Iceberg</strong></summary>
 
 Importing from an [Iceberg Table Json Schema Definition](https://iceberg.apache.org/spec/#appendix-c-json-serialization). Specify location of json files using the `source` parameter.
 
@@ -1914,7 +1914,10 @@ Examples:
 datacontract import iceberg --source ./tests/fixtures/iceberg/simple_schema.json --table test-table
 ```
 
-#### CSV
+</details>
+
+<details markdown="1">
+<summary><strong>CSV</strong></summary>
 
 Importing from CSV File. Specify file in `source` parameter. It does autodetection for encoding and csv dialect
 
@@ -1924,7 +1927,10 @@ Example:
 datacontract import csv --source "test.csv"
 ```
 
-#### protobuf
+</details>
+
+<details markdown="1">
+<summary><strong>protobuf</strong></summary>
 
 Importing from protobuf File. Specify file in `source` parameter. 
 
@@ -1933,6 +1939,8 @@ Example:
 ```bash
 datacontract import protobuf --source "test.proto"
 ```
+
+</details>
 
 
 ### catalog

--- a/README.md
+++ b/README.md
@@ -1338,7 +1338,7 @@ The SQL dialect is determined from the `servers` block in the data contract (e.g
 datacontract export sql datacontract.yaml --server-type postgres --output output.sql
 ```
 
-If using Databricks, an error is thrown when trying to deploy the SQL DDLs with `variant` columns set the following properties.
+If using Databricks and an error is thrown when deploying SQL DDLs with `variant` columns, set the following property.
 
 ```shell
 spark.conf.set(“spark.databricks.delta.schema.typeCheck.enabled”, “false”)

--- a/README.md
+++ b/README.md
@@ -299,34 +299,29 @@ Commands
 
 ### lint
 ```
-                                                                                
- Usage: datacontract lint [OPTIONS] [LOCATION]                                  
-                                                                                
- Validate that the datacontract.yaml is correctly formatted.                    
-                                                                                
-╭─ Arguments ──────────────────────────────────────────────────────────────────╮
-│   location      [LOCATION]  The location (url or path) of the data contract  │
-│                             yaml.                                            │
-│                             [default: datacontract.yaml]                     │
-╰──────────────────────────────────────────────────────────────────────────────╯
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --json-schema                    TEXT          The location (url or path) of │
-│                                                the ODCS JSON Schema          │
-│ --output                         PATH          Specify the file path where   │
-│                                                the test results should be    │
-│                                                written to (e.g.,             │
-│                                                './test-results/TEST-datacon… │
-│                                                If no path is provided, the   │
-│                                                output will be printed to     │
-│                                                stdout.                       │
-│ --output-format                  [json|junit]  The target format for the     │
-│                                                test results.                 │
-│ --all-errors                                   Report all JSON Schema        │
-│                                                validation errors instead of  │
-│                                                stopping after the first one. │
-│ --debug            --no-debug                  Enable debug logging          │
-│ --help                                         Show this message and exit.   │
-╰──────────────────────────────────────────────────────────────────────────────╯
+                                                                                                    
+ Usage: datacontract lint [OPTIONS] [LOCATION]                                                      
+                                                                                                    
+ Validate that the datacontract.yaml is correctly formatted.                                        
+                                                                                                    
+╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────╮
+│   location      [LOCATION]  The location (url or path) of the data contract yaml.                │
+│                             [default: datacontract.yaml]                                         │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
+│ --json-schema                    TEXT          The location (url or path) of the ODCS JSON       │
+│                                                Schema                                            │
+│ --output                         PATH          Specify the file path where the test results      │
+│                                                should be written to (e.g.,                       │
+│                                                './test-results/TEST-datacontract.xml'). If no    │
+│                                                path is provided, the output will be printed to   │
+│                                                stdout.                                           │
+│ --output-format                  [json|junit]  The target format for the test results.           │
+│ --all-errors                                   Report all JSON Schema validation errors instead  │
+│                                                of stopping after the first one.                  │
+│ --debug            --no-debug                  Enable debug logging                              │
+│ --help                                         Show this message and exit.                       │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 
 ```
 
@@ -355,79 +350,61 @@ $ datacontract changelog v1.odcs.yaml v2.odcs.yaml
 ### test
 ```
                                                                                                     
- Usage: datacontract test [OPTIONS] [LOCATION]
+ Usage: datacontract test [OPTIONS] [LOCATION]                                                      
                                                                                                     
  Run schema and quality tests on configured servers.                                                
-                                                                                                    
                                                                                                     
 ╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────╮
 │   location      [LOCATION]  The location (url or path) of the data contract yaml.                │
 │                             [default: datacontract.yaml]                                         │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --json-schema                              TEXT          The location (url   │
-│                                                          or path) of the     │
-│                                                          ODCS JSON Schema    │
-│ --server                                   TEXT          The server          │
-│                                                          configuration to    │
-│                                                          run the schema and  │
-│                                                          quality tests. Use  │
-│                                                          the key of the      │
-│                                                          server object in    │
-│                                                          the data contract   │
-│                                                          yaml file to refer  │
-│                                                          to a server, e.g.,  │
-│                                                          `production`, or    │
-│                                                          `all` for all       │
-│                                                          servers (default).  │
-│                                                          [default: all]      │
-│ --schema-name                              TEXT          Which model to      │
-│                                                          test, e.g.,         │
-│                                                          `orders`, or `all`  │
-│                                                          for all models      │
-│                                                          (default). Distinct │
-│                                                          from --json-schema, │
-│                                                          which is the ODCS   │
-│                                                          validation schema.  │
-│                                                          [default: all]      │
-│ --publish-test-re…    --no-publish-tes…                  Deprecated. Use     │
-│                                                          publish parameter.  │
-│                                                          Publish the results │
-│                                                          after the test      │
-│                                                          [default:           │
-│                                                          no-publish-test-re… │
-│ --publish                                  TEXT          The url to publish  │
-│                                                          the results after   │
-│                                                          the test.           │
-│ --output                                   PATH          Specify the file    │
-│                                                          path where the test │
-│                                                          results should be   │
-│                                                          written to (e.g.,   │
-│                                                          './test-results/TE… │
-│ --output-format                            [json|junit]  The target format   │
-│                                                          for the test        │
-│                                                          results.            │
-│ --checks                                   TEXT          Comma-separated     │
-│                                                          list of check       │
-│                                                          categories to run.  │
-│                                                          Available           │
-│                                                          categories: schema, │
-│                                                          quality,            │
-│                                                          servicelevel,       │
-│                                                          custom. Omit to     │
-│                                                          enable all.         │
-│ --logs                --no-logs                          Print logs          │
-│                                                          [default: no-logs]  │
-│ --ssl-verification    --no-ssl-verific…                  SSL verification    │
-│                                                          when publishing the │
-│                                                          data contract.      │
-│                                                          [default:           │
-│                                                          ssl-verification]   │
-│ --debug               --no-debug                         Enable debug        │
-│                                                          logging             │
-│ --help                                                   Show this message   │
-│                                                          and exit.           │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
+│ --json-schema                                          TEXT          The location (url or path)  │
+│                                                                      of the ODCS JSON Schema     │
+│ --server                                               TEXT          The server configuration to │
+│                                                                      run the schema and quality  │
+│                                                                      tests. Use the key of the   │
+│                                                                      server object in the data   │
+│                                                                      contract yaml file to refer │
+│                                                                      to a server, e.g.,          │
+│                                                                      `production`, or `all` for  │
+│                                                                      all servers (default).      │
+│                                                                      [default: all]              │
+│ --schema-name                                          TEXT          Which model to test, e.g.,  │
+│                                                                      `orders`, or `all` for all  │
+│                                                                      models (default). Distinct  │
+│                                                                      from --json-schema, which   │
+│                                                                      is the ODCS validation      │
+│                                                                      schema.                     │
+│                                                                      [default: all]              │
+│ --publish-test-results    --no-publish-test-results                  Deprecated. Use publish     │
+│                                                                      parameter. Publish the      │
+│                                                                      results after the test      │
+│                                                                      [default:                   │
+│                                                                      no-publish-test-results]    │
+│ --publish                                              TEXT          The url to publish the      │
+│                                                                      results after the test.     │
+│ --output                                               PATH          Specify the file path where │
+│                                                                      the test results should be  │
+│                                                                      written to (e.g.,           │
+│                                                                      './test-results/TEST-datac… │
+│ --output-format                                        [json|junit]  The target format for the   │
+│                                                                      test results.               │
+│ --checks                                               TEXT          Comma-separated list of     │
+│                                                                      check categories to run.    │
+│                                                                      Available categories:       │
+│                                                                      schema, quality,            │
+│                                                                      servicelevel, custom. Omit  │
+│                                                                      to enable all.              │
+│ --logs                    --no-logs                                  Print logs                  │
+│                                                                      [default: no-logs]          │
+│ --ssl-verification        --no-ssl-verification                      SSL verification when       │
+│                                                                      publishing the data         │
+│                                                                      contract.                   │
+│                                                                      [default: ssl-verification] │
+│ --debug                   --no-debug                                 Enable debug logging        │
+│ --help                                                               Show this message and exit. │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 
 ```
 
@@ -1138,71 +1115,54 @@ models:
 
 ### ci
 ```
-                                                                                
- Usage: datacontract ci [OPTIONS] [LOCATIONS]...                                
-                                                                                
- Run tests for CI/CD pipelines. Emits GitHub Actions annotations and step       
- summary.                                                                       
-                                                                                
-╭─ Arguments ──────────────────────────────────────────────────────────────────╮
-│   locations      [LOCATIONS]...  The location(s) (url or path) of the data   │
-│                                  contract yaml file(s).                      │
-╰──────────────────────────────────────────────────────────────────────────────╯
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --json-schema                            TEXT              The location (url │
-│                                                            or path) of the   │
-│                                                            ODCS JSON Schema  │
-│ --server                                 TEXT              The server        │
-│                                                            configuration to  │
-│                                                            run the schema    │
-│                                                            and quality       │
-│                                                            tests. Use the    │
-│                                                            key of the server │
-│                                                            object in the     │
-│                                                            data contract     │
-│                                                            yaml file to      │
-│                                                            refer to a        │
-│                                                            server, e.g.,     │
-│                                                            `production`, or  │
-│                                                            `all` for all     │
-│                                                            servers           │
-│                                                            (default).        │
-│                                                            [default: all]    │
-│ --publish                                TEXT              The url to        │
-│                                                            publish the       │
-│                                                            results after the │
-│                                                            test.             │
-│ --output                                 PATH              Specify the file  │
-│                                                            path where the    │
-│                                                            test results      │
-│                                                            should be written │
-│                                                            to (e.g.,         │
-│                                                            './test-results/… │
-│ --output-format                          [json|junit]      The target format │
-│                                                            for the test      │
-│                                                            results.          │
-│ --logs               --no-logs                             Print logs        │
-│                                                            [default:         │
-│                                                            no-logs]          │
-│ --json                                                     Print test        │
-│                                                            results as JSON   │
-│                                                            to stdout.        │
-│ --fail-on                                [warning|error|n  Minimum severity  │
-│                                          ever]             that causes a     │
-│                                                            non-zero exit     │
-│                                                            code.             │
-│                                                            [default: error]  │
-│ --ssl-verificati…    --no-ssl-verifi…                      SSL verification  │
-│                                                            when publishing   │
-│                                                            the data          │
-│                                                            contract.         │
-│                                                            [default:         │
-│                                                            ssl-verification] │
-│ --debug              --no-debug                            Enable debug      │
-│                                                            logging           │
-│ --help                                                     Show this message │
-│                                                            and exit.         │
-╰──────────────────────────────────────────────────────────────────────────────╯
+                                                                                                    
+ Usage: datacontract ci [OPTIONS] [LOCATIONS]...                                                    
+                                                                                                    
+ Run tests for CI/CD pipelines. Emits GitHub Actions annotations and step summary.                  
+                                                                                                    
+╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────╮
+│   locations      [LOCATIONS]...  The location(s) (url or path) of the data contract yaml         │
+│                                  file(s).                                                        │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
+│ --json-schema                                  TEXT                   The location (url or path) │
+│                                                                       of the ODCS JSON Schema    │
+│ --server                                       TEXT                   The server configuration   │
+│                                                                       to run the schema and      │
+│                                                                       quality tests. Use the key │
+│                                                                       of the server object in    │
+│                                                                       the data contract yaml     │
+│                                                                       file to refer to a server, │
+│                                                                       e.g., `production`, or     │
+│                                                                       `all` for all servers      │
+│                                                                       (default).                 │
+│                                                                       [default: all]             │
+│ --publish                                      TEXT                   The url to publish the     │
+│                                                                       results after the test.    │
+│ --output                                       PATH                   Specify the file path      │
+│                                                                       where the test results     │
+│                                                                       should be written to       │
+│                                                                       (e.g.,                     │
+│                                                                       './test-results/TEST-data… │
+│ --output-format                                [json|junit]           The target format for the  │
+│                                                                       test results.              │
+│ --logs                --no-logs                                       Print logs                 │
+│                                                                       [default: no-logs]         │
+│ --json                                                                Print test results as JSON │
+│                                                                       to stdout.                 │
+│ --fail-on                                      [warning|error|never]  Minimum severity that      │
+│                                                                       causes a non-zero exit     │
+│                                                                       code.                      │
+│                                                                       [default: error]           │
+│ --ssl-verification    --no-ssl-verification                           SSL verification when      │
+│                                                                       publishing the data        │
+│                                                                       contract.                  │
+│                                                                       [default:                  │
+│                                                                       ssl-verification]          │
+│ --debug               --no-debug                                      Enable debug logging       │
+│ --help                                                                Show this message and      │
+│                                                                       exit.                      │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 
 ```
 
@@ -1286,43 +1246,44 @@ steps:
 
 ### export
 ```
- Usage: datacontract export [OPTIONS] COMMAND [ARGS]...                         
-                                                                                
- Convert a data contract to a target format.                                    
-                                                                                
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --help          Show this message and exit.                                  │
-╰──────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ sql                 Export a data contract to SQL DDL.                       │
-│ sql-query           Export a data contract to a SQL query.                   │
-│ dbt-models          Export a data contract to dbt model schema YAML.         │
-│ dbt-sources         Export a data contract to dbt sources YAML.              │
-│ dbt-staging-sql     Export a data contract to a dbt staging SQL file.        │
-│ avro                Export a data contract to Avro schema.                   │
-│ avro-idl            Export a data contract to Avro IDL.                      │
-│ jsonschema          Export a data contract to JSON Schema.                   │
-│ pydantic-model      Export a data contract to a Pydantic model.              │
-│ protobuf            Export a data contract to Protobuf schema.               │
-│ odcs                Export a data contract to ODCS format.                   │
-│ rdf                 Export a data contract to RDF.                           │
-│ html                Export a data contract to HTML.                          │
-│ markdown            Export a data contract to Markdown.                      │
-│ mermaid             Export a data contract to Mermaid diagram.               │
-│ bigquery            Export a data contract to BigQuery schema.               │
-│ dbml                Export a data contract to DBML.                          │
-│ go                  Export a data contract to Go structs.                    │
-│ spark               Export a data contract to Spark schema.                  │
-│ sqlalchemy          Export a data contract to SQLAlchemy models.             │
-│ iceberg             Export a data contract to Iceberg schema.                │
-│ sodacl              Export a data contract to SodaCL checks.                 │
-│ great-expectations  Export a data contract to Great Expectations suite.      │
-│ data-caterer        Export a data contract to Data Caterer format.           │
-│ dcs                 Export a data contract to DCS format.                    │
-│ dqx                 Export a data contract to DQX format.                    │
-│ excel               Export a data contract to Excel.                         │
-│ custom              Export a data contract using a custom Jinja template.    │
-╰──────────────────────────────────────────────────────────────────────────────╯
+                                                                                                    
+ Usage: datacontract export [OPTIONS] COMMAND [ARGS]...                                             
+                                                                                                    
+ Convert a data contract to a target format.                                                        
+                                                                                                    
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                                      │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────╮
+│ sql                 Export a data contract to SQL DDL.                                           │
+│ sql-query           Export a data contract to a SQL query.                                       │
+│ dbt-models          Export a data contract to dbt model schema YAML.                             │
+│ dbt-sources         Export a data contract to dbt sources YAML.                                  │
+│ dbt-staging-sql     Export a data contract to a dbt staging SQL file.                            │
+│ avro                Export a data contract to Avro schema.                                       │
+│ avro-idl            Export a data contract to Avro IDL.                                          │
+│ jsonschema          Export a data contract to JSON Schema.                                       │
+│ pydantic-model      Export a data contract to a Pydantic model.                                  │
+│ protobuf            Export a data contract to Protobuf schema.                                   │
+│ odcs                Export a data contract to ODCS format.                                       │
+│ rdf                 Export a data contract to RDF.                                               │
+│ html                Export a data contract to HTML.                                              │
+│ markdown            Export a data contract to Markdown.                                          │
+│ mermaid             Export a data contract to Mermaid diagram.                                   │
+│ bigquery            Export a data contract to BigQuery schema.                                   │
+│ dbml                Export a data contract to DBML.                                              │
+│ go                  Export a data contract to Go structs.                                        │
+│ spark               Export a data contract to Spark schema.                                      │
+│ sqlalchemy          Export a data contract to SQLAlchemy models.                                 │
+│ iceberg             Export a data contract to Iceberg schema.                                    │
+│ sodacl              Export a data contract to SodaCL checks.                                     │
+│ great-expectations  Export a data contract to Great Expectations suite.                          │
+│ data-caterer        Export a data contract to Data Caterer format.                               │
+│ dcs                 Export a data contract to DCS format.                                        │
+│ dqx                 Export a data contract to DQX format.                                        │
+│ excel               Export a data contract to Excel.                                             │
+│ custom              Export a data contract using a custom Jinja template.                        │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 
 ```
 
@@ -1650,31 +1611,32 @@ For more information about the Excel template structure, visit the [ODCS Excel T
 
 ### import
 ```
- Usage: datacontract import [OPTIONS] COMMAND [ARGS]...                         
-                                                                                
- Create a data contract from a source format.                                   
-                                                                                
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --help          Show this message and exit.                                  │
-╰──────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ sql         Import a data contract from a SQL DDL file.                      │
-│ avro        Import a data contract from an Avro schema file.                 │
-│ dbt         Import a data contract from a dbt manifest file.                 │
-│ dbml        Import a data contract from a DBML file.                         │
-│ glue        Import a data contract from AWS Glue.                            │
-│ bigquery    Import a data contract from BigQuery.                            │
-│ unity       Import a data contract from Databricks Unity Catalog.            │
-│ jsonschema  Import a data contract from a JSON Schema file.                  │
-│ json        Import a data contract from a JSON file.                         │
-│ odcs        Import a data contract from an ODCS file.                        │
-│ parquet     Import a data contract from a Parquet file.                      │
-│ csv         Import a data contract from a CSV file.                          │
-│ protobuf    Import a data contract from a Protobuf schema file.              │
-│ spark       Import a data contract from a Spark schema.                      │
-│ iceberg     Import a data contract from an Iceberg schema.                   │
-│ excel       Import a data contract from an Excel file.                       │
-╰──────────────────────────────────────────────────────────────────────────────╯
+                                                                                                    
+ Usage: datacontract import [OPTIONS] COMMAND [ARGS]...                                             
+                                                                                                    
+ Create a data contract from a source format.                                                       
+                                                                                                    
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                                      │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────╮
+│ sql         Import a data contract from a SQL DDL file.                                          │
+│ avro        Import a data contract from an Avro schema file.                                     │
+│ dbt         Import a data contract from a dbt manifest file.                                     │
+│ dbml        Import a data contract from a DBML file.                                             │
+│ glue        Import a data contract from AWS Glue.                                                │
+│ bigquery    Import a data contract from BigQuery.                                                │
+│ unity       Import a data contract from Databricks Unity Catalog.                                │
+│ jsonschema  Import a data contract from a JSON Schema file.                                      │
+│ json        Import a data contract from a JSON file.                                             │
+│ odcs        Import a data contract from an ODCS file.                                            │
+│ parquet     Import a data contract from a Parquet file.                                          │
+│ csv         Import a data contract from a CSV file.                                              │
+│ protobuf    Import a data contract from a Protobuf schema file.                                  │
+│ spark       Import a data contract from a Spark schema.                                          │
+│ iceberg     Import a data contract from an Iceberg schema.                                       │
+│ excel       Import a data contract from an Excel file.                                           │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 
 ```
 
@@ -1896,14 +1858,14 @@ datacontract import protobuf --source "test.proto"
                                                                                                     
                                                                                                     
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
-│ --files                   TEXT  Glob pattern for the data contract files to include in the       │
-│                                 catalog. Applies recursively to any subfolders.                  │
-│                                 [default: *.yaml]                                                │
-│ --output                  TEXT  Output directory for the catalog html files. [default: catalog/] │
-│ --json-schema             TEXT  The location (url or path) of the ODCS JSON Schema               │
-│                                 [default: None]                                                  │
-│ --debug     --no-debug          Enable debug logging [default: no-debug]                         │
-│ --help                          Show this message and exit.                                      │
+│ --files                        TEXT  Glob pattern for the data contract files to include in the  │
+│                                      catalog. Applies recursively to any subfolders.             │
+│                                      [default: *.yaml]                                           │
+│ --output                       TEXT  Output directory for the catalog html files.                │
+│                                      [default: catalog/]                                         │
+│ --json-schema                  TEXT  The location (url or path) of the ODCS JSON Schema          │
+│ --debug          --no-debug          Enable debug logging                                        │
+│ --help                               Show this message and exit.                                 │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 
 ```
@@ -1933,11 +1895,10 @@ datacontract catalog --files "*.odcs.yaml"
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --json-schema                                  TEXT  The location (url or path) of the ODCS JSON │
 │                                                      Schema                                      │
-│                                                      [default: None]                             │
 │ --ssl-verification    --no-ssl-verification          SSL verification when publishing the data   │
 │                                                      contract.                                   │
 │                                                      [default: ssl-verification]                 │
-│ --debug               --no-debug                     Enable debug logging [default: no-debug]    │
+│ --debug               --no-debug                     Enable debug logging                        │
 │ --help                                               Show this message and exit.                 │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Voilà, the CLI tested that the YAML itself is valid, all records comply with th
 We can also use the data contract metadata to export in many [formats](#format), e.g., to generate a SQL DDL:
 
 ```bash
-$ datacontract export --format sql https://datacontract.com/orders-v1.odcs.yaml
+$ datacontract export sql https://datacontract.com/orders-v1.odcs.yaml
 
 # returns:
 -- Data Contract: orders
@@ -105,7 +105,7 @@ CREATE TABLE line_items (
 Or generate an HTML export:
 
 ```bash
-$ datacontract export --format html --output orders-v1.odcs.html https://datacontract.com/orders-v1.odcs.yaml
+$ datacontract export html --output orders-v1.odcs.html https://datacontract.com/orders-v1.odcs.yaml
 ```
 
 [//]: # (which will create this [HTML export]&#40;https://datacontract.com/examples/orders-latest/datacontract.html&#41;.)
@@ -126,17 +126,17 @@ $ datacontract changelog v1.odcs.yaml v2.odcs.yaml
 # execute schema and quality checks (define credentials as environment variables)
 $ datacontract test odcs.yaml
 
-# export data contract as html (other formats: avro, dbt, dbt-sources, dbt-staging-sql, jsonschema, odcs, rdf, sql, sodacl, terraform, ...)
-$ datacontract export --format html datacontract.yaml --output odcs.html
+# export data contract as html (other formats: avro, dbt-models, dbt-sources, dbt-staging-sql, jsonschema, odcs, rdf, sql, sodacl, terraform, ...)
+$ datacontract export html datacontract.yaml --output odcs.html
 
 # import sql (other formats: avro, glue, bigquery, jsonschema, excel ...)
-$ datacontract import --format sql --source my-ddl.sql --dialect postgres --output odcs.yaml
+$ datacontract import sql --source my-ddl.sql --dialect postgres --output odcs.yaml
 
 # import from Excel template
-$ datacontract import --format excel --source odcs.xlsx --output odcs.yaml
+$ datacontract import excel --source odcs.xlsx --output odcs.yaml
 
 # export to Excel template  
-$ datacontract export --format excel --output odcs.xlsx odcs.yaml
+$ datacontract export excel --output odcs.xlsx odcs.yaml
 ```
 
 ## Programmatic (Python)
@@ -1263,25 +1263,21 @@ steps:
 ### export
 ```
                                                                                                     
- Usage: datacontract export [OPTIONS] [LOCATION]                                                    
+ Usage: datacontract export FORMAT [OPTIONS] [LOCATION]                                              
                                                                                                     
  Convert data contract to a specific format. Saves to file specified by `output` option if present, 
  otherwise prints to stdout.                                                                        
                                                                                                     
+ FORMAT is a subcommand: jsonschema, pydantic-model, sodacl, dbt-models, dbt-sources,              
+ dbt-staging-sql, odcs, rdf, avro, protobuf, great-expectations, avro-idl, sql, sql-query,        
+ mermaid, html, go, bigquery, dbml, spark, sqlalchemy, data-caterer, dcs, markdown, iceberg,       
+ custom, excel, dqx                                                                                
                                                                                                     
 ╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────╮
 │   location      [LOCATION]  The location (url or path) of the data contract yaml.                │
 │                             [default: datacontract.yaml]                                         │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
-│ *  --format                       [jsonschema|pydantic-model|sod  The export format.             │
-│                                   acl|dbt|dbt-sources|dbt-stagin  [default: None]                │
-│                                   g-sql|odcs|rdf|avro|protobuf|g  [required]                     │
-│                                   reat-expectations|avro-idl|sql                                 │
-│                                   |sql-query|mermaid|html|go|big                                 │
-│                                   query|dbml|spark|sqlalchemy|da                                 │
-│                                   ta-caterer|dcs|markdown|iceber                                 │
-│                                   g|custom|excel|dqx]                                            │
 │    --output                       PATH                            Specify the file path where    │
 │                                                                   the exported data will be      │
 │                                                                   saved. If no path is provided, │
@@ -1307,26 +1303,26 @@ steps:
 │                                                                   template. For custom format:   │
 │                                                                   path to Jinja template.        │
 │                                                                   [default: None]                │
+│    --base                         TEXT                            [rdf] The base URI used to     │
+│                                                                   generate the RDF graph.        │
+│                                                                   [default: None]                │
+│    --server-type                  TEXT                            [sql] The server type to       │
+│                                                                   determine the sql dialect.     │
+│                                                                   Accepted values: auto,         │
+│                                                                   snowflake, postgres, mysql,    │
+│                                                                   databricks, sqlserver,         │
+│                                                                   bigquery, trino, oracle.       │
+│                                                                   [default: auto]                │
 │    --debug          --no-debug                                    Enable debug logging           │
 │                                                                   [default: no-debug]            │
 │    --help                                                         Show this message and exit.    │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ RDF Options ────────────────────────────────────────────────────────────────────────────────────╮
-│ --rdf-base        TEXT  [rdf] The base URI used to generate the RDF graph. [default: None]       │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ SQL Options ────────────────────────────────────────────────────────────────────────────────────╮
-│ --sql-server-type        TEXT  [sql] The server type to determine the sql dialect. By default,   │
-│                                it uses 'auto' to automatically detect the sql dialect via the    │
-│                                specified servers in the data contract. Accepted values: auto,    │
-│                                snowflake, postgres, mysql, databricks, sqlserver, bigquery,      │
-│                                trino, oracle. [default: auto]                                    │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 
 ```
 
 ```bash
 # Example export data contract as HTML
-datacontract export --format html --output datacontract.html
+datacontract export html --output datacontract.html
 ```
 
 Available export options:
@@ -1337,7 +1333,7 @@ Available export options:
 | `jsonschema`         | Export to JSON Schema                                   | ✅       |
 | `odcs`               | Export to Open Data Contract Standard (ODCS) V3         | ✅       |
 | `sodacl`             | Export to SodaCL quality checks in YAML format          | ✅       |
-| `dbt`                | Export to dbt models in YAML format                     | ✅       |
+| `dbt-models`         | Export to dbt models in YAML format                     | ✅       |
 | `dbt-sources`        | Export to dbt sources in YAML format                    | ✅       |
 | `dbt-staging-sql`    | Export to dbt staging SQL models                        | ✅       |
 | `rdf`                | Export data contract to RDF representation in N3 format | ✅       |
@@ -1367,7 +1363,7 @@ Available export options:
 The `export` function converts a given data contract into a SQL data definition language (DDL).
 
 ```shell
-datacontract export datacontract.yaml --format sql --output output.sql
+datacontract export sql datacontract.yaml --output output.sql
 ```
 
 If using Databricks, and an error is thrown when trying to deploy the SQL DDLs with `variant` columns set the following properties.
@@ -1382,7 +1378,7 @@ The `export` function transforms a specified data contract into a comprehensive 
 If the contract includes multiple models, you need to specify the names of the schema/models you wish to export.
 
 ```shell
-datacontract export datacontract.yaml --format great-expectations --model orders
+datacontract export great-expectations datacontract.yaml --model orders
 ```
 
 The export creates a list of expectations by utilizing:
@@ -1411,7 +1407,7 @@ The `export` function converts a given data contract into a RDF representation. 
 add a base_url which will be used as the default prefix to resolve relative IRIs inside the document.
 
 ```shell
-datacontract export --format rdf --rdf-base https://www.example.com/ datacontract.yaml
+datacontract export rdf --base https://www.example.com/ datacontract.yaml
 ```
 
 The data contract is mapped onto the following concepts of a yet to be defined Data Contract
@@ -1495,7 +1491,7 @@ ingested by [Data Caterer](https://github.com/data-catering/data-caterer). This 
 ability to generate production-like data in any environment based off your data contract.
 
 ```shell
-datacontract export datacontract.yaml --format data-caterer --model orders
+datacontract export data-caterer datacontract.yaml --model orders
 ```
 
 You can further customise the way data is generated via adding
@@ -1510,7 +1506,7 @@ This export only supports a single model export at a time because Iceberg's sche
 to limit your contract export to a single model.
 
 ```bash
- $ datacontract export --format iceberg --model orders https://datacontract.com/examples/orders-latest/datacontract.yaml --output /tmp/orders_iceberg.json
+ $ datacontract export iceberg --model orders https://datacontract.com/examples/orders-latest/datacontract.yaml --output /tmp/orders_iceberg.json
  
  $ cat /tmp/orders_iceberg.json | jq '.'
 {
@@ -1565,7 +1561,7 @@ to limit your contract export to a single model.
 The export function converts the data contract specification into the custom format with Jinja. You can specify the path to a Jinja template with the `--template` argument, allowing you to output files in any format.
 
 ```shell
-datacontract export --format custom --template template.txt datacontract.yaml
+datacontract export custom --template template.txt datacontract.yaml
 ```
 
 ##### Jinja templates & variables
@@ -1581,7 +1577,7 @@ models:
   - name: {{ model.name }}
 {%- endfor %}
 
-$ datacontract export --format custom --template template.txt datacontract.yaml
+$ datacontract export custom --template template.txt datacontract.yaml
 title: Orders Latest
 ```
 {% endraw %}
@@ -1612,7 +1608,7 @@ Below is an example of a dbt staging layer that converts a field of `type: times
   {% endraw %}
 - export command
   ```shell
-  datacontract export datacontract.odcs.yaml --format custom --template template.sql --schema-name orders
+  datacontract export custom datacontract.odcs.yaml --template template.sql --schema-name orders
   ```
 - `output.sql`
   {% raw %}
@@ -1633,7 +1629,7 @@ Below is an example of a dbt staging layer that converts a field of `type: times
 The `export` function converts a data contract into an ODCS (Open Data Contract Standard) Excel template. This creates a user-friendly Excel spreadsheet that can be used for authoring, sharing, and managing data contracts using the familiar Excel interface.
 
 ```shell
-datacontract export --format excel --output datacontract.xlsx datacontract.yaml
+datacontract export excel --output datacontract.xlsx datacontract.yaml
 ```
 
 The Excel format enables:
@@ -1647,18 +1643,15 @@ For more information about the Excel template structure, visit the [ODCS Excel T
 ### import
 ```
                                                                                                     
- Usage: datacontract import [OPTIONS]                                                               
+ Usage: datacontract import FORMAT [OPTIONS]                                                        
                                                                                                     
  Create a data contract from the given source location. Saves to file specified by `output` option  
  if present, otherwise prints to stdout.                                                            
                                                                                                     
+ FORMAT is a subcommand: sql, avro, dbt, dbml, glue, jsonschema, json, bigquery, odcs, unity,      
+ spark, iceberg, parquet, csv, protobuf, excel                                                     
                                                                                                     
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
-│ *  --format                                 [sql|avro|dbt|dbml|glue|  The format of the source   │
-│                                             jsonschema|json|bigquery  file.                      │
-│                                             |odcs|unity|spark|iceber  [default: None]            │
-│                                             g|parquet|csv|protobuf|e  [required]                 │
-│                                             xcel]                                                │
 │    --output                                 PATH                      Specify the file path      │
 │                                                                       where the Data Contract    │
 │                                                                       will be saved. If no path  │
@@ -1673,56 +1666,36 @@ For more information about the Excel template structure, visit the [ODCS Excel T
 │                                                                       tsql, bigquery, snowflake, │
 │                                                                       databricks, spark, duckdb. │
 │                                                                       [default: None]            │
-│    --glue-table                             TEXT                      List of table ids to       │
-│                                                                       import from the Glue       │
-│                                                                       Database (repeat for       │
-│                                                                       multiple table ids, leave  │
-│                                                                       empty for all tables in    │
-│                                                                       the dataset).              │
-│                                                                       [default: None]            │
-│    --bigquery-project                       TEXT                      The bigquery project id.   │
-│                                                                       [default: None]            │
-│    --bigquery-dataset                       TEXT                      The bigquery dataset id.   │
-│                                                                       [default: None]            │
-│    --bigquery-table                         TEXT                      List of table ids to       │
-│                                                                       import from the bigquery   │
-│                                                                       API (repeat for multiple   │
-│                                                                       table ids, leave empty for │
+│    --table                                  TEXT                      List of table ids/names to │
+│                                                                       import (repeat for         │
+│                                                                       multiple, leave empty for  │
 │                                                                       all tables in the          │
-│                                                                       dataset).                  │
+│                                                                       dataset). Used by glue,    │
+│                                                                       bigquery, dbml, iceberg,   │
+│                                                                       unity.                     │
 │                                                                       [default: None]            │
-│    --unity-table-full-name                  TEXT                      Full name of a table in    │
-│                                                                       the unity catalog          │
+│    --project                                TEXT                      The bigquery project id.   │
 │                                                                       [default: None]            │
-│    --dbt-model                              TEXT                      List of models names to    │
+│    --dataset                                TEXT                      The bigquery dataset id.   │
+│                                                                       [default: None]            │
+│    --model                                  TEXT                      List of models names to    │
 │                                                                       import from the dbt        │
 │                                                                       manifest file (repeat for  │
 │                                                                       multiple models names,     │
 │                                                                       leave empty for all models │
 │                                                                       in the dataset).           │
 │                                                                       [default: None]            │
-│    --dbml-schema                            TEXT                      List of schema names to    │
+│    --schema                                 TEXT                      List of schema names to    │
 │                                                                       import from the DBML file  │
 │                                                                       (repeat for multiple       │
 │                                                                       schema names, leave empty  │
 │                                                                       for all tables in the      │
-│                                                                       file).                     │
-│                                                                       [default: None]            │
-│    --dbml-table                             TEXT                      List of table names to     │
-│                                                                       import from the DBML file  │
-│                                                                       (repeat for multiple table │
-│                                                                       names, leave empty for all │
-│                                                                       tables in the file).       │
-│                                                                       [default: None]            │
-│    --iceberg-table                          TEXT                      Table name to assign to    │
-│                                                                       the model created from the │
-│                                                                       Iceberg schema.            │
+│                                                                       file). Also: the location  │
+│                                                                       (url or path) of the ODCS  │
+│                                                                       JSON Schema.               │
 │                                                                       [default: None]            │
 │    --template                               TEXT                      The location (url or path) │
 │                                                                       of the ODCS template       │
-│                                                                       [default: None]            │
-│    --schema                                 TEXT                      The location (url or path) │
-│                                                                       of the ODCS JSON Schema    │
 │                                                                       [default: None]            │
 │    --owner                                  TEXT                      The owner or team          │
 │                                                                       responsible for managing   │
@@ -1742,9 +1715,9 @@ For more information about the Excel template structure, visit the [ODCS Excel T
 Example:
 ```bash
 # Example import from SQL DDL
-datacontract import --format sql --source my_ddl.sql --dialect postgres
+datacontract import sql --source my_ddl.sql --dialect postgres
 # To save to file
-datacontract import --format sql --source my_ddl.sql --dialect postgres --output datacontract.yaml
+datacontract import sql --source my_ddl.sql --dialect postgres --output datacontract.yaml
 ```
 
 Available import options:
@@ -1772,7 +1745,7 @@ Available import options:
 
 BigQuery data can either be imported off of JSON Files generated from the table descriptions or directly from the Bigquery API. In case you want to use JSON Files, specify the `source` parameter with a path to the JSON File.
 
-To import from the Bigquery API, you have to _omit_ `source` and instead need to provide `bigquery-project` and `bigquery-dataset`. Additionally you may specify `bigquery-table` to enumerate the tables that should be imported. If no tables are given, _all_ available tables of the dataset will be imported.
+To import from the Bigquery API, you have to _omit_ `source` and instead need to provide `--project` and `--dataset`. Additionally you may specify `--table` to enumerate the tables that should be imported. If no tables are given, _all_ available tables of the dataset will be imported.
 
 For providing authentication to the Client, please see [the google documentation](https://cloud.google.com/docs/authentication/provide-credentials-adc#how-to) or the one [about authorizing client libraries](https://cloud.google.com/bigquery/docs/authentication#client-libs).
 
@@ -1780,53 +1753,53 @@ Examples:
 
 ```bash
 # Example import from Bigquery JSON
-datacontract import --format bigquery --source my_bigquery_table.json
+datacontract import bigquery --source my_bigquery_table.json
 ```
 
 ```bash
 # Example import from Bigquery API with specifying the tables to import
-datacontract import --format bigquery --bigquery-project <project_id> --bigquery-dataset <dataset_id> --bigquery-table <tableid_1> --bigquery-table <tableid_2> --bigquery-table <tableid_3>
+datacontract import bigquery --project <project_id> --dataset <dataset_id> --table <tableid_1> --table <tableid_2> --table <tableid_3>
 ```
 
 ```bash
 # Example import from Bigquery API importing all tables in the dataset
-datacontract import --format bigquery --bigquery-project <project_id> --bigquery-dataset <dataset_id>
+datacontract import bigquery --project <project_id> --dataset <dataset_id>
 ```
 
 #### Unity Catalog
 ```bash
 # Example import from a Unity Catalog JSON file
-datacontract import --format unity --source my_unity_table.json
+datacontract import unity --source my_unity_table.json
 ```
 
 ```bash
 # Example import single table from Unity Catalog via HTTP endpoint using PAT
 export DATACONTRACT_DATABRICKS_SERVER_HOSTNAME="https://xyz.cloud.databricks.com"
 export DATACONTRACT_DATABRICKS_TOKEN=<token>
-datacontract import --format unity --unity-table-full-name <table_full_name>
+datacontract import unity --table <table_full_name>
 ```
  Please refer to [Databricks documentation](https://docs.databricks.com/aws/en/dev-tools/auth/unified-auth) on how to set up a profile
 ```bash
 # Example import single table from Unity Catalog via HTTP endpoint using Profile
 export DATACONTRACT_DATABRICKS_PROFILE="my-profile"
-datacontract import --format unity --unity-table-full-name <table_full_name>
+datacontract import unity --table <table_full_name>
 ```
 
 #### dbt
 
 Importing from dbt manifest file.
-You may give the `dbt-model` parameter to enumerate the tables that should be imported. If no tables are given, _all_ available tables of the database will be imported.
+You may give the `--model` parameter to enumerate the tables that should be imported. If no tables are given, _all_ available tables of the database will be imported.
 
 Examples:
 
 ```bash
 # Example import from dbt manifest with specifying the tables to import
-datacontract import --format dbt --source <manifest_path> --dbt-model <model_name_1> --dbt-model <model_name_2> --dbt-model <model_name_3>
+datacontract import dbt --source <manifest_path> --model <model_name_1> --model <model_name_2> --model <model_name_3>
 ```
 
 ```bash
 # Example import from dbt manifest importing all tables in the database
-datacontract import --format dbt --source <manifest_path>
+datacontract import dbt --source <manifest_path>
 ```
 
 #### Excel
@@ -1837,24 +1810,24 @@ Examples:
 
 ```bash
 # Example import from ODCS Excel Template
-datacontract import --format excel --source odcs.xlsx
+datacontract import excel --source odcs.xlsx
 ```
 
 #### Glue
 
 Importing from Glue reads the necessary Data directly off of the AWS API.
-You may give the `glue-table` parameter to enumerate the tables that should be imported. If no tables are given, _all_ available tables of the database will be imported.
+You may give the `--table` parameter to enumerate the tables that should be imported. If no tables are given, _all_ available tables of the database will be imported.
 
 Examples:
 
 ```bash
 # Example import from AWS Glue with specifying the tables to import
-datacontract import --format glue --source <database_name> --glue-table <table_name_1> --glue-table <table_name_2> --glue-table <table_name_3>
+datacontract import glue --source <database_name> --table <table_name_1> --table <table_name_2> --table <table_name_3>
 ```
 
 ```bash
 # Example import from AWS Glue importing all tables in the database
-datacontract import --format glue --source <database_name>
+datacontract import glue --source <database_name>
 ```
 
 #### Spark
@@ -1863,7 +1836,7 @@ Importing from Spark table or view these must be created or accessible in the Sp
 
 ```bash
 # Example: Import Spark table(s) from Spark context
-datacontract import --format spark --source "users,orders"
+datacontract import spark --source "users,orders"
 ```
 
 ```bash
@@ -1890,29 +1863,29 @@ Importing from DBML Documents.
 **NOTE:** Since DBML does _not_ have strict requirements on the types of columns, this import _may_ create non-valid datacontracts, as not all types of fields can be properly mapped. In this case you will have to adapt the generated document manually.
 We also assume, that the description for models and fields is stored in a Note within the DBML model.
 
-You may give the `dbml-table` or `dbml-schema` parameter to enumerate the tables or schemas that should be imported. 
+You may give the `--table` or `--schema` parameter to enumerate the tables or schemas that should be imported. 
 If no tables are given, _all_ available tables of the source will be imported. Likewise, if no schema is given, _all_ schemas are imported.
 
 Examples:
 
 ```bash
 # Example import from DBML file, importing everything
-datacontract import --format dbml --source <file_path>
+datacontract import dbml --source <file_path>
 ```
 
 ```bash
 # Example import from DBML file, filtering for tables from specific schemas
-datacontract import --format dbml --source <file_path> --dbml-schema <schema_1> --dbml-schema <schema_2>
+datacontract import dbml --source <file_path> --schema <schema_1> --schema <schema_2>
 ```
 
 ```bash
 # Example import from DBML file, filtering for tables with specific names
-datacontract import --format dbml --source <file_path> --dbml-table <table_name_1> --dbml-table <table_name_2>
+datacontract import dbml --source <file_path> --table <table_name_1> --table <table_name_2>
 ```
 
 ```bash
 # Example import from DBML file, filtering for tables with specific names from a specific schema
-datacontract import --format dbml --source <file_path> --dbml-table <table_name_1> --dbml-schema <schema_1>
+datacontract import dbml --source <file_path> --table <table_name_1> --schema <schema_1>
 ```
 
 #### Iceberg
@@ -1922,7 +1895,7 @@ Importing from an [Iceberg Table Json Schema Definition](https://iceberg.apache.
 Examples:
 
 ```bash
-datacontract import --format iceberg --source ./tests/fixtures/iceberg/simple_schema.json --iceberg-table test-table
+datacontract import iceberg --source ./tests/fixtures/iceberg/simple_schema.json --table test-table
 ```
 
 #### CSV
@@ -1932,7 +1905,7 @@ Importing from CSV File. Specify file in `source` parameter. It does autodetecti
 Example:
 
 ```bash
-datacontract import --format csv --source "test.csv"
+datacontract import csv --source "test.csv"
 ```
 
 #### protobuf
@@ -1942,7 +1915,7 @@ Importing from protobuf File. Specify file in `source` parameter.
 Example:
 
 ```bash
-datacontract import --format protobuf --source "test.proto"
+datacontract import protobuf --source "test.proto"
 ```
 
 
@@ -2059,7 +2032,7 @@ Create a data contract based on the actual data. This is the fastest way to get 
 
 1. Use an existing physical schema (e.g., SQL DDL) as a starting point to define your logical data model in the contract. Double check right after the import whether the actual data meets the imported logical data model. Just to be sure.
     ```bash
-    $ datacontract import --format sql --source ddl.sql
+    $ datacontract import sql --source ddl.sql
     $ datacontract test
     ```
 
@@ -2100,10 +2073,10 @@ Create a data contract based on the requirements from use cases.
    into the consuming data products.
     ```bash
     # data provider
-    $ datacontract export --format dbt
+    $ datacontract export dbt-models
     # data consumer
-    $ datacontract export --format dbt-sources
-    $ datacontract export --format dbt-staging-sql
+    $ datacontract export dbt-sources
+    $ datacontract export dbt-staging-sql
     ```
 
 4. Test that your data product implementation adheres to the contract.

--- a/README.md
+++ b/README.md
@@ -1338,7 +1338,7 @@ The SQL dialect is determined from the `servers` block in the data contract (e.g
 datacontract export sql datacontract.yaml --server-type postgres --output output.sql
 ```
 
-If using Databricks, and an error is thrown when trying to deploy the SQL DDLs with `variant` columns set the following properties.
+If using Databricks, an error is thrown when trying to deploy the SQL DDLs with `variant` columns set the following properties.
 
 ```shell
 spark.conf.set(“spark.databricks.delta.schema.typeCheck.enabled”, “false”)
@@ -1680,7 +1680,6 @@ For more information about the Excel template structure, visit the [ODCS Excel T
 │                                      saved. If no path is provided, the output will be printed   │
 │                                      to stdout.                                                  │
 │ --odcs-schema                  TEXT  The location (url or path) of the ODCS JSON Schema          │
-│ --template                     TEXT  The location (url or path) of the ODCS template             │
 │ --owner                        TEXT  The owner or team responsible for managing the data         │
 │                                      contract.                                                   │
 │ --id                           TEXT  The identifier for the data contract.                       │

--- a/README.md
+++ b/README.md
@@ -282,19 +282,17 @@ Commands
                                                                                                     
  Create an empty data contract.                                                                     
                                                                                                     
-                                                                                                    
 ╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────╮
 │   location      [LOCATION]  The location of the data contract file to create.                    │
 │                             [default: datacontract.yaml]                                         │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
-│ --template                       TEXT  URL of a template or data contract [default: None]        │
+│ --template                       TEXT  URL of a template or data contract                        │
 │ --overwrite    --no-overwrite          Replace the existing datacontract.yaml                    │
 │                                        [default: no-overwrite]                                   │
-│ --debug        --no-debug              Enable debug logging [default: no-debug]                  │
+│ --debug        --no-debug              Enable debug logging                                      │
 │ --help                                 Show this message and exit.                               │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-
 ```
 
 ### lint
@@ -337,10 +335,9 @@ Commands
 │ *    v2      TEXT  The location (path) of the target (after) data contract YAML. [required]      │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
-│ --debug     --no-debug                 Enable debug logging                                      │
-│ --help                                 Show this message and exit.                               │
+│ --debug    --no-debug      Enable debug logging                                                  │
+│ --help                     Show this message and exit.                                           │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-
 ```
 
 ```bash
@@ -372,10 +369,7 @@ $ datacontract changelog v1.odcs.yaml v2.odcs.yaml
 │                                                                      [default: all]              │
 │ --schema-name                                          TEXT          Which model to test, e.g.,  │
 │                                                                      `orders`, or `all` for all  │
-│                                                                      models (default). Distinct  │
-│                                                                      from --json-schema, which   │
-│                                                                      is the ODCS validation      │
-│                                                                      schema.                     │
+│                                                                      models (default).           │
 │                                                                      [default: all]              │
 │ --publish-test-results    --no-publish-test-results                  Deprecated. Use publish     │
 │                                                                      parameter. Publish the      │
@@ -1284,7 +1278,42 @@ steps:
 │ excel               Export a data contract to Excel.                                             │
 │ custom              Export a data contract using a custom Jinja template.                        │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
-
+╭─ Options for each command ───────────────────────────────────────────────────────────────────────╮
+│ --output                       PATH  Specify the file path where the exported data will be       │
+│                                      saved. If no path is provided, the output will be printed   │
+│                                      to stdout.                                                  │
+│ --server                       TEXT  The server name to export.                                  │
+│ --schema-name                  TEXT  Which schema to export, e.g., `orders`, or `all` for all    │
+│                                      schemas (default).                                          │
+│                                      [default: all]                                              │
+│ --json-schema                  TEXT  The location (url or path) of the ODCS JSON Schema          │
+│ --debug          --no-debug          Enable debug logging                                        │
+│ --help                               Show a command-specific help message and exit.              │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options for sql, sql-query ─────────────────────────────────────────────────────────────────────╮
+│ --server-type                  TEXT  The server type to determine the SQL dialect. By default,   │
+│                                      it uses 'auto' to automatically detect the SQL dialect via  │
+│                                      the specified servers in the data contract. Accepted        │
+│                                      values: auto, snowflake, postgres, mysql, databricks,       │
+│                                      sqlserver, bigquery, trino, oracle.                         │
+│                                      [default: auto]                                             │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options for rdf ────────────────────────────────────────────────────────────────────────────────╮
+│ --base                         TEXT  The base URI used to generate the RDF graph.                │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options for great-expectations ─────────────────────────────────────────────────────────────────╮
+│ --engine                       TEXT  The engine used for Great Expectations run.                 │
+│ --server-type                  TEXT  The server type to determine the SQL dialect (when using    │
+│                                      --engine sql). Accepted values: auto, snowflake, postgres,  │
+│                                      mysql, databricks, sqlserver, bigquery, trino, oracle.      │
+│                                      [default: auto]                                             │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options for excel ──────────────────────────────────────────────────────────────────────────────╮
+│ --template                     PATH  Path/URL to custom Excel template.                          │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options for custom ─────────────────────────────────────────────────────────────────────────────╮
+│ --template                     PATH  Path to Jinja template.                                     │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 Each format is a subcommand with its own options. Run `datacontract export <format> --help` to see the format-specific options (e.g. `datacontract export sql --help`).
@@ -1645,6 +1674,55 @@ For more information about the Excel template structure, visit the [ODCS Excel T
 │ iceberg     Import a data contract from an Iceberg schema.                                       │
 │ excel       Import a data contract from an Excel file.                                           │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options for each command ───────────────────────────────────────────────────────────────────────╮
+│ --source                       TEXT  The path to the file that should be imported.               │
+│ --output                       PATH  Specify the file path where the Data Contract will be       │
+│                                      saved. If no path is provided, the output will be printed   │
+│                                      to stdout.                                                  │
+│ --json-schema                  TEXT  The location (url or path) of the ODCS JSON Schema          │
+│ --template                     TEXT  The location (url or path) of the ODCS template             │
+│ --owner                        TEXT  The owner or team responsible for managing the data         │
+│                                      contract.                                                   │
+│ --id                           TEXT  The identifier for the data contract.                       │
+│ --debug          --no-debug          Enable debug logging                                        │
+│ --help                               Show a command-specific help message and exit.              │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options for sql ────────────────────────────────────────────────────────────────────────────────╮
+│ --dialect                      TEXT  The SQL dialect. Accepted values: postgres, tsql, bigquery, │
+│                                      snowflake, databricks, spark, duckdb.                       │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options for dbt ────────────────────────────────────────────────────────────────────────────────╮
+│ --model                        TEXT  List of models names to import from the dbt manifest file   │
+│                                      (repeat for multiple models names, leave empty for all      │
+│                                      models in the dataset).                                     │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options for dbml ───────────────────────────────────────────────────────────────────────────────╮
+│ --schema                       TEXT  List of schema names to import from the DBML file (repeat   │
+│                                      for multiple schema names, leave empty for all tables in    │
+│                                      the file).                                                  │
+│ --table                        TEXT  List of table names to import from the DBML file (repeat    │
+│                                      for multiple table names, leave empty for all tables in the │
+│                                      file).                                                      │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options for glue ───────────────────────────────────────────────────────────────────────────────╮
+│ --table                        TEXT  List of table ids to import from the Glue Database (repeat  │
+│                                      for multiple table ids, leave empty for all tables in the   │
+│                                      dataset).                                                   │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options for bigquery ───────────────────────────────────────────────────────────────────────────╮
+│ --project                      TEXT  The BigQuery project id.                                    │
+│ --dataset                      TEXT  The BigQuery dataset id.                                    │
+│ --table                        TEXT  List of table ids to import from the BigQuery API (repeat   │
+│                                      for multiple table ids, leave empty for all tables in the   │
+│                                      dataset).                                                   │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options for unity ──────────────────────────────────────────────────────────────────────────────╮
+│ --table                        TEXT  Full name of a table in the Unity Catalog                   │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options for iceberg ────────────────────────────────────────────────────────────────────────────╮
+│ --table                        TEXT  Table name to assign to the model created from the Iceberg  │
+│                                      schema.                                                     │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 
 ```
 
@@ -1864,7 +1942,6 @@ datacontract import protobuf --source "test.proto"
                                                                                                     
  Create a html catalog of data contracts.                                                           
                                                                                                     
-                                                                                                    
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --files                        TEXT  Glob pattern for the data contract files to include in the  │
 │                                      catalog. Applies recursively to any subfolders.             │
@@ -1894,7 +1971,6 @@ datacontract catalog --files "*.odcs.yaml"
  Usage: datacontract publish [OPTIONS] [LOCATION]                                                   
                                                                                                     
  Publish the data contract to the Entropy Data.                                                     
-                                                                                                    
                                                                                                     
 ╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────╮
 │   location      [LOCATION]  The location (url or path) of the data contract yaml.                │
@@ -1935,7 +2011,7 @@ datacontract catalog --files "*.odcs.yaml"
 │ --host                   TEXT     Bind socket to this host. Hint: For running in docker, set it  │
 │                                   to 0.0.0.0                                                     │
 │                                   [default: 127.0.0.1]                                           │
-│ --debug    --no-debug             Enable debug logging [default: no-debug]                       │
+│ --debug    --no-debug             Enable debug logging                                           │
 │ --help                            Show this message and exit.                                    │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -332,8 +332,6 @@ def ci(
         raise typer.Exit(code=1)
 
 
-
-
 @app.command(name="publish")
 def publish(
     location: Annotated[

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -35,6 +35,43 @@ class OrderedCommands(TyperGroup):
         return self.commands.keys()
 
 
+class OrderedCommandsWithMigrationHints(OrderedCommands):
+    """Intercepts removed or renamed options on import/export and points the user to the v0.12.0 migration notes."""
+
+    RENAMED_FLAGS = frozenset(
+        {
+            "--format",
+            "--rdf-base",
+            "--sql-server-type",
+            "--bigquery-project",
+            "--bigquery-dataset",
+            "--bigquery-table",
+            "--unity-table-full-name",
+            "--dbt-model",
+            "--dbml-schema",
+            "--dbml-table",
+            "--glue-table",
+            "--iceberg-table",
+        }
+    )
+
+    def parse_args(self, ctx: Context, args):
+        first_positional_arg = next((a for a in args if isinstance(a, str) and not a.startswith("-")), None)
+        for arg in args:
+            if isinstance(arg, str) and arg.startswith("--"):
+                flag = arg.split("=", 1)[0]
+                is_renamed = (
+                    flag in self.RENAMED_FLAGS
+                    or (flag == "--schema" and first_positional_arg != "dbml")
+                    or (flag == "--source" and first_positional_arg in ("glue", "spark"))
+                )
+                if is_renamed:
+                    ctx.fail(
+                        f"{flag} was removed in v0.12.0 of datacontract-cli. See https://github.com/datacontract/datacontract-cli/releases/tag/v0.12.0"
+                    )
+        return super().parse_args(ctx, args)
+
+
 app = typer.Typer(
     cls=OrderedCommands,
     no_args_is_help=True,

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -100,7 +100,7 @@ def lint(
     ] = "datacontract.yaml",
     schema: Annotated[
         str,
-        typer.Option("--json-schema", help="The location (url or path) of the ODCS JSON Schema"),
+        typer.Option("--odcs-schema", help="The location (url or path) of the ODCS JSON Schema"),
     ] = None,
     output: Annotated[
         Path,
@@ -154,7 +154,7 @@ def test(
     ] = "datacontract.yaml",
     schema: Annotated[
         str,
-        typer.Option("--json-schema", help="The location (url or path) of the ODCS JSON Schema"),
+        typer.Option("--odcs-schema", help="The location (url or path) of the ODCS JSON Schema"),
     ] = None,
     server: Annotated[
         str,
@@ -244,7 +244,7 @@ def ci(
     ] = None,
     schema: Annotated[
         str,
-        typer.Option("--json-schema", help="The location (url or path) of the ODCS JSON Schema"),
+        typer.Option("--odcs-schema", help="The location (url or path) of the ODCS JSON Schema"),
     ] = None,
     server: Annotated[
         str,
@@ -340,7 +340,7 @@ def publish(
     ] = "datacontract.yaml",
     schema: Annotated[
         str,
-        typer.Option("--json-schema", help="The location (url or path) of the ODCS JSON Schema"),
+        typer.Option("--odcs-schema", help="The location (url or path) of the ODCS JSON Schema"),
     ] = None,
     ssl_verification: Annotated[
         bool,
@@ -370,7 +370,7 @@ def catalog(
     output: Annotated[Optional[str], typer.Option(help="Output directory for the catalog html files.")] = "catalog/",
     schema: Annotated[
         str,
-        typer.Option("--json-schema", help="The location (url or path) of the ODCS JSON Schema"),
+        typer.Option("--odcs-schema", help="The location (url or path) of the ODCS JSON Schema"),
     ] = None,
     debug: debug_option = None,
 ):

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -100,7 +100,7 @@ def lint(
     ] = "datacontract.yaml",
     schema: Annotated[
         str,
-        typer.Option(help="The location (url or path) of the ODCS JSON Schema"),
+        typer.Option("--json-schema", "--schema", help="The location (url or path) of the ODCS JSON Schema"),
     ] = None,
     output: Annotated[
         Path,
@@ -154,7 +154,7 @@ def test(
     ] = "datacontract.yaml",
     schema: Annotated[
         str,
-        typer.Option(help="The location (url or path) of the ODCS JSON Schema"),
+        typer.Option("--json-schema", "--schema", help="The location (url or path) of the ODCS JSON Schema"),
     ] = None,
     server: Annotated[
         str,
@@ -167,7 +167,7 @@ def test(
     ] = "all",
     schema_name: Annotated[
         str,
-        typer.Option(help="The name of the schema to test, e.g., `orders`, or `all` for all schemas (default)."),
+        typer.Option(help="Which model to test, e.g., `orders`, or `all` for all models (default). Distinct from --json-schema, which is the ODCS validation schema."),
     ] = "all",
     publish_test_results: Annotated[
         bool, typer.Option(help="Deprecated. Use publish parameter. Publish the results after the test")
@@ -244,7 +244,7 @@ def ci(
     ] = None,
     schema: Annotated[
         str,
-        typer.Option(help="The location (url or path) of the ODCS JSON Schema"),
+        typer.Option("--json-schema", "--schema", help="The location (url or path) of the ODCS JSON Schema"),
     ] = None,
     server: Annotated[
         str,
@@ -340,7 +340,7 @@ def publish(
     ] = "datacontract.yaml",
     schema: Annotated[
         str,
-        typer.Option(help="The location (url or path) of the ODCS JSON Schema"),
+        typer.Option("--json-schema", "--schema", help="The location (url or path) of the ODCS JSON Schema"),
     ] = None,
     ssl_verification: Annotated[
         bool,
@@ -370,7 +370,7 @@ def catalog(
     output: Annotated[Optional[str], typer.Option(help="Output directory for the catalog html files.")] = "catalog/",
     schema: Annotated[
         str,
-        typer.Option(help="The location (url or path) of the ODCS JSON Schema"),
+        typer.Option("--json-schema", "--schema", help="The location (url or path) of the ODCS JSON Schema"),
     ] = None,
     debug: debug_option = None,
 ):

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -3,7 +3,7 @@ import os
 import sys
 from importlib import metadata
 from pathlib import Path
-from typing import Iterable, List, Optional
+from typing import Iterable, Optional
 
 import click
 import typer
@@ -13,8 +13,7 @@ from typer.core import TyperGroup
 from typing_extensions import Annotated
 
 from datacontract.catalog.catalog import create_data_contract_html, create_index_html
-from datacontract.data_contract import DataContract, ExportFormat
-from datacontract.imports.importer import ImportFormat
+from datacontract.data_contract import DataContract
 from datacontract.init.init_template import get_init_template
 from datacontract.integration.entropy_data import (
     publish_data_contract_to_entropy_data,
@@ -333,199 +332,6 @@ def ci(
         raise typer.Exit(code=1)
 
 
-@app.command(name="export")
-def export(
-    format: Annotated[ExportFormat, typer.Option(help="The export format.")],
-    output: Annotated[
-        Path,
-        typer.Option(
-            help="Specify the file path where the exported data will be saved. If no path is provided, the output will be printed to stdout."
-        ),
-    ] = None,
-    server: Annotated[str, typer.Option(help="The server name to export.")] = None,
-    schema_name: Annotated[
-        str,
-        typer.Option(help="The name of the schema to export, e.g., `orders`, or `all` for all schemas (default)."),
-    ] = "all",
-    # TODO: this should be a subcommand
-    rdf_base: Annotated[
-        Optional[str],
-        typer.Option(
-            help="[rdf] The base URI used to generate the RDF graph.",
-            rich_help_panel="RDF Options",
-        ),
-    ] = None,
-    # TODO: this should be a subcommand
-    sql_server_type: Annotated[
-        Optional[str],
-        typer.Option(
-            help="[sql] The server type to determine the sql dialect. By default, it uses 'auto' to automatically detect the sql dialect via the specified servers in the data contract. Accepted values: auto, snowflake, postgres, mysql, databricks, sqlserver, bigquery, trino, oracle.",
-            rich_help_panel="SQL Options",
-        ),
-    ] = "auto",
-    location: Annotated[
-        str,
-        typer.Argument(help="The location (url or path) of the data contract yaml."),
-    ] = "datacontract.yaml",
-    schema: Annotated[
-        str,
-        typer.Option(help="The location (url or path) of the ODCS JSON Schema"),
-    ] = None,
-    # TODO: this should be a subcommand
-    engine: Annotated[
-        Optional[str],
-        typer.Option(help="[engine] The engine used for great expection run."),
-    ] = None,
-    # TODO: this should be a subcommand
-    template: Annotated[
-        Optional[Path],
-        typer.Option(
-            help="The file path or URL of a template. For Excel format: path/URL to custom Excel template. For custom format: path to Jinja template."
-        ),
-    ] = None,
-    debug: debug_option = None,
-):
-    """
-    Convert data contract to a specific format. Saves to file specified by `output` option if present, otherwise prints to stdout.
-    """
-    enable_debug_logging(debug)
-
-    # Validate that Excel format requires an output file path
-    if format == ExportFormat.excel and output is None:
-        console.print("❌ Error: Excel export requires an output file path.")
-        console.print("💡 Hint: Use --output to specify where to save the Excel file, e.g.:")
-        console.print("   datacontract export --format excel --output datacontract.xlsx")
-        raise typer.Exit(code=1)
-
-    # TODO exception handling
-    result = DataContract(data_contract_file=location, schema_location=schema, server=server).export(
-        export_format=format,
-        schema_name=schema_name,
-        server=server,
-        rdf_base=rdf_base,
-        sql_server_type=sql_server_type,
-        engine=engine,
-        template=template,
-    )
-    # Don't interpret console markup in output.
-    if output is None:
-        console.print(result, markup=False, soft_wrap=True)
-    else:
-        if isinstance(result, bytes):
-            # If the result is bytes, we assume it's a binary file (e.g., Excel, PDF)
-            with output.open(mode="wb") as f:
-                f.write(result)
-        else:
-            with output.open(mode="w", encoding="utf-8") as f:
-                f.write(result)
-        console.print(f"Written result to {output}")
-
-
-@app.command(name="import")
-def import_(
-    format: Annotated[ImportFormat, typer.Option(help="The format of the source file.")],
-    output: Annotated[
-        Path,
-        typer.Option(
-            help="Specify the file path where the Data Contract will be saved. If no path is provided, the output will be printed to stdout."
-        ),
-    ] = None,
-    source: Annotated[
-        Optional[str],
-        typer.Option(help="The path to the file that should be imported."),
-    ] = None,
-    dialect: Annotated[
-        Optional[str],
-        typer.Option(
-            help="The SQL dialect. Accepted values: postgres, tsql, bigquery, snowflake, databricks, spark, duckdb."
-        ),
-    ] = None,
-    glue_table: Annotated[
-        Optional[List[str]],
-        typer.Option(
-            help="List of table ids to import from the Glue Database (repeat for multiple table ids, leave empty for all tables in the dataset)."
-        ),
-    ] = None,
-    bigquery_project: Annotated[Optional[str], typer.Option(help="The bigquery project id.")] = None,
-    bigquery_dataset: Annotated[Optional[str], typer.Option(help="The bigquery dataset id.")] = None,
-    bigquery_table: Annotated[
-        Optional[List[str]],
-        typer.Option(
-            help="List of table ids to import from the bigquery API (repeat for multiple table ids, leave empty for all tables in the dataset)."
-        ),
-    ] = None,
-    unity_table_full_name: Annotated[
-        Optional[List[str]], typer.Option(help="Full name of a table in the unity catalog")
-    ] = None,
-    dbt_model: Annotated[
-        Optional[List[str]],
-        typer.Option(
-            help="List of models names to import from the dbt manifest file (repeat for multiple models names, leave empty for all models in the dataset)."
-        ),
-    ] = None,
-    dbml_schema: Annotated[
-        Optional[List[str]],
-        typer.Option(
-            help="List of schema names to import from the DBML file (repeat for multiple schema names, leave empty for all tables in the file)."
-        ),
-    ] = None,
-    dbml_table: Annotated[
-        Optional[List[str]],
-        typer.Option(
-            help="List of table names to import from the DBML file (repeat for multiple table names, leave empty for all tables in the file)."
-        ),
-    ] = None,
-    iceberg_table: Annotated[
-        Optional[str],
-        typer.Option(help="Table name to assign to the model created from the Iceberg schema."),
-    ] = None,
-    template: Annotated[
-        Optional[str],
-        typer.Option(help="The location (url or path) of the ODCS template"),
-    ] = None,
-    schema: Annotated[
-        str,
-        typer.Option(help="The location (url or path) of the ODCS JSON Schema"),
-    ] = None,
-    owner: Annotated[
-        Optional[str],
-        typer.Option(help="The owner or team responsible for managing the data contract."),
-    ] = None,
-    id: Annotated[
-        Optional[str],
-        typer.Option(help="The identifier for the the data contract."),
-    ] = None,
-    debug: debug_option = None,
-):
-    """
-    Create a data contract from the given source location. Saves to file specified by `output` option if present, otherwise prints to stdout.
-    """
-    enable_debug_logging(debug)
-
-    result = DataContract.import_from_source(
-        format=format,
-        source=source,
-        template=template,
-        schema=schema,
-        dialect=dialect,
-        glue_table=glue_table,
-        bigquery_table=bigquery_table,
-        bigquery_project=bigquery_project,
-        bigquery_dataset=bigquery_dataset,
-        unity_table_full_name=unity_table_full_name,
-        dbt_model=dbt_model,
-        dbml_schema=dbml_schema,
-        dbml_table=dbml_table,
-        iceberg_table=iceberg_table,
-        owner=owner,
-        id=id,
-    )
-    if output is None:
-        console.print(result.to_yaml(), markup=False, soft_wrap=True)
-    else:
-        with output.open(mode="w", encoding="utf-8") as f:
-            f.write(result.to_yaml())
-        console.print(f"Written result to {output}")
 
 
 @app.command(name="publish")
@@ -663,6 +469,16 @@ def _print_logs(run, out=None):
     for log in run.logs:
         out.print(log.timestamp.strftime("%y-%m-%d %H:%M:%S"), log.level.ljust(5), log.message)
 
+
+# ---------------------------------------------------------------------------
+# Register import/export sub-apps (must be after app is fully defined to
+# avoid circular imports, since cli_import/cli_export import from this module)
+# ---------------------------------------------------------------------------
+from datacontract.cli_export import export_app  # noqa: E402
+from datacontract.cli_import import import_app  # noqa: E402
+
+app.add_typer(import_app, name="import", help="Create a data contract from a source format.")
+app.add_typer(export_app, name="export", help="Convert a data contract to a target format.")
 
 if __name__ == "__main__":
     app()

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -167,7 +167,7 @@ def test(
     ] = "all",
     schema_name: Annotated[
         str,
-        typer.Option(help="Which model to test, e.g., `orders`, or `all` for all models (default). Distinct from --json-schema, which is the ODCS validation schema."),
+        typer.Option(help="Which schema to test, e.g., `orders`, or `all` for all schemas (default)."),
     ] = "all",
     publish_test_results: Annotated[
         bool, typer.Option(help="Deprecated. Use publish parameter. Publish the results after the test")

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -100,7 +100,7 @@ def lint(
     ] = "datacontract.yaml",
     schema: Annotated[
         str,
-        typer.Option("--json-schema", "--schema", help="The location (url or path) of the ODCS JSON Schema"),
+        typer.Option("--json-schema", help="The location (url or path) of the ODCS JSON Schema"),
     ] = None,
     output: Annotated[
         Path,
@@ -154,7 +154,7 @@ def test(
     ] = "datacontract.yaml",
     schema: Annotated[
         str,
-        typer.Option("--json-schema", "--schema", help="The location (url or path) of the ODCS JSON Schema"),
+        typer.Option("--json-schema", help="The location (url or path) of the ODCS JSON Schema"),
     ] = None,
     server: Annotated[
         str,
@@ -244,7 +244,7 @@ def ci(
     ] = None,
     schema: Annotated[
         str,
-        typer.Option("--json-schema", "--schema", help="The location (url or path) of the ODCS JSON Schema"),
+        typer.Option("--json-schema", help="The location (url or path) of the ODCS JSON Schema"),
     ] = None,
     server: Annotated[
         str,
@@ -340,7 +340,7 @@ def publish(
     ] = "datacontract.yaml",
     schema: Annotated[
         str,
-        typer.Option("--json-schema", "--schema", help="The location (url or path) of the ODCS JSON Schema"),
+        typer.Option("--json-schema", help="The location (url or path) of the ODCS JSON Schema"),
     ] = None,
     ssl_verification: Annotated[
         bool,
@@ -370,7 +370,7 @@ def catalog(
     output: Annotated[Optional[str], typer.Option(help="Output directory for the catalog html files.")] = "catalog/",
     schema: Annotated[
         str,
-        typer.Option("--json-schema", "--schema", help="The location (url or path) of the ODCS JSON Schema"),
+        typer.Option("--json-schema", help="The location (url or path) of the ODCS JSON Schema"),
     ] = None,
     debug: debug_option = None,
 ):

--- a/datacontract/cli_export.py
+++ b/datacontract/cli_export.py
@@ -20,7 +20,7 @@ location_arg = Annotated[str, typer.Argument(help="The location (url or path) of
 output_option = Annotated[
     Optional[Path],
     typer.Option(
-        help="Specify the file path where the exported data will be saved. If no path is provided, the output will be printed to stdout."
+        help="File path where the exported data will be saved. If not provided, it will be printed to stdout."
     ),
 ]
 server_option = Annotated[Optional[str], typer.Option(help="The server name to export.")]
@@ -30,7 +30,7 @@ schema_name_option = Annotated[
 ]
 schema_option = Annotated[
     Optional[str],
-    typer.Option("--odcs-schema", help="The location (url or path) of the ODCS JSON Schema"),
+    typer.Option("--odcs-schema", help="The location (url or path) of the ODCS JSON Schema."),
 ]
 
 
@@ -78,7 +78,7 @@ def export_sql(
     server_type: Annotated[
         Optional[str],
         typer.Option(
-            help="The server type to determine the SQL dialect. By default, it uses 'auto' to automatically detect the SQL dialect via the specified servers in the data contract. Accepted values: auto, snowflake, postgres, mysql, databricks, sqlserver, bigquery, trino, oracle."
+            help="The server type to determine the SQL dialect. By default, detect the SQL dialect via the specified servers in the data contract. Accepted values: auto, snowflake, postgres, mysql, databricks, sqlserver, bigquery, trino, oracle."
         ),
     ] = "auto",
     output: output_option = None,
@@ -98,7 +98,7 @@ def export_sql_query(
     server_type: Annotated[
         Optional[str],
         typer.Option(
-            help="The server type to determine the SQL dialect. By default, it uses 'auto' to automatically detect the SQL dialect via the specified servers in the data contract. Accepted values: auto, snowflake, postgres, mysql, databricks, sqlserver, bigquery, trino, oracle."
+            help="The server type to determine the SQL dialect. By default, detect the SQL dialect via the specified servers in the data contract. Accepted values: auto, snowflake, postgres, mysql, databricks, sqlserver, bigquery, trino, oracle."
         ),
     ] = "auto",
     output: output_option = None,
@@ -406,7 +406,7 @@ def export_great_expectations(
     server_type: Annotated[
         Optional[str],
         typer.Option(
-            help="The server type to determine the SQL dialect (when using --engine sql). Accepted values: auto, snowflake, postgres, mysql, databricks, sqlserver, bigquery, trino, oracle."
+            help="The server type to determine the SQL dialect (when using --engine sql). By default, automatically detect it via the specified servers in the data contract. Accepted values: auto, snowflake, postgres, mysql, databricks, sqlserver, bigquery, trino, oracle."
         ),
     ] = "auto",
     output: output_option = None,
@@ -475,8 +475,8 @@ def export_dqx(
 def export_excel(
     location: location_arg = "datacontract.yaml",
     template: Annotated[
-        Optional[Path],
-        typer.Option(help="Path/URL to custom Excel template."),
+        Optional[str],
+        typer.Option(help="Path or URL to a custom Excel template."),
     ] = None,
     output: output_option = None,
     server: server_option = None,

--- a/datacontract/cli_export.py
+++ b/datacontract/cli_export.py
@@ -413,7 +413,16 @@ def export_great_expectations(
 ):
     """Export a data contract to Great Expectations suite."""
     enable_debug_logging(debug)
-    _export(ExportFormat.great_expectations, location, output, server, schema_name, schema, engine=engine, sql_server_type=server_type)
+    _export(
+        ExportFormat.great_expectations,
+        location,
+        output,
+        server,
+        schema_name,
+        schema,
+        engine=engine,
+        sql_server_type=server_type,
+    )
 
 
 @export_app.command(name="data-caterer")

--- a/datacontract/cli_export.py
+++ b/datacontract/cli_export.py
@@ -5,13 +5,13 @@ import typer
 from rich.console import Console
 from typing_extensions import Annotated
 
-from datacontract.cli import OrderedCommands, debug_option, enable_debug_logging
+from datacontract.cli import OrderedCommandsWithMigrationHints, debug_option, enable_debug_logging
 from datacontract.data_contract import DataContract
 from datacontract.export.exporter import ExportFormat
 
 console = Console()
 
-export_app = typer.Typer(cls=OrderedCommands, no_args_is_help=True)
+export_app = typer.Typer(cls=OrderedCommandsWithMigrationHints, no_args_is_help=True)
 
 # ---------------------------------------------------------------------------
 # Shared option type aliases
@@ -44,7 +44,7 @@ def _export(
     sql_server_type: str = "auto",
     rdf_base: Optional[str] = None,
     engine: Optional[str] = None,
-    template: Optional[Path] = None,
+    template: Optional[Path | str] = None,
 ):
     result = DataContract(data_contract_file=location, schema_location=schema, server=server).export(
         export_format=export_format,

--- a/datacontract/cli_export.py
+++ b/datacontract/cli_export.py
@@ -30,7 +30,7 @@ schema_name_option = Annotated[
 ]
 schema_option = Annotated[
     Optional[str],
-    typer.Option("--json-schema", help="The location (url or path) of the ODCS JSON Schema"),
+    typer.Option("--odcs-schema", help="The location (url or path) of the ODCS JSON Schema"),
 ]
 
 

--- a/datacontract/cli_export.py
+++ b/datacontract/cli_export.py
@@ -27,7 +27,7 @@ server_option = Annotated[Optional[str], typer.Option(help="The server name to e
 schema_name_option = Annotated[
     str,
     typer.Option(
-        help="Which model to export, e.g., `orders`, or `all` for all models (default). Distinct from --json-schema, which is the ODCS validation schema."
+        help="Which schema to export, e.g., `orders`, or `all` for all schemas (default)."
     ),
 ]
 schema_option = Annotated[

--- a/datacontract/cli_export.py
+++ b/datacontract/cli_export.py
@@ -399,6 +399,12 @@ def export_great_expectations(
         Optional[str],
         typer.Option(help="The engine used for the Great Expectations run."),
     ] = None,
+    server_type: Annotated[
+        Optional[str],
+        typer.Option(
+            help="The server type to determine the SQL dialect (when using --engine sql). Accepted values: auto, snowflake, postgres, mysql, databricks, sqlserver, bigquery, trino, oracle."
+        ),
+    ] = "auto",
     output: output_option = None,
     server: server_option = None,
     schema_name: schema_name_option = "all",
@@ -407,7 +413,7 @@ def export_great_expectations(
 ):
     """Export a data contract to Great Expectations suite."""
     enable_debug_logging(debug)
-    _export(ExportFormat.great_expectations, location, output, server, schema_name, schema, engine=engine)
+    _export(ExportFormat.great_expectations, location, output, server, schema_name, schema, engine=engine, sql_server_type=server_type)
 
 
 @export_app.command(name="data-caterer")

--- a/datacontract/cli_export.py
+++ b/datacontract/cli_export.py
@@ -1,0 +1,491 @@
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+from typing_extensions import Annotated
+
+from datacontract.cli import OrderedCommands, debug_option, enable_debug_logging
+from datacontract.data_contract import DataContract
+from datacontract.export.exporter import ExportFormat
+
+console = Console()
+
+export_app = typer.Typer(cls=OrderedCommands, no_args_is_help=True)
+
+# ---------------------------------------------------------------------------
+# Shared option type aliases
+# ---------------------------------------------------------------------------
+location_arg = Annotated[str, typer.Argument(help="The location (url or path) of the data contract yaml.")]
+output_option = Annotated[
+    Optional[Path],
+    typer.Option(
+        help="Specify the file path where the exported data will be saved. If no path is provided, the output will be printed to stdout."
+    ),
+]
+server_option = Annotated[Optional[str], typer.Option(help="The server name to export.")]
+schema_name_option = Annotated[
+    str, typer.Option(help="The name of the schema to export, e.g., `orders`, or `all` for all schemas (default).")
+]
+schema_option = Annotated[Optional[str], typer.Option(help="The location (url or path) of the ODCS JSON Schema")]
+
+
+def _export(
+    export_format: ExportFormat,
+    location: str,
+    output: Optional[Path],
+    server: Optional[str],
+    schema_name: str,
+    schema: Optional[str],
+    sql_server_type: str = "auto",
+    rdf_base: Optional[str] = None,
+    engine: Optional[str] = None,
+    template: Optional[Path] = None,
+):
+    result = DataContract(data_contract_file=location, schema_location=schema, server=server).export(
+        export_format=export_format,
+        schema_name=schema_name,
+        server=server,
+        rdf_base=rdf_base,
+        sql_server_type=sql_server_type,
+        engine=engine,
+        template=template,
+    )
+    if output is None:
+        console.print(result, markup=False, soft_wrap=True)
+    else:
+        if isinstance(result, bytes):
+            with output.open(mode="wb") as f:
+                f.write(result)
+        else:
+            with output.open(mode="w", encoding="utf-8") as f:
+                f.write(result)
+        console.print(f"Written result to {output}")
+
+
+# ---------------------------------------------------------------------------
+# Export subcommands
+# ---------------------------------------------------------------------------
+
+
+@export_app.command(name="sql")
+def export_sql(
+    location: location_arg = "datacontract.yaml",
+    server_type: Annotated[
+        Optional[str],
+        typer.Option(
+            help="The server type to determine the SQL dialect. Accepted values: auto, snowflake, postgres, mysql, databricks, sqlserver, bigquery, trino, oracle."
+        ),
+    ] = "auto",
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to SQL DDL."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.sql, location, output, server, schema_name, schema, sql_server_type=server_type)
+
+
+@export_app.command(name="sql-query")
+def export_sql_query(
+    location: location_arg = "datacontract.yaml",
+    server_type: Annotated[
+        Optional[str],
+        typer.Option(
+            help="The server type to determine the SQL dialect. Accepted values: auto, snowflake, postgres, mysql, databricks, sqlserver, bigquery, trino, oracle."
+        ),
+    ] = "auto",
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to a SQL query."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.sql_query, location, output, server, schema_name, schema, sql_server_type=server_type)
+
+
+@export_app.command(name="dbt-models")
+def export_dbt_models(
+    location: location_arg = "datacontract.yaml",
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to dbt model schema YAML."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.dbt_models, location, output, server, schema_name, schema)
+
+
+@export_app.command(name="dbt-sources")
+def export_dbt_sources(
+    location: location_arg = "datacontract.yaml",
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to dbt sources YAML."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.dbt_sources, location, output, server, schema_name, schema)
+
+
+@export_app.command(name="dbt-staging-sql")
+def export_dbt_staging_sql(
+    location: location_arg = "datacontract.yaml",
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to a dbt staging SQL file."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.dbt_staging_sql, location, output, server, schema_name, schema)
+
+
+@export_app.command(name="avro")
+def export_avro(
+    location: location_arg = "datacontract.yaml",
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to Avro schema."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.avro, location, output, server, schema_name, schema)
+
+
+@export_app.command(name="avro-idl")
+def export_avro_idl(
+    location: location_arg = "datacontract.yaml",
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to Avro IDL."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.avro_idl, location, output, server, schema_name, schema)
+
+
+@export_app.command(name="jsonschema")
+def export_jsonschema(
+    location: location_arg = "datacontract.yaml",
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to JSON Schema."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.jsonschema, location, output, server, schema_name, schema)
+
+
+@export_app.command(name="pydantic-model")
+def export_pydantic_model(
+    location: location_arg = "datacontract.yaml",
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to a Pydantic model."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.pydantic_model, location, output, server, schema_name, schema)
+
+
+@export_app.command(name="protobuf")
+def export_protobuf(
+    location: location_arg = "datacontract.yaml",
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to Protobuf schema."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.protobuf, location, output, server, schema_name, schema)
+
+
+@export_app.command(name="odcs")
+def export_odcs(
+    location: location_arg = "datacontract.yaml",
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to ODCS format."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.odcs, location, output, server, schema_name, schema)
+
+
+@export_app.command(name="rdf")
+def export_rdf(
+    location: location_arg = "datacontract.yaml",
+    base: Annotated[
+        Optional[str],
+        typer.Option(help="The base URI used to generate the RDF graph."),
+    ] = None,
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to RDF."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.rdf, location, output, server, schema_name, schema, rdf_base=base)
+
+
+@export_app.command(name="html")
+def export_html(
+    location: location_arg = "datacontract.yaml",
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to HTML."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.html, location, output, server, schema_name, schema)
+
+
+@export_app.command(name="markdown")
+def export_markdown(
+    location: location_arg = "datacontract.yaml",
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to Markdown."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.markdown, location, output, server, schema_name, schema)
+
+
+@export_app.command(name="mermaid")
+def export_mermaid(
+    location: location_arg = "datacontract.yaml",
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to Mermaid diagram."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.mermaid, location, output, server, schema_name, schema)
+
+
+@export_app.command(name="bigquery")
+def export_bigquery(
+    location: location_arg = "datacontract.yaml",
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to BigQuery schema."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.bigquery, location, output, server, schema_name, schema)
+
+
+@export_app.command(name="dbml")
+def export_dbml(
+    location: location_arg = "datacontract.yaml",
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to DBML."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.dbml, location, output, server, schema_name, schema)
+
+
+@export_app.command(name="go")
+def export_go(
+    location: location_arg = "datacontract.yaml",
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to Go structs."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.go, location, output, server, schema_name, schema)
+
+
+@export_app.command(name="spark")
+def export_spark(
+    location: location_arg = "datacontract.yaml",
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to Spark schema."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.spark, location, output, server, schema_name, schema)
+
+
+@export_app.command(name="sqlalchemy")
+def export_sqlalchemy(
+    location: location_arg = "datacontract.yaml",
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to SQLAlchemy models."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.sqlalchemy, location, output, server, schema_name, schema)
+
+
+@export_app.command(name="iceberg")
+def export_iceberg(
+    location: location_arg = "datacontract.yaml",
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to Iceberg schema."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.iceberg, location, output, server, schema_name, schema)
+
+
+@export_app.command(name="sodacl")
+def export_sodacl(
+    location: location_arg = "datacontract.yaml",
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to SodaCL checks."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.sodacl, location, output, server, schema_name, schema)
+
+
+@export_app.command(name="great-expectations")
+def export_great_expectations(
+    location: location_arg = "datacontract.yaml",
+    engine: Annotated[
+        Optional[str],
+        typer.Option(help="The engine used for the Great Expectations run."),
+    ] = None,
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to Great Expectations suite."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.great_expectations, location, output, server, schema_name, schema, engine=engine)
+
+
+@export_app.command(name="data-caterer")
+def export_data_caterer(
+    location: location_arg = "datacontract.yaml",
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to Data Caterer format."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.data_caterer, location, output, server, schema_name, schema)
+
+
+@export_app.command(name="dcs")
+def export_dcs(
+    location: location_arg = "datacontract.yaml",
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to DCS format."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.dcs, location, output, server, schema_name, schema)
+
+
+@export_app.command(name="dqx")
+def export_dqx(
+    location: location_arg = "datacontract.yaml",
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to DQX format."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.dqx, location, output, server, schema_name, schema)
+
+
+@export_app.command(name="excel")
+def export_excel(
+    location: location_arg = "datacontract.yaml",
+    template: Annotated[
+        Optional[Path],
+        typer.Option(help="Path or URL to a custom Excel template."),
+    ] = None,
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract to Excel."""
+    enable_debug_logging(debug)
+    if output is None:
+        console.print("Error: Excel export requires --output.")
+        raise typer.Exit(code=1)
+    _export(ExportFormat.excel, location, output, server, schema_name, schema, template=template)
+
+
+@export_app.command(name="custom")
+def export_custom(
+    location: location_arg = "datacontract.yaml",
+    template: Annotated[
+        Optional[Path],
+        typer.Option(help="Path to a Jinja template for custom export."),
+    ] = None,
+    output: output_option = None,
+    server: server_option = None,
+    schema_name: schema_name_option = "all",
+    schema: schema_option = None,
+    debug: debug_option = None,
+):
+    """Export a data contract using a custom Jinja template."""
+    enable_debug_logging(debug)
+    _export(ExportFormat.custom, location, output, server, schema_name, schema, template=template)

--- a/datacontract/cli_export.py
+++ b/datacontract/cli_export.py
@@ -32,7 +32,7 @@ schema_name_option = Annotated[
 ]
 schema_option = Annotated[
     Optional[str],
-    typer.Option("--json-schema", "--schema", help="The location (url or path) of the ODCS JSON Schema"),
+    typer.Option("--json-schema", help="The location (url or path) of the ODCS JSON Schema"),
 ]
 
 

--- a/datacontract/cli_export.py
+++ b/datacontract/cli_export.py
@@ -25,9 +25,15 @@ output_option = Annotated[
 ]
 server_option = Annotated[Optional[str], typer.Option(help="The server name to export.")]
 schema_name_option = Annotated[
-    str, typer.Option(help="The name of the schema to export, e.g., `orders`, or `all` for all schemas (default).")
+    str,
+    typer.Option(
+        help="Which model to export, e.g., `orders`, or `all` for all models (default). Distinct from --json-schema, which is the ODCS validation schema."
+    ),
 ]
-schema_option = Annotated[Optional[str], typer.Option(help="The location (url or path) of the ODCS JSON Schema")]
+schema_option = Annotated[
+    Optional[str],
+    typer.Option("--json-schema", "--schema", help="The location (url or path) of the ODCS JSON Schema"),
+]
 
 
 def _export(
@@ -74,7 +80,7 @@ def export_sql(
     server_type: Annotated[
         Optional[str],
         typer.Option(
-            help="The server type to determine the SQL dialect. Accepted values: auto, snowflake, postgres, mysql, databricks, sqlserver, bigquery, trino, oracle."
+            help="The server type to determine the SQL dialect. By default, it uses 'auto' to automatically detect the SQL dialect via the specified servers in the data contract. Accepted values: auto, snowflake, postgres, mysql, databricks, sqlserver, bigquery, trino, oracle."
         ),
     ] = "auto",
     output: output_option = None,
@@ -94,7 +100,7 @@ def export_sql_query(
     server_type: Annotated[
         Optional[str],
         typer.Option(
-            help="The server type to determine the SQL dialect. Accepted values: auto, snowflake, postgres, mysql, databricks, sqlserver, bigquery, trino, oracle."
+            help="The server type to determine the SQL dialect. By default, it uses 'auto' to automatically detect the SQL dialect via the specified servers in the data contract. Accepted values: auto, snowflake, postgres, mysql, databricks, sqlserver, bigquery, trino, oracle."
         ),
     ] = "auto",
     output: output_option = None,
@@ -397,7 +403,7 @@ def export_great_expectations(
     location: location_arg = "datacontract.yaml",
     engine: Annotated[
         Optional[str],
-        typer.Option(help="The engine used for the Great Expectations run."),
+        typer.Option(help="The engine used for Great Expectations run."),
     ] = None,
     server_type: Annotated[
         Optional[str],
@@ -472,7 +478,7 @@ def export_excel(
     location: location_arg = "datacontract.yaml",
     template: Annotated[
         Optional[Path],
-        typer.Option(help="Path or URL to a custom Excel template."),
+        typer.Option(help="Path/URL to custom Excel template."),
     ] = None,
     output: output_option = None,
     server: server_option = None,
@@ -483,7 +489,9 @@ def export_excel(
     """Export a data contract to Excel."""
     enable_debug_logging(debug)
     if output is None:
-        console.print("Error: Excel export requires --output.")
+        console.print("❌ Error: Excel export requires an output file path.")
+        console.print("💡 Hint: Use --output to specify where to save the Excel file, e.g.:")
+        console.print("   datacontract export excel --output datacontract.xlsx")
         raise typer.Exit(code=1)
     _export(ExportFormat.excel, location, output, server, schema_name, schema, template=template)
 
@@ -493,7 +501,7 @@ def export_custom(
     location: location_arg = "datacontract.yaml",
     template: Annotated[
         Optional[Path],
-        typer.Option(help="Path to a Jinja template for custom export."),
+        typer.Option(help="Path to Jinja template."),
     ] = None,
     output: output_option = None,
     server: server_option = None,

--- a/datacontract/cli_export.py
+++ b/datacontract/cli_export.py
@@ -26,9 +26,7 @@ output_option = Annotated[
 server_option = Annotated[Optional[str], typer.Option(help="The server name to export.")]
 schema_name_option = Annotated[
     str,
-    typer.Option(
-        help="Which schema to export, e.g., `orders`, or `all` for all schemas (default)."
-    ),
+    typer.Option(help="Which schema to export, e.g., `orders`, or `all` for all schemas (default)."),
 ]
 schema_option = Annotated[
     Optional[str],

--- a/datacontract/cli_import.py
+++ b/datacontract/cli_import.py
@@ -24,7 +24,7 @@ output_option = Annotated[
 ]
 schema_option = Annotated[
     Optional[str],
-    typer.Option("--json-schema", "--schema", help="The location (url or path) of the ODCS JSON Schema"),
+    typer.Option("--json-schema", help="The location (url or path) of the ODCS JSON Schema"),
 ]
 template_option = Annotated[Optional[str], typer.Option(help="The location (url or path) of the ODCS template")]
 owner_option = Annotated[

--- a/datacontract/cli_import.py
+++ b/datacontract/cli_import.py
@@ -5,17 +5,16 @@ import typer
 from rich.console import Console
 from typing_extensions import Annotated
 
-from datacontract.cli import OrderedCommands, debug_option, enable_debug_logging
+from datacontract.cli import OrderedCommandsWithMigrationHints, debug_option, enable_debug_logging
 from datacontract.data_contract import DataContract
 
 console = Console()
 
-import_app = typer.Typer(cls=OrderedCommands, no_args_is_help=True)
+import_app = typer.Typer(cls=OrderedCommandsWithMigrationHints, no_args_is_help=True)
 
 # ---------------------------------------------------------------------------
 # Shared option type aliases
 # ---------------------------------------------------------------------------
-source_option = Annotated[Optional[str], typer.Option(help="Path to the file that should be imported.")]
 output_option = Annotated[
     Optional[Path],
     typer.Option(
@@ -48,7 +47,7 @@ def _write_result(result, output: Optional[Path]):
 
 @import_app.command(name="sql")
 def import_sql(
-    source: source_option = None,
+    source: Annotated[Optional[str], typer.Option(help="Path to the SQL DDL file.")] = None,
     dialect: Annotated[
         Optional[str],
         typer.Option(
@@ -71,7 +70,7 @@ def import_sql(
 
 @import_app.command(name="avro")
 def import_avro(
-    source: source_option = None,
+    source: Annotated[Optional[str], typer.Option(help="Path to the Avro schema file.")] = None,
     output: output_option = None,
     schema: schema_option = None,
     owner: owner_option = None,
@@ -86,7 +85,7 @@ def import_avro(
 
 @import_app.command(name="dbt")
 def import_dbt(
-    source: source_option = None,
+    source: Annotated[Optional[str], typer.Option(help="Path to the dbt manifest.json file.")] = None,
     model: Annotated[
         Optional[List[str]],
         typer.Option(
@@ -109,7 +108,7 @@ def import_dbt(
 
 @import_app.command(name="dbml")
 def import_dbml(
-    source: source_option = None,
+    source: Annotated[Optional[str], typer.Option(help="Path to the DBML file.")] = None,
     schema: Annotated[
         Optional[List[str]],
         typer.Option(
@@ -146,7 +145,7 @@ def import_dbml(
 
 @import_app.command(name="glue")
 def import_glue(
-    source: source_option = None,
+    database: Annotated[Optional[str], typer.Option(help="Name of the AWS Glue database.")] = None,
     table: Annotated[
         Optional[List[str]],
         typer.Option(
@@ -162,14 +161,19 @@ def import_glue(
     """Import a data contract from AWS Glue."""
     enable_debug_logging(debug)
     result = DataContract.import_from_source(
-        format="glue", source=source, schema=schema, glue_table=table, owner=owner, id=id
+        format="glue", source=database, schema=schema, glue_table=table, owner=owner, id=id
     )
     _write_result(result, output)
 
 
 @import_app.command(name="bigquery")
 def import_bigquery(
-    source: source_option = None,
+    source: Annotated[
+        Optional[str],
+        typer.Option(
+            help="Path to a BigQuery schema JSON file. If omitted, imports from the BigQuery API using --project/--dataset/--table."
+        ),
+    ] = None,
     project: Annotated[Optional[str], typer.Option(help="The BigQuery project id.")] = None,
     dataset: Annotated[Optional[str], typer.Option(help="The BigQuery dataset id.")] = None,
     table: Annotated[
@@ -201,7 +205,12 @@ def import_bigquery(
 
 @import_app.command(name="unity")
 def import_unity(
-    source: source_option = None,
+    source: Annotated[
+        Optional[str],
+        typer.Option(
+            help="Path to a Unity Catalog TableInfo JSON file. If omitted, imports from the Unity API using --table."
+        ),
+    ] = None,
     table: Annotated[
         Optional[List[str]],
         typer.Option(help="Full name of a table in the Unity Catalog (repeat for multiple tables)."),
@@ -222,7 +231,7 @@ def import_unity(
 
 @import_app.command(name="jsonschema")
 def import_jsonschema(
-    source: source_option = None,
+    source: Annotated[Optional[str], typer.Option(help="Path to the JSON Schema file.")] = None,
     output: output_option = None,
     schema: schema_option = None,
     owner: owner_option = None,
@@ -237,7 +246,7 @@ def import_jsonschema(
 
 @import_app.command(name="json")
 def import_json(
-    source: source_option = None,
+    source: Annotated[Optional[str], typer.Option(help="Path to the JSON data file.")] = None,
     output: output_option = None,
     schema: schema_option = None,
     owner: owner_option = None,
@@ -252,7 +261,7 @@ def import_json(
 
 @import_app.command(name="odcs")
 def import_odcs(
-    source: source_option = None,
+    source: Annotated[Optional[str], typer.Option(help="Path to the ODCS data contract file.")] = None,
     output: output_option = None,
     schema: schema_option = None,
     owner: owner_option = None,
@@ -267,7 +276,7 @@ def import_odcs(
 
 @import_app.command(name="parquet")
 def import_parquet(
-    source: source_option = None,
+    source: Annotated[Optional[str], typer.Option(help="Path to the Parquet file.")] = None,
     output: output_option = None,
     schema: schema_option = None,
     owner: owner_option = None,
@@ -282,7 +291,7 @@ def import_parquet(
 
 @import_app.command(name="csv")
 def import_csv(
-    source: source_option = None,
+    source: Annotated[Optional[str], typer.Option(help="Path to the CSV file.")] = None,
     output: output_option = None,
     schema: schema_option = None,
     owner: owner_option = None,
@@ -297,7 +306,7 @@ def import_csv(
 
 @import_app.command(name="protobuf")
 def import_protobuf(
-    source: source_option = None,
+    source: Annotated[Optional[str], typer.Option(help="Path to the Protobuf .proto file.")] = None,
     output: output_option = None,
     schema: schema_option = None,
     owner: owner_option = None,
@@ -312,7 +321,10 @@ def import_protobuf(
 
 @import_app.command(name="spark")
 def import_spark(
-    source: source_option = None,
+    tables: Annotated[
+        Optional[str],
+        typer.Option(help="Comma-separated list of Spark table names to import from the current Spark session."),
+    ] = None,
     output: output_option = None,
     schema: schema_option = None,
     owner: owner_option = None,
@@ -321,13 +333,13 @@ def import_spark(
 ):
     """Import a data contract from a Spark schema."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(format="spark", source=source, schema=schema, owner=owner, id=id)
+    result = DataContract.import_from_source(format="spark", source=tables, schema=schema, owner=owner, id=id)
     _write_result(result, output)
 
 
 @import_app.command(name="iceberg")
 def import_iceberg(
-    source: source_option = None,
+    source: Annotated[Optional[str], typer.Option(help="Path to the Iceberg schema JSON file.")] = None,
     table: Annotated[
         Optional[str],
         typer.Option(help="Table name to assign to the model created from the Iceberg schema."),
@@ -348,7 +360,7 @@ def import_iceberg(
 
 @import_app.command(name="excel")
 def import_excel(
-    source: source_option = None,
+    source: Annotated[Optional[str], typer.Option(help="Path to the Excel file.")] = None,
     output: output_option = None,
     schema: schema_option = None,
     owner: owner_option = None,

--- a/datacontract/cli_import.py
+++ b/datacontract/cli_import.py
@@ -126,6 +126,10 @@ def import_dbml(
 
 @import_app.command(name="glue")
 def import_glue(
+    source: Annotated[
+        Optional[str],
+        typer.Option(help="The Glue database name to import from."),
+    ] = None,
     table: Annotated[
         Optional[List[str]],
         typer.Option(help="List of table ids to import (repeat for multiple, omit for all)."),
@@ -139,12 +143,13 @@ def import_glue(
 ):
     """Import a data contract from AWS Glue."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(format="glue", template=template, schema=schema, glue_table=table, owner=owner, id=id)
+    result = DataContract.import_from_source(format="glue", source=source, template=template, schema=schema, glue_table=table, owner=owner, id=id)
     _write_result(result, output)
 
 
 @import_app.command(name="bigquery")
 def import_bigquery(
+    source: source_option = None,
     project: Annotated[Optional[str], typer.Option(help="The BigQuery project id.")] = None,
     dataset: Annotated[Optional[str], typer.Option(help="The BigQuery dataset id.")] = None,
     table: Annotated[
@@ -161,13 +166,14 @@ def import_bigquery(
     """Import a data contract from BigQuery."""
     enable_debug_logging(debug)
     result = DataContract.import_from_source(
-        format="bigquery", template=template, schema=schema, bigquery_project=project, bigquery_dataset=dataset, bigquery_table=table, owner=owner, id=id
+        format="bigquery", source=source, template=template, schema=schema, bigquery_project=project, bigquery_dataset=dataset, bigquery_table=table, owner=owner, id=id
     )
     _write_result(result, output)
 
 
 @import_app.command(name="unity")
 def import_unity(
+    source: source_option = None,
     table: Annotated[
         Optional[List[str]], typer.Option(help="Full name of a table in the Unity Catalog.")
     ] = None,
@@ -180,7 +186,7 @@ def import_unity(
 ):
     """Import a data contract from Databricks Unity Catalog."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(format="unity", template=template, schema=schema, unity_table_full_name=table, owner=owner, id=id)
+    result = DataContract.import_from_source(format="unity", source=source, template=template, schema=schema, unity_table_full_name=table, owner=owner, id=id)
     _write_result(result, output)
 
 

--- a/datacontract/cli_import.py
+++ b/datacontract/cli_import.py
@@ -24,7 +24,7 @@ output_option = Annotated[
 ]
 schema_option = Annotated[
     Optional[str],
-    typer.Option("--json-schema", help="The location (url or path) of the ODCS JSON Schema"),
+    typer.Option("--odcs-schema", help="The location (url or path) of the ODCS JSON Schema"),
 ]
 template_option = Annotated[Optional[str], typer.Option(help="The location (url or path) of the ODCS template")]
 owner_option = Annotated[
@@ -129,8 +129,8 @@ def import_dbml(
         ),
     ] = None,
     output: output_option = None,
-    json_schema: Annotated[
-        Optional[str], typer.Option("--json-schema", help="The location (url or path) of the ODCS JSON Schema")
+    odcs_schema: Annotated[
+        Optional[str], typer.Option("--odcs-schema", help="The location (url or path) of the ODCS JSON Schema")
     ] = None,
     template: template_option = None,
     owner: owner_option = None,
@@ -143,7 +143,7 @@ def import_dbml(
         format="dbml",
         source=source,
         template=template,
-        schema=json_schema,
+        schema=odcs_schema,
         dbml_schema=schema,
         dbml_table=table,
         owner=owner,

--- a/datacontract/cli_import.py
+++ b/datacontract/cli_import.py
@@ -24,7 +24,9 @@ output_option = Annotated[
 ]
 schema_option = Annotated[Optional[str], typer.Option(help="The location (url or path) of the ODCS JSON Schema")]
 template_option = Annotated[Optional[str], typer.Option(help="The location (url or path) of the ODCS template")]
-owner_option = Annotated[Optional[str], typer.Option(help="The owner or team responsible for managing the data contract.")]
+owner_option = Annotated[
+    Optional[str], typer.Option(help="The owner or team responsible for managing the data contract.")
+]
 id_option = Annotated[Optional[str], typer.Option(help="The identifier for the data contract.")]
 
 
@@ -47,7 +49,9 @@ def import_sql(
     source: source_option = None,
     dialect: Annotated[
         Optional[str],
-        typer.Option(help="The SQL dialect. Accepted values: postgres, tsql, bigquery, snowflake, databricks, spark, duckdb."),
+        typer.Option(
+            help="The SQL dialect. Accepted values: postgres, tsql, bigquery, snowflake, databricks, spark, duckdb."
+        ),
     ] = None,
     output: output_option = None,
     schema: schema_option = None,
@@ -58,7 +62,9 @@ def import_sql(
 ):
     """Import a data contract from a SQL DDL file."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(format="sql", source=source, template=template, schema=schema, dialect=dialect, owner=owner, id=id)
+    result = DataContract.import_from_source(
+        format="sql", source=source, template=template, schema=schema, dialect=dialect, owner=owner, id=id
+    )
     _write_result(result, output)
 
 
@@ -74,7 +80,9 @@ def import_avro(
 ):
     """Import a data contract from an Avro schema file."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(format="avro", source=source, template=template, schema=schema, owner=owner, id=id)
+    result = DataContract.import_from_source(
+        format="avro", source=source, template=template, schema=schema, owner=owner, id=id
+    )
     _write_result(result, output)
 
 
@@ -94,7 +102,9 @@ def import_dbt(
 ):
     """Import a data contract from a dbt manifest file."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(format="dbt", source=source, template=template, schema=schema, dbt_model=model, owner=owner, id=id)
+    result = DataContract.import_from_source(
+        format="dbt", source=source, template=template, schema=schema, dbt_model=model, owner=owner, id=id
+    )
     _write_result(result, output)
 
 
@@ -110,7 +120,9 @@ def import_dbml(
         typer.Option(help="List of table names to import (repeat for multiple, omit for all)."),
     ] = None,
     output: output_option = None,
-    json_schema: Annotated[Optional[str], typer.Option("--json-schema", help="The location (url or path) of the ODCS JSON Schema")] = None,
+    json_schema: Annotated[
+        Optional[str], typer.Option("--json-schema", help="The location (url or path) of the ODCS JSON Schema")
+    ] = None,
     template: template_option = None,
     owner: owner_option = None,
     id: id_option = None,
@@ -119,7 +131,14 @@ def import_dbml(
     """Import a data contract from a DBML file."""
     enable_debug_logging(debug)
     result = DataContract.import_from_source(
-        format="dbml", source=source, template=template, schema=json_schema, dbml_schema=schema, dbml_table=table, owner=owner, id=id
+        format="dbml",
+        source=source,
+        template=template,
+        schema=json_schema,
+        dbml_schema=schema,
+        dbml_table=table,
+        owner=owner,
+        id=id,
     )
     _write_result(result, output)
 
@@ -143,7 +162,9 @@ def import_glue(
 ):
     """Import a data contract from AWS Glue."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(format="glue", source=source, template=template, schema=schema, glue_table=table, owner=owner, id=id)
+    result = DataContract.import_from_source(
+        format="glue", source=source, template=template, schema=schema, glue_table=table, owner=owner, id=id
+    )
     _write_result(result, output)
 
 
@@ -166,7 +187,15 @@ def import_bigquery(
     """Import a data contract from BigQuery."""
     enable_debug_logging(debug)
     result = DataContract.import_from_source(
-        format="bigquery", source=source, template=template, schema=schema, bigquery_project=project, bigquery_dataset=dataset, bigquery_table=table, owner=owner, id=id
+        format="bigquery",
+        source=source,
+        template=template,
+        schema=schema,
+        bigquery_project=project,
+        bigquery_dataset=dataset,
+        bigquery_table=table,
+        owner=owner,
+        id=id,
     )
     _write_result(result, output)
 
@@ -174,9 +203,7 @@ def import_bigquery(
 @import_app.command(name="unity")
 def import_unity(
     source: source_option = None,
-    table: Annotated[
-        Optional[List[str]], typer.Option(help="Full name of a table in the Unity Catalog.")
-    ] = None,
+    table: Annotated[Optional[List[str]], typer.Option(help="Full name of a table in the Unity Catalog.")] = None,
     output: output_option = None,
     schema: schema_option = None,
     template: template_option = None,
@@ -186,7 +213,9 @@ def import_unity(
 ):
     """Import a data contract from Databricks Unity Catalog."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(format="unity", source=source, template=template, schema=schema, unity_table_full_name=table, owner=owner, id=id)
+    result = DataContract.import_from_source(
+        format="unity", source=source, template=template, schema=schema, unity_table_full_name=table, owner=owner, id=id
+    )
     _write_result(result, output)
 
 
@@ -202,7 +231,9 @@ def import_jsonschema(
 ):
     """Import a data contract from a JSON Schema file."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(format="jsonschema", source=source, template=template, schema=schema, owner=owner, id=id)
+    result = DataContract.import_from_source(
+        format="jsonschema", source=source, template=template, schema=schema, owner=owner, id=id
+    )
     _write_result(result, output)
 
 
@@ -218,7 +249,9 @@ def import_json(
 ):
     """Import a data contract from a JSON file."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(format="json", source=source, template=template, schema=schema, owner=owner, id=id)
+    result = DataContract.import_from_source(
+        format="json", source=source, template=template, schema=schema, owner=owner, id=id
+    )
     _write_result(result, output)
 
 
@@ -234,7 +267,9 @@ def import_odcs(
 ):
     """Import a data contract from an ODCS file."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(format="odcs", source=source, template=template, schema=schema, owner=owner, id=id)
+    result = DataContract.import_from_source(
+        format="odcs", source=source, template=template, schema=schema, owner=owner, id=id
+    )
     _write_result(result, output)
 
 
@@ -250,7 +285,9 @@ def import_parquet(
 ):
     """Import a data contract from a Parquet file."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(format="parquet", source=source, template=template, schema=schema, owner=owner, id=id)
+    result = DataContract.import_from_source(
+        format="parquet", source=source, template=template, schema=schema, owner=owner, id=id
+    )
     _write_result(result, output)
 
 
@@ -266,7 +303,9 @@ def import_csv(
 ):
     """Import a data contract from a CSV file."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(format="csv", source=source, template=template, schema=schema, owner=owner, id=id)
+    result = DataContract.import_from_source(
+        format="csv", source=source, template=template, schema=schema, owner=owner, id=id
+    )
     _write_result(result, output)
 
 
@@ -282,7 +321,9 @@ def import_protobuf(
 ):
     """Import a data contract from a Protobuf schema file."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(format="protobuf", source=source, template=template, schema=schema, owner=owner, id=id)
+    result = DataContract.import_from_source(
+        format="protobuf", source=source, template=template, schema=schema, owner=owner, id=id
+    )
     _write_result(result, output)
 
 
@@ -298,7 +339,9 @@ def import_spark(
 ):
     """Import a data contract from a Spark schema."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(format="spark", source=source, template=template, schema=schema, owner=owner, id=id)
+    result = DataContract.import_from_source(
+        format="spark", source=source, template=template, schema=schema, owner=owner, id=id
+    )
     _write_result(result, output)
 
 
@@ -318,7 +361,9 @@ def import_iceberg(
 ):
     """Import a data contract from an Iceberg schema."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(format="iceberg", source=source, template=template, schema=schema, iceberg_table=table, owner=owner, id=id)
+    result = DataContract.import_from_source(
+        format="iceberg", source=source, template=template, schema=schema, iceberg_table=table, owner=owner, id=id
+    )
     _write_result(result, output)
 
 
@@ -334,5 +379,7 @@ def import_excel(
 ):
     """Import a data contract from an Excel file."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(format="excel", source=source, template=template, schema=schema, owner=owner, id=id)
+    result = DataContract.import_from_source(
+        format="excel", source=source, template=template, schema=schema, owner=owner, id=id
+    )
     _write_result(result, output)

--- a/datacontract/cli_import.py
+++ b/datacontract/cli_import.py
@@ -22,7 +22,10 @@ output_option = Annotated[
         help="Specify the file path where the Data Contract will be saved. If no path is provided, the output will be printed to stdout."
     ),
 ]
-schema_option = Annotated[Optional[str], typer.Option(help="The location (url or path) of the ODCS JSON Schema")]
+schema_option = Annotated[
+    Optional[str],
+    typer.Option("--json-schema", "--schema", help="The location (url or path) of the ODCS JSON Schema"),
+]
 template_option = Annotated[Optional[str], typer.Option(help="The location (url or path) of the ODCS template")]
 owner_option = Annotated[
     Optional[str], typer.Option(help="The owner or team responsible for managing the data contract.")
@@ -91,7 +94,9 @@ def import_dbt(
     source: source_option = None,
     model: Annotated[
         Optional[List[str]],
-        typer.Option(help="List of model names to import (repeat for multiple, omit for all)."),
+        typer.Option(
+            help="List of models names to import from the dbt manifest file (repeat for multiple models names, leave empty for all models in the dataset)."
+        ),
     ] = None,
     output: output_option = None,
     schema: schema_option = None,
@@ -113,11 +118,15 @@ def import_dbml(
     source: source_option = None,
     schema: Annotated[
         Optional[List[str]],
-        typer.Option("--schema", help="List of schema names to import (repeat for multiple, omit for all)."),
+        typer.Option(
+            help="List of schema names to import from the DBML file (repeat for multiple schema names, leave empty for all tables in the file)."
+        ),
     ] = None,
     table: Annotated[
         Optional[List[str]],
-        typer.Option(help="List of table names to import (repeat for multiple, omit for all)."),
+        typer.Option(
+            help="List of table names to import from the DBML file (repeat for multiple table names, leave empty for all tables in the file)."
+        ),
     ] = None,
     output: output_option = None,
     json_schema: Annotated[
@@ -145,13 +154,12 @@ def import_dbml(
 
 @import_app.command(name="glue")
 def import_glue(
-    source: Annotated[
-        Optional[str],
-        typer.Option(help="The Glue database name to import from."),
-    ] = None,
+    source: source_option = None,
     table: Annotated[
         Optional[List[str]],
-        typer.Option(help="List of table ids to import (repeat for multiple, omit for all)."),
+        typer.Option(
+            help="List of table ids to import from the Glue Database (repeat for multiple table ids, leave empty for all tables in the dataset)."
+        ),
     ] = None,
     output: output_option = None,
     schema: schema_option = None,
@@ -175,7 +183,9 @@ def import_bigquery(
     dataset: Annotated[Optional[str], typer.Option(help="The BigQuery dataset id.")] = None,
     table: Annotated[
         Optional[List[str]],
-        typer.Option(help="List of table ids to import (repeat for multiple, omit for all)."),
+        typer.Option(
+            help="List of table ids to import from the BigQuery API (repeat for multiple table ids, leave empty for all tables in the dataset)."
+        ),
     ] = None,
     output: output_option = None,
     schema: schema_option = None,
@@ -203,7 +213,7 @@ def import_bigquery(
 @import_app.command(name="unity")
 def import_unity(
     source: source_option = None,
-    table: Annotated[Optional[List[str]], typer.Option(help="Full name of a table in the Unity Catalog.")] = None,
+    table: Annotated[Optional[List[str]], typer.Option(help="Full name of a table in the Unity Catalog")] = None,
     output: output_option = None,
     schema: schema_option = None,
     template: template_option = None,

--- a/datacontract/cli_import.py
+++ b/datacontract/cli_import.py
@@ -1,0 +1,332 @@
+from pathlib import Path
+from typing import List, Optional
+
+import typer
+from rich.console import Console
+from typing_extensions import Annotated
+
+from datacontract.cli import OrderedCommands, debug_option, enable_debug_logging
+from datacontract.data_contract import DataContract
+
+console = Console()
+
+import_app = typer.Typer(cls=OrderedCommands, no_args_is_help=True)
+
+# ---------------------------------------------------------------------------
+# Shared option type aliases
+# ---------------------------------------------------------------------------
+source_option = Annotated[Optional[str], typer.Option(help="The path to the file that should be imported.")]
+output_option = Annotated[
+    Optional[Path],
+    typer.Option(
+        help="Specify the file path where the Data Contract will be saved. If no path is provided, the output will be printed to stdout."
+    ),
+]
+schema_option = Annotated[Optional[str], typer.Option(help="The location (url or path) of the ODCS JSON Schema")]
+template_option = Annotated[Optional[str], typer.Option(help="The location (url or path) of the ODCS template")]
+owner_option = Annotated[Optional[str], typer.Option(help="The owner or team responsible for managing the data contract.")]
+id_option = Annotated[Optional[str], typer.Option(help="The identifier for the data contract.")]
+
+
+def _write_result(result, output: Optional[Path]):
+    if output is None:
+        console.print(result.to_yaml(), markup=False, soft_wrap=True)
+    else:
+        with output.open(mode="w", encoding="utf-8") as f:
+            f.write(result.to_yaml())
+        console.print(f"Written result to {output}")
+
+
+# ---------------------------------------------------------------------------
+# Import subcommands
+# ---------------------------------------------------------------------------
+
+
+@import_app.command(name="sql")
+def import_sql(
+    source: source_option = None,
+    dialect: Annotated[
+        Optional[str],
+        typer.Option(help="The SQL dialect. Accepted values: postgres, tsql, bigquery, snowflake, databricks, spark, duckdb."),
+    ] = None,
+    output: output_option = None,
+    schema: schema_option = None,
+    template: template_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from a SQL DDL file."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(format="sql", source=source, template=template, schema=schema, dialect=dialect, owner=owner, id=id)
+    _write_result(result, output)
+
+
+@import_app.command(name="avro")
+def import_avro(
+    source: source_option = None,
+    output: output_option = None,
+    schema: schema_option = None,
+    template: template_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from an Avro schema file."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(format="avro", source=source, template=template, schema=schema, owner=owner, id=id)
+    _write_result(result, output)
+
+
+@import_app.command(name="dbt")
+def import_dbt(
+    source: source_option = None,
+    model: Annotated[
+        Optional[List[str]],
+        typer.Option(help="List of model names to import (repeat for multiple, omit for all)."),
+    ] = None,
+    output: output_option = None,
+    schema: schema_option = None,
+    template: template_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from a dbt manifest file."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(format="dbt", source=source, template=template, schema=schema, dbt_model=model, owner=owner, id=id)
+    _write_result(result, output)
+
+
+@import_app.command(name="dbml")
+def import_dbml(
+    source: source_option = None,
+    schema: Annotated[
+        Optional[List[str]],
+        typer.Option("--schema", help="List of schema names to import (repeat for multiple, omit for all)."),
+    ] = None,
+    table: Annotated[
+        Optional[List[str]],
+        typer.Option(help="List of table names to import (repeat for multiple, omit for all)."),
+    ] = None,
+    output: output_option = None,
+    json_schema: Annotated[Optional[str], typer.Option("--json-schema", help="The location (url or path) of the ODCS JSON Schema")] = None,
+    template: template_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from a DBML file."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(
+        format="dbml", source=source, template=template, schema=json_schema, dbml_schema=schema, dbml_table=table, owner=owner, id=id
+    )
+    _write_result(result, output)
+
+
+@import_app.command(name="glue")
+def import_glue(
+    table: Annotated[
+        Optional[List[str]],
+        typer.Option(help="List of table ids to import (repeat for multiple, omit for all)."),
+    ] = None,
+    output: output_option = None,
+    schema: schema_option = None,
+    template: template_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from AWS Glue."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(format="glue", template=template, schema=schema, glue_table=table, owner=owner, id=id)
+    _write_result(result, output)
+
+
+@import_app.command(name="bigquery")
+def import_bigquery(
+    project: Annotated[Optional[str], typer.Option(help="The BigQuery project id.")] = None,
+    dataset: Annotated[Optional[str], typer.Option(help="The BigQuery dataset id.")] = None,
+    table: Annotated[
+        Optional[List[str]],
+        typer.Option(help="List of table ids to import (repeat for multiple, omit for all)."),
+    ] = None,
+    output: output_option = None,
+    schema: schema_option = None,
+    template: template_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from BigQuery."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(
+        format="bigquery", template=template, schema=schema, bigquery_project=project, bigquery_dataset=dataset, bigquery_table=table, owner=owner, id=id
+    )
+    _write_result(result, output)
+
+
+@import_app.command(name="unity")
+def import_unity(
+    table: Annotated[
+        Optional[List[str]], typer.Option(help="Full name of a table in the Unity Catalog.")
+    ] = None,
+    output: output_option = None,
+    schema: schema_option = None,
+    template: template_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from Databricks Unity Catalog."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(format="unity", template=template, schema=schema, unity_table_full_name=table, owner=owner, id=id)
+    _write_result(result, output)
+
+
+@import_app.command(name="jsonschema")
+def import_jsonschema(
+    source: source_option = None,
+    output: output_option = None,
+    schema: schema_option = None,
+    template: template_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from a JSON Schema file."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(format="jsonschema", source=source, template=template, schema=schema, owner=owner, id=id)
+    _write_result(result, output)
+
+
+@import_app.command(name="json")
+def import_json(
+    source: source_option = None,
+    output: output_option = None,
+    schema: schema_option = None,
+    template: template_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from a JSON file."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(format="json", source=source, template=template, schema=schema, owner=owner, id=id)
+    _write_result(result, output)
+
+
+@import_app.command(name="odcs")
+def import_odcs(
+    source: source_option = None,
+    output: output_option = None,
+    schema: schema_option = None,
+    template: template_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from an ODCS file."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(format="odcs", source=source, template=template, schema=schema, owner=owner, id=id)
+    _write_result(result, output)
+
+
+@import_app.command(name="parquet")
+def import_parquet(
+    source: source_option = None,
+    output: output_option = None,
+    schema: schema_option = None,
+    template: template_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from a Parquet file."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(format="parquet", source=source, template=template, schema=schema, owner=owner, id=id)
+    _write_result(result, output)
+
+
+@import_app.command(name="csv")
+def import_csv(
+    source: source_option = None,
+    output: output_option = None,
+    schema: schema_option = None,
+    template: template_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from a CSV file."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(format="csv", source=source, template=template, schema=schema, owner=owner, id=id)
+    _write_result(result, output)
+
+
+@import_app.command(name="protobuf")
+def import_protobuf(
+    source: source_option = None,
+    output: output_option = None,
+    schema: schema_option = None,
+    template: template_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from a Protobuf schema file."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(format="protobuf", source=source, template=template, schema=schema, owner=owner, id=id)
+    _write_result(result, output)
+
+
+@import_app.command(name="spark")
+def import_spark(
+    source: source_option = None,
+    output: output_option = None,
+    schema: schema_option = None,
+    template: template_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from a Spark schema."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(format="spark", source=source, template=template, schema=schema, owner=owner, id=id)
+    _write_result(result, output)
+
+
+@import_app.command(name="iceberg")
+def import_iceberg(
+    source: source_option = None,
+    table: Annotated[
+        Optional[str],
+        typer.Option(help="Table name to assign to the model created from the Iceberg schema."),
+    ] = None,
+    output: output_option = None,
+    schema: schema_option = None,
+    template: template_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from an Iceberg schema."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(format="iceberg", source=source, template=template, schema=schema, iceberg_table=table, owner=owner, id=id)
+    _write_result(result, output)
+
+
+@import_app.command(name="excel")
+def import_excel(
+    source: source_option = None,
+    output: output_option = None,
+    schema: schema_option = None,
+    template: template_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from an Excel file."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(format="excel", source=source, template=template, schema=schema, owner=owner, id=id)
+    _write_result(result, output)

--- a/datacontract/cli_import.py
+++ b/datacontract/cli_import.py
@@ -15,18 +15,17 @@ import_app = typer.Typer(cls=OrderedCommands, no_args_is_help=True)
 # ---------------------------------------------------------------------------
 # Shared option type aliases
 # ---------------------------------------------------------------------------
-source_option = Annotated[Optional[str], typer.Option(help="The path to the file that should be imported.")]
+source_option = Annotated[Optional[str], typer.Option(help="Path to the file that should be imported.")]
 output_option = Annotated[
     Optional[Path],
     typer.Option(
-        help="Specify the file path where the Data Contract will be saved. If no path is provided, the output will be printed to stdout."
+        help="File path where the Data Contract will be saved. If not provided, it will be printed to stdout."
     ),
 ]
 schema_option = Annotated[
     Optional[str],
     typer.Option("--odcs-schema", help="The location (url or path) of the ODCS JSON Schema"),
 ]
-template_option = Annotated[Optional[str], typer.Option(help="The location (url or path) of the ODCS template")]
 owner_option = Annotated[
     Optional[str], typer.Option(help="The owner or team responsible for managing the data contract.")
 ]
@@ -58,7 +57,6 @@ def import_sql(
     ] = None,
     output: output_option = None,
     schema: schema_option = None,
-    template: template_option = None,
     owner: owner_option = None,
     id: id_option = None,
     debug: debug_option = None,
@@ -66,7 +64,7 @@ def import_sql(
     """Import a data contract from a SQL DDL file."""
     enable_debug_logging(debug)
     result = DataContract.import_from_source(
-        format="sql", source=source, template=template, schema=schema, dialect=dialect, owner=owner, id=id
+        format="sql", source=source, schema=schema, dialect=dialect, owner=owner, id=id
     )
     _write_result(result, output)
 
@@ -76,16 +74,13 @@ def import_avro(
     source: source_option = None,
     output: output_option = None,
     schema: schema_option = None,
-    template: template_option = None,
     owner: owner_option = None,
     id: id_option = None,
     debug: debug_option = None,
 ):
     """Import a data contract from an Avro schema file."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(
-        format="avro", source=source, template=template, schema=schema, owner=owner, id=id
-    )
+    result = DataContract.import_from_source(format="avro", source=source, schema=schema, owner=owner, id=id)
     _write_result(result, output)
 
 
@@ -100,7 +95,6 @@ def import_dbt(
     ] = None,
     output: output_option = None,
     schema: schema_option = None,
-    template: template_option = None,
     owner: owner_option = None,
     id: id_option = None,
     debug: debug_option = None,
@@ -108,7 +102,7 @@ def import_dbt(
     """Import a data contract from a dbt manifest file."""
     enable_debug_logging(debug)
     result = DataContract.import_from_source(
-        format="dbt", source=source, template=template, schema=schema, dbt_model=model, owner=owner, id=id
+        format="dbt", source=source, schema=schema, dbt_model=model, owner=owner, id=id
     )
     _write_result(result, output)
 
@@ -132,7 +126,6 @@ def import_dbml(
     odcs_schema: Annotated[
         Optional[str], typer.Option("--odcs-schema", help="The location (url or path) of the ODCS JSON Schema")
     ] = None,
-    template: template_option = None,
     owner: owner_option = None,
     id: id_option = None,
     debug: debug_option = None,
@@ -142,7 +135,6 @@ def import_dbml(
     result = DataContract.import_from_source(
         format="dbml",
         source=source,
-        template=template,
         schema=odcs_schema,
         dbml_schema=schema,
         dbml_table=table,
@@ -163,7 +155,6 @@ def import_glue(
     ] = None,
     output: output_option = None,
     schema: schema_option = None,
-    template: template_option = None,
     owner: owner_option = None,
     id: id_option = None,
     debug: debug_option = None,
@@ -171,7 +162,7 @@ def import_glue(
     """Import a data contract from AWS Glue."""
     enable_debug_logging(debug)
     result = DataContract.import_from_source(
-        format="glue", source=source, template=template, schema=schema, glue_table=table, owner=owner, id=id
+        format="glue", source=source, schema=schema, glue_table=table, owner=owner, id=id
     )
     _write_result(result, output)
 
@@ -189,7 +180,6 @@ def import_bigquery(
     ] = None,
     output: output_option = None,
     schema: schema_option = None,
-    template: template_option = None,
     owner: owner_option = None,
     id: id_option = None,
     debug: debug_option = None,
@@ -199,7 +189,6 @@ def import_bigquery(
     result = DataContract.import_from_source(
         format="bigquery",
         source=source,
-        template=template,
         schema=schema,
         bigquery_project=project,
         bigquery_dataset=dataset,
@@ -213,10 +202,12 @@ def import_bigquery(
 @import_app.command(name="unity")
 def import_unity(
     source: source_option = None,
-    table: Annotated[Optional[List[str]], typer.Option(help="Full name of a table in the Unity Catalog")] = None,
+    table: Annotated[
+        Optional[List[str]],
+        typer.Option(help="Full name of a table in the Unity Catalog (repeat for multiple tables)."),
+    ] = None,
     output: output_option = None,
     schema: schema_option = None,
-    template: template_option = None,
     owner: owner_option = None,
     id: id_option = None,
     debug: debug_option = None,
@@ -224,7 +215,7 @@ def import_unity(
     """Import a data contract from Databricks Unity Catalog."""
     enable_debug_logging(debug)
     result = DataContract.import_from_source(
-        format="unity", source=source, template=template, schema=schema, unity_table_full_name=table, owner=owner, id=id
+        format="unity", source=source, schema=schema, unity_table_full_name=table, owner=owner, id=id
     )
     _write_result(result, output)
 
@@ -234,16 +225,13 @@ def import_jsonschema(
     source: source_option = None,
     output: output_option = None,
     schema: schema_option = None,
-    template: template_option = None,
     owner: owner_option = None,
     id: id_option = None,
     debug: debug_option = None,
 ):
     """Import a data contract from a JSON Schema file."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(
-        format="jsonschema", source=source, template=template, schema=schema, owner=owner, id=id
-    )
+    result = DataContract.import_from_source(format="jsonschema", source=source, schema=schema, owner=owner, id=id)
     _write_result(result, output)
 
 
@@ -252,16 +240,13 @@ def import_json(
     source: source_option = None,
     output: output_option = None,
     schema: schema_option = None,
-    template: template_option = None,
     owner: owner_option = None,
     id: id_option = None,
     debug: debug_option = None,
 ):
     """Import a data contract from a JSON file."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(
-        format="json", source=source, template=template, schema=schema, owner=owner, id=id
-    )
+    result = DataContract.import_from_source(format="json", source=source, schema=schema, owner=owner, id=id)
     _write_result(result, output)
 
 
@@ -270,16 +255,13 @@ def import_odcs(
     source: source_option = None,
     output: output_option = None,
     schema: schema_option = None,
-    template: template_option = None,
     owner: owner_option = None,
     id: id_option = None,
     debug: debug_option = None,
 ):
     """Import a data contract from an ODCS file."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(
-        format="odcs", source=source, template=template, schema=schema, owner=owner, id=id
-    )
+    result = DataContract.import_from_source(format="odcs", source=source, schema=schema, owner=owner, id=id)
     _write_result(result, output)
 
 
@@ -288,16 +270,13 @@ def import_parquet(
     source: source_option = None,
     output: output_option = None,
     schema: schema_option = None,
-    template: template_option = None,
     owner: owner_option = None,
     id: id_option = None,
     debug: debug_option = None,
 ):
     """Import a data contract from a Parquet file."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(
-        format="parquet", source=source, template=template, schema=schema, owner=owner, id=id
-    )
+    result = DataContract.import_from_source(format="parquet", source=source, schema=schema, owner=owner, id=id)
     _write_result(result, output)
 
 
@@ -306,16 +285,13 @@ def import_csv(
     source: source_option = None,
     output: output_option = None,
     schema: schema_option = None,
-    template: template_option = None,
     owner: owner_option = None,
     id: id_option = None,
     debug: debug_option = None,
 ):
     """Import a data contract from a CSV file."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(
-        format="csv", source=source, template=template, schema=schema, owner=owner, id=id
-    )
+    result = DataContract.import_from_source(format="csv", source=source, schema=schema, owner=owner, id=id)
     _write_result(result, output)
 
 
@@ -324,16 +300,13 @@ def import_protobuf(
     source: source_option = None,
     output: output_option = None,
     schema: schema_option = None,
-    template: template_option = None,
     owner: owner_option = None,
     id: id_option = None,
     debug: debug_option = None,
 ):
     """Import a data contract from a Protobuf schema file."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(
-        format="protobuf", source=source, template=template, schema=schema, owner=owner, id=id
-    )
+    result = DataContract.import_from_source(format="protobuf", source=source, schema=schema, owner=owner, id=id)
     _write_result(result, output)
 
 
@@ -342,16 +315,13 @@ def import_spark(
     source: source_option = None,
     output: output_option = None,
     schema: schema_option = None,
-    template: template_option = None,
     owner: owner_option = None,
     id: id_option = None,
     debug: debug_option = None,
 ):
     """Import a data contract from a Spark schema."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(
-        format="spark", source=source, template=template, schema=schema, owner=owner, id=id
-    )
+    result = DataContract.import_from_source(format="spark", source=source, schema=schema, owner=owner, id=id)
     _write_result(result, output)
 
 
@@ -364,7 +334,6 @@ def import_iceberg(
     ] = None,
     output: output_option = None,
     schema: schema_option = None,
-    template: template_option = None,
     owner: owner_option = None,
     id: id_option = None,
     debug: debug_option = None,
@@ -372,7 +341,7 @@ def import_iceberg(
     """Import a data contract from an Iceberg schema."""
     enable_debug_logging(debug)
     result = DataContract.import_from_source(
-        format="iceberg", source=source, template=template, schema=schema, iceberg_table=table, owner=owner, id=id
+        format="iceberg", source=source, schema=schema, iceberg_table=table, owner=owner, id=id
     )
     _write_result(result, output)
 
@@ -382,14 +351,11 @@ def import_excel(
     source: source_option = None,
     output: output_option = None,
     schema: schema_option = None,
-    template: template_option = None,
     owner: owner_option = None,
     id: id_option = None,
     debug: debug_option = None,
 ):
     """Import a data contract from an Excel file."""
     enable_debug_logging(debug)
-    result = DataContract.import_from_source(
-        format="excel", source=source, template=template, schema=schema, owner=owner, id=id
-    )
+    result = DataContract.import_from_source(format="excel", source=source, schema=schema, owner=owner, id=id)
     _write_result(result, output)

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -256,7 +256,6 @@ class DataContract:
         cls,
         format: str,
         source: typing.Optional[str] = None,
-        template: typing.Optional[str] = None,
         **kwargs,
     ) -> OpenDataContractStandard:
         """Import a data contract from a source in a given format.

--- a/datacontract/export/dbt_exporter.py
+++ b/datacontract/export/dbt_exporter.py
@@ -19,7 +19,7 @@ def _get_description_str(description: Union[str, Description, None]) -> Optional
     return None
 
 
-class DbtExporter(Exporter):
+class DbtModelsExporter(Exporter):
     def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> dict:
         return to_dbt_models_yaml(data_contract, server)
 

--- a/datacontract/export/exporter.py
+++ b/datacontract/export/exporter.py
@@ -36,7 +36,7 @@ class ExportFormat(str, Enum):
     jsonschema = "jsonschema"
     pydantic_model = "pydantic-model"
     sodacl = "sodacl"
-    dbt = "dbt"
+    dbt_models = "dbt-models"
     dbt_sources = "dbt-sources"
     dbt_staging_sql = "dbt-staging-sql"
     odcs = "odcs"

--- a/datacontract/export/exporter_factory.py
+++ b/datacontract/export/exporter_factory.py
@@ -84,7 +84,7 @@ exporter_factory.register_lazy_exporter(
 )
 
 exporter_factory.register_lazy_exporter(
-    name=ExportFormat.dbt,
+    name=ExportFormat.dbt_models,
     module_path="datacontract.export.dbt_exporter",
     class_name="DbtExporter",
 )

--- a/datacontract/export/exporter_factory.py
+++ b/datacontract/export/exporter_factory.py
@@ -86,7 +86,7 @@ exporter_factory.register_lazy_exporter(
 exporter_factory.register_lazy_exporter(
     name=ExportFormat.dbt_models,
     module_path="datacontract.export.dbt_exporter",
-    class_name="DbtExporter",
+    class_name="DbtModelsExporter",
 )
 
 exporter_factory.register_lazy_exporter(

--- a/tests/test_export_avro.py
+++ b/tests/test_export_avro.py
@@ -12,7 +12,7 @@ from datacontract.imports.dcs_importer import convert_dcs_to_odcs
 
 def test_cli():
     runner = CliRunner()
-    result = runner.invoke(app, ["export", "./fixtures/avro/export/datacontract.yaml", "--format", "avro"])
+    result = runner.invoke(app, ["export", "avro", "./fixtures/avro/export/datacontract.yaml"])
     assert result.exit_code == 0
 
 

--- a/tests/test_export_avro_idl.py
+++ b/tests/test_export_avro_idl.py
@@ -63,7 +63,7 @@ def test_avro_idl_str():
 
 def test_avro_idl_cli_export():
     runner = CliRunner()
-    result = runner.invoke(app, ["export", "./fixtures/lint/valid_datacontract_ref.yaml", "--format", "avro-idl"])
+    result = runner.invoke(app, ["export", "avro-idl", "./fixtures/lint/valid_datacontract_ref.yaml"])
     if result.exit_code:
         print(result.output)
     assert result.exit_code == 0

--- a/tests/test_export_bigquery.py
+++ b/tests/test_export_bigquery.py
@@ -15,11 +15,10 @@ def test_cli():
         app,
         [
             "export",
-            "--format",
-            "bigquery",
-            "--server",
             "bigquery",
             "fixtures/bigquery/export/datacontract.odcs.yaml",
+            "--server",
+            "bigquery",
         ],
     )
     assert result.exit_code == 0

--- a/tests/test_export_complex_data_contract.py
+++ b/tests/test_export_complex_data_contract.py
@@ -86,7 +86,7 @@ models:
     data_contract.test()
     data_contract.export(export_format="avro", schema_name="orders")
     data_contract.export(export_format="odcs")
-    data_contract.export(export_format="dbt")
+    data_contract.export(export_format="dbt-models")
     data_contract.export(export_format="dbt-sources")
     data_contract.export(export_format="dbt-staging-sql", schema_name="orders")
     data_contract.export(export_format="jsonschema", schema_name="orders")

--- a/tests/test_export_custom.py
+++ b/tests/test_export_custom.py
@@ -16,9 +16,8 @@ def test_cli():
         app,
         [
             "export",
-            "./fixtures/custom/export/datacontract.yaml",
-            "--format",
             "custom",
+            "./fixtures/custom/export/datacontract.yaml",
             "--template",
             "./fixtures/custom/export/template.sql",
         ],

--- a/tests/test_export_custom_model.py
+++ b/tests/test_export_custom_model.py
@@ -12,9 +12,8 @@ def test_cli():
         app,
         [
             "export",
-            "./fixtures/custom/export_model/datacontract.odcs.yaml",
-            "--format",
             "custom",
+            "./fixtures/custom/export_model/datacontract.odcs.yaml",
             "--template",
             "./fixtures/custom/export_model/template.sql",
             "--schema-name",

--- a/tests/test_export_data_caterer.py
+++ b/tests/test_export_data_caterer.py
@@ -11,7 +11,7 @@ from datacontract.lint.resolve import resolve_data_contract
 
 def test_cli():
     runner = CliRunner()
-    result = runner.invoke(app, ["export", "./fixtures/export/datacontract.odcs.yaml", "--format", "data-caterer"])
+    result = runner.invoke(app, ["export", "data-caterer", "./fixtures/export/datacontract.odcs.yaml"])
     assert result.exit_code == 0
 
 

--- a/tests/test_export_dbml.py
+++ b/tests/test_export_dbml.py
@@ -18,9 +18,7 @@ def test_cli():
 
 def test_cli_with_server():
     runner = CliRunner()
-    result = runner.invoke(
-        app, ["export", "dbml", "./fixtures/dbml/datacontract.odcs.yaml", "--server", "production"]
-    )
+    result = runner.invoke(app, ["export", "dbml", "./fixtures/dbml/datacontract.odcs.yaml", "--server", "production"])
     assert result.exit_code == 0
 
 

--- a/tests/test_export_dbml.py
+++ b/tests/test_export_dbml.py
@@ -12,14 +12,14 @@ from datacontract.data_contract import DataContract
 
 def test_cli():
     runner = CliRunner()
-    result = runner.invoke(app, ["export", "./fixtures/dbml/datacontract.odcs.yaml", "--format", "dbml"])
+    result = runner.invoke(app, ["export", "dbml", "./fixtures/dbml/datacontract.odcs.yaml"])
     assert result.exit_code == 0
 
 
 def test_cli_with_server():
     runner = CliRunner()
     result = runner.invoke(
-        app, ["export", "./fixtures/dbml/datacontract.odcs.yaml", "--format", "dbml", "--server", "production"]
+        app, ["export", "dbml", "./fixtures/dbml/datacontract.odcs.yaml", "--server", "production"]
     )
     assert result.exit_code == 0
 

--- a/tests/test_export_dbt_models.py
+++ b/tests/test_export_dbt_models.py
@@ -13,7 +13,7 @@ from datacontract.export.dbt_exporter import to_dbt_models_yaml
 
 def test_cli():
     runner = CliRunner()
-    result = runner.invoke(app, ["export", "./fixtures/export/datacontract.odcs.yaml", "--format", "dbt"])
+    result = runner.invoke(app, ["export", "dbt-models", "./fixtures/export/datacontract.odcs.yaml"])
     assert result.exit_code == 0
 
 

--- a/tests/test_export_dbt_sources.py
+++ b/tests/test_export_dbt_sources.py
@@ -13,7 +13,7 @@ from datacontract.imports.dcs_importer import convert_dcs_to_odcs
 def test_cli():
     runner = CliRunner()
     result = runner.invoke(
-        app, ["export", "./fixtures/export/datacontract.odcs.yaml", "--format", "dbt-sources", "--server", "production"]
+        app, ["export", "dbt-sources", "./fixtures/export/datacontract.odcs.yaml", "--server", "production"]
     )
     print(result.stdout)
     assert result.exit_code == 0
@@ -22,7 +22,7 @@ def test_cli():
 def test_cli_bigquery():
     runner = CliRunner()
     result = runner.invoke(
-        app, ["export", "./fixtures/dbt/export/datacontract.yaml", "--format", "dbt-sources", "--server", "production"]
+        app, ["export", "dbt-sources", "./fixtures/dbt/export/datacontract.yaml", "--server", "production"]
     )
     print(result.stdout)
     assert result.exit_code == 0

--- a/tests/test_export_dbt_staging_sql.py
+++ b/tests/test_export_dbt_staging_sql.py
@@ -14,9 +14,8 @@ def test_cli():
         app,
         [
             "export",
-            "./fixtures/dbt/export/datacontract.odcs.yaml",
-            "--format",
             "dbt-staging-sql",
+            "./fixtures/dbt/export/datacontract.odcs.yaml",
             "--schema-name",
             "orders",
         ],

--- a/tests/test_export_dqx.py
+++ b/tests/test_export_dqx.py
@@ -9,7 +9,7 @@ from datacontract.data_contract import DataContract
 
 def test_cli():
     runner = CliRunner()
-    result = runner.invoke(app, ["export", "./fixtures/dqx/datacontract.odcs.yaml", "--format", "dqx"])
+    result = runner.invoke(app, ["export", "dqx", "./fixtures/dqx/datacontract.odcs.yaml"])
     assert result.exit_code == 0
 
 

--- a/tests/test_export_excel.py
+++ b/tests/test_export_excel.py
@@ -23,9 +23,8 @@ def test_cli_export_excel():
             app,
             [
                 "export",
-                "./fixtures/excel/shipments-odcs.yaml",
-                "--format",
                 "excel",
+                "./fixtures/excel/shipments-odcs.yaml",
                 "--output",
                 tmp_path,
             ],

--- a/tests/test_export_go.py
+++ b/tests/test_export_go.py
@@ -8,7 +8,7 @@ from datacontract.data_contract import DataContract
 
 def test_cli():
     runner = CliRunner()
-    result = runner.invoke(app, ["export", "./fixtures/export/datacontract.odcs.yaml", "--format", "go"])
+    result = runner.invoke(app, ["export", "go", "./fixtures/export/datacontract.odcs.yaml"])
     assert result.exit_code == 0
 
 

--- a/tests/test_export_great_expectations.py
+++ b/tests/test_export_great_expectations.py
@@ -20,9 +20,8 @@ def test_cli():
         app,
         [
             "export",
-            "./fixtures/export/datacontract.odcs.yaml",
-            "--format",
             "great-expectations",
+            "./fixtures/export/datacontract.odcs.yaml",
         ],
     )
     assert result.exit_code == 0
@@ -544,9 +543,8 @@ def test_cli_with_spark_engine(expected_spark_engine: Dict[str, Any]):
         app,
         [
             "export",
-            "./fixtures/great-expectations/odcs.yaml",
-            "--format",
             "great-expectations",
+            "./fixtures/great-expectations/odcs.yaml",
             "--engine",
             "spark",
         ],
@@ -560,9 +558,8 @@ def test_cli_with_pandas_engine(expected_pandas_engine: Dict[str, Any]):
         app,
         [
             "export",
-            "./fixtures/great-expectations/odcs.yaml",
-            "--format",
             "great-expectations",
+            "./fixtures/great-expectations/odcs.yaml",
             "--engine",
             "pandas",
         ],
@@ -576,9 +573,8 @@ def test_cli_with_sql_engine(expected_sql_engine: Dict[str, Any]):
         app,
         [
             "export",
-            "./fixtures/great-expectations/odcs.yaml",
-            "--format",
             "great-expectations",
+            "./fixtures/great-expectations/odcs.yaml",
             "--engine",
             "sql",
         ],
@@ -592,12 +588,11 @@ def test_cli_with_sql_trino_engine(expected_sql_trino_engine: Dict[str, Any]):
         app,
         [
             "export",
-            "./fixtures/great-expectations/odcs.yaml",
-            "--format",
             "great-expectations",
+            "./fixtures/great-expectations/odcs.yaml",
             "--engine",
             "sql",
-            "--sql-server-type",
+            "--server-type",
             "trino",
         ],
     )

--- a/tests/test_export_html.py
+++ b/tests/test_export_html.py
@@ -10,7 +10,7 @@ from datacontract.cli import app
 
 def test_cli():
     runner = CliRunner()
-    result = runner.invoke(app, ["export", "./fixtures/export/datacontract.odcs.yaml", "--format", "html"])
+    result = runner.invoke(app, ["export", "html", "./fixtures/export/datacontract.odcs.yaml"])
     assert result.exit_code == 0
 
 
@@ -20,9 +20,8 @@ def test_cli_with_output(tmp_path: Path):
         app,
         [
             "export",
-            "./fixtures/export/datacontract.odcs.yaml",
-            "--format",
             "html",
+            "./fixtures/export/datacontract.odcs.yaml",
             "--output",
             tmp_path / "datacontract.html",
         ],
@@ -34,7 +33,7 @@ def test_cli_with_output(tmp_path: Path):
 def test_schemas_are_rendered():
     """Regression test for #880: schemas should render in the ODCS HTML template."""
     runner = CliRunner()
-    result = runner.invoke(app, ["export", "./fixtures/export/datacontract.odcs.yaml", "--format", "html"])
+    result = runner.invoke(app, ["export", "html", "./fixtures/export/datacontract.odcs.yaml"])
     assert result.exit_code == 0
     # The schema name 'orders' and a property name 'order_id' should appear in the output
     assert "orders" in result.output

--- a/tests/test_export_iceberg.py
+++ b/tests/test_export_iceberg.py
@@ -31,9 +31,7 @@ schema:
 
         with tempfile.NamedTemporaryFile(delete=True) as tmp_output_file:
             runner = CliRunner()
-            result = runner.invoke(
-                app, ["export", "iceberg", tmp_input_file.name, "--output", tmp_output_file.name]
-            )
+            result = runner.invoke(app, ["export", "iceberg", tmp_input_file.name, "--output", tmp_output_file.name])
             assert result.exit_code == 0
 
             with open(tmp_output_file.name, "r") as f:
@@ -212,9 +210,7 @@ def test_round_trip():
 
         with tempfile.NamedTemporaryFile(delete=True) as tmp_output_file:
             runner = CliRunner()
-            result = runner.invoke(
-                app, ["export", "iceberg", tmp_input_file.name, "--output", tmp_output_file.name]
-            )
+            result = runner.invoke(app, ["export", "iceberg", tmp_input_file.name, "--output", tmp_output_file.name])
             assert result.exit_code == 0
 
             with open(tmp_output_file.name, "r") as f:

--- a/tests/test_export_iceberg.py
+++ b/tests/test_export_iceberg.py
@@ -32,7 +32,7 @@ schema:
         with tempfile.NamedTemporaryFile(delete=True) as tmp_output_file:
             runner = CliRunner()
             result = runner.invoke(
-                app, ["export", tmp_input_file.name, "--format", "iceberg", "--output", tmp_output_file.name]
+                app, ["export", "iceberg", tmp_input_file.name, "--output", tmp_output_file.name]
             )
             assert result.exit_code == 0
 
@@ -194,11 +194,10 @@ def test_round_trip():
         app,
         [
             "import",
-            "--format",
             "iceberg",
             "--source",
             "fixtures/iceberg/nested_schema.json",
-            "--iceberg-table",
+            "--table",
             "test-table",
         ],
     )
@@ -214,7 +213,7 @@ def test_round_trip():
         with tempfile.NamedTemporaryFile(delete=True) as tmp_output_file:
             runner = CliRunner()
             result = runner.invoke(
-                app, ["export", tmp_input_file.name, "--format", "iceberg", "--output", tmp_output_file.name]
+                app, ["export", "iceberg", tmp_input_file.name, "--output", tmp_output_file.name]
             )
             assert result.exit_code == 0
 

--- a/tests/test_export_jsonschema.py
+++ b/tests/test_export_jsonschema.py
@@ -14,7 +14,7 @@ from datacontract.lint.resolve import resolve_data_contract
 
 def test_cli():
     runner = CliRunner()
-    result = runner.invoke(app, ["export", "./fixtures/local-json/datacontract.yaml", "--format", "jsonschema"])
+    result = runner.invoke(app, ["export", "jsonschema", "./fixtures/local-json/datacontract.yaml"])
     assert result.exit_code == 0
 
 

--- a/tests/test_export_markdown.py
+++ b/tests/test_export_markdown.py
@@ -16,9 +16,8 @@ def test_cli():
         app,
         [
             "export",
-            "./fixtures/markdown/export/datacontract.yaml",
-            "--format",
             "markdown",
+            "./fixtures/markdown/export/datacontract.yaml",
         ],
     )
     assert result.exit_code == 0

--- a/tests/test_export_mermaid.py
+++ b/tests/test_export_mermaid.py
@@ -8,7 +8,7 @@ from datacontract.cli import app
 
 def test_cli():
     runner = CliRunner()
-    result = runner.invoke(app, ["export", "./fixtures/export/datacontract.odcs.yaml", "--format", "mermaid"])
+    result = runner.invoke(app, ["export", "mermaid", "./fixtures/export/datacontract.odcs.yaml"])
     assert result.exit_code == 0
 
 
@@ -18,9 +18,8 @@ def test_cli_with_output(tmp_path: Path):
         app,
         [
             "export",
-            "./fixtures/export/datacontract.odcs.yaml",
-            "--format",
             "mermaid",
+            "./fixtures/export/datacontract.odcs.yaml",
             "--output",
             tmp_path / "datacontract.mermaid",
         ],
@@ -36,9 +35,8 @@ def test_mermaid_structure(tmp_path: Path):
         app,
         [
             "export",
-            datacontract_file,
-            "--format",
             "mermaid",
+            datacontract_file,
             "--output",
             tmp_path / "datacontract.mermaid",
         ],

--- a/tests/test_export_odcs_v3.py
+++ b/tests/test_export_odcs_v3.py
@@ -14,7 +14,7 @@ from datacontract.lint.resolve import resolve_data_contract
 
 def test_cli():
     runner = CliRunner()
-    result = runner.invoke(app, ["export", "./fixtures/export/datacontract.odcs.yaml", "--format", "odcs"])
+    result = runner.invoke(app, ["export", "odcs", "./fixtures/export/datacontract.odcs.yaml"])
     assert result.exit_code == 0
 
 

--- a/tests/test_export_protobuf.py
+++ b/tests/test_export_protobuf.py
@@ -10,7 +10,7 @@ from datacontract.export.protobuf_exporter import to_protobuf
 
 def test_cli():
     runner = CliRunner()
-    result = runner.invoke(app, ["export", "./fixtures/protobuf/datacontract.yaml", "--format", "protobuf"])
+    result = runner.invoke(app, ["export", "protobuf", "./fixtures/protobuf/datacontract.yaml"])
     assert result.exit_code == 0
 
 

--- a/tests/test_export_rdf.py
+++ b/tests/test_export_rdf.py
@@ -14,9 +14,7 @@ from datacontract.lint.resolve import resolve_data_contract
 
 def test_cli():
     runner = CliRunner()
-    result = runner.invoke(
-        app, ["export", "rdf", "./fixtures/export/rdf/datacontract.yaml", "--base", "urn:acme:"]
-    )
+    result = runner.invoke(app, ["export", "rdf", "./fixtures/export/rdf/datacontract.yaml", "--base", "urn:acme:"])
     assert result.exit_code == 0
 
 

--- a/tests/test_export_rdf.py
+++ b/tests/test_export_rdf.py
@@ -15,14 +15,14 @@ from datacontract.lint.resolve import resolve_data_contract
 def test_cli():
     runner = CliRunner()
     result = runner.invoke(
-        app, ["export", "./fixtures/export/rdf/datacontract.yaml", "--format", "rdf", "--rdf-base", "urn:acme:"]
+        app, ["export", "rdf", "./fixtures/export/rdf/datacontract.yaml", "--base", "urn:acme:"]
     )
     assert result.exit_code == 0
 
 
 def test_no_rdf_base():
     runner = CliRunner()
-    result = runner.invoke(app, ["export", "./fixtures/export/rdf/datacontract.yaml", "--format", "rdf"])
+    result = runner.invoke(app, ["export", "rdf", "./fixtures/export/rdf/datacontract.yaml"])
     assert result.exit_code == 0
 
 

--- a/tests/test_export_spark.py
+++ b/tests/test_export_spark.py
@@ -13,7 +13,7 @@ def test_cli():
     runner = CliRunner()
     result = runner.invoke(
         app,
-        ["export", "./fixtures/spark/export/datacontract.yaml", "--format", "spark"],
+        ["export", "spark", "./fixtures/spark/export/datacontract.yaml"],
     )
     assert result.exit_code == 0
     assert result.output == expected_str

--- a/tests/test_export_sql.py
+++ b/tests/test_export_sql.py
@@ -8,7 +8,7 @@ from datacontract.data_contract import DataContract
 
 def test_cli():
     runner = CliRunner()
-    result = runner.invoke(app, ["export", "./fixtures/postgres-export/datacontract.yaml", "--format", "sql"])
+    result = runner.invoke(app, ["export", "sql", "./fixtures/postgres-export/datacontract.yaml"])
     assert result.exit_code == 0
 
 

--- a/tests/test_export_sql_query.py
+++ b/tests/test_export_sql_query.py
@@ -8,7 +8,7 @@ from datacontract.data_contract import DataContract
 
 def test_cli():
     runner = CliRunner()
-    result = runner.invoke(app, ["export", "./fixtures/postgres-export/datacontract.yaml", "--format", "sql-query"])
+    result = runner.invoke(app, ["export", "sql-query", "./fixtures/postgres-export/datacontract.yaml"])
     assert result.exit_code == 0
 
 

--- a/tests/test_import_avro.py
+++ b/tests/test_import_avro.py
@@ -15,7 +15,6 @@ def test_cli():
         app,
         [
             "import",
-            "--format",
             "avro",
             "--source",
             "fixtures/avro/data/orders.avsc",

--- a/tests/test_import_bigquery.py
+++ b/tests/test_import_bigquery.py
@@ -14,7 +14,6 @@ def test_cli():
         app,
         [
             "import",
-            "--format",
             "bigquery",
             "--source",
             "fixtures/bigquery/import/complete_table_schema.json",

--- a/tests/test_import_csv.py
+++ b/tests/test_import_csv.py
@@ -15,7 +15,6 @@ def test_cli():
         app,
         [
             "import",
-            "--format",
             "csv",
             "--source",
             csv_file_path,

--- a/tests/test_import_dbml.py
+++ b/tests/test_import_dbml.py
@@ -13,7 +13,6 @@ def test_cli():
         app,
         [
             "import",
-            "--format",
             "dbml",
             "--source",
             "fixtures/dbml/import/dbml.txt",
@@ -28,13 +27,12 @@ def test_cli_with_filters():
         app,
         [
             "import",
-            "--format",
             "dbml",
             "--source",
             "fixtures/dbml/import/dbml.txt",
-            "--dbml-schema",
+            "--schema",
             "test",
-            "--dbml-table",
+            "--table",
             "foo",
         ],
     )

--- a/tests/test_import_dbt.py
+++ b/tests/test_import_dbt.py
@@ -23,7 +23,6 @@ def test_cli():
         app,
         [
             "import",
-            "--format",
             "dbt",
             "--source",
             dbt_manifest,
@@ -38,7 +37,6 @@ def test_cli_bigquery():
         app,
         [
             "import",
-            "--format",
             "dbt",
             "--source",
             dbt_manifest_bigquery,
@@ -53,13 +51,12 @@ def test_cli_with_filter():
         app,
         [
             "import",
-            "--format",
             "dbt",
             "--source",
             dbt_manifest,
-            "--dbt-model",
+            "--model",
             "customers",
-            "--dbt-model",
+            "--model",
             "orders",
         ],
     )

--- a/tests/test_import_excel.py
+++ b/tests/test_import_excel.py
@@ -16,7 +16,6 @@ def test_cli():
         app,
         [
             "import",
-            "--format",
             "excel",
             "--source",
             "./fixtures/excel/shipments-odcs.xlsx",

--- a/tests/test_import_glue.py
+++ b/tests/test_import_glue.py
@@ -128,7 +128,7 @@ def test_cli(setup_mock_glue):
         [
             "import",
             "glue",
-            "--source",
+            "--database",
             "test_database",
         ],
     )
@@ -143,7 +143,7 @@ def test_cli_with_table_filters(setup_mock_glue):
         [
             "import",
             "glue",
-            "--source",
+            "--database",
             "test_database",
             "--table",
             "table_1",

--- a/tests/test_import_glue.py
+++ b/tests/test_import_glue.py
@@ -127,7 +127,6 @@ def test_cli(setup_mock_glue):
         app,
         [
             "import",
-            "--format",
             "glue",
             "--source",
             "test_database",
@@ -143,13 +142,12 @@ def test_cli_with_table_filters(setup_mock_glue):
         app,
         [
             "import",
-            "--format",
             "glue",
             "--source",
             "test_database",
-            "--glue-table",
+            "--table",
             "table_1",
-            "--glue-table",
+            "--table",
             "table_2",
         ],
     )

--- a/tests/test_import_iceberg.py
+++ b/tests/test_import_iceberg.py
@@ -129,11 +129,10 @@ def test_cli():
         app,
         [
             "import",
-            "--format",
             "iceberg",
             "--source",
             "fixtures/iceberg/nested_schema.json",
-            "--iceberg-table",
+            "--table",
             "test-table",
         ],
     )

--- a/tests/test_import_json.py
+++ b/tests/test_import_json.py
@@ -11,7 +11,6 @@ def test_cli():
         app,
         [
             "import",
-            "--format",
             "json",
             "--source",
             "fixtures/import/json/product_detail.json",

--- a/tests/test_import_jsonschema.py
+++ b/tests/test_import_jsonschema.py
@@ -16,7 +16,6 @@ def test_cli():
         app,
         [
             "import",
-            "--format",
             "jsonschema",
             "--source",
             "fixtures/import/orders.json",
@@ -31,7 +30,6 @@ def test_cli_with_output(tmp_path: Path):
         app,
         [
             "import",
-            "--format",
             "jsonschema",
             "--source",
             "fixtures/import/orders_union-types.json",

--- a/tests/test_import_parquet.py
+++ b/tests/test_import_parquet.py
@@ -18,7 +18,6 @@ def test_cli():
         app,
         [
             "import",
-            "--format",
             "parquet",
             "--source",
             parquet_file_path,

--- a/tests/test_import_protobuf.py
+++ b/tests/test_import_protobuf.py
@@ -17,7 +17,6 @@ def test_cli():
         app,
         [
             "import",
-            "--format",
             "protobuf",
             "--source",
             protobuf_file_path,

--- a/tests/test_import_spark.py
+++ b/tests/test_import_spark.py
@@ -118,7 +118,6 @@ def test_cli(spark: SparkSession, df_user, user_datacontract_no_desc):
         app,
         [
             "import",
-            "--format",
             "spark",
             "--source",
             "users",
@@ -136,7 +135,6 @@ def test_table_not_exists():
         app,
         [
             "import",
-            "--format",
             "spark",
             "--source",
             "table_not_exists",

--- a/tests/test_import_spark.py
+++ b/tests/test_import_spark.py
@@ -119,7 +119,7 @@ def test_cli(spark: SparkSession, df_user, user_datacontract_no_desc):
         [
             "import",
             "spark",
-            "--source",
+            "--tables",
             "users",
         ],
     )
@@ -136,7 +136,7 @@ def test_table_not_exists():
         [
             "import",
             "spark",
-            "--source",
+            "--tables",
             "table_not_exists",
         ],
     )

--- a/tests/test_import_sql_oracle.py
+++ b/tests/test_import_sql_oracle.py
@@ -15,7 +15,6 @@ def test_cli():
         app,
         [
             "import",
-            "--format",
             "sql",
             "--source",
             data_definition_file,

--- a/tests/test_import_sql_postgres.py
+++ b/tests/test_import_sql_postgres.py
@@ -14,7 +14,7 @@ def test_cli():
     runner = CliRunner()
     result = runner.invoke(
         app,
-        ["import", "--format", "sql", "--source", sql_file_path, "--dialect", "postgres"],
+        ["import", "sql", "--source", sql_file_path, "--dialect", "postgres"],
     )
     assert result.exit_code == 0
 

--- a/tests/test_import_unity_file.py
+++ b/tests/test_import_unity_file.py
@@ -14,7 +14,6 @@ def test_cli():
         app,
         [
             "import",
-            "--format",
             "unity",
             "--source",
             "fixtures/databricks-unity/import/unity_table_schema.json",
@@ -68,7 +67,6 @@ def test_cli_with_owner_and_id():
         app,
         [
             "import",
-            "--format",
             "unity",
             "--source",
             "fixtures/databricks-unity/import/unity_table_schema.json",

--- a/tests/test_roundtrip_jsonschema.py
+++ b/tests/test_roundtrip_jsonschema.py
@@ -15,7 +15,6 @@ def test_import_cli():
         app,
         [
             "import",
-            "--format",
             "jsonschema",
             "--source",
             "fixtures/import/orders.json",
@@ -26,7 +25,7 @@ def test_import_cli():
 
 def test_export_cli():
     runner = CliRunner()
-    result = runner.invoke(app, ["export", "./fixtures/local-json/datacontract.yaml", "--format", "jsonschema"])
+    result = runner.invoke(app, ["export", "jsonschema", "./fixtures/local-json/datacontract.yaml"])
     assert result.exit_code == 0
 
 


### PR DESCRIPTION
## Summary

- Replaces flat `--format` option with Typer subcommands for `import` and `export`
- Each format gets its own subcommand with only its relevant options shown in `--help`
- Format-prefixed options simplified: `--bigquery-project` → `--project`, `--dbt-model` → `--model`, etc.
- Renames `ExportFormat.dbt` → `ExportFormat.dbt_models` (`dbt-models` subcommand)
- Updates all tests and documentation

**Before:**
```bash
datacontract import --format sql --source ddl.sql --dialect postgres
datacontract export --format dbt datacontract.yaml
```

**After:**
```bash
datacontract import sql --source ddl.sql --dialect postgres
datacontract export dbt-models datacontract.yaml
```

**Breaking change:** The `--format` option is removed from `import` and `export`.

Closes #1134

## Test plan

- [x] All 613 tests pass
- [x] `datacontract import --help` shows format subcommand list
- [x] `datacontract import sql --help` shows only SQL-relevant options
- [x] `datacontract export dbt-models --help` shows only dbt-relevant options
- [x] Real import/export workflows tested end-to-end
- [x] Lint passes (`ruff check`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)