### PR TITLE
fix(output): infer output format from file extension when --output-format omitted

### DIFF
--- a/datacontract/output/test_results_writer.py
+++ b/datacontract/output/test_results_writer.py
@@ -13,6 +13,13 @@ from datacontract.output.junit_test_results import write_junit_test_results
 from datacontract.output.output_format import OutputFormat
 
 
+def _infer_output_format(output_path: Path) -> Optional[OutputFormat]:
+    """Infer output format from file extension."""
+    ext = output_path.suffix.lower()
+    mapping = {".json": OutputFormat.json, ".xml": OutputFormat.junit}
+    return mapping.get(ext)
+
+
 def write_test_result(
     run: Run,
     console: Console,
@@ -20,6 +27,15 @@ def write_test_result(
     output_path: Path,
     data_contract: Optional[OpenDataContractStandard] = None,
 ):
+    if output_format is None and output_path:
+        output_format = _infer_output_format(output_path)
+        if output_format is None:
+            console.print(
+                f"Error: Cannot infer output format from extension '{output_path.suffix}'. "
+                f"Please specify --output-format ({', '.join(OutputFormat.get_supported_formats())})."
+            )
+            raise typer.Exit(code=1)
+
     if output_format is not None and not output_path:
         console.print(f"No output path specified for {output_format.value} test results. Skip writing test results.")
     elif output_format == OutputFormat.json:


### PR DESCRIPTION
## Problem

Running `datacontract test --output results.xml datacontract.yaml` silently writes no file, produces no error, and gives no warning. The exit code only reflects test results, so the user has no indication that anything went wrong.

This happens because `write_test_result()` in `test_results_writer.py` skips writing when `output_format is None`, and when `--output-format` is not explicitly provided, it defaults to `None`.

## Fix

When `--output` is specified but `--output-format` is omitted, infer the format from the file extension:

- `.json` → `json`
- `.xml` → `junit`

If the extension cannot be mapped (e.g., `.txt`), print a clear error message listing supported formats and exit with code 1.

The inference logic is encapsulated in a small `_infer_output_format()` helper that maps extensions to `OutputFormat` enum values. This keeps the main function clean and makes it easy to extend with new formats later.

## Changes

- **`datacontract/output/test_results_writer.py`**: Added `_infer_output_format()` helper (5 lines) and an early inference block in `write_test_result()` (11 lines) that runs before the existing format dispatch logic. Total: +16 lines, no modifications to existing behavior when `--output-format` is explicitly provided.

Fixes #1156