### PR TITLE
feat: attach failing row samples to quality check output

### DIFF
--- a/datacontract/engines/soda/check_soda_execute.py
+++ b/datacontract/engines/soda/check_soda_execute.py
@@ -1,6 +1,11 @@
+import decimal
 import logging
 import typing
 import uuid
+from datetime import date, datetime, time
+from typing import Any
+
+import yaml
 
 from datacontract.engines.soda.connections.athena import to_athena_soda_configuration
 from datacontract.engines.soda.connections.oracle import initialize_client_and_create_soda_configuration
@@ -23,6 +28,8 @@ from datacontract.engines.soda.connections.sqlserver import to_sqlserver_soda_co
 from datacontract.engines.soda.connections.trino import to_trino_soda_configuration
 from datacontract.export.sodacl_exporter import to_sodacl_yaml
 from datacontract.model.run import Check, Log, ResultEnum, Run
+
+FAILED_ROWS_SAMPLES_LIMIT = 5
 
 
 def check_soda_execute(
@@ -150,8 +157,7 @@ def check_soda_execute(
         run.log_warn(f"Server type {server.type} not yet supported by datacontract CLI")
         return
 
-    sodacl_yaml_str = to_sodacl_yaml(run)
-    # print("sodacl_yaml_str:\n" + sodacl_yaml_str)
+    sodacl_yaml_str = _inject_samples_limit(to_sodacl_yaml(run), FAILED_ROWS_SAMPLES_LIMIT)
     scan.add_sodacl_yaml_str(sodacl_yaml_str)
 
     # Execute the scan
@@ -179,6 +185,8 @@ def check_soda_execute(
         check.result = to_result(scan_result)
         check.reason = ", ".join(scan_result.get("outcomeReasons"))
         check.diagnostics = scan_result.get("diagnostics")
+        if check.result == ResultEnum.failed:
+            check.failed_rows_samples = _fetch_failed_rows_samples(scan, scan_result, scan_results)
         update_reason(check, scan_result)
 
     for log in scan_results.get("logs"):
@@ -226,17 +234,139 @@ def update_reason(check, c):
     """Try to find a reason in diagnostics"""
     if check.result == "passed":
         return
-    if check.reason is not None and check.reason != "":
-        return
-    for block in c["diagnostics"]["blocks"]:
-        if block["title"] == "Diagnostics":
-            # Extract and print the 'text' value
-            diagnostics_text = block["text"]
-            # print(diagnostics_text)
-            diagnostics_text_split = diagnostics_text.split(":icon-fail: ")
-            if len(diagnostics_text_split) > 1:
-                check.reason = diagnostics_text_split[1].strip()
-                # print(check.reason)
-            break  # Exit the loop once the desired block is found
-    if "fail" in c["diagnostics"]:
-        check.reason = f"Value: {c['diagnostics']['value']} Fail: {c['diagnostics']['fail']}"
+    base_reason: str | None = None
+    if check.reason:
+        base_reason = check.reason
+    else:
+        for block in c["diagnostics"]["blocks"]:
+            if block["title"] == "Diagnostics":
+                diagnostics_text_split = block["text"].split(":icon-fail: ")
+                if len(diagnostics_text_split) > 1:
+                    base_reason = diagnostics_text_split[1].strip()
+                break
+        if not base_reason and "fail" in c["diagnostics"]:
+            base_reason = f"Value: {c['diagnostics']['value']} Fail: {c['diagnostics']['fail']}"
+
+    sample_summary = _format_sample_summary(check.failed_rows_samples)
+    if base_reason and sample_summary:
+        check.reason = f"{base_reason}. {sample_summary}"
+    elif sample_summary:
+        check.reason = sample_summary
+    else:
+        check.reason = base_reason
+
+
+def _inject_samples_limit(sodacl_yaml_str: str, limit: int) -> str:
+    """Add `samples limit: N` to every `invalid_count(...)` check so Soda
+    runs the follow-up SELECT that lists failing rows. The rows themselves
+    aren't persisted by Soda, but the SQL surfaces in scan_results['queries']
+    and we can re-execute it via Soda's own connection.
+    """
+    try:
+        sodacl_dict = yaml.safe_load(sodacl_yaml_str)
+    except yaml.YAMLError:
+        return sodacl_yaml_str
+    if not isinstance(sodacl_dict, dict):
+        return sodacl_yaml_str
+    for checks in sodacl_dict.values():
+        if not isinstance(checks, list):
+            continue
+        for check in checks:
+            if not isinstance(check, dict):
+                continue
+            for check_key, check_config in check.items():
+                if isinstance(check_config, dict) and str(check_key).startswith("invalid_count"):
+                    check_config.setdefault("samples limit", limit)
+    return yaml.dump(sodacl_dict)
+
+
+def _fetch_failed_rows_samples(scan, scan_result: dict, scan_results: dict) -> list[dict] | None:
+    """Re-execute the `failing_sql` query Soda built for this check, via
+    Soda's own data source connection, and return the rows as JSON-safe dicts.
+
+    Returns None if no matching query exists (e.g. non-SQL backend), or if the
+    connection can't be reached for any reason. Errors are logged but never
+    raised — sample capture is best-effort.
+    """
+    data_source_name = scan_result.get("dataSource")
+    if not data_source_name:
+        return None
+
+    table = scan_result.get("table")
+    column = scan_result.get("column")
+    failing_query_name = _extract_failing_query_name(scan_result)
+    queries = scan_results.get("queries") or []
+
+    failed_rows_sql: str | None = None
+    if failing_query_name:
+        failed_rows_sql = next(
+            (q.get("sql") for q in queries if q.get("name") == failing_query_name),
+            None,
+        )
+    if not failed_rows_sql and table and column:
+        prefix = f".{data_source_name}.{table}.{column}.failed_rows["
+        failed_rows_sql = next(
+            (
+                q.get("sql")
+                for q in queries
+                if prefix in q.get("name", "").replace('"', "") and q.get("name", "").endswith(".failing_sql")
+            ),
+            None,
+        )
+    if not failed_rows_sql:
+        return None
+
+    try:
+        data_source = scan._data_source_manager.get_data_source(data_source_name)
+        connection = data_source.connection
+        cursor = connection.cursor()
+        try:
+            cursor.execute(failed_rows_sql)
+            columns = [d[0] for d in cursor.description]
+            rows = cursor.fetchall()
+        finally:
+            cursor.close()
+    except Exception as e:
+        logging.warning(f"Could not fetch failed-rows sample for {table}.{column}: {e}")
+        return None
+
+    return [{col: _json_safe(val) for col, val in zip(columns, row)} for row in rows]
+
+
+def _extract_failing_query_name(scan_result: dict) -> str | None:
+    """Soda puts the exact failing-rows query name in the diagnostics block,
+    already quoted the way the dialect needs. Prefer that over rebuilding it."""
+    diagnostics = scan_result.get("diagnostics") or {}
+    for block in diagnostics.get("blocks") or []:
+        if block.get("type") == "failedRowsAnalysis":
+            name = block.get("failingRowsQueryName")
+            if name:
+                return name
+    return None
+
+
+def _json_safe(value: Any) -> Any:
+    """Coerce database values (Decimal, datetime, bytes, etc.) into JSON-safe
+    primitives so Pydantic / json.dumps don't choke on them later."""
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, decimal.Decimal):
+        return str(value)
+    if isinstance(value, (datetime, date, time)):
+        return value.isoformat()
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        try:
+            return bytes(value).decode("utf-8")
+        except UnicodeDecodeError:
+            return bytes(value).hex()
+    return str(value)
+
+
+def _format_sample_summary(samples: list[dict] | None) -> str | None:
+    if not samples:
+        return None
+    first = samples[0]
+    rendered = ", ".join(f"{k}={v}" for k, v in first.items())
+    if len(samples) == 1:
+        return f"Sample failing row: {rendered}"
+    return f"Sample failing row (1 of {len(samples)}): {rendered}"

--- a/datacontract/model/run.py
+++ b/datacontract/model/run.py
@@ -33,6 +33,7 @@ class Check(BaseModel):
     reason: str | None = None
     details: str | None = None
     diagnostics: dict | None = None
+    failed_rows_samples: list[dict] | None = None
 
 
 class Log(BaseModel):

--- a/tests/fixtures/quality-samples/data/data.sql
+++ b/tests/fixtures/quality-samples/data/data.sql
@@ -1,0 +1,9 @@
+CREATE TABLE public.orders
+(
+    order_id    varchar(20) PRIMARY KEY,
+    order_total numeric     NOT NULL
+);
+
+INSERT INTO public.orders VALUES ('O-GOOD1', 10.0);
+INSERT INTO public.orders VALUES ('O-GOOD2', 20.0);
+INSERT INTO public.orders VALUES ('O-BAD123', -5.0);

--- a/tests/fixtures/quality-samples/datacontract.yaml
+++ b/tests/fixtures/quality-samples/datacontract.yaml
@@ -1,0 +1,25 @@
+dataContractSpecification: 1.2.1
+id: quality-samples
+info:
+  title: Quality Samples
+  version: 0.0.1
+  owner: test
+servers:
+  s:
+    type: postgres
+    host: localhost
+    port: 5432
+    database: test
+    schema: public
+models:
+  orders:
+    type: table
+    fields:
+      order_id:
+        type: varchar
+        required: true
+        unique: true
+      order_total:
+        type: decimal
+        required: true
+        minimum: 0

--- a/tests/test_test_quality_samples.py
+++ b/tests/test_test_quality_samples.py
@@ -1,0 +1,70 @@
+import pytest
+from testcontainers.postgres import PostgresContainer
+
+from datacontract.data_contract import DataContract
+from datacontract.model.run import ResultEnum
+
+postgres = PostgresContainer("postgres:16")
+
+
+@pytest.fixture(scope="function")
+def postgres_container(request):
+    postgres.start()
+    request.addfinalizer(postgres.stop)
+
+
+def test_failing_minimum_check_attaches_row_sample(postgres_container, monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_POSTGRES_USERNAME", postgres.username)
+    monkeypatch.setenv("DATACONTRACT_POSTGRES_PASSWORD", postgres.password)
+    _init_sql("fixtures/quality-samples/data/data.sql")
+
+    data_contract_str = _setup_datacontract("fixtures/quality-samples/datacontract.yaml")
+    run = DataContract(data_contract_str=data_contract_str).test()
+
+    assert run.result == ResultEnum.failed
+
+    minimum_check = next(
+        (c for c in run.checks if c.type == "field_minimum" and c.field == "order_total"),
+        None,
+    )
+    assert minimum_check is not None, "Expected a field_minimum check on order_total"
+    assert minimum_check.result == ResultEnum.failed
+
+    # Structured samples: the bad row should be captured with its actual values.
+    assert minimum_check.failed_rows_samples, (
+        "Expected failed_rows_samples to contain at least the offending row, "
+        f"got: {minimum_check.failed_rows_samples!r}"
+    )
+    sample = minimum_check.failed_rows_samples[0]
+    assert sample.get("order_id") == "O-BAD123"
+    assert str(sample.get("order_total")) == "-5" or str(sample.get("order_total")) == "-5.0"
+
+    # Inline summary in reason: user should see the offending value without
+    # needing to open the JSON output.
+    assert "order_total" in minimum_check.reason
+    assert "-5" in minimum_check.reason
+
+
+def _setup_datacontract(file):
+    with open(file) as f:
+        data_contract_str = f.read()
+    port = postgres.get_exposed_port(5432)
+    return data_contract_str.replace("5432", str(port))
+
+
+def _init_sql(file_path):
+    import psycopg2
+
+    connection = psycopg2.connect(
+        database=postgres.dbname,
+        user=postgres.username,
+        password=postgres.password,
+        host=postgres.get_container_host_ip(),
+        port=postgres.get_exposed_port(5432),
+    )
+    try:
+        with connection.cursor() as cursor, open(file_path) as f:
+            cursor.execute(f.read())
+        connection.commit()
+    finally:
+        connection.close()


### PR DESCRIPTION
Closes #1180.

## Summary
- When a field quality check fails, we now attach up to 5 sample failing rows to the `Check`, so the offending values show up directly in the JSON / JUnit output and inline in the check's `reason` — no more re-running SQL by hand to figure out what broke.
- Works by injecting `samples limit: N` into the sodacl we already generate, then re-executing Soda's own `failing_sql` query via its connection and attaching the rows.
- Best-effort: if sample capture fails for any reason (non-SQL backend, connection blip, etc.) we log a warning and the check is otherwise untouched.

## Test plan
- [x] New integration test `tests/test_test_quality_samples.py` — postgres container, bad row `{order_id: O-BAD123, order_total: -5}` captured in `failed_rows_samples` and surfaced inline in `reason`.
- [x] Ran existing `test_test_postgres.py` and `test_test_quality.py` — no regressions.
- [x] `ruff check` / `ruff format` clean.