### PR TITLE
fix(duckdb): use explicit contract schema columns for CSV/Parquet reads (#1065)

### DIFF
--- a/datacontract/engines/soda/connections/duckdb_connection.py
+++ b/datacontract/engines/soda/connections/duckdb_connection.py
@@ -97,19 +97,13 @@ def create_view_with_schema_union(con, schema_obj: SchemaObject, model_path: str
         create_empty_table = f"""CREATE TABLE "{model_name}" ({", ".join(columns_def)});"""
         con.sql(create_empty_table)
 
-        # Read columns existing in both current data contract and data
-        intersecting_columns = con.sql(f"""SELECT column_name
-            FROM (DESCRIBE SELECT * FROM {read_function}('{model_path}', union_by_name=true, hive_partitioning=1))
-            INTERSECT SELECT column_name
-            FROM information_schema.columns
-            WHERE table_name = '{model_name}'""").fetchall()
-
-        # Insert data into table by name, but only columns existing in contract and data
-        if intersecting_columns:
-            selected_columns = ", ".join(f'"{column[0]}"' for column in intersecting_columns)
-            insert_data_sql = f"""INSERT INTO "{model_name}" BY NAME
-                (SELECT {selected_columns} FROM {read_function}('{model_path}', union_by_name=true, hive_partitioning=1));"""
-            con.sql(insert_data_sql)
+        # Build explicit SELECT using contract schema columns.
+        # Missing columns in the data file will be NULL — this allows the
+        # "required column missing" field_is_present check to catch them.
+        selected_columns = ", ".join(f'"{col_name}"' for col_name in converted_types.keys())
+        insert_data_sql = f"""INSERT INTO "{model_name}" BY NAME
+            (SELECT {selected_columns} FROM {read_function}('{model_path}', union_by_name=true, hive_partitioning=1));"""
+        con.sql(insert_data_sql)
     else:
         # Fallback
         con.sql(


### PR DESCRIPTION
## Summary
Fixes #1065 — `field_is_present` check always passes for CSV/Parquet files because the current implementation compares row counts instead of checking actual column overlap. Uses explicit SELECT of contract schema columns so missing data columns = NULL, allowing `field_is_present` to catch them.

## Changes
- Modified `create_view_with_schema_union` in `datacontract/engines/soda/connections/duckdb_connection.py`
- Previously used INTERSECT to find columns in both contract and data (missing contract columns were silently ignored)
- Now explicitly SELECTs contract schema columns by name, so missing data columns become NULL

## Testing
- All existing tests pass