### PR TITLE
fix(soda): detect missing columns in CSV/Parquet files via field_is_present

### DIFF
--- a/datacontract/engines/soda/check_soda_execute.py
+++ b/datacontract/engines/soda/check_soda_execute.py
@@ -163,18 +163,23 @@ def check_soda_execute(
                 if schema_name != "all" and model_name != schema_name:
                     continue
                 try:
-                    cols = con.sql(f"SELECT column_name FROM information_schema.columns WHERE table_name = '{model_name}'").fetchall()
+                    cols = con.sql(
+                        f"SELECT column_name FROM information_schema.columns WHERE table_name = '{model_name}'"
+                    ).fetchall()
                     table_columns[model_name] = {row[0] for row in cols}
                 except Exception:
                     pass
             if table_columns:
                 filtered_checks = []
                 for check in run.checks:
-                    if (check.engine == "soda" and check.language == "sodacl"
-                            and check.model in table_columns
-                            and check.field
-                            and check.field not in table_columns[check.model]
-                            and check.type != "field_is_present"):
+                    if (
+                        check.engine == "soda"
+                        and check.language == "sodacl"
+                        and check.model in table_columns
+                        and check.field
+                        and check.field not in table_columns[check.model]
+                        and check.type != "field_is_present"
+                    ):
                         # Constraint/quality check for missing column — record as failed,
                         # exclude from SodaCL to avoid SQL errors
                         check.result = ResultEnum.failed

--- a/datacontract/engines/soda/check_soda_execute.py
+++ b/datacontract/engines/soda/check_soda_execute.py
@@ -150,6 +150,39 @@ def check_soda_execute(
         run.log_warn(f"Server type {server.type} not yet supported by datacontract CLI")
         return
 
+    # For local/csv/parquet servers using DuckDB, filter out constraint/quality
+    # checks that reference columns not present in the actual data file. These
+    # columns were dropped during table setup (see create_view_with_schema_union).
+    # field_is_present checks are intentionally left in — Soda will correctly
+    # detect the missing column and report them as failed.
+    if server.type in ["s3", "gcs", "azure", "local"] and server.format in ["csv", "parquet"]:
+        if data_contract.schema_:
+            table_columns = {}
+            for schema_obj in data_contract.schema_:
+                model_name = schema_obj.name
+                if schema_name != "all" and model_name != schema_name:
+                    continue
+                try:
+                    cols = con.sql(f"SELECT column_name FROM information_schema.columns WHERE table_name = '{model_name}'").fetchall()
+                    table_columns[model_name] = {row[0] for row in cols}
+                except Exception:
+                    pass
+            if table_columns:
+                filtered_checks = []
+                for check in run.checks:
+                    if (check.engine == "soda" and check.language == "sodacl"
+                            and check.model in table_columns
+                            and check.field
+                            and check.field not in table_columns[check.model]
+                            and check.type != "field_is_present"):
+                        # Constraint/quality check for missing column — record as failed,
+                        # exclude from SodaCL to avoid SQL errors
+                        check.result = ResultEnum.failed
+                        check.reason = f"Column '{check.field}' not found in data file"
+                        continue
+                    filtered_checks.append(check)
+                run.checks = filtered_checks
+
     sodacl_yaml_str = to_sodacl_yaml(run)
     # print("sodacl_yaml_str:\n" + sodacl_yaml_str)
     scan.add_sodacl_yaml_str(sodacl_yaml_str)

--- a/datacontract/engines/soda/connections/duckdb_connection.py
+++ b/datacontract/engines/soda/connections/duckdb_connection.py
@@ -110,6 +110,15 @@ def create_view_with_schema_union(con, schema_obj: SchemaObject, model_path: str
             insert_data_sql = f"""INSERT INTO "{model_name}" BY NAME
                 (SELECT {selected_columns} FROM {read_function}('{model_path}', union_by_name=true, hive_partitioning=1));"""
             con.sql(insert_data_sql)
+
+        # Drop columns that don't exist in the data file so field_is_present
+        # correctly detects missing columns (schema-only columns would be all-NULL,
+        # causing the check to incorrectly pass)
+        schema_column_names = set(converted_types.keys())
+        data_column_names = {col[0] for col in intersecting_columns}
+        missing_from_data = schema_column_names - data_column_names
+        for col_name in missing_from_data:
+            con.sql(f'ALTER TABLE "{model_name}" DROP COLUMN "{col_name}";')
     else:
         # Fallback
         con.sql(

--- a/tests/test_test_schema_evolution.py
+++ b/tests/test_test_schema_evolution.py
@@ -2,15 +2,16 @@ from datacontract.data_contract import DataContract
 
 
 def test_csv_optional_field_missing_from_old_data():
-    """Optional field not present in historical CSV data should pass validation"""
+    """Optional field not present in historical CSV data should fail field_is_present check"""
     data_contract = DataContract(
         data_contract_file="fixtures/schema-evolution/odcs-datacontract-cities-version-2.yaml", server="historical-csv"
     )
 
     run = data_contract.test()
 
-    assert run.result == "passed"
-    assert all(check.result == "passed" for check in run.checks)
+    # field_is_present should detect that 'population' is missing from the CSV
+    assert run.result == "failed"
+    assert any(check.result == "failed" and check.type == "field_is_present" for check in run.checks)
 
 
 def test_csv_optional_field_present_in_new_data():
@@ -67,7 +68,7 @@ def test_csv_required_field_missing_fails():
 
 
 def test_parquet_optional_field_missing_from_old_data():
-    """Optional field not present in historical Parquet data should pass validation"""
+    """Optional field not present in historical Parquet data should fail field_is_present check"""
     data_contract = DataContract(
         data_contract_file="fixtures/schema-evolution/odcs-datacontract-cities-version-2.yaml",
         server="historical-parquet",
@@ -75,8 +76,9 @@ def test_parquet_optional_field_missing_from_old_data():
 
     run = data_contract.test()
 
-    assert run.result == "passed"
-    assert all(check.result == "passed" for check in run.checks)
+    # field_is_present should detect that 'population' is missing from the Parquet file
+    assert run.result == "failed"
+    assert any(check.result == "failed" and check.type == "field_is_present" for check in run.checks)
 
 
 def test_parquet_optional_field_present_in_new_data():


### PR DESCRIPTION
## Summary

Fixes #1065 — **`field_is_present` always passes for CSV/Parquet files even when the column is missing from the data.**

## Root Cause

In `create_view_with_schema_union()`, when reading CSV/Parquet files via DuckDB, all columns from the datacontract schema are created in the table (even if they don't exist in the actual data file). Missing columns are filled with NULL values. Soda's `when required column missing` check only verifies column existence in the table — so it always passes, regardless of whether the column was actually in the source file.

## Fix

**Two coordinated changes:**

1. **`duckdb_connection.py`**: After inserting data into the schema-based table, drop any columns that don't exist in the source data file. This ensures Soda's `field_is_present` check correctly detects missing columns.

2. **`check_soda_execute.py`**: Before running Soda scans, pre-filter constraint/quality checks (e.g., `field_required`, `field_minimum`) that reference dropped columns. These are marked as **failed** with reason `"Column X not found in data file"` and excluded from the SodaCL YAML to prevent SQL errors. `field_is_present` checks are intentionally left in so Soda can evaluate them normally (and correctly report them as failed).

## Test Updates

Updated 2 tests to reflect the corrected behavior:
- `test_csv_optional_field_missing_from_old_data` — now expects `field_is_present` failure for missing optional field
- `test_parquet_optional_field_missing_from_old_data` — same for Parquet

All 10 schema evolution tests pass.