### PR TITLE
Revert dbml import flag rename; make --schema a deprecated alias for --json-schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- make `--schema` a deprecated alias for `--json-schema` to (will be removed in v0.13.0)
+
 ## [0.12.0] - 2026-04-20
 
 This release introduces several changes to improve the usability of `datacontract-cli` for AI Agents.
@@ -15,7 +17,7 @@ This release introduces several changes to improve the usability of `datacontrac
 
   | Command                                    | Old option                                    | New option                             |
   |--------------------------------------------|-----------------------------------------------|----------------------------------------|
-  | `lint`, `test`, `ci`, `publish`, `catalog` | `--schema <PATH>`                             | `--json-schema <PATH>`                 |
+  | `lint`, `test`, `ci`, `publish`, `catalog` | `--schema <PATH>` (will work until v0.13.0)   | `--json-schema <PATH>`                 |
   | `export`, `import`                         | `--format <FORMAT> <OPTIONS>`                 | `<FORMAT> <OPTIONS>` (drop `--format`) |
   | **Export options:**                        |                                               |                                        |
   | `export --format dbt`                      | `--format dbt`                                | `dbt-models` (format renamed)          |
@@ -25,13 +27,15 @@ This release introduces several changes to improve the usability of `datacontrac
   | `export --format sql-query`                | `--sql-server-type <TYPE>`                    | `--dialect <TYPE>`                     |
   | **Import options:**                        |                                               |                                        |
   | `import --format bigquery`                 | `--bigquery-[project\|dataset\|table] <NAME>` | `--[project\|dataset\|table] <NAME>`   |
-  | `import --format dbml`                     | `--dbml-[schema\|table] <NAME>`               | `--[schema\|table] <NAME>`             |
   | `import --format dbt`                      | `--dbt-model <NAME>`                          | `--model <NAME>`                       |
   | `import --format glue`                     | `--source <NAME>`, `--glue-table <NAME>`      | `--database <NAME>`, `--table <NAME>`  |
   | `import --format iceberg`                  | `--iceberg-table <NAME>`                      | `--table <NAME>`                       |
   | `import --format unity`                    | `--unity-table-full-name <NAME>`              | `--table <NAME>`                       |
   | `import --format spark`                    | `--source <NAMES>`                            | `--tables <NAMES>`                     |
   | `import`                                   | `--template`                                  | dropped (was a no-op)                  |
+
+The `--schema` option (referring to the ODCS JSON schema) was renamed to `--json-schema` to avoid confusion with `--schema-name`, which refers to the schema within the data contract to test for.
+
 - Error messages for uncaught exceptions are shortened now. Pass `--debug` (or set `DATACONTRACT_CLI_DEBUG=1`) to see the full traceback. (#1175)
 - Add example calls to `--help` outputs (#1176)
 - Add explicit errors when required env vars for soda connections are missing (#1177)

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -32,8 +32,6 @@ class OrderedCommandsWithMigrationHints(OrderedCommands):
         "--bigquery-table": "--table",
         "--unity-table-full-name": "--table",
         "--dbt-model": "--model",
-        "--dbml-schema": "--schema",
-        "--dbml-table": "--table",
         "--glue-table": "--table",
         "--iceberg-table": "--table",
     }
@@ -42,29 +40,38 @@ class OrderedCommandsWithMigrationHints(OrderedCommands):
         # First positional argument
         subcommand = next((a for a in args if isinstance(a, str) and not a.startswith("-")), None)
 
+        rewritten_args = []
         for arg in args:
             if isinstance(arg, str) and arg.startswith("--"):
-                flag = arg.split("=", 1)[0]
+                flag, _, value = arg.partition("=")
+                if flag == "--schema":
+                    typer.secho(
+                        "Warning: --schema was replaced with --json-schema in v0.12.0 and will be removed in v0.13.0.",
+                        err=True,
+                        fg=typer.colors.YELLOW,
+                    )
+                    rewritten_args.append(f"--json-schema={value}" if value else "--json-schema")
+                    continue
                 if flag in self.RENAMED_FLAGS:
                     new_flag = self.RENAMED_FLAGS[flag]
-                elif flag == "--schema" and subcommand != "dbml":
-                    new_flag = "--json-schema"
                 elif flag == "--source" and subcommand == "glue":
                     new_flag = "--database"
                 elif flag == "--source" and subcommand == "spark":
                     new_flag = "--tables"
                 else:
+                    rewritten_args.append(arg)
                     continue
                 change = "needs to be omitted since" if new_flag is None else f"was replaced with {new_flag} in"
                 ctx.fail(
                     f"{flag} {change} v0.12.0 of datacontract-cli. "
                     f"See https://github.com/datacontract/datacontract-cli/releases/tag/v0.12.0"
                 )
-        return super().parse_args(ctx, args)
+            rewritten_args.append(arg)
+        return super().parse_args(ctx, rewritten_args)
 
 
 app = typer.Typer(
-    cls=OrderedCommands,
+    cls=OrderedCommandsWithMigrationHints,
     no_args_is_help=True,
     add_completion=False,
 )

--- a/datacontract/command_import.py
+++ b/datacontract/command_import.py
@@ -128,13 +128,15 @@ def import_dbml(
     schema: Annotated[
         Optional[List[str]],
         typer.Option(
-            help="List of schema names to import from the DBML file (repeat for multiple schema names, leave empty for all tables in the file)."
+            "--dbml-schema",
+            help="List of schema names to import from the DBML file (repeat for multiple schema names, leave empty for all tables in the file).",
         ),
     ] = None,
     table: Annotated[
         Optional[List[str]],
         typer.Option(
-            help="List of table names to import from the DBML file (repeat for multiple table names, leave empty for all tables in the file)."
+            "--dbml-table",
+            help="List of table names to import from the DBML file (repeat for multiple table names, leave empty for all tables in the file).",
         ),
     ] = None,
     output: output_option = None,

--- a/tests/test_import_dbml.py
+++ b/tests/test_import_dbml.py
@@ -30,9 +30,9 @@ def test_cli_with_filters():
             "dbml",
             "--source",
             "fixtures/dbml/import/dbml.txt",
-            "--schema",
+            "--dbml-schema",
             "test",
-            "--table",
+            "--dbml-table",
             "foo",
         ],
     )


### PR DESCRIPTION
## Summary
- Revert the v0.12.0 rename of `import dbml` options — `--schema`/`--table` are back to `--dbml-schema`/`--dbml-table`
- Accept `--schema` everywhere as a deprecated alias for `--json-schema` with a warning on stderr; removal planned for v0.13.0
- Update CHANGELOG (remove the dbml row from the v0.12.0 migration table; note the alias in Unreleased)

## Test plan
- [x] `pytest tests/test_cli.py tests/test_import_dbml.py tests/test_export_jsonschema.py` passes
- [x] `datacontract import dbml --source ... --dbml-schema X --dbml-table Y` works
- [x] `datacontract lint --schema <path> ...` prints the deprecation warning and proceeds as if `--json-schema` was passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)