### PR TITLE
Fixed import sql ignoring multiple tables in a ddl file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** `test` command now exits non-zero when a server is specified, but soda-core fails to connect or authenticate (#1181)
 - correct swapped `check_type` labels  `model_qualty_sql` and `field_quality_sql` (#1187)
 - `import spark` now emits a native Spark SQL physicalType (e.g. `string`) instead of Python repr (e.g. `StringType()`). Contracts imported using Spark in v0.11.0–v0.12.1 did not perform type checks and must be re-imported. (#1048)
+- Fixed issue where `import sql` would only import a single table from a sql ddl file even if multiple were defined
+- Added additional type conversions for mysql for BIGINT, TINYINT, SMALLINT, and handling of int(10) format
 
 ## [0.12.1] - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Added additional type conversions for mysql for BIGINT, TINYINT, SMALLINT, and handling of int(10) format
+
 ### Fixed
 - `changelog` command help text now advertises `(url or path)` for V1/V2 arguments, clarifying that HTTP/HTTPS URLs are accepted (#1162)
 - **breaking:** `test` command now exits non-zero when a server is specified, but soda-core fails to connect or authenticate (#1181)
 - correct swapped `check_type` labels  `model_qualty_sql` and `field_quality_sql` (#1187)
 - `import spark` now emits a native Spark SQL physicalType (e.g. `string`) instead of Python repr (e.g. `StringType()`). Contracts imported using Spark in v0.11.0–v0.12.1 did not perform type checks and must be re-imported. (#1048)
 - Fixed issue where `import sql` would only import a single table from a sql ddl file even if multiple were defined
-- Added additional type conversions for mysql for BIGINT, TINYINT, SMALLINT, and handling of int(10) format
 
 ## [0.12.1] - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - correct swapped `check_type` labels  `model_qualty_sql` and `field_quality_sql` (#1187)
 - `import spark` now emits a native Spark SQL physicalType (e.g. `string`) instead of Python repr (e.g. `StringType()`). Contracts imported using Spark in v0.11.0–v0.12.1 did not perform type checks and must be re-imported. (#1048)
 - Fixed issue where `import sql` would only import a single table from a sql ddl file even if multiple were defined
+- Fixed issue where foreign key constraint in sql ddl was creating duplicate table entries during on `import sql` action
 
 ## [0.12.1] - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added additional type conversions for mysql for BIGINT, TINYINT, SMALLINT, and handling of int(10) format
+- Add support for composite primary keys during SQL import
 
 ### Fixed
 - `changelog` command help text now advertises `(url or path)` for V1/V2 arguments, clarifying that HTTP/HTTPS URLs are accepted (#1162)

--- a/datacontract/imports/sql_importer.py
+++ b/datacontract/imports/sql_importer.py
@@ -311,7 +311,7 @@ def map_type_from_sql(sql_type: str) -> tuple[str, str | None]:
         return ("integer", None)
     elif sql_type_normed.startswith("smallint"):
         return ("integer", None)
-    elif re.search(r"^(small)?int(\(\d+\))?(\sunsigned)?$", sql_type_normed):         # Looking for format int(10)
+    elif re.search(r"^(small)?int(\(\d+\))?(\sunsigned)?$", sql_type_normed):  # Looking for format int(10)
         return ("integer", None)
     elif sql_type_normed.startswith("tinyint") and not sql_type_normed.startswith("tinyint(1)"):
         return ("integer", None)
@@ -329,7 +329,7 @@ def map_type_from_sql(sql_type: str) -> tuple[str, str | None]:
         return ("number", None)
     elif sql_type_normed.startswith("money"):
         return ("number", None)
-    elif re.search(r"^bigint(\(\d+\))?", sql_type_normed):         # Looking for format bigint(10)
+    elif re.search(r"^bigint(\(\d+\))?", sql_type_normed):  # Looking for format bigint(10)
         return ("number", None)
     elif sql_type_normed.startswith("bool"):
         return ("boolean", None)

--- a/datacontract/imports/sql_importer.py
+++ b/datacontract/imports/sql_importer.py
@@ -309,8 +309,6 @@ def map_type_from_sql(sql_type: str) -> tuple[str, str | None]:
         return ("integer", None)
     elif sql_type_normed.endswith("integer"):
         return ("integer", None)
-    elif sql_type_normed.startswith("smallint"):
-        return ("integer", None)
     elif re.search(r"^(small)?int(\(\d+\))?(\sunsigned)?$", sql_type_normed):  # Looking for format int(10)
         return ("integer", None)
     elif sql_type_normed.startswith("tinyint") and not sql_type_normed.startswith("tinyint(1)"):

--- a/datacontract/imports/sql_importer.py
+++ b/datacontract/imports/sql_importer.py
@@ -80,6 +80,12 @@ def import_sql(source: str, import_args: dict = None) -> OpenDataContractStandar
                 column for column in parsed.find_all(sqlglot.exp.ColumnDef) if column.parent.this.name == table_name
             ]
 
+            primary_keys = [
+                expression.name
+                for key in parsed.find_all(sqlglot.expressions.PrimaryKey)
+                for expression in key.expressions
+            ]
+
             # table foreign keys were duplicating the referenced tables-- so only include tables with columns
             if columns:
                 primary_key_position = 1
@@ -90,7 +96,7 @@ def import_sql(source: str, import_args: dict = None) -> OpenDataContractStandar
                     col_description = get_description(column)
                     max_length = get_max_length(column)
                     precision, scale = get_precision_scale(column)
-                    is_primary_key = get_primary_key(column)
+                    is_primary_key = get_primary_key(column, primary_keys)
                     is_required = column.find(sqlglot.exp.NotNullColumnConstraint) is not None or None
                     tags = get_tags(column)
 
@@ -139,7 +145,12 @@ def import_sql(source: str, import_args: dict = None) -> OpenDataContractStandar
     return odcs
 
 
-def get_primary_key(column) -> bool | None:
+def get_primary_key(column, table_primary_keys=None) -> bool | None:
+    col_name = column.this.name
+    if table_primary_keys is None:
+        table_primary_keys = []
+    if col_name in table_primary_keys:
+        return True
     if column.find(sqlglot.exp.PrimaryKeyColumnConstraint) is not None:
         return True
     if column.find(sqlglot.exp.PrimaryKey) is not None:

--- a/datacontract/imports/sql_importer.py
+++ b/datacontract/imports/sql_importer.py
@@ -88,7 +88,7 @@ def import_sql(source: str, import_args: dict = None) -> OpenDataContractStandar
 
             # table foreign keys were duplicating the referenced tables-- so only include tables with columns
             if columns:
-                primary_key_position = 1
+                column_primary_key_index = 1
                 for column in columns:
                     col_name = column.this.name
                     col_type = to_col_type(column, dialect)
@@ -99,6 +99,12 @@ def import_sql(source: str, import_args: dict = None) -> OpenDataContractStandar
                     is_primary_key = get_primary_key(column, primary_keys)
                     is_required = column.find(sqlglot.exp.NotNullColumnConstraint) is not None or None
                     tags = get_tags(column)
+
+                    # Primary key can be defined at the column level OR table level.  If defined at the table level
+                    # use the index rather than the position of the columns to define primary key position.
+                    primary_key_position = column_primary_key_index
+                    if is_primary_key and col_name in primary_keys:
+                        primary_key_position = primary_keys.index(col_name) + 1
 
                     prop = create_property(
                         name=col_name,
@@ -116,7 +122,7 @@ def import_sql(source: str, import_args: dict = None) -> OpenDataContractStandar
                     )
 
                     if is_primary_key:
-                        primary_key_position += 1
+                        column_primary_key_index += 1
 
                     properties.append(prop)
 

--- a/datacontract/imports/sql_importer.py
+++ b/datacontract/imports/sql_importer.py
@@ -42,7 +42,7 @@ def import_sql(source: str, import_args: dict = None) -> OpenDataContractStandar
     dialect = to_dialect(import_args)
 
     try:
-        parsed = sqlglot.parse_one(sql=sql, read=dialect)
+        parsed_statements = sqlglot.parse(sql=sql, read=dialect)
     except Exception as e:
         logging.error(f"Error sqlglot SQL: {str(e)}")
         raise DataContractException(
@@ -65,72 +65,73 @@ def import_sql(source: str, import_args: dict = None) -> OpenDataContractStandar
             "Update host, port, database, and schema in the output before use."
         )
 
-    tables = [
-        t
-        for t in parsed.find_all(sqlglot.expressions.Table)
-        if isinstance(t.find_ancestor(sqlglot.expressions.Create), sqlglot.expressions.Create)
-    ]
+    for parsed in parsed_statements:
+        tables = [
+            t
+            for t in parsed.find_all(sqlglot.expressions.Table)
+            if isinstance(t.find_ancestor(sqlglot.expressions.Create), sqlglot.expressions.Create)
+        ]
 
-    for table in tables:
-        table_name = table.this.name
-        properties = []
+        for table in tables:
+            table_name = table.this.name
+            properties = []
 
-        primary_key_position = 1
-        for column in parsed.find_all(sqlglot.exp.ColumnDef):
-            if column.parent.this.name != table_name:
-                continue
+            primary_key_position = 1
+            for column in parsed.find_all(sqlglot.exp.ColumnDef):
+                if column.parent.this.name != table_name:
+                    continue
 
-            col_name = column.this.name
-            col_type = to_col_type(column, dialect)
-            logical_type, format = map_type_from_sql(col_type)
-            col_description = get_description(column)
-            max_length = get_max_length(column)
-            precision, scale = get_precision_scale(column)
-            is_primary_key = get_primary_key(column)
-            is_required = column.find(sqlglot.exp.NotNullColumnConstraint) is not None or None
-            tags = get_tags(column)
+                col_name = column.this.name
+                col_type = to_col_type(column, dialect)
+                logical_type, format = map_type_from_sql(col_type)
+                col_description = get_description(column)
+                max_length = get_max_length(column)
+                precision, scale = get_precision_scale(column)
+                is_primary_key = get_primary_key(column)
+                is_required = column.find(sqlglot.exp.NotNullColumnConstraint) is not None or None
+                tags = get_tags(column)
 
-            prop = create_property(
-                name=col_name,
-                logical_type=logical_type,
-                physical_type=col_type,
-                description=col_description,
-                max_length=max_length,
-                precision=precision,
-                scale=scale,
-                format=format,
-                primary_key=is_primary_key,
-                primary_key_position=primary_key_position if is_primary_key else None,
-                required=is_required if is_required else None,
-                tags=tags,
+                prop = create_property(
+                    name=col_name,
+                    logical_type=logical_type,
+                    physical_type=col_type,
+                    description=col_description,
+                    max_length=max_length,
+                    precision=precision,
+                    scale=scale,
+                    format=format,
+                    primary_key=is_primary_key,
+                    primary_key_position=primary_key_position if is_primary_key else None,
+                    required=is_required if is_required else None,
+                    tags=tags,
+                )
+
+                if is_primary_key:
+                    primary_key_position += 1
+
+                properties.append(prop)
+
+            table_comment_property = parsed.find(sqlglot.expressions.SchemaCommentProperty)
+
+            table_description = None
+            if table_comment_property:
+                table_description = table_comment_property.this.this
+
+            table_tags = None
+            table_props = parsed.find(sqlglot.expressions.Properties)
+            if table_props:
+                tags = table_props.find(sqlglot.expressions.Tags)
+                if tags:
+                    table_tags = [str(t) for t in tags.expressions]
+
+            schema_obj = create_schema_object(
+                name=table_name,
+                physical_type="table",
+                description=table_description,
+                tags=table_tags,
+                properties=properties,
             )
-
-            if is_primary_key:
-                primary_key_position += 1
-
-            properties.append(prop)
-
-        table_comment_property = parsed.find(sqlglot.expressions.SchemaCommentProperty)
-
-        table_description = None
-        if table_comment_property:
-            table_description = table_comment_property.this.this
-
-        table_tags = None
-        table_props = parsed.find(sqlglot.expressions.Properties)
-        if table_props:
-            tags = table_props.find(sqlglot.expressions.Tags)
-            if tags:
-                table_tags = [str(t) for t in tags.expressions]
-
-        schema_obj = create_schema_object(
-            name=table_name,
-            physical_type="table",
-            description=table_description,
-            tags=table_tags,
-            properties=properties,
-        )
-        odcs.schema_.append(schema_obj)
+            odcs.schema_.append(schema_obj)
 
     return odcs
 
@@ -308,6 +309,12 @@ def map_type_from_sql(sql_type: str) -> tuple[str, str | None]:
         return ("integer", None)
     elif sql_type_normed.endswith("integer"):
         return ("integer", None)
+    elif sql_type_normed.startswith("smallint"):
+        return ("integer", None)
+    elif re.search(r"^(small)?int(\(\d+\))?", sql_type_normed):         # Looking for format int(10)
+        return ("integer", None)
+    elif sql_type_normed.startswith("tinyint") and not sql_type_normed.startswith("tinyint(1)"):
+        return ("integer", None)
     elif sql_type_normed.startswith("float"):
         return ("number", None)
     elif sql_type_normed.startswith("double"):
@@ -322,9 +329,13 @@ def map_type_from_sql(sql_type: str) -> tuple[str, str | None]:
         return ("number", None)
     elif sql_type_normed.startswith("money"):
         return ("number", None)
+    elif re.search(r"^bigint(\(\d+\))?", sql_type_normed):         # Looking for format bigint(10)
+        return ("number", None)
     elif sql_type_normed.startswith("bool"):
         return ("boolean", None)
     elif sql_type_normed.startswith("bit"):
+        return ("boolean", None)
+    elif sql_type_normed.startswith("tinyint(1)"):
         return ("boolean", None)
     elif sql_type_normed.startswith("binary"):
         return ("string", "binary")

--- a/datacontract/imports/sql_importer.py
+++ b/datacontract/imports/sql_importer.py
@@ -76,62 +76,65 @@ def import_sql(source: str, import_args: dict = None) -> OpenDataContractStandar
             table_name = table.this.name
             properties = []
 
-            primary_key_position = 1
-            for column in parsed.find_all(sqlglot.exp.ColumnDef):
-                if column.parent.this.name != table_name:
-                    continue
+            columns = [
+                column for column in parsed.find_all(sqlglot.exp.ColumnDef) if column.parent.this.name == table_name
+            ]
 
-                col_name = column.this.name
-                col_type = to_col_type(column, dialect)
-                logical_type, format = map_type_from_sql(col_type)
-                col_description = get_description(column)
-                max_length = get_max_length(column)
-                precision, scale = get_precision_scale(column)
-                is_primary_key = get_primary_key(column)
-                is_required = column.find(sqlglot.exp.NotNullColumnConstraint) is not None or None
-                tags = get_tags(column)
+            # table foreign keys were duplicating the referenced tables-- so only include tables with columns
+            if columns:
+                primary_key_position = 1
+                for column in columns:
+                    col_name = column.this.name
+                    col_type = to_col_type(column, dialect)
+                    logical_type, format = map_type_from_sql(col_type)
+                    col_description = get_description(column)
+                    max_length = get_max_length(column)
+                    precision, scale = get_precision_scale(column)
+                    is_primary_key = get_primary_key(column)
+                    is_required = column.find(sqlglot.exp.NotNullColumnConstraint) is not None or None
+                    tags = get_tags(column)
 
-                prop = create_property(
-                    name=col_name,
-                    logical_type=logical_type,
-                    physical_type=col_type,
-                    description=col_description,
-                    max_length=max_length,
-                    precision=precision,
-                    scale=scale,
-                    format=format,
-                    primary_key=is_primary_key,
-                    primary_key_position=primary_key_position if is_primary_key else None,
-                    required=is_required if is_required else None,
-                    tags=tags,
+                    prop = create_property(
+                        name=col_name,
+                        logical_type=logical_type,
+                        physical_type=col_type,
+                        description=col_description,
+                        max_length=max_length,
+                        precision=precision,
+                        scale=scale,
+                        format=format,
+                        primary_key=is_primary_key,
+                        primary_key_position=primary_key_position if is_primary_key else None,
+                        required=is_required if is_required else None,
+                        tags=tags,
+                    )
+
+                    if is_primary_key:
+                        primary_key_position += 1
+
+                    properties.append(prop)
+
+                table_comment_property = parsed.find(sqlglot.expressions.SchemaCommentProperty)
+
+                table_description = None
+                if table_comment_property:
+                    table_description = table_comment_property.this.this
+
+                table_tags = None
+                table_props = parsed.find(sqlglot.expressions.Properties)
+                if table_props:
+                    tags = table_props.find(sqlglot.expressions.Tags)
+                    if tags:
+                        table_tags = [str(t) for t in tags.expressions]
+
+                schema_obj = create_schema_object(
+                    name=table_name,
+                    physical_type="table",
+                    description=table_description,
+                    tags=table_tags,
+                    properties=properties,
                 )
-
-                if is_primary_key:
-                    primary_key_position += 1
-
-                properties.append(prop)
-
-            table_comment_property = parsed.find(sqlglot.expressions.SchemaCommentProperty)
-
-            table_description = None
-            if table_comment_property:
-                table_description = table_comment_property.this.this
-
-            table_tags = None
-            table_props = parsed.find(sqlglot.expressions.Properties)
-            if table_props:
-                tags = table_props.find(sqlglot.expressions.Tags)
-                if tags:
-                    table_tags = [str(t) for t in tags.expressions]
-
-            schema_obj = create_schema_object(
-                name=table_name,
-                physical_type="table",
-                description=table_description,
-                tags=table_tags,
-                properties=properties,
-            )
-            odcs.schema_.append(schema_obj)
+                odcs.schema_.append(schema_obj)
 
     return odcs
 

--- a/datacontract/imports/sql_importer.py
+++ b/datacontract/imports/sql_importer.py
@@ -312,7 +312,7 @@ def map_type_from_sql(sql_type: str) -> tuple[str, str | None]:
         return ("integer", None)
     elif sql_type_normed.endswith("integer"):
         return ("integer", None)
-    elif re.search(r"^(small)?int(\(\d+\))?(\sunsigned)?$", sql_type_normed):  # Looking for format int(10)
+    elif re.search(r"^(small|big)?int(\(\d+\))?(\sunsigned)?$", sql_type_normed):  # Looking for format int(10)
         return ("integer", None)
     elif sql_type_normed.startswith("tinyint") and not sql_type_normed.startswith("tinyint(1)"):
         return ("integer", None)
@@ -329,8 +329,6 @@ def map_type_from_sql(sql_type: str) -> tuple[str, str | None]:
     elif sql_type_normed.startswith("decimal"):
         return ("number", None)
     elif sql_type_normed.startswith("money"):
-        return ("number", None)
-    elif re.search(r"^bigint(\(\d+\))?", sql_type_normed):  # Looking for format bigint(10)
         return ("number", None)
     elif sql_type_normed.startswith("bool"):
         return ("boolean", None)

--- a/datacontract/imports/sql_importer.py
+++ b/datacontract/imports/sql_importer.py
@@ -311,7 +311,7 @@ def map_type_from_sql(sql_type: str) -> tuple[str, str | None]:
         return ("integer", None)
     elif sql_type_normed.startswith("smallint"):
         return ("integer", None)
-    elif re.search(r"^(small)?int(\(\d+\))?", sql_type_normed):         # Looking for format int(10)
+    elif re.search(r"^(small)?int(\(\d+\))?(\sunsigned)?$", sql_type_normed):         # Looking for format int(10)
         return ("integer", None)
     elif sql_type_normed.startswith("tinyint") and not sql_type_normed.startswith("tinyint(1)"):
         return ("integer", None)

--- a/tests/test_import_sql_oracle.py
+++ b/tests/test_import_sql_oracle.py
@@ -179,8 +179,10 @@ schema:
     physicalName: customer_location
     properties:
       - name: id
-        logicalType: number
         physicalType: DECIMAL
+        primaryKey: true
+        primaryKeyPosition: 1
+        logicalType: number
         required: true
       - name: created_by
         logicalType: string

--- a/tests/test_import_sql_postgres.py
+++ b/tests/test_import_sql_postgres.py
@@ -87,6 +87,8 @@ schema:
       - name: id
         logicalType: number
         physicalType: DECIMAL
+        primaryKey: true
+        primaryKeyPosition: 1
         required: true
       - name: created_by
         logicalType: string

--- a/tests/test_import_sql_snowflake.py
+++ b/tests/test_import_sql_snowflake.py
@@ -31,6 +31,8 @@ schema:
   - name: field_primary_key
     physicalType: DECIMAL(38, 0)
     description: Primary key
+    primaryKey: true
+    primaryKeyPosition: 1
     customProperties:
     - property: precision
       value: 38


### PR DESCRIPTION
There was an issue I noticed where when a sql ddl file had multiple tables defined the import functionality would only convert the first one to ODCS and ignore the rest.

Also, a few mysql types were not handled so I added handling for those.

Edit: sorry made a few other changes to accommodate primary keys defined at the table level.

- [ ] Tests pass (`uv run pytest`)  [I ran relevant tests and they passed-- I do not have docker setup locally so did not run the full suite, also did not see any documentation on this part of the testing?]
- [x] Code formatted (`uv run ruff check --fix && uv run ruff format`)
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added

This is a test sql ddl I used where only the first table was processed:
``` sql
CREATE TABLE customers (
  id INT(10) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'Primary key, unique customer identifier',
  first_name VARCHAR(50) NOT NULL COMMENT 'Customer first name',
  last_name VARCHAR(50) NOT NULL COMMENT 'Customer last name',
  email VARCHAR(255) NOT NULL COMMENT 'Customer email address, used for login',
  phone VARCHAR(20) COMMENT 'Optional contact phone number',
  date_of_birth DATE COMMENT 'Customer date of birth',
  is_active TINYINT(1) UNSIGNED NOT NULL DEFAULT 1 COMMENT 'Whether the customer account is active',
  created_at DATETIME NOT NULL COMMENT 'Timestamp when the record was created',
  updated_at DATETIME COMMENT 'Timestamp when the record was last updated',
  PRIMARY KEY (id),
  UNIQUE KEY customers_email_uk (email)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

CREATE TABLE orders (
  id INT(10) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'Primary key, unique order identifier',
  customer_id INT(10) UNSIGNED NOT NULL COMMENT 'Foreign key referencing the customer who placed the order',
  status VARCHAR(20) NOT NULL DEFAULT 'pending' COMMENT 'Order status: pending, processing, shipped, delivered, cancelled',
  total_amount DECIMAL(10,2) NOT NULL COMMENT 'Total monetary value of the order',
  item_count SMALLINT UNSIGNED NOT NULL COMMENT 'Number of items in the order',
  notes VARCHAR(1000) COMMENT 'Optional free-text notes about the order',
  shipped_at DATETIME COMMENT 'Timestamp when the order was shipped',
  created_at DATETIME NOT NULL COMMENT 'Timestamp when the order was placed',
  updated_at DATETIME COMMENT 'Timestamp when the record was last updated',
  PRIMARY KEY (id),
  KEY orders_customer_id_idx (customer_id),
  CONSTRAINT orders_customer_fk FOREIGN KEY (customer_id) REFERENCES customers (id)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
```