### PR TITLE
fix(engines): correct swapped check_type labels for SQL quality checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- `changelog` command help text now advertises `(url or path)` for V1/V2 arguments, clarifying that HTTP/HTTPS URLs are accepted (closes #1162)
+- `changelog` command help text now advertises `(url or path)` for V1/V2 arguments, clarifying that HTTP/HTTPS URLs are accepted (#1162)
 - **breaking:** `test` command now exits non-zero when a server is specified, but soda-core fails to connect or authenticate (#1181)
+- correct swapped `check_type` labels  `model_qualty_sql` and `field_quality_sql` (#1187)
 
 ## [0.12.1] - 2026-04-21
 

--- a/datacontract/engines/data_contract_checks.py
+++ b/datacontract/engines/data_contract_checks.py
@@ -750,10 +750,10 @@ def check_quality_list(
         elif quality.type == "sql":
             if property_name is None:
                 check_key = f"{schema_name}__quality_sql_{count}"
-                check_type = "field_quality_sql"
+                check_type = "model_quality_sql"
             else:
                 check_key = f"{schema_name}__{property_name}__quality_sql_{count}"
-                check_type = "model_quality_sql"
+                check_type = "field_quality_sql"
             threshold = to_sodacl_threshold(quality)
             query = prepare_query(quality, schema_name, property_name, quoting_config, server)
             if query is None:


### PR DESCRIPTION
## Summary

In `check_quality_list()`, the `check_type` labels for SQL quality checks are swapped:

- When `property_name is None` (model-level check), the type was set to `"field_quality_sql"` (incorrect)
- When `property_name` is set (field-level check), the type was set to `"model_quality_sql"` (incorrect)

This swaps them so that model-level SQL quality checks get `"model_quality_sql"` and field-level ones get `"field_quality_sql"`.

## Details

**File:** `datacontract/engines/data_contract_checks.py`

The bug is a simple label swap on lines 753/756. The logic correctly distinguishes model vs field level by checking `property_name is None`, but the assigned `check_type` strings were reversed.

**Before:**
```python
if property_name is None:
    check_type = "field_quality_sql"    # wrong
else:
    check_type = "model_quality_sql"    # wrong
```

**After:**
```python
if property_name is None:
    check_type = "model_quality_sql"    # correct
else:
    check_type = "field_quality_sql"    # correct
```