### PR TITLE
Fix/trino http scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Add `http_scheme` support for Trino connections, allowing HTTP or HTTPS to be configured via server config or `model_extra`
+- Propagate `http_scheme` field when importing DCS servers to ODCS format
+
 ### Fixed
 - `changelog` command help text now advertises `(url or path)` for V1/V2 arguments, clarifying that HTTP/HTTPS URLs are accepted (#1162)
 - **breaking:** `test` command now exits non-zero when a server is specified, but soda-core fails to connect or authenticate (#1181)

--- a/datacontract/engines/soda/connections/trino.py
+++ b/datacontract/engines/soda/connections/trino.py
@@ -9,7 +9,13 @@ def to_trino_soda_configuration(server):
     # trino always needs a user for session headers; password missing falls back to NoAuthentication.
     username = require_env("DATACONTRACT_TRINO_USERNAME", server_type="trino")
     password = os.getenv("DATACONTRACT_TRINO_PASSWORD")
-
+    
+    http_scheme = getattr(server, "http_scheme", None)
+    if http_scheme is None and hasattr(server, "model_extra") and server.model_extra:
+        http_scheme = server.model_extra.get("http_scheme", "https")
+    if http_scheme is None:
+        http_scheme = "https"
+    
     data_source = {
         "type": "trino",
         "host": server.host,
@@ -18,7 +24,8 @@ def to_trino_soda_configuration(server):
         "password": password,
         "catalog": server.catalog,
         "schema": server.schema_,
-    }
+        "http_scheme": http_scheme,
+        }
 
     if password is None or password == "":
         data_source["auth_type"] = "NoAuthentication"  # default is BasicAuthentication

--- a/datacontract/imports/dcs_importer.py
+++ b/datacontract/imports/dcs_importer.py
@@ -174,6 +174,8 @@ def _convert_servers(dcs_servers: Dict[str, DCSServer]) -> List[ODCSServer]:
             odcs_server.port = dcs_server.port
         if dcs_server.catalog:
             odcs_server.catalog = dcs_server.catalog
+        if dcs_server.http_scheme:
+            odcs_server.http_scheme = dcs_server.http_scheme
         if dcs_server.description:
             odcs_server.description = dcs_server.description
         if dcs_server.roles:


### PR DESCRIPTION
### Summary

This PR add `http_scheme` propertie for fixes an issue where the `http_scheme` defined in `data-contract.yml` was ignored during the conversion from DCS to ODCS.

Trino connections in soda-core are `https`, even when `http` was explicitly configured. This breaks common local and non-SSL setups.

### Root Cause

Although `http_scheme` is a valid field in the Data Contract specification, it was not being propagated during the internal model transformation (DCS → ODCS). Consequently, the value never reached the connection layer in soda-core.

### Changes

* Added `http_scheme` to the `Server` model in both:

  * DCS (Data Contract Specification)
  * ODCS (Operational Data Contract Specification)
* Fixed the mapping logic to ensure the field is preserved during DCS → ODCS conversion
* Ensured the value is correctly passed to the soda-core connection layer

### Why this matters

The Trino connector in soda-core supports `http_scheme="http"` as the official way to connect to instances without SSL (e.g., local environments), as seen in:

* [`trino_data_source_connection.py`](https://github.com/sodadata/soda-core/blob/main/soda-trino/src/soda_trino/common/data_sources/trino_data_source_connection.py#L24)

Without this fix, users cannot connect to:

* Local Trino instances
* Test environments without HTTPS
* Custom deployments without SSL/Auth

### Example

```yaml
server:
  host: localhost
  port: 8080
  http_scheme: http
```

Before this fix:

* `http_scheme` was ignored → connection attempted via `https`

After this fix:

* `http_scheme` is respected → connection uses `http` as expected

### Impact

* Enables local development workflows with Trino

- [x] Tests pass (`uv run pytest`)
- [x] Code formatted (`uv run ruff format`)
- ~~[ ] README.md updated (if relevant)~~
- [x] CHANGELOG.md entry added
