### PR TITLE
ci: pin mysql-connector-python<9.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ kafka = [
 
 mysql = [
   "soda-core-mysql>=3.3.20,<3.6.0",
-  "mysql-connector-python>=8.0.30,<10.0.0",
+  "mysql-connector-python>=8.0.30,<9.7.0",
 ]
 
 postgres = [
@@ -175,7 +175,7 @@ build-backend = "setuptools.build_meta"
 # protobuf<=3.20.1, conflicting with dbt-core. Newer mysql-connector-python (9.x)
 # works fine with soda and resolves the conflict. See: https://github.com/sodadata/soda-core/issues/2515
 override-dependencies = [
-    "mysql-connector-python>=8.0.30,<10.0.0",
+    "mysql-connector-python>=8.0.30,<9.7.0",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary
- 9.7.0 published cp310 Linux wheels only — no manylinux for cp311/cp312+, no sdist
- uv fails to install it on the 3.11/3.12 Linux CI jobs and on the lint job
- Pinning below 9.7.0 lets uv resolve back to 9.6.0 (full wheel matrix)

## Test plan
- [ ] CI passes on 3.10 / 3.11 / 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)