### PR TITLE
fix: warn when --output is set but --output-format is missing

### DIFF
--- a/datacontract/output/test_results_writer.py
+++ b/datacontract/output/test_results_writer.py
@@ -22,6 +22,11 @@ def write_test_result(
 ):
     if output_format is not None and not output_path:
         console.print(f"No output path specified for {output_format.value} test results. Skip writing test results.")
+    elif output_path is not None and output_format is None:
+        console.print(
+            "[yellow]Warning:[/yellow] Output path specified but --output-format is missing. "
+            "No test results file will be written. Supported formats: json, junit."
+        )
     elif output_format == OutputFormat.json:
         write_json_test_results(run, output_path)
         console.print(f"Written {output_format.value} test results to {output_path}")


### PR DESCRIPTION
## Summary
When `--output <path>` is provided to `lint` or `test` commands without `--output-format`, the CLI silently writes nothing. A yellow warning is now printed guiding the user to also specify `--output-format`.

## Changes
- **File:** `datacontract/output/test_results_writer.py`
- Added a warning branch: if `output_path` is set but `output_format` is `None`, prints a clear message indicating which flag is also needed
- No behavior change for valid invocations

## Testing
- Existing tests pass

Fixes #1156.