### PR TITLE
fix: exit non-zero when soda connection or auth fails (#1179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `changelog` command help text now advertises `(url or path)` for V1/V2 arguments, clarifying that HTTP/HTTPS URLs are accepted (closes #1162)
+- **breaking:** `test` command now exits non-zero when a server is specified, but soda-core fails to connect or authenticate (#1181)
 
 ## [0.12.1] - 2026-04-21
 

--- a/datacontract/engines/soda/check_soda_execute.py
+++ b/datacontract/engines/soda/check_soda_execute.py
@@ -191,13 +191,14 @@ def check_soda_execute(
         )
 
     if scan.has_error_logs():
-        run.log_warn("Engine soda-core has errors. See the logs for details.")
+        reason = _first_error_message(scan_results) or "Engine soda-core has errors. See the logs for details."
+        run.log_error(f"Engine soda-core has errors: {reason}")
         run.checks.append(
             Check(
                 type="general",
                 name="Data Contract Tests",
-                result=ResultEnum.warning,
-                reason="Engine soda-core has errors. See the logs for details.",
+                result=ResultEnum.failed,
+                reason=reason,
                 engine="soda-core",
             )
         )
@@ -209,6 +210,15 @@ def get_check(run, scan_result) -> Check | None:
     if check_by_name is not None:
         return check_by_name
 
+    return None
+
+
+def _first_error_message(scan_results: dict) -> str | None:
+    for log in scan_results.get("logs") or []:
+        if log.get("level") == "ERROR":
+            message = log.get("message")
+            if message:
+                return message.strip().splitlines()[0]
     return None
 
 

--- a/tests/fixtures/soda-connection-error/datacontract.yaml
+++ b/tests/fixtures/soda-connection-error/datacontract.yaml
@@ -1,0 +1,20 @@
+dataContractSpecification: 1.2.1
+id: unreachable
+info:
+  title: Unreachable Postgres
+  version: 0.0.1
+  owner: test
+servers:
+  unreachable:
+    type: postgres
+    host: 127.0.0.1
+    port: 15999
+    database: x
+    schema: public
+models:
+  m:
+    type: table
+    fields:
+      f:
+        type: varchar
+        required: true

--- a/tests/test_test_soda_connection_error.py
+++ b/tests/test_test_soda_connection_error.py
@@ -1,0 +1,32 @@
+from typer.testing import CliRunner
+
+from datacontract.cli import app
+from datacontract.data_contract import DataContract
+from datacontract.model.run import ResultEnum
+
+runner = CliRunner()
+
+CONTRACT = "fixtures/soda-connection-error/datacontract.yaml"
+
+
+def test_soda_connection_error_result_is_failed(monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_POSTGRES_USERNAME", "u")
+    monkeypatch.setenv("DATACONTRACT_POSTGRES_PASSWORD", "p")
+
+    run = DataContract(data_contract_file=CONTRACT).test()
+
+    assert run.result == ResultEnum.failed
+    assert any(check.result == ResultEnum.failed and check.engine == "soda-core" for check in run.checks), (
+        "Expected a failed soda-core check for the unreachable server"
+    )
+
+
+def test_soda_connection_error_cli_exit_code(monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_POSTGRES_USERNAME", "u")
+    monkeypatch.setenv("DATACONTRACT_POSTGRES_PASSWORD", "p")
+
+    result = runner.invoke(app, ["test", CONTRACT])
+
+    assert result.exit_code == 1, (
+        f"Expected exit_code 1 for a connection failure, got {result.exit_code}. stdout:\n{result.stdout}"
+    )


### PR DESCRIPTION
Fixes #1179.

Right now `datacontract test` exits 0 even when soda-core can't connect to the server or the credentials are wrong — so broken CI runs look green.

The engine was recording these as a `warning`, which the output writer treats as "not a failure" and skips the non-zero exit. Flipped the result to `failed` and carried the real soda error message into the check reason so operators can see *why* it failed without digging through logs.

## Test plan
- [x] Repro from the issue (unreachable port) now exits 1
- [x] Wrong password against a reachable postgres now exits 1
- [x] Happy path (reachable + correct creds + valid data) still exits 0
- [x] Added `tests/test_test_soda_connection_error.py` covering both the `Run.result` and CLI exit code
- [x] Existing `test_test_server_not_found.py` and output tests still pass