### PR TITLE
docs: advertise URL support in changelog command help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- `changelog` command help text now advertises `(url or path)` for V1/V2 arguments, clarifying that HTTP/HTTPS URLs are accepted (closes #1162)
+
 ## [0.12.1] - 2026-04-21
 
 ### Fixed

--- a/datacontract/command_changelog.py
+++ b/datacontract/command_changelog.py
@@ -11,8 +11,8 @@ from datacontract.output.text_changelog_results import write_text_changelog_resu
     epilog="Example: datacontract changelog datacontract-v1.yaml datacontract-v2.yaml",
 )
 def changelog(
-    v1: Annotated[str, typer.Argument(help="The location (path) of the source (before) data contract YAML.")],
-    v2: Annotated[str, typer.Argument(help="The location (path) of the target (after) data contract YAML.")],
+    v1: Annotated[str, typer.Argument(help="The location (url or path) of the source (before) data contract YAML.")],
+    v2: Annotated[str, typer.Argument(help="The location (url or path) of the target (after) data contract YAML.")],
     debug: debug_option = None,
 ):
     """Show a changelog between two data contracts."""


### PR DESCRIPTION
## Summary

- Updates the `changelog` command's `V1` and `V2` argument help text from `(path)` to `(url or path)`

The capability to pass HTTP/HTTPS URLs as inputs to `datacontract changelog` already exists — `DataContract` resolves both local files and remote URLs transparently. The help text incorrectly implied file paths only, which led users (see #1162) to believe URLs were unsupported and report a feature request.

## Changes

- `datacontract/command_changelog.py` — `(path)` → `(url or path)` for both `V1` and `V2` argument descriptions

## Test plan

- [x] `datacontract changelog --help` shows `(url or path)` for both arguments
- [x] `datacontract changelog https://... https://...` works end-to-end against publicly accessible contract URLs

## Checklist

- [x] Tests pass (`uv run pytest`)
- [x] Code formatted (`uv run ruff format`)
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added

Closes #1162