### PR TITLE
fix(test): return non-zero exit code on connection errors

### DIFF
--- a/datacontract/engines/soda/check_soda_execute.py
+++ b/datacontract/engines/soda/check_soda_execute.py
@@ -196,7 +196,7 @@ def check_soda_execute(
             Check(
                 type="general",
                 name="Data Contract Tests",
-                result=ResultEnum.warning,
+                result=ResultEnum.error,
                 reason="Engine soda-core has errors. See the logs for details.",
                 engine="soda-core",
             )


### PR DESCRIPTION
## Problem

When `datacontract test` runs against a server that is unreachable or has wrong credentials, soda-core logs errors (e.g. "Could not connect to data source", "connection refused") but the CLI exits with code 0. This causes CI pipelines to silently pass for contracts with broken server configurations.

## Root Cause

In `check_soda_execute()`, when `scan.has_error_logs()` is true (which includes connection failures and auth errors), the appended check uses `ResultEnum.warning`. Since warnings do not trigger a non-zero exit code in `write_test_result()`, the process exits cleanly.

## Fix

Change the result from `ResultEnum.warning` to `ResultEnum.error` when soda-core reports error logs. This ensures:

1. `run.finish()` sets overall result to `"error"` 
2. `write_test_result()` hits the error branch and calls `raise typer.Exit(code=1)`

## Repro (from issue)

```yaml
dataContractSpecification: 1.2.1
id: unreach
info: {title: T, version: 0.0.1, owner: t}
servers:
  s: {type: postgres, host: 127.0.0.1, port: 15999, database: x, schema: public}
models:
  m: {type: table, fields: {f: {type: varchar, required: true}}}
```

```
$ datacontract test contract.yaml
ERROR:soda.scan: Could not connect to data source "postgres": connection refused
WARNING:soda.scan: No valid checks found, 0 checks evaluated.
$ echo $?   # Before: 0, After: 1
```

Fixes #1179