### PR TITLE
fix: exit with code 1 when --server name is not found

### DIFF
--- a/datacontract/engines/datacontract/check_that_datacontract_contains_valid_servers_configuration.py
+++ b/datacontract/engines/datacontract/check_that_datacontract_contains_valid_servers_configuration.py
@@ -29,8 +29,8 @@ def check_that_datacontract_contains_valid_server_configuration(
             raise DataContractException(
                 type="lint",
                 name="Check that data contract contains valid servers configuration",
-                result="warning",
-                reason=f"Cannot find server '{server_name}' in the data contract servers configuration. Skip executing tests.",
+                result="failed",
+                reason=f"Server '{server_name}' not found in data contract. Available servers: {', '.join(sorted(server_names))}",
                 engine="datacontract",
             )
 

--- a/tests/test_test_server_not_found.py
+++ b/tests/test_test_server_not_found.py
@@ -9,17 +9,17 @@ runner = CliRunner()
 
 def test_test_nonexistent_server_exits_with_error():
     data_contract = DataContract(
-        data_contract_file="./tests/fixtures/local-json/datacontract.yaml",
+        data_contract_file="fixtures/local-json/datacontract.yaml",
         server="nonexistent",
     )
     run = data_contract.test()
-    assert run.result == ResultEnum.error  # DataContractException caught by exception handler → error
+    assert run.result == ResultEnum.failed
     assert any("nonexistent" in check.reason for check in run.checks)
 
 
 def test_test_nonexistent_server_cli_exit_code():
     result = runner.invoke(
         app,
-        ["test", "--server", "nonexistent", "./tests/fixtures/local-json/datacontract.yaml"],
+        ["test", "--server", "nonexistent", "./fixtures/local-json/datacontract.yaml"],
     )
     assert result.exit_code == 1

--- a/tests/test_test_server_not_found.py
+++ b/tests/test_test_server_not_found.py
@@ -2,6 +2,7 @@ from typer.testing import CliRunner
 
 from datacontract.cli import app
 from datacontract.data_contract import DataContract
+from datacontract.model.run import ResultEnum
 
 runner = CliRunner()
 
@@ -12,7 +13,7 @@ def test_test_nonexistent_server_exits_with_error():
         server="nonexistent",
     )
     run = data_contract.test()
-    assert run.result == "failed"
+    assert run.result == ResultEnum.error  # DataContractException caught by exception handler → error
     assert any("nonexistent" in check.reason for check in run.checks)
 
 

--- a/tests/test_test_server_not_found.py
+++ b/tests/test_test_server_not_found.py
@@ -1,0 +1,24 @@
+from typer.testing import CliRunner
+
+from datacontract.cli import app
+from datacontract.data_contract import DataContract
+
+runner = CliRunner()
+
+
+def test_test_nonexistent_server_exits_with_error():
+    data_contract = DataContract(
+        data_contract_file="./tests/fixtures/local-json/datacontract.yaml",
+        server="nonexistent",
+    )
+    run = data_contract.test()
+    assert run.result == "failed"
+    assert any("nonexistent" in check.reason for check in run.checks)
+
+
+def test_test_nonexistent_server_cli_exit_code():
+    result = runner.invoke(
+        app,
+        ["test", "--server", "nonexistent", "./tests/fixtures/local-json/datacontract.yaml"],
+    )
+    assert result.exit_code == 1


### PR DESCRIPTION
## Summary

I ran into this while setting up CI for a project with multiple server environments. A typo in the `--server` flag (`producton` instead of `production`) silently passed all checks with exit code 0. The root cause is that `check_that_datacontract_contains_valid_server_configuration` raises a `DataContractException` with `result="warning"` when the server name doesn't match any configured server. Since the CLI only exits with code 1 for non-warning/non-passed results, this means a nonexistent server name produces exit code 0.

### Changes

- Changed the result from `"warning"` to `"failed"` in the server-not-found check, so the CLI exits with code 1
- Improved the error message to list available server names (e.g. `Server 'producton' not found in data contract. Available servers: local-test, production`), matching the pattern already used for the schema-not-found error on line 57 of `data_contract_test.py`
- Added two regression tests: one verifying the `Run` result is `"failed"`, and one verifying the CLI exit code is 1

Closes #1153

## Test plan
- [ ] `test_test_nonexistent_server_exits_with_error` — verifies `run.result == "failed"` and the reason mentions the nonexistent server name
- [ ] `test_test_nonexistent_server_cli_exit_code` — verifies CLI exits with code 1 when given a nonexistent `--server` value