### PR TITLE
fix: move precision/scale from logicalTypeOptions for number types (i…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `--schema-name` option to `test` command to test a specific schema instead of all schemas (#1079 @kelsoufi-sanofi)
 
 ### Fixed
-- Drop `precision`/`scale` from `logicalTypeOptions` for `number` types in SQL importer — these fields are forbidden by the ODCS v3.1.0 schema (#1145)
+- Move `precision`/`scale` from `logicalTypeOptions` to `customProperties` for `number` types — these fields are forbidden under `logicalTypeOptions` by the ODCS v3.1.0 schema (#1145)
 - Emit placeholder server values in SQL importer so generated contracts pass lint (#1146)
 - Fix Protobuf export for arrays of objects and improve message/enum naming to UpperCamelCase (#1012 @Schokuroff)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `--schema-name` option to `test` command to test a specific schema instead of all schemas (#1079 @kelsoufi-sanofi)
 
 ### Fixed
+- Drop `precision`/`scale` from `logicalTypeOptions` for `number` types in SQL importer — these fields are forbidden by the ODCS v3.1.0 schema (#1145)
 - Emit placeholder server values in SQL importer so generated contracts pass lint (#1146)
 - Fix Protobuf export for arrays of objects and improve message/enum naming to UpperCamelCase (#1012 @Schokuroff)
 

--- a/datacontract/imports/odcs_helper.py
+++ b/datacontract/imports/odcs_helper.py
@@ -122,10 +122,6 @@ def create_property(
         logical_type_options["exclusiveMinimum"] = exclusive_minimum
     if exclusive_maximum is not None:
         logical_type_options["exclusiveMaximum"] = exclusive_maximum
-    if precision is not None:
-        logical_type_options["precision"] = precision
-    if scale is not None:
-        logical_type_options["scale"] = scale
     if format:
         logical_type_options["format"] = format
     if logical_type_options:

--- a/datacontract/imports/odcs_helper.py
+++ b/datacontract/imports/odcs_helper.py
@@ -127,7 +127,13 @@ def create_property(
     if logical_type_options:
         prop.logicalTypeOptions = logical_type_options
 
-    # Custom properties
+    # precision/scale are forbidden in logicalTypeOptions for number types per ODCS v3.1.0,
+    # so carry them in customProperties instead.
+    custom_properties = dict(custom_properties or {})
+    if precision is not None:
+        custom_properties.setdefault("precision", precision)
+    if scale is not None:
+        custom_properties.setdefault("scale", scale)
     if custom_properties:
         prop.customProperties = [CustomProperty(property=k, value=v) for k, v in custom_properties.items()]
 

--- a/tests/fixtures/bigquery/import/datacontract.yaml
+++ b/tests/fixtures/bigquery/import/datacontract.yaml
@@ -67,10 +67,20 @@ schema:
   - name: Numeric_Field
     physicalType: NUMERIC
     description: A Numeric field with precision 5 and scale 3
+    customProperties:
+    - property: precision
+      value: 5
+    - property: scale
+      value: 3
     logicalType: number
   - name: Bignumeric_field
     physicalType: BIGNUMERIC
     description: A bignumeric field with precision 8 and sclae 4
+    customProperties:
+    - property: precision
+      value: 8
+    - property: scale
+      value: 4
     logicalType: number
   - name: Record_field
     physicalType: RECORD

--- a/tests/fixtures/bigquery/import/datacontract.yaml
+++ b/tests/fixtures/bigquery/import/datacontract.yaml
@@ -68,16 +68,10 @@ schema:
     physicalType: NUMERIC
     description: A Numeric field with precision 5 and scale 3
     logicalType: number
-    logicalTypeOptions:
-      precision: 5
-      scale: 3
   - name: Bignumeric_field
     physicalType: BIGNUMERIC
     description: A bignumeric field with precision 8 and sclae 4
     logicalType: number
-    logicalTypeOptions:
-      precision: 8
-      scale: 4
   - name: Record_field
     physicalType: RECORD
     description: A record field with two subfields

--- a/tests/fixtures/glue/datacontract.yaml
+++ b/tests/fixtures/glue/datacontract.yaml
@@ -28,6 +28,11 @@ schema:
     logicalType: date
   - name: field_four
     physicalType: decimal
+    customProperties:
+    - property: precision
+      value: 6
+    - property: scale
+      value: 2
     logicalType: number
   - name: field_five
     physicalType: struct

--- a/tests/fixtures/glue/datacontract.yaml
+++ b/tests/fixtures/glue/datacontract.yaml
@@ -29,9 +29,6 @@ schema:
   - name: field_four
     physicalType: decimal
     logicalType: number
-    logicalTypeOptions:
-      precision: 6
-      scale: 2
   - name: field_five
     physicalType: struct
     logicalType: object

--- a/tests/test_import_avro.py
+++ b/tests/test_import_avro.py
@@ -372,9 +372,6 @@ schema:
   - name: some_bytes_decimal
     physicalType: bytes
     logicalType: number
-    logicalTypeOptions:
-      precision: 25
-      scale: 2
     required: true
 """
     print("Result:\n", result.to_yaml())

--- a/tests/test_import_avro.py
+++ b/tests/test_import_avro.py
@@ -371,6 +371,11 @@ schema:
     required: true
   - name: some_bytes_decimal
     physicalType: bytes
+    customProperties:
+    - property: precision
+      value: 25
+    - property: scale
+      value: 2
     logicalType: number
     required: true
 """

--- a/tests/test_import_parquet.py
+++ b/tests/test_import_parquet.py
@@ -53,6 +53,11 @@ schema:
     logicalType: boolean
   - name: decimal_field
     physicalType: DECIMAL
+    customProperties:
+    - property: precision
+      value: 10
+    - property: scale
+      value: 2
     logicalType: number
   - name: float_field
     physicalType: FLOAT

--- a/tests/test_import_parquet.py
+++ b/tests/test_import_parquet.py
@@ -54,9 +54,6 @@ schema:
   - name: decimal_field
     physicalType: DECIMAL
     logicalType: number
-    logicalTypeOptions:
-      precision: 10
-      scale: 2
   - name: float_field
     physicalType: FLOAT
     logicalType: number

--- a/tests/test_import_sql_snowflake.py
+++ b/tests/test_import_sql_snowflake.py
@@ -31,6 +31,11 @@ schema:
   - name: field_primary_key
     physicalType: DECIMAL(38, 0)
     description: Primary key
+    customProperties:
+    - property: precision
+      value: 38
+    - property: scale
+      value: 0
     logicalType: number
     required: true
   - name: field_not_null
@@ -90,10 +95,20 @@ schema:
   - name: field_decimal
     physicalType: DECIMAL(10, 2)
     description: Fixed precision decimal
+    customProperties:
+    - property: precision
+      value: 10
+    - property: scale
+      value: 2
     logicalType: number
   - name: field_numeric
     physicalType: DECIMAL(10, 2)
     description: Same as DECIMAL
+    customProperties:
+    - property: precision
+      value: 10
+    - property: scale
+      value: 2
     logicalType: number
   - name: field_float
     physicalType: DOUBLE

--- a/tests/test_import_sql_snowflake.py
+++ b/tests/test_import_sql_snowflake.py
@@ -32,9 +32,6 @@ schema:
     physicalType: DECIMAL(38, 0)
     description: Primary key
     logicalType: number
-    logicalTypeOptions:
-      precision: 38
-      scale: 0
     required: true
   - name: field_not_null
     physicalType: INT
@@ -94,16 +91,10 @@ schema:
     physicalType: DECIMAL(10, 2)
     description: Fixed precision decimal
     logicalType: number
-    logicalTypeOptions:
-      precision: 10
-      scale: 2
   - name: field_numeric
     physicalType: DECIMAL(10, 2)
     description: Same as DECIMAL
     logicalType: number
-    logicalTypeOptions:
-      precision: 10
-      scale: 2
   - name: field_float
     physicalType: DOUBLE
     description: Approximate floating-point

--- a/tests/test_import_sql_sqlserver.py
+++ b/tests/test_import_sql_sqlserver.py
@@ -91,10 +91,20 @@ schema:
         logicalType: number
         physicalType: NUMERIC(10, 2)
         description: Fixed precision decimal
+        customProperties:
+        - property: precision
+          value: 10
+        - property: scale
+          value: 2
       - name: field_numeric
         logicalType: number
         physicalType: NUMERIC(10, 2)
         description: Same as DECIMAL
+        customProperties:
+        - property: precision
+          value: 10
+        - property: scale
+          value: 2
       - name: field_float
         logicalType: number
         physicalType: FLOAT

--- a/tests/test_import_sql_sqlserver.py
+++ b/tests/test_import_sql_sqlserver.py
@@ -89,16 +89,10 @@ schema:
         description: Large integer (-9 quintillion to 9 quintillion)
       - name: field_decimal
         logicalType: number
-        logicalTypeOptions:
-          precision: 10
-          scale: 2
         physicalType: NUMERIC(10, 2)
         description: Fixed precision decimal
       - name: field_numeric
         logicalType: number
-        logicalTypeOptions:
-          precision: 10
-          scale: 2
         physicalType: NUMERIC(10, 2)
         description: Same as DECIMAL
       - name: field_float


### PR DESCRIPTION
## Summary

Fixes https://github.com/datacontract/datacontract-cli/issues/1145.

When importing SQL DDL with `DECIMAL`/`NUMERIC` columns, the SQL importer was writing `precision` and `scale` into `logicalTypeOptions`. The ODCS v3.1.0 schema forbids these properties under `logicalType: number` (`additionalProperties: false`), causing `datacontract lint` to fail on the imported output.

## Root cause

`odcs_helper.py` unconditionally populated `logicalTypeOptions` with `precision` and `scale`:

```python
if precision is not None:
    logical_type_options["precision"] = precision
if scale is not None:
    logical_type_options["scale"] = scale
```

## Fix

Remove those two assignments from `logicalTypeOptions` and move them to `schemas.item.properties.item.customProperties[item]`as per https://github.com/datacontract/datacontract-cli/issues/1145#issuecomment-4261330277

```
- id: EmergencyDepartmentCopay__c_propId
    name: EmergencyDepartmentCopay__c
    physicalType: NUMBER(38,18)
    description: ''
    customProperties:
    - property: precision
      value: 38
    - property: scale
      value: 18
    logicalType: number
```

## Check List
- [x] Tests pass (`uv run pytest`)
- [x] Code formatted (`uv run ruff format`)
- [x] README.md update NOT relevant
- [x] CHANGELOG.md entry added
