### PR TITLE
fix: quote column identifiers in SLA freshness checks per SQL dialect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `import spark` now emits a native Spark SQL physicalType (e.g. `string`) instead of Python repr (e.g. `StringType()`). Contracts imported using Spark in v0.11.0–v0.12.1 did not perform type checks and must be re-imported. (#1048)
 - Remove unnecessary `setuptools` dependency from `pyproject.toml` (temporary workaround for soda-core#2091 resolved) (#1199)
 - SLA freshness checks now quote column identifiers with special characters (#1202)
-- Schema and quality checks on Impala, dataframe, and Kafka servers now backtick-quote field and model names, matching the existing behavior for Databricks/BigQuery/MySQL (#1202)
+- update field / model quotation for Impala, dataframe, and Kafka (#1202)
 
 ## [0.12.1] - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - correct swapped `check_type` labels  `model_qualty_sql` and `field_quality_sql` (#1187)
 - `import spark` now emits a native Spark SQL physicalType (e.g. `string`) instead of Python repr (e.g. `StringType()`). Contracts imported using Spark in v0.11.0–v0.12.1 did not perform type checks and must be re-imported. (#1048)
 - Remove unnecessary `setuptools` dependency from `pyproject.toml` (temporary workaround for soda-core#2091 resolved) (#1199)
-- SLA freshness checks now quote column identifiers with special characters (#1190)
-
+- SLA freshness checks now quote column identifiers with special characters (#1202)
+- Schema and quality checks on Impala, dataframe, and Kafka servers now backtick-quote field and model names, matching the existing behavior for Databricks/BigQuery/MySQL (#1202)
 
 ## [0.12.1] - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** `test` command now exits non-zero when a server is specified, but soda-core fails to connect or authenticate (#1181)
 - correct swapped `check_type` labels  `model_qualty_sql` and `field_quality_sql` (#1187)
 - `import spark` now emits a native Spark SQL physicalType (e.g. `string`) instead of Python repr (e.g. `StringType()`). Contracts imported using Spark in v0.11.0–v0.12.1 did not perform type checks and must be re-imported. (#1048)
+- SLA freshness checks now quote column identifiers that contain characters the dialect rejects bare (e.g. Athena pseudo-columns like `$file_modified_time`). Ordinary identifiers stay unquoted, so dialect case-folding behavior is unchanged. (#1190)
 
 ## [0.12.1] - 2026-04-21
 

--- a/datacontract/engines/data_contract_checks.py
+++ b/datacontract/engines/data_contract_checks.py
@@ -50,6 +50,27 @@ def _quote_field_name(field_name: str, quoting_config: QuotingConfig) -> str:
     return field_name
 
 
+_BACKTICK_DIALECTS = {"databricks", "bigquery", "mysql", "impala", "dataframe", "kafka"}
+
+_BARE_IDENTIFIER_STRICT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_BARE_IDENTIFIER_PERMISSIVE = re.compile(r"^[A-Za-z_][A-Za-z0-9_$]*$")
+_PERMISSIVE_BARE_DIALECTS = {"postgres", "snowflake", "oracle", "sqlserver"}
+
+
+def _quote_identifier_if_needed(identifier: str, server: Optional[Server]) -> str:
+    """Quote an identifier only when the target dialect would reject it bare.
+
+    Avoids unnecessary quoting, because quoting leads to case-sensitivity.
+    """
+    if identifier is None:
+        return identifier
+    server_type = server.type if server and server.type else None
+    pattern = _BARE_IDENTIFIER_PERMISSIVE if server_type in _PERMISSIVE_BARE_DIALECTS else _BARE_IDENTIFIER_STRICT
+    if pattern.match(identifier):
+        return identifier
+    return f"`{identifier}`" if server_type in _BACKTICK_DIALECTS else f'"{identifier}"'
+
+
 def _get_logical_type_option(prop: SchemaProperty, key: str):
     """Get a logical type option value."""
     if prop.logicalTypeOptions is None:
@@ -86,7 +107,7 @@ def create_checks(data_contract: OpenDataContractStandard, server: Server, schem
             continue
         schema_checks = to_schema_checks(schema_obj, server)
         checks.extend(schema_checks)
-    checks.extend(to_servicelevel_checks(data_contract))
+    checks.extend(to_servicelevel_checks(data_contract, server))
     return [check for check in checks if check is not None]
 
 
@@ -931,14 +952,14 @@ def _get_schema_by_name(data_contract: OpenDataContractStandard, name: str) -> O
     return next((s for s in data_contract.schema_ if s.name == name), None)
 
 
-def to_servicelevel_checks(data_contract: OpenDataContractStandard) -> List[Check]:
+def to_servicelevel_checks(data_contract: OpenDataContractStandard, server: Optional[Server] = None) -> List[Check]:
     checks: List[Check] = []
     if data_contract.slaProperties is None:
         return checks
 
     for sla in data_contract.slaProperties:
         if sla.property == "freshness":
-            check = to_sla_freshness_check(data_contract, sla)
+            check = to_sla_freshness_check(data_contract, sla, server)
             if check is not None:
                 checks.append(check)
         elif sla.property == "retention":
@@ -949,7 +970,9 @@ def to_servicelevel_checks(data_contract: OpenDataContractStandard) -> List[Chec
     return checks
 
 
-def to_sla_freshness_check(data_contract: OpenDataContractStandard, sla) -> Check | None:
+def to_sla_freshness_check(
+    data_contract: OpenDataContractStandard, sla, server: Optional[Server] = None
+) -> Check | None:
     """Create a freshness check from an ODCS latency SLA property."""
     if sla.element is None:
         logger.info("slaProperties.latency.element is not defined, skipping freshness check")
@@ -995,10 +1018,11 @@ def to_sla_freshness_check(data_contract: OpenDataContractStandard, sla) -> Chec
 
     check_type = "servicelevel_freshness"
     check_key = "servicelevel_freshness"
+    quoted_field = _quote_identifier_if_needed(field_name, server)
     sodacl_check_dict = {
         f"checks for {model_name}": [
             {
-                f"freshness({field_name}) < {threshold}": {
+                f"freshness({quoted_field}) < {threshold}": {
                     "name": check_key,
                 },
             }

--- a/datacontract/engines/data_contract_checks.py
+++ b/datacontract/engines/data_contract_checks.py
@@ -1,7 +1,6 @@
 import logging
 import re
 import uuid
-from dataclasses import dataclass
 from typing import List, Optional
 
 import yaml
@@ -19,12 +18,26 @@ from datacontract.model.run import Check
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class QuotingConfig:
-    quote_field_name: bool = False
-    quote_field_name_with_backticks: bool = False
-    quote_model_name: bool = False
-    quote_model_name_with_backticks: bool = False
+# Single source of truth for dialects that quote identifiers with backticks.
+_BACKTICK_DIALECTS = {"databricks", "bigquery", "mysql", "impala", "dataframe", "kafka"}
+# Dialects whose schema/quality checks have historically been emitted with ANSI-quoted
+# identifiers. Anything not in this or _BACKTICK_DIALECTS gets bare identifiers.
+_ANSI_QUOTING_DIALECTS = {"postgres", "sqlserver", "snowflake", "azure", "s3", "gcs", "local"}
+# Subset of dialects that case-fold unquoted identifiers AND accept `$` as a continuation
+# character in bare identifiers. Used by _quote_identifier_if_needed (the conservative
+# rule for SLA freshness checks) so we don't force avoidable case-sensitivity on `$`.
+_PERMISSIVE_BARE_DIALECTS = {"postgres", "snowflake", "oracle", "sqlserver"}
+
+_BARE_IDENTIFIER_STRICT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_BARE_IDENTIFIER_PERMISSIVE = re.compile(r"^[A-Za-z_][A-Za-z0-9_$]*$")
+
+
+def _server_type(server: Optional[Server]) -> Optional[str]:
+    return server.type if server and server.type else None
+
+
+def _dialect_uses_backtick_quotation(server: Optional[Server]) -> bool:
+    return _server_type(server) in _BACKTICK_DIALECTS
 
 
 def _escape_sql_string_values(values):
@@ -39,22 +52,16 @@ def _escape_sql_string_values(values):
     return [v.replace("'", "''") if isinstance(v, str) else v for v in values]
 
 
-def _quote_field_name(field_name: str, quoting_config: QuotingConfig) -> str:
-    """Quote a field name according to the quoting configuration."""
+def _quote_field_name(field_name: str, server: Optional[Server]) -> str:
+    """Quote a field/model name per dialect: backticks for backtick dialects,
+    ANSI for known ANSI-quoting dialects, bare otherwise."""
     if field_name is None:
         return field_name
-    if quoting_config.quote_field_name:
-        return f'"{field_name}"'
-    elif quoting_config.quote_field_name_with_backticks:
+    if _dialect_uses_backtick_quotation(server):
         return f"`{field_name}`"
+    if _server_type(server) in _ANSI_QUOTING_DIALECTS:
+        return f'"{field_name}"'
     return field_name
-
-
-_BACKTICK_DIALECTS = {"databricks", "bigquery", "mysql", "impala", "dataframe", "kafka"}
-
-_BARE_IDENTIFIER_STRICT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-_BARE_IDENTIFIER_PERMISSIVE = re.compile(r"^[A-Za-z_][A-Za-z0-9_$]*$")
-_PERMISSIVE_BARE_DIALECTS = {"postgres", "snowflake", "oracle", "sqlserver"}
 
 
 def _quote_identifier_if_needed(identifier: str, server: Optional[Server]) -> str:
@@ -64,11 +71,12 @@ def _quote_identifier_if_needed(identifier: str, server: Optional[Server]) -> st
     """
     if identifier is None:
         return identifier
-    server_type = server.type if server and server.type else None
-    pattern = _BARE_IDENTIFIER_PERMISSIVE if server_type in _PERMISSIVE_BARE_DIALECTS else _BARE_IDENTIFIER_STRICT
+    pattern = (
+        _BARE_IDENTIFIER_PERMISSIVE if _server_type(server) in _PERMISSIVE_BARE_DIALECTS else _BARE_IDENTIFIER_STRICT
+    )
     if pattern.match(identifier):
         return identifier
-    return f"`{identifier}`" if server_type in _BACKTICK_DIALECTS else f'"{identifier}"'
+    return f"`{identifier}`" if _dialect_uses_backtick_quotation(server) else f'"{identifier}"'
 
 
 def _get_logical_type_option(prop: SchemaProperty, key: str):
@@ -119,80 +127,71 @@ def to_schema_checks(schema_object: SchemaObject, server: Server) -> List[Check]
 
     check_types = is_check_types(server)
 
-    type1 = server.type if server and server.type else None
-    config = QuotingConfig(
-        quote_field_name=type1 in ["postgres", "sqlserver", "snowflake", "azure", "s3", "gcs", "local"],
-        quote_field_name_with_backticks=type1 in ["databricks", "bigquery", "mysql"],
-        quote_model_name=type1 in ["postgres", "sqlserver", "snowflake", "azure", "s3", "gcs", "local"],
-        quote_model_name_with_backticks=type1 in ["databricks", "bigquery", "mysql"],
-    )
-    quoting_config = config
-
     for prop in properties:
         property_name = prop.name
 
-        checks.append(check_property_is_present(schema_name, property_name, quoting_config))
+        checks.append(check_property_is_present(schema_name, property_name, server))
         if check_types and (prop.physicalType is not None or prop.logicalType is not None):
             sql_type: str = convert_to_sql_type(prop, server_type)
             if sql_type is not None:
-                checks.append(check_property_type(schema_name, property_name, sql_type, quoting_config))
+                checks.append(check_property_type(schema_name, property_name, sql_type, server))
         if prop.required:
-            checks.append(check_property_required(schema_name, property_name, quoting_config))
+            checks.append(check_property_required(schema_name, property_name, server))
         if prop.unique:
-            checks.append(check_property_unique(schema_name, property_name, quoting_config))
+            checks.append(check_property_unique(schema_name, property_name, server))
 
         min_length = _get_logical_type_option(prop, "minLength")
         if min_length is not None:
-            checks.append(check_property_min_length(schema_name, property_name, min_length, quoting_config))
+            checks.append(check_property_min_length(schema_name, property_name, min_length, server))
 
         max_length = _get_logical_type_option(prop, "maxLength")
         if max_length is not None:
-            checks.append(check_property_max_length(schema_name, property_name, max_length, quoting_config))
+            checks.append(check_property_max_length(schema_name, property_name, max_length, server))
 
         minimum = _get_logical_type_option(prop, "minimum")
         if minimum is not None:
-            checks.append(check_property_minimum(schema_name, property_name, minimum, quoting_config))
+            checks.append(check_property_minimum(schema_name, property_name, minimum, server))
 
         maximum = _get_logical_type_option(prop, "maximum")
         if maximum is not None:
-            checks.append(check_property_maximum(schema_name, property_name, maximum, quoting_config))
+            checks.append(check_property_maximum(schema_name, property_name, maximum, server))
 
         exclusive_minimum = _get_logical_type_option(prop, "exclusiveMinimum")
         if exclusive_minimum is not None:
-            checks.append(check_property_minimum(schema_name, property_name, exclusive_minimum, quoting_config))
-            checks.append(check_property_not_equal(schema_name, property_name, exclusive_minimum, quoting_config))
+            checks.append(check_property_minimum(schema_name, property_name, exclusive_minimum, server))
+            checks.append(check_property_not_equal(schema_name, property_name, exclusive_minimum, server))
 
         exclusive_maximum = _get_logical_type_option(prop, "exclusiveMaximum")
         if exclusive_maximum is not None:
-            checks.append(check_property_maximum(schema_name, property_name, exclusive_maximum, quoting_config))
-            checks.append(check_property_not_equal(schema_name, property_name, exclusive_maximum, quoting_config))
+            checks.append(check_property_maximum(schema_name, property_name, exclusive_maximum, server))
+            checks.append(check_property_not_equal(schema_name, property_name, exclusive_maximum, server))
 
         pattern = _get_logical_type_option(prop, "pattern")
         if pattern is not None:
-            checks.append(check_property_regex(schema_name, property_name, pattern, quoting_config))
+            checks.append(check_property_regex(schema_name, property_name, pattern, server))
 
         enum_values = _get_logical_type_option(prop, "enum")
         if enum_values is not None and len(enum_values) > 0:
-            checks.append(check_property_enum(schema_name, property_name, enum_values, quoting_config))
+            checks.append(check_property_enum(schema_name, property_name, enum_values, server))
 
         if prop.quality is not None and len(prop.quality) > 0:
-            quality_list = check_quality_list(schema_name, property_name, prop.quality, quoting_config, server)
+            quality_list = check_quality_list(schema_name, property_name, prop.quality, server)
             if (quality_list is not None) and len(quality_list) > 0:
                 checks.extend(quality_list)
 
     if schema_object.quality is not None and len(schema_object.quality) > 0:
-        quality_list = check_quality_list(schema_name, None, schema_object.quality, quoting_config, server)
+        quality_list = check_quality_list(schema_name, None, schema_object.quality, server)
         if (quality_list is not None) and len(quality_list) > 0:
             checks.extend(quality_list)
 
     return checks
 
 
-def checks_for(model_name: str, quoting_config: QuotingConfig, check_type: str) -> str:
-    if quoting_config.quote_model_name:
-        return f'checks for "{model_name}"'
-    elif quoting_config.quote_model_name_with_backticks and check_type not in ["field_is_present", "field_type"]:
+def checks_for(model_name: str, server: Optional[Server], check_type: str) -> str:
+    if _dialect_uses_backtick_quotation(server) and check_type not in ["field_is_present", "field_type"]:
         return f"checks for `{model_name}`"
+    if _server_type(server) in _ANSI_QUOTING_DIALECTS:
+        return f'checks for "{model_name}"'
     return f"checks for {model_name}"
 
 
@@ -215,11 +214,11 @@ def to_schema_name(schema_object: SchemaObject, server_type: str) -> str:
     return schema_object.name
 
 
-def check_property_is_present(model_name, field_name, quoting_config: QuotingConfig = QuotingConfig()) -> Check:
+def check_property_is_present(model_name, field_name, server: Optional[Server] = None) -> Check:
     check_type = "field_is_present"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, quoting_config, check_type): [
+        checks_for(model_name, server, check_type): [
             {
                 "schema": {
                     "name": check_key,
@@ -244,16 +243,14 @@ def check_property_is_present(model_name, field_name, quoting_config: QuotingCon
     )
 
 
-def check_property_type(
-    model_name: str, field_name: str, expected_type: str, quoting_config: QuotingConfig = QuotingConfig()
-):
+def check_property_type(model_name: str, field_name: str, expected_type: str, server: Optional[Server] = None):
     if expected_type is None:
         logger.warning(f"Cannot build type check for {model_name}.{field_name}: expected_type is None.")
         return None
     check_type = "field_type"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, quoting_config, check_type): [
+        checks_for(model_name, server, check_type): [
             {
                 "schema": {
                     "name": check_key,
@@ -280,13 +277,13 @@ def check_property_type(
     )
 
 
-def check_property_required(model_name: str, field_name: str, quoting_config: QuotingConfig = QuotingConfig()):
-    field_name_for_soda = _quote_field_name(field_name, quoting_config)
+def check_property_required(model_name: str, field_name: str, server: Optional[Server] = None):
+    field_name_for_soda = _quote_field_name(field_name, server)
 
     check_type = "field_required"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, quoting_config, check_type): [
+        checks_for(model_name, server, check_type): [
             {
                 f"missing_count({field_name_for_soda}) = 0": {
                     "name": check_key,
@@ -308,13 +305,13 @@ def check_property_required(model_name: str, field_name: str, quoting_config: Qu
     )
 
 
-def check_property_unique(model_name: str, field_name: str, quoting_config: QuotingConfig = QuotingConfig()):
-    field_name_for_soda = _quote_field_name(field_name, quoting_config)
+def check_property_unique(model_name: str, field_name: str, server: Optional[Server] = None):
+    field_name_for_soda = _quote_field_name(field_name, server)
 
     check_type = "field_unique"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, quoting_config, check_type): [
+        checks_for(model_name, server, check_type): [
             {
                 f"duplicate_count({field_name_for_soda}) = 0": {
                     "name": check_key,
@@ -336,15 +333,13 @@ def check_property_unique(model_name: str, field_name: str, quoting_config: Quot
     )
 
 
-def check_property_min_length(
-    model_name: str, field_name: str, min_length: int, quoting_config: QuotingConfig = QuotingConfig()
-):
-    field_name_for_soda = _quote_field_name(field_name, quoting_config)
+def check_property_min_length(model_name: str, field_name: str, min_length: int, server: Optional[Server] = None):
+    field_name_for_soda = _quote_field_name(field_name, server)
 
     check_type = "field_min_length"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, quoting_config, check_type): [
+        checks_for(model_name, server, check_type): [
             {
                 f"invalid_count({field_name_for_soda}) = 0": {
                     "name": check_key,
@@ -367,15 +362,13 @@ def check_property_min_length(
     )
 
 
-def check_property_max_length(
-    model_name: str, field_name: str, max_length: int, quoting_config: QuotingConfig = QuotingConfig()
-):
-    field_name_for_soda = _quote_field_name(field_name, quoting_config)
+def check_property_max_length(model_name: str, field_name: str, max_length: int, server: Optional[Server] = None):
+    field_name_for_soda = _quote_field_name(field_name, server)
 
     check_type = "field_max_length"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, quoting_config, check_type): [
+        checks_for(model_name, server, check_type): [
             {
                 f"invalid_count({field_name_for_soda}) = 0": {
                     "name": check_key,
@@ -398,15 +391,13 @@ def check_property_max_length(
     )
 
 
-def check_property_minimum(
-    model_name: str, field_name: str, minimum: int, quoting_config: QuotingConfig = QuotingConfig()
-):
-    field_name_for_soda = _quote_field_name(field_name, quoting_config)
+def check_property_minimum(model_name: str, field_name: str, minimum: int, server: Optional[Server] = None):
+    field_name_for_soda = _quote_field_name(field_name, server)
 
     check_type = "field_minimum"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, quoting_config, check_type): [
+        checks_for(model_name, server, check_type): [
             {
                 f"invalid_count({field_name_for_soda}) = 0": {
                     "name": check_key,
@@ -429,15 +420,13 @@ def check_property_minimum(
     )
 
 
-def check_property_maximum(
-    model_name: str, field_name: str, maximum: int, quoting_config: QuotingConfig = QuotingConfig()
-):
-    field_name_for_soda = _quote_field_name(field_name, quoting_config)
+def check_property_maximum(model_name: str, field_name: str, maximum: int, server: Optional[Server] = None):
+    field_name_for_soda = _quote_field_name(field_name, server)
 
     check_type = "field_maximum"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, quoting_config, check_type): [
+        checks_for(model_name, server, check_type): [
             {
                 f"invalid_count({field_name_for_soda}) = 0": {
                     "name": check_key,
@@ -460,15 +449,13 @@ def check_property_maximum(
     )
 
 
-def check_property_not_equal(
-    model_name: str, field_name: str, value: int, quoting_config: QuotingConfig = QuotingConfig()
-):
-    field_name_for_soda = _quote_field_name(field_name, quoting_config)
+def check_property_not_equal(model_name: str, field_name: str, value: int, server: Optional[Server] = None):
+    field_name_for_soda = _quote_field_name(field_name, server)
 
     check_type = "field_not_equal"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, quoting_config, check_type): [
+        checks_for(model_name, server, check_type): [
             {
                 f"invalid_count({field_name_for_soda}) = 0": {
                     "name": check_key,
@@ -491,13 +478,13 @@ def check_property_not_equal(
     )
 
 
-def check_property_enum(model_name: str, field_name: str, enum: list, quoting_config: QuotingConfig = QuotingConfig()):
-    field_name_for_soda = _quote_field_name(field_name, quoting_config)
+def check_property_enum(model_name: str, field_name: str, enum: list, server: Optional[Server] = None):
+    field_name_for_soda = _quote_field_name(field_name, server)
 
     check_type = "field_enum"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, quoting_config, check_type): [
+        checks_for(model_name, server, check_type): [
             {
                 f"invalid_count({field_name_for_soda}) = 0": {
                     "name": check_key,
@@ -520,15 +507,13 @@ def check_property_enum(model_name: str, field_name: str, enum: list, quoting_co
     )
 
 
-def check_property_regex(
-    model_name: str, field_name: str, pattern: str, quoting_config: QuotingConfig = QuotingConfig()
-):
-    field_name_for_soda = _quote_field_name(field_name, quoting_config)
+def check_property_regex(model_name: str, field_name: str, pattern: str, server: Optional[Server] = None):
+    field_name_for_soda = _quote_field_name(field_name, server)
 
     check_type = "field_regex"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, quoting_config, check_type): [
+        checks_for(model_name, server, check_type): [
             {
                 f"invalid_count({field_name_for_soda}) = 0": {
                     "name": check_key,
@@ -551,11 +536,11 @@ def check_property_regex(
     )
 
 
-def check_row_count(model_name: str, threshold: str, quoting_config: QuotingConfig = QuotingConfig()):
+def check_row_count(model_name: str, threshold: str, server: Optional[Server] = None):
     check_type = "row_count"
     check_key = f"{model_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, quoting_config, check_type): [
+        checks_for(model_name, server, check_type): [
             {
                 f"row_count {threshold}": {"name": check_key},
             }
@@ -575,14 +560,12 @@ def check_row_count(model_name: str, threshold: str, quoting_config: QuotingConf
     )
 
 
-def check_model_duplicate_values(
-    model_name: str, cols: list[str], threshold: str, quoting_config: QuotingConfig = QuotingConfig()
-):
+def check_model_duplicate_values(model_name: str, cols: list[str], threshold: str, server: Optional[Server] = None):
     check_type = "model_duplicate_values"
     check_key = f"{model_name}__{check_type}"
-    col_joined = ", ".join(_quote_field_name(col, quoting_config) for col in cols)
+    col_joined = ", ".join(_quote_field_name(col, server) for col in cols)
     sodacl_check_dict = {
-        checks_for(model_name, quoting_config, check_type): [
+        checks_for(model_name, server, check_type): [
             {
                 f"duplicate_count({col_joined}) {threshold}": {"name": check_key},
             }
@@ -602,15 +585,13 @@ def check_model_duplicate_values(
     )
 
 
-def check_property_duplicate_values(
-    model_name: str, field_name: str, threshold: str, quoting_config: QuotingConfig = QuotingConfig()
-):
-    field_name_for_soda = _quote_field_name(field_name, quoting_config)
+def check_property_duplicate_values(model_name: str, field_name: str, threshold: str, server: Optional[Server] = None):
+    field_name_for_soda = _quote_field_name(field_name, server)
 
     check_type = "field_duplicate_values"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, quoting_config, check_type): [
+        checks_for(model_name, server, check_type): [
             {
                 f"duplicate_count({field_name_for_soda}) {threshold}": {
                     "name": check_key,
@@ -632,15 +613,13 @@ def check_property_duplicate_values(
     )
 
 
-def check_property_null_values(
-    model_name: str, field_name: str, threshold: str, quoting_config: QuotingConfig = QuotingConfig()
-):
-    field_name_for_soda = _quote_field_name(field_name, quoting_config)
+def check_property_null_values(model_name: str, field_name: str, threshold: str, server: Optional[Server] = None):
+    field_name_for_soda = _quote_field_name(field_name, server)
 
     check_type = "field_null_values"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, quoting_config, check_type): [
+        checks_for(model_name, server, check_type): [
             {
                 f"missing_count({field_name_for_soda}) {threshold}": {
                     "name": check_key,
@@ -667,9 +646,9 @@ def check_property_invalid_values(
     field_name: str,
     threshold: str,
     valid_values: list = None,
-    quoting_config: QuotingConfig = QuotingConfig(),
+    server: Optional[Server] = None,
 ):
-    field_name_for_soda = _quote_field_name(field_name, quoting_config)
+    field_name_for_soda = _quote_field_name(field_name, server)
 
     check_type = "field_invalid_values"
     check_key = f"{model_name}__{field_name}__{check_type}"
@@ -682,7 +661,7 @@ def check_property_invalid_values(
         sodacl_check_config["valid values"] = _escape_sql_string_values(valid_values)
 
     sodacl_check_dict = {
-        checks_for(model_name, quoting_config, check_type): [
+        checks_for(model_name, server, check_type): [
             {
                 f"invalid_count({field_name_for_soda}) {threshold}": sodacl_check_config,
             }
@@ -707,9 +686,9 @@ def check_property_missing_values(
     field_name: str,
     threshold: str,
     missing_values: list = None,
-    quoting_config: QuotingConfig = QuotingConfig(),
+    server: Optional[Server] = None,
 ):
-    field_name_for_soda = _quote_field_name(field_name, quoting_config)
+    field_name_for_soda = _quote_field_name(field_name, server)
 
     check_type = "field_missing_values"
     check_key = f"{model_name}__{field_name}__{check_type}"
@@ -724,7 +703,7 @@ def check_property_missing_values(
             sodacl_check_config["missing values"] = _escape_sql_string_values(filtered_missing_values)
 
     sodacl_check_dict = {
-        checks_for(model_name, quoting_config, check_type): [
+        checks_for(model_name, server, check_type): [
             {
                 f"missing_count({field_name_for_soda}) {threshold}": sodacl_check_config,
             }
@@ -748,8 +727,7 @@ def check_quality_list(
     schema_name,
     property_name,
     quality_list: List[DataQuality],
-    quoting_config: QuotingConfig = QuotingConfig(),
-    server: Server = None,
+    server: Optional[Server] = None,
 ) -> List[Check]:
     checks: List[Check] = []
 
@@ -781,7 +759,7 @@ def check_quality_list(
                 check_key = f"{schema_name}__{property_name}__quality_sql_{count}"
                 check_type = "field_quality_sql"
             threshold = to_sodacl_threshold(quality)
-            query = prepare_query(quality, schema_name, property_name, quoting_config, server)
+            query = prepare_query(quality, schema_name, property_name, server)
             if query is None:
                 logger.warning(f"Quality check {check_key} has no query")
                 continue
@@ -789,7 +767,7 @@ def check_quality_list(
                 logger.warning(f"Quality check {check_key} has no valid threshold")
                 continue
 
-            if quoting_config.quote_model_name:
+            if _server_type(server) in _ANSI_QUOTING_DIALECTS:
                 model_name_for_soda = f'"{schema_name}"'
             else:
                 model_name_for_soda = schema_name
@@ -825,30 +803,26 @@ def check_quality_list(
                 continue
 
             if quality.metric == "rowCount":
-                checks.append(check_row_count(schema_name, threshold, quoting_config))
+                checks.append(check_row_count(schema_name, threshold, server))
             elif quality.metric == "duplicateValues":
                 if property_name is None:
                     checks.append(
                         check_model_duplicate_values(
-                            schema_name, quality.arguments.get("properties"), threshold, quoting_config
+                            schema_name, quality.arguments.get("properties"), threshold, server
                         )
                     )
                 else:
-                    checks.append(
-                        check_property_duplicate_values(schema_name, property_name, threshold, quoting_config)
-                    )
+                    checks.append(check_property_duplicate_values(schema_name, property_name, threshold, server))
             elif quality.metric == "nullValues":
                 if property_name is not None:
-                    checks.append(check_property_null_values(schema_name, property_name, threshold, quoting_config))
+                    checks.append(check_property_null_values(schema_name, property_name, threshold, server))
                 else:
                     logger.warning("Quality check nullValues is only supported at field level")
             elif quality.metric == "invalidValues":
                 if property_name is not None:
                     valid_values = quality.arguments.get("validValues") if quality.arguments else None
                     checks.append(
-                        check_property_invalid_values(
-                            schema_name, property_name, threshold, valid_values, quoting_config
-                        )
+                        check_property_invalid_values(schema_name, property_name, threshold, valid_values, server)
                     )
                 else:
                     logger.warning("Quality check invalidValues is only supported at field level")
@@ -856,9 +830,7 @@ def check_quality_list(
                 if property_name is not None:
                     missing_values = quality.arguments.get("missingValues") if quality.arguments else None
                     checks.append(
-                        check_property_missing_values(
-                            schema_name, property_name, threshold, missing_values, quoting_config
-                        )
+                        check_property_missing_values(schema_name, property_name, threshold, missing_values, server)
                     )
                 else:
                     logger.warning("Quality check missingValues is only supported at field level")
@@ -874,8 +846,7 @@ def prepare_query(
     quality: DataQuality,
     model_name: str,
     field_name: str = None,
-    quoting_config: QuotingConfig = QuotingConfig(),
-    server: Server = None,
+    server: Optional[Server] = None,
 ) -> str | None:
     if quality.query is None:
         return None
@@ -884,25 +855,14 @@ def prepare_query(
 
     query = quality.query
 
-    field_name_for_soda = _quote_field_name(field_name, quoting_config)
-
-    if quoting_config.quote_model_name:
-        model_name_for_soda = f'"{model_name}"'
-    elif quoting_config.quote_model_name_with_backticks:
-        model_name_for_soda = f"`{model_name}`"
-    else:
-        model_name_for_soda = model_name
+    field_name_for_soda = _quote_field_name(field_name, server)
+    model_name_for_soda = _quote_field_name(model_name, server)
 
     query = re.sub(r'["\']?\$?\{model}["\']?', model_name_for_soda, query)
     query = re.sub(r'["\']?\$?\{table}["\']?', model_name_for_soda, query)
 
     if server and server.schema_:
-        if quoting_config.quote_model_name:
-            schema_name_for_soda = f'"{server.schema_}"'
-        elif quoting_config.quote_model_name_with_backticks:
-            schema_name_for_soda = f"`{server.schema_}`"
-        else:
-            schema_name_for_soda = server.schema_
+        schema_name_for_soda = _quote_field_name(server.schema_, server)
         query = re.sub(r'["\']?\$?\{schema}["\']?', schema_name_for_soda, query)
     else:
         query = re.sub(r'["\']?\$?\{schema}["\']?', model_name_for_soda, query)

--- a/datacontract/engines/data_contract_checks.py
+++ b/datacontract/engines/data_contract_checks.py
@@ -1,6 +1,7 @@
 import logging
 import re
 import uuid
+from dataclasses import dataclass
 from typing import List, Optional
 
 import yaml
@@ -18,26 +19,12 @@ from datacontract.model.run import Check
 logger = logging.getLogger(__name__)
 
 
-# Single source of truth for dialects that quote identifiers with backticks.
-_BACKTICK_DIALECTS = {"databricks", "bigquery", "mysql", "impala", "dataframe", "kafka"}
-# Dialects whose schema/quality checks have historically been emitted with ANSI-quoted
-# identifiers. Anything not in this or _BACKTICK_DIALECTS gets bare identifiers.
-_ANSI_QUOTING_DIALECTS = {"postgres", "sqlserver", "snowflake", "azure", "s3", "gcs", "local"}
-# Subset of dialects that case-fold unquoted identifiers AND accept `$` as a continuation
-# character in bare identifiers. Used by _quote_identifier_if_needed (the conservative
-# rule for SLA freshness checks) so we don't force avoidable case-sensitivity on `$`.
-_PERMISSIVE_BARE_DIALECTS = {"postgres", "snowflake", "oracle", "sqlserver"}
-
-_BARE_IDENTIFIER_STRICT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-_BARE_IDENTIFIER_PERMISSIVE = re.compile(r"^[A-Za-z_][A-Za-z0-9_$]*$")
-
-
-def _server_type(server: Optional[Server]) -> Optional[str]:
-    return server.type if server and server.type else None
-
-
-def _dialect_uses_backtick_quotation(server: Optional[Server]) -> bool:
-    return _server_type(server) in _BACKTICK_DIALECTS
+@dataclass
+class QuotingConfig:
+    quote_field_name: bool = False
+    quote_field_name_with_backticks: bool = False
+    quote_model_name: bool = False
+    quote_model_name_with_backticks: bool = False
 
 
 def _escape_sql_string_values(values):
@@ -52,16 +39,22 @@ def _escape_sql_string_values(values):
     return [v.replace("'", "''") if isinstance(v, str) else v for v in values]
 
 
-def _quote_field_name(field_name: str, server: Optional[Server]) -> str:
-    """Quote a field/model name per dialect: backticks for backtick dialects,
-    ANSI for known ANSI-quoting dialects, bare otherwise."""
+def _quote_field_name(field_name: str, quoting_config: QuotingConfig) -> str:
+    """Quote a field name according to the quoting configuration."""
     if field_name is None:
         return field_name
-    if _dialect_uses_backtick_quotation(server):
-        return f"`{field_name}`"
-    if _server_type(server) in _ANSI_QUOTING_DIALECTS:
+    if quoting_config.quote_field_name:
         return f'"{field_name}"'
+    elif quoting_config.quote_field_name_with_backticks:
+        return f"`{field_name}`"
     return field_name
+
+
+_BACKTICK_DIALECTS = {"databricks", "bigquery", "mysql", "impala", "dataframe", "kafka"}
+
+_BARE_IDENTIFIER_STRICT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_BARE_IDENTIFIER_PERMISSIVE = re.compile(r"^[A-Za-z_][A-Za-z0-9_$]*$")
+_PERMISSIVE_BARE_DIALECTS = {"postgres", "snowflake", "oracle", "sqlserver"}
 
 
 def _quote_identifier_if_needed(identifier: str, server: Optional[Server]) -> str:
@@ -71,12 +64,11 @@ def _quote_identifier_if_needed(identifier: str, server: Optional[Server]) -> st
     """
     if identifier is None:
         return identifier
-    pattern = (
-        _BARE_IDENTIFIER_PERMISSIVE if _server_type(server) in _PERMISSIVE_BARE_DIALECTS else _BARE_IDENTIFIER_STRICT
-    )
+    server_type = server.type if server and server.type else None
+    pattern = _BARE_IDENTIFIER_PERMISSIVE if server_type in _PERMISSIVE_BARE_DIALECTS else _BARE_IDENTIFIER_STRICT
     if pattern.match(identifier):
         return identifier
-    return f"`{identifier}`" if _dialect_uses_backtick_quotation(server) else f'"{identifier}"'
+    return f"`{identifier}`" if server_type in _BACKTICK_DIALECTS else f'"{identifier}"'
 
 
 def _get_logical_type_option(prop: SchemaProperty, key: str):
@@ -127,71 +119,80 @@ def to_schema_checks(schema_object: SchemaObject, server: Server) -> List[Check]
 
     check_types = is_check_types(server)
 
+    type1 = server.type if server and server.type else None
+    config = QuotingConfig(
+        quote_field_name=type1 in ["postgres", "sqlserver", "snowflake", "azure", "s3", "gcs", "local"],
+        quote_field_name_with_backticks=type1 in ["databricks", "bigquery", "mysql"],
+        quote_model_name=type1 in ["postgres", "sqlserver", "snowflake", "azure", "s3", "gcs", "local"],
+        quote_model_name_with_backticks=type1 in ["databricks", "bigquery", "mysql"],
+    )
+    quoting_config = config
+
     for prop in properties:
         property_name = prop.name
 
-        checks.append(check_property_is_present(schema_name, property_name, server))
+        checks.append(check_property_is_present(schema_name, property_name, quoting_config))
         if check_types and (prop.physicalType is not None or prop.logicalType is not None):
             sql_type: str = convert_to_sql_type(prop, server_type)
             if sql_type is not None:
-                checks.append(check_property_type(schema_name, property_name, sql_type, server))
+                checks.append(check_property_type(schema_name, property_name, sql_type, quoting_config))
         if prop.required:
-            checks.append(check_property_required(schema_name, property_name, server))
+            checks.append(check_property_required(schema_name, property_name, quoting_config))
         if prop.unique:
-            checks.append(check_property_unique(schema_name, property_name, server))
+            checks.append(check_property_unique(schema_name, property_name, quoting_config))
 
         min_length = _get_logical_type_option(prop, "minLength")
         if min_length is not None:
-            checks.append(check_property_min_length(schema_name, property_name, min_length, server))
+            checks.append(check_property_min_length(schema_name, property_name, min_length, quoting_config))
 
         max_length = _get_logical_type_option(prop, "maxLength")
         if max_length is not None:
-            checks.append(check_property_max_length(schema_name, property_name, max_length, server))
+            checks.append(check_property_max_length(schema_name, property_name, max_length, quoting_config))
 
         minimum = _get_logical_type_option(prop, "minimum")
         if minimum is not None:
-            checks.append(check_property_minimum(schema_name, property_name, minimum, server))
+            checks.append(check_property_minimum(schema_name, property_name, minimum, quoting_config))
 
         maximum = _get_logical_type_option(prop, "maximum")
         if maximum is not None:
-            checks.append(check_property_maximum(schema_name, property_name, maximum, server))
+            checks.append(check_property_maximum(schema_name, property_name, maximum, quoting_config))
 
         exclusive_minimum = _get_logical_type_option(prop, "exclusiveMinimum")
         if exclusive_minimum is not None:
-            checks.append(check_property_minimum(schema_name, property_name, exclusive_minimum, server))
-            checks.append(check_property_not_equal(schema_name, property_name, exclusive_minimum, server))
+            checks.append(check_property_minimum(schema_name, property_name, exclusive_minimum, quoting_config))
+            checks.append(check_property_not_equal(schema_name, property_name, exclusive_minimum, quoting_config))
 
         exclusive_maximum = _get_logical_type_option(prop, "exclusiveMaximum")
         if exclusive_maximum is not None:
-            checks.append(check_property_maximum(schema_name, property_name, exclusive_maximum, server))
-            checks.append(check_property_not_equal(schema_name, property_name, exclusive_maximum, server))
+            checks.append(check_property_maximum(schema_name, property_name, exclusive_maximum, quoting_config))
+            checks.append(check_property_not_equal(schema_name, property_name, exclusive_maximum, quoting_config))
 
         pattern = _get_logical_type_option(prop, "pattern")
         if pattern is not None:
-            checks.append(check_property_regex(schema_name, property_name, pattern, server))
+            checks.append(check_property_regex(schema_name, property_name, pattern, quoting_config))
 
         enum_values = _get_logical_type_option(prop, "enum")
         if enum_values is not None and len(enum_values) > 0:
-            checks.append(check_property_enum(schema_name, property_name, enum_values, server))
+            checks.append(check_property_enum(schema_name, property_name, enum_values, quoting_config))
 
         if prop.quality is not None and len(prop.quality) > 0:
-            quality_list = check_quality_list(schema_name, property_name, prop.quality, server)
+            quality_list = check_quality_list(schema_name, property_name, prop.quality, quoting_config, server)
             if (quality_list is not None) and len(quality_list) > 0:
                 checks.extend(quality_list)
 
     if schema_object.quality is not None and len(schema_object.quality) > 0:
-        quality_list = check_quality_list(schema_name, None, schema_object.quality, server)
+        quality_list = check_quality_list(schema_name, None, schema_object.quality, quoting_config, server)
         if (quality_list is not None) and len(quality_list) > 0:
             checks.extend(quality_list)
 
     return checks
 
 
-def checks_for(model_name: str, server: Optional[Server], check_type: str) -> str:
-    if _dialect_uses_backtick_quotation(server) and check_type not in ["field_is_present", "field_type"]:
-        return f"checks for `{model_name}`"
-    if _server_type(server) in _ANSI_QUOTING_DIALECTS:
+def checks_for(model_name: str, quoting_config: QuotingConfig, check_type: str) -> str:
+    if quoting_config.quote_model_name:
         return f'checks for "{model_name}"'
+    elif quoting_config.quote_model_name_with_backticks and check_type not in ["field_is_present", "field_type"]:
+        return f"checks for `{model_name}`"
     return f"checks for {model_name}"
 
 
@@ -214,11 +215,11 @@ def to_schema_name(schema_object: SchemaObject, server_type: str) -> str:
     return schema_object.name
 
 
-def check_property_is_present(model_name, field_name, server: Optional[Server] = None) -> Check:
+def check_property_is_present(model_name, field_name, quoting_config: QuotingConfig = QuotingConfig()) -> Check:
     check_type = "field_is_present"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, server, check_type): [
+        checks_for(model_name, quoting_config, check_type): [
             {
                 "schema": {
                     "name": check_key,
@@ -243,14 +244,16 @@ def check_property_is_present(model_name, field_name, server: Optional[Server] =
     )
 
 
-def check_property_type(model_name: str, field_name: str, expected_type: str, server: Optional[Server] = None):
+def check_property_type(
+    model_name: str, field_name: str, expected_type: str, quoting_config: QuotingConfig = QuotingConfig()
+):
     if expected_type is None:
         logger.warning(f"Cannot build type check for {model_name}.{field_name}: expected_type is None.")
         return None
     check_type = "field_type"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, server, check_type): [
+        checks_for(model_name, quoting_config, check_type): [
             {
                 "schema": {
                     "name": check_key,
@@ -277,13 +280,13 @@ def check_property_type(model_name: str, field_name: str, expected_type: str, se
     )
 
 
-def check_property_required(model_name: str, field_name: str, server: Optional[Server] = None):
-    field_name_for_soda = _quote_field_name(field_name, server)
+def check_property_required(model_name: str, field_name: str, quoting_config: QuotingConfig = QuotingConfig()):
+    field_name_for_soda = _quote_field_name(field_name, quoting_config)
 
     check_type = "field_required"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, server, check_type): [
+        checks_for(model_name, quoting_config, check_type): [
             {
                 f"missing_count({field_name_for_soda}) = 0": {
                     "name": check_key,
@@ -305,13 +308,13 @@ def check_property_required(model_name: str, field_name: str, server: Optional[S
     )
 
 
-def check_property_unique(model_name: str, field_name: str, server: Optional[Server] = None):
-    field_name_for_soda = _quote_field_name(field_name, server)
+def check_property_unique(model_name: str, field_name: str, quoting_config: QuotingConfig = QuotingConfig()):
+    field_name_for_soda = _quote_field_name(field_name, quoting_config)
 
     check_type = "field_unique"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, server, check_type): [
+        checks_for(model_name, quoting_config, check_type): [
             {
                 f"duplicate_count({field_name_for_soda}) = 0": {
                     "name": check_key,
@@ -333,13 +336,15 @@ def check_property_unique(model_name: str, field_name: str, server: Optional[Ser
     )
 
 
-def check_property_min_length(model_name: str, field_name: str, min_length: int, server: Optional[Server] = None):
-    field_name_for_soda = _quote_field_name(field_name, server)
+def check_property_min_length(
+    model_name: str, field_name: str, min_length: int, quoting_config: QuotingConfig = QuotingConfig()
+):
+    field_name_for_soda = _quote_field_name(field_name, quoting_config)
 
     check_type = "field_min_length"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, server, check_type): [
+        checks_for(model_name, quoting_config, check_type): [
             {
                 f"invalid_count({field_name_for_soda}) = 0": {
                     "name": check_key,
@@ -362,13 +367,15 @@ def check_property_min_length(model_name: str, field_name: str, min_length: int,
     )
 
 
-def check_property_max_length(model_name: str, field_name: str, max_length: int, server: Optional[Server] = None):
-    field_name_for_soda = _quote_field_name(field_name, server)
+def check_property_max_length(
+    model_name: str, field_name: str, max_length: int, quoting_config: QuotingConfig = QuotingConfig()
+):
+    field_name_for_soda = _quote_field_name(field_name, quoting_config)
 
     check_type = "field_max_length"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, server, check_type): [
+        checks_for(model_name, quoting_config, check_type): [
             {
                 f"invalid_count({field_name_for_soda}) = 0": {
                     "name": check_key,
@@ -391,13 +398,15 @@ def check_property_max_length(model_name: str, field_name: str, max_length: int,
     )
 
 
-def check_property_minimum(model_name: str, field_name: str, minimum: int, server: Optional[Server] = None):
-    field_name_for_soda = _quote_field_name(field_name, server)
+def check_property_minimum(
+    model_name: str, field_name: str, minimum: int, quoting_config: QuotingConfig = QuotingConfig()
+):
+    field_name_for_soda = _quote_field_name(field_name, quoting_config)
 
     check_type = "field_minimum"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, server, check_type): [
+        checks_for(model_name, quoting_config, check_type): [
             {
                 f"invalid_count({field_name_for_soda}) = 0": {
                     "name": check_key,
@@ -420,13 +429,15 @@ def check_property_minimum(model_name: str, field_name: str, minimum: int, serve
     )
 
 
-def check_property_maximum(model_name: str, field_name: str, maximum: int, server: Optional[Server] = None):
-    field_name_for_soda = _quote_field_name(field_name, server)
+def check_property_maximum(
+    model_name: str, field_name: str, maximum: int, quoting_config: QuotingConfig = QuotingConfig()
+):
+    field_name_for_soda = _quote_field_name(field_name, quoting_config)
 
     check_type = "field_maximum"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, server, check_type): [
+        checks_for(model_name, quoting_config, check_type): [
             {
                 f"invalid_count({field_name_for_soda}) = 0": {
                     "name": check_key,
@@ -449,13 +460,15 @@ def check_property_maximum(model_name: str, field_name: str, maximum: int, serve
     )
 
 
-def check_property_not_equal(model_name: str, field_name: str, value: int, server: Optional[Server] = None):
-    field_name_for_soda = _quote_field_name(field_name, server)
+def check_property_not_equal(
+    model_name: str, field_name: str, value: int, quoting_config: QuotingConfig = QuotingConfig()
+):
+    field_name_for_soda = _quote_field_name(field_name, quoting_config)
 
     check_type = "field_not_equal"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, server, check_type): [
+        checks_for(model_name, quoting_config, check_type): [
             {
                 f"invalid_count({field_name_for_soda}) = 0": {
                     "name": check_key,
@@ -478,13 +491,13 @@ def check_property_not_equal(model_name: str, field_name: str, value: int, serve
     )
 
 
-def check_property_enum(model_name: str, field_name: str, enum: list, server: Optional[Server] = None):
-    field_name_for_soda = _quote_field_name(field_name, server)
+def check_property_enum(model_name: str, field_name: str, enum: list, quoting_config: QuotingConfig = QuotingConfig()):
+    field_name_for_soda = _quote_field_name(field_name, quoting_config)
 
     check_type = "field_enum"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, server, check_type): [
+        checks_for(model_name, quoting_config, check_type): [
             {
                 f"invalid_count({field_name_for_soda}) = 0": {
                     "name": check_key,
@@ -507,13 +520,15 @@ def check_property_enum(model_name: str, field_name: str, enum: list, server: Op
     )
 
 
-def check_property_regex(model_name: str, field_name: str, pattern: str, server: Optional[Server] = None):
-    field_name_for_soda = _quote_field_name(field_name, server)
+def check_property_regex(
+    model_name: str, field_name: str, pattern: str, quoting_config: QuotingConfig = QuotingConfig()
+):
+    field_name_for_soda = _quote_field_name(field_name, quoting_config)
 
     check_type = "field_regex"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, server, check_type): [
+        checks_for(model_name, quoting_config, check_type): [
             {
                 f"invalid_count({field_name_for_soda}) = 0": {
                     "name": check_key,
@@ -536,11 +551,11 @@ def check_property_regex(model_name: str, field_name: str, pattern: str, server:
     )
 
 
-def check_row_count(model_name: str, threshold: str, server: Optional[Server] = None):
+def check_row_count(model_name: str, threshold: str, quoting_config: QuotingConfig = QuotingConfig()):
     check_type = "row_count"
     check_key = f"{model_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, server, check_type): [
+        checks_for(model_name, quoting_config, check_type): [
             {
                 f"row_count {threshold}": {"name": check_key},
             }
@@ -560,12 +575,14 @@ def check_row_count(model_name: str, threshold: str, server: Optional[Server] = 
     )
 
 
-def check_model_duplicate_values(model_name: str, cols: list[str], threshold: str, server: Optional[Server] = None):
+def check_model_duplicate_values(
+    model_name: str, cols: list[str], threshold: str, quoting_config: QuotingConfig = QuotingConfig()
+):
     check_type = "model_duplicate_values"
     check_key = f"{model_name}__{check_type}"
-    col_joined = ", ".join(_quote_field_name(col, server) for col in cols)
+    col_joined = ", ".join(_quote_field_name(col, quoting_config) for col in cols)
     sodacl_check_dict = {
-        checks_for(model_name, server, check_type): [
+        checks_for(model_name, quoting_config, check_type): [
             {
                 f"duplicate_count({col_joined}) {threshold}": {"name": check_key},
             }
@@ -585,13 +602,15 @@ def check_model_duplicate_values(model_name: str, cols: list[str], threshold: st
     )
 
 
-def check_property_duplicate_values(model_name: str, field_name: str, threshold: str, server: Optional[Server] = None):
-    field_name_for_soda = _quote_field_name(field_name, server)
+def check_property_duplicate_values(
+    model_name: str, field_name: str, threshold: str, quoting_config: QuotingConfig = QuotingConfig()
+):
+    field_name_for_soda = _quote_field_name(field_name, quoting_config)
 
     check_type = "field_duplicate_values"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, server, check_type): [
+        checks_for(model_name, quoting_config, check_type): [
             {
                 f"duplicate_count({field_name_for_soda}) {threshold}": {
                     "name": check_key,
@@ -613,13 +632,15 @@ def check_property_duplicate_values(model_name: str, field_name: str, threshold:
     )
 
 
-def check_property_null_values(model_name: str, field_name: str, threshold: str, server: Optional[Server] = None):
-    field_name_for_soda = _quote_field_name(field_name, server)
+def check_property_null_values(
+    model_name: str, field_name: str, threshold: str, quoting_config: QuotingConfig = QuotingConfig()
+):
+    field_name_for_soda = _quote_field_name(field_name, quoting_config)
 
     check_type = "field_null_values"
     check_key = f"{model_name}__{field_name}__{check_type}"
     sodacl_check_dict = {
-        checks_for(model_name, server, check_type): [
+        checks_for(model_name, quoting_config, check_type): [
             {
                 f"missing_count({field_name_for_soda}) {threshold}": {
                     "name": check_key,
@@ -646,9 +667,9 @@ def check_property_invalid_values(
     field_name: str,
     threshold: str,
     valid_values: list = None,
-    server: Optional[Server] = None,
+    quoting_config: QuotingConfig = QuotingConfig(),
 ):
-    field_name_for_soda = _quote_field_name(field_name, server)
+    field_name_for_soda = _quote_field_name(field_name, quoting_config)
 
     check_type = "field_invalid_values"
     check_key = f"{model_name}__{field_name}__{check_type}"
@@ -661,7 +682,7 @@ def check_property_invalid_values(
         sodacl_check_config["valid values"] = _escape_sql_string_values(valid_values)
 
     sodacl_check_dict = {
-        checks_for(model_name, server, check_type): [
+        checks_for(model_name, quoting_config, check_type): [
             {
                 f"invalid_count({field_name_for_soda}) {threshold}": sodacl_check_config,
             }
@@ -686,9 +707,9 @@ def check_property_missing_values(
     field_name: str,
     threshold: str,
     missing_values: list = None,
-    server: Optional[Server] = None,
+    quoting_config: QuotingConfig = QuotingConfig(),
 ):
-    field_name_for_soda = _quote_field_name(field_name, server)
+    field_name_for_soda = _quote_field_name(field_name, quoting_config)
 
     check_type = "field_missing_values"
     check_key = f"{model_name}__{field_name}__{check_type}"
@@ -703,7 +724,7 @@ def check_property_missing_values(
             sodacl_check_config["missing values"] = _escape_sql_string_values(filtered_missing_values)
 
     sodacl_check_dict = {
-        checks_for(model_name, server, check_type): [
+        checks_for(model_name, quoting_config, check_type): [
             {
                 f"missing_count({field_name_for_soda}) {threshold}": sodacl_check_config,
             }
@@ -727,7 +748,8 @@ def check_quality_list(
     schema_name,
     property_name,
     quality_list: List[DataQuality],
-    server: Optional[Server] = None,
+    quoting_config: QuotingConfig = QuotingConfig(),
+    server: Server = None,
 ) -> List[Check]:
     checks: List[Check] = []
 
@@ -759,7 +781,7 @@ def check_quality_list(
                 check_key = f"{schema_name}__{property_name}__quality_sql_{count}"
                 check_type = "field_quality_sql"
             threshold = to_sodacl_threshold(quality)
-            query = prepare_query(quality, schema_name, property_name, server)
+            query = prepare_query(quality, schema_name, property_name, quoting_config, server)
             if query is None:
                 logger.warning(f"Quality check {check_key} has no query")
                 continue
@@ -767,7 +789,7 @@ def check_quality_list(
                 logger.warning(f"Quality check {check_key} has no valid threshold")
                 continue
 
-            if _server_type(server) in _ANSI_QUOTING_DIALECTS:
+            if quoting_config.quote_model_name:
                 model_name_for_soda = f'"{schema_name}"'
             else:
                 model_name_for_soda = schema_name
@@ -803,26 +825,30 @@ def check_quality_list(
                 continue
 
             if quality.metric == "rowCount":
-                checks.append(check_row_count(schema_name, threshold, server))
+                checks.append(check_row_count(schema_name, threshold, quoting_config))
             elif quality.metric == "duplicateValues":
                 if property_name is None:
                     checks.append(
                         check_model_duplicate_values(
-                            schema_name, quality.arguments.get("properties"), threshold, server
+                            schema_name, quality.arguments.get("properties"), threshold, quoting_config
                         )
                     )
                 else:
-                    checks.append(check_property_duplicate_values(schema_name, property_name, threshold, server))
+                    checks.append(
+                        check_property_duplicate_values(schema_name, property_name, threshold, quoting_config)
+                    )
             elif quality.metric == "nullValues":
                 if property_name is not None:
-                    checks.append(check_property_null_values(schema_name, property_name, threshold, server))
+                    checks.append(check_property_null_values(schema_name, property_name, threshold, quoting_config))
                 else:
                     logger.warning("Quality check nullValues is only supported at field level")
             elif quality.metric == "invalidValues":
                 if property_name is not None:
                     valid_values = quality.arguments.get("validValues") if quality.arguments else None
                     checks.append(
-                        check_property_invalid_values(schema_name, property_name, threshold, valid_values, server)
+                        check_property_invalid_values(
+                            schema_name, property_name, threshold, valid_values, quoting_config
+                        )
                     )
                 else:
                     logger.warning("Quality check invalidValues is only supported at field level")
@@ -830,7 +856,9 @@ def check_quality_list(
                 if property_name is not None:
                     missing_values = quality.arguments.get("missingValues") if quality.arguments else None
                     checks.append(
-                        check_property_missing_values(schema_name, property_name, threshold, missing_values, server)
+                        check_property_missing_values(
+                            schema_name, property_name, threshold, missing_values, quoting_config
+                        )
                     )
                 else:
                     logger.warning("Quality check missingValues is only supported at field level")
@@ -846,7 +874,8 @@ def prepare_query(
     quality: DataQuality,
     model_name: str,
     field_name: str = None,
-    server: Optional[Server] = None,
+    quoting_config: QuotingConfig = QuotingConfig(),
+    server: Server = None,
 ) -> str | None:
     if quality.query is None:
         return None
@@ -855,14 +884,25 @@ def prepare_query(
 
     query = quality.query
 
-    field_name_for_soda = _quote_field_name(field_name, server)
-    model_name_for_soda = _quote_field_name(model_name, server)
+    field_name_for_soda = _quote_field_name(field_name, quoting_config)
+
+    if quoting_config.quote_model_name:
+        model_name_for_soda = f'"{model_name}"'
+    elif quoting_config.quote_model_name_with_backticks:
+        model_name_for_soda = f"`{model_name}`"
+    else:
+        model_name_for_soda = model_name
 
     query = re.sub(r'["\']?\$?\{model}["\']?', model_name_for_soda, query)
     query = re.sub(r'["\']?\$?\{table}["\']?', model_name_for_soda, query)
 
     if server and server.schema_:
-        schema_name_for_soda = _quote_field_name(server.schema_, server)
+        if quoting_config.quote_model_name:
+            schema_name_for_soda = f'"{server.schema_}"'
+        elif quoting_config.quote_model_name_with_backticks:
+            schema_name_for_soda = f"`{server.schema_}`"
+        else:
+            schema_name_for_soda = server.schema_
         query = re.sub(r'["\']?\$?\{schema}["\']?', schema_name_for_soda, query)
     else:
         query = re.sub(r'["\']?\$?\{schema}["\']?', model_name_for_soda, query)

--- a/datacontract/engines/data_contract_checks.py
+++ b/datacontract/engines/data_contract_checks.py
@@ -51,6 +51,7 @@ def _quote_field_name(field_name: str, quoting_config: QuotingConfig) -> str:
 
 
 _BACKTICK_DIALECTS = {"databricks", "bigquery", "mysql", "impala", "dataframe", "kafka"}
+_ANSI_QUOTING_DIALECTS = {"postgres", "sqlserver", "snowflake", "azure", "s3", "gcs", "local"}
 
 _BARE_IDENTIFIER_STRICT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _BARE_IDENTIFIER_PERMISSIVE = re.compile(r"^[A-Za-z_][A-Za-z0-9_$]*$")
@@ -121,10 +122,10 @@ def to_schema_checks(schema_object: SchemaObject, server: Server) -> List[Check]
 
     type1 = server.type if server and server.type else None
     config = QuotingConfig(
-        quote_field_name=type1 in ["postgres", "sqlserver", "snowflake", "azure", "s3", "gcs", "local"],
-        quote_field_name_with_backticks=type1 in ["databricks", "bigquery", "mysql"],
-        quote_model_name=type1 in ["postgres", "sqlserver", "snowflake", "azure", "s3", "gcs", "local"],
-        quote_model_name_with_backticks=type1 in ["databricks", "bigquery", "mysql"],
+        quote_field_name=type1 in _ANSI_QUOTING_DIALECTS,
+        quote_field_name_with_backticks=type1 in _BACKTICK_DIALECTS,
+        quote_model_name=type1 in _ANSI_QUOTING_DIALECTS,
+        quote_model_name_with_backticks=type1 in _BACKTICK_DIALECTS,
     )
     quoting_config = config
 

--- a/tests/test_data_contract_checks.py
+++ b/tests/test_data_contract_checks.py
@@ -1,5 +1,12 @@
 import yaml
-from open_data_contract_standard.model import DataQuality, OpenDataContractStandard, Server
+from open_data_contract_standard.model import (
+    DataQuality,
+    OpenDataContractStandard,
+    SchemaObject,
+    SchemaProperty,
+    Server,
+    ServiceLevelAgreementProperty,
+)
 
 from datacontract.data_contract import DataContract
 from datacontract.engines.data_contract_checks import (
@@ -16,6 +23,7 @@ from datacontract.engines.data_contract_checks import (
     create_checks,
     prepare_query,
     to_schema_checks,
+    to_sla_freshness_check,
 )
 
 
@@ -442,3 +450,61 @@ def test_check_property_missing_values_escapes_single_quotes():
     check_config = checks[0]["missing_count(status) = 0"]
     assert "peter''s" in check_config["missing values"]
     assert "n/a" in check_config["missing values"]
+
+
+def _freshness_contract(model_name: str = "events"):
+    return OpenDataContractStandard(
+        kind="DataContract",
+        apiVersion="v3.1.0",
+        id="freshness-test",
+        schema=[
+            SchemaObject(
+                name=model_name,
+                properties=[SchemaProperty(name="ts", logicalType="timestamp")],
+            )
+        ],
+    )
+
+
+def _freshness_sla(element: str):
+    return ServiceLevelAgreementProperty(property="freshness", element=element, value=24, unit="h")
+
+
+def test_freshness_check_quotes_dollar_field_on_athena():
+    """Athena pseudo-columns like $file_modified_time must be ANSI-quoted to parse."""
+    contract = _freshness_contract("events")
+    sla = _freshness_sla("events.$file_modified_time")
+    server = Server(type="athena")
+
+    check = to_sla_freshness_check(contract, sla, server)
+
+    impl = yaml.safe_load(check.implementation)
+    keys = list(impl["checks for events"][0].keys())
+    assert keys == ['freshness("$file_modified_time") < 24h']
+
+
+def test_freshness_check_leaves_dollar_field_bare_on_postgres():
+    """Postgres allows `$` as a continuation char in bare identifiers; quoting it would
+    force avoidable case-sensitivity on a case-folding dialect."""
+    contract = _freshness_contract("orders")
+    sla = _freshness_sla("orders.col$ext")
+    server = Server(type="postgres")
+
+    check = to_sla_freshness_check(contract, sla, server)
+
+    impl = yaml.safe_load(check.implementation)
+    keys = list(impl["checks for orders"][0].keys())
+    assert keys == ["freshness(col$ext) < 24h"]
+
+
+def test_freshness_check_backticks_special_field_on_databricks():
+    """Backtick dialects (Databricks/Spark) reject `$` bare and need backtick-quoting."""
+    contract = _freshness_contract("events")
+    sla = _freshness_sla("events.$file_modified_time")
+    server = Server(type="databricks")
+
+    check = to_sla_freshness_check(contract, sla, server)
+
+    impl = yaml.safe_load(check.implementation)
+    keys = list(impl["checks for events"][0].keys())
+    assert keys == ["freshness(`$file_modified_time`) < 24h"]

--- a/tests/test_data_contract_checks.py
+++ b/tests/test_data_contract_checks.py
@@ -10,7 +10,6 @@ from open_data_contract_standard.model import (
 
 from datacontract.data_contract import DataContract
 from datacontract.engines.data_contract_checks import (
-    QuotingConfig,
     _escape_sql_string_values,
     check_property_enum,
     check_property_invalid_values,
@@ -28,11 +27,11 @@ from datacontract.engines.data_contract_checks import (
 
 
 def test_prepare_query_schema_placeholder():
-    """Test that {schema} placeholder is replaced with server schema."""
+    """Test that {schema} placeholder is replaced with server schema (no-quoting dialect)."""
     quality = DataQuality(type="sql", query="SELECT * FROM {schema}.{model}")
-    server = Server(**{"type": "postgres", "schema": "my_schema"})
+    server = Server(**{"type": "duckdb", "schema": "my_schema"})
 
-    result = prepare_query(quality, "my_table", None, QuotingConfig(), server)
+    result = prepare_query(quality, "my_table", None, server)
 
     assert result == "SELECT * FROM my_schema.my_table"
 
@@ -41,9 +40,8 @@ def test_prepare_query_schema_placeholder_quoted():
     """Test that {schema} placeholder is quoted for postgres/sqlserver."""
     quality = DataQuality(type="sql", query="SELECT * FROM {schema}.{model}")
     server = Server(**{"type": "postgres", "schema": "my_schema"})
-    quoting_config = QuotingConfig(quote_model_name=True)
 
-    result = prepare_query(quality, "my_table", None, quoting_config, server)
+    result = prepare_query(quality, "my_table", None, server)
 
     assert result == 'SELECT * FROM "my_schema"."my_table"'
 
@@ -52,9 +50,8 @@ def test_prepare_query_schema_placeholder_backticks():
     """Test that {schema} placeholder uses backticks for bigquery."""
     quality = DataQuality(type="sql", query="SELECT * FROM {schema}.{model}")
     server = Server(**{"type": "bigquery", "schema": "my_dataset"})
-    quoting_config = QuotingConfig(quote_model_name_with_backticks=True)
 
-    result = prepare_query(quality, "my_table", None, quoting_config, server)
+    result = prepare_query(quality, "my_table", None, server)
 
     assert result == "SELECT * FROM `my_dataset`.`my_table`"
 
@@ -63,17 +60,17 @@ def test_prepare_query_schema_placeholder_no_server():
     """Test that {schema} falls back to model name when server is None."""
     quality = DataQuality(type="sql", query="SELECT * FROM {schema}")
 
-    result = prepare_query(quality, "my_table", None, QuotingConfig(), None)
+    result = prepare_query(quality, "my_table", None, None)
 
     assert result == "SELECT * FROM my_table"
 
 
 def test_prepare_query_schema_placeholder_no_schema():
-    """Test that {schema} falls back to model name when server has no schema."""
+    """Test that {schema} falls back to model name when server has no schema (no-quoting dialect)."""
     quality = DataQuality(type="sql", query="SELECT * FROM {schema}")
-    server = Server(type="postgres")
+    server = Server(type="duckdb")
 
-    result = prepare_query(quality, "my_table", None, QuotingConfig(), server)
+    result = prepare_query(quality, "my_table", None, server)
 
     assert result == "SELECT * FROM my_table"
 
@@ -81,9 +78,9 @@ def test_prepare_query_schema_placeholder_no_schema():
 def test_prepare_query_schema_placeholder_with_dollar():
     """Test that ${schema} placeholder (with $) is replaced with server schema."""
     quality = DataQuality(type="sql", query="SELECT * FROM ${schema}.${model}")
-    server = Server(**{"type": "postgres", "schema": "my_schema"})
+    server = Server(**{"type": "duckdb", "schema": "my_schema"})
 
-    result = prepare_query(quality, "my_table", None, QuotingConfig(), server)
+    result = prepare_query(quality, "my_table", None, server)
 
     assert result == "SELECT * FROM my_schema.my_table"
 
@@ -91,42 +88,38 @@ def test_prepare_query_schema_placeholder_with_dollar():
 def test_prepare_query_all_placeholders_with_dollar():
     """Test that all placeholders work with $ prefix."""
     quality = DataQuality(type="sql", query="SELECT ${column} FROM ${schema}.${table}")
-    server = Server(**{"type": "postgres", "schema": "my_schema"})
+    server = Server(**{"type": "duckdb", "schema": "my_schema"})
 
-    result = prepare_query(quality, "my_table", "my_field", QuotingConfig(), server)
+    result = prepare_query(quality, "my_table", "my_field", server)
 
     assert result == "SELECT my_field FROM my_schema.my_table"
 
 
 def test_prepare_query_field_backtick_quoting():
-    """Test that field placeholders use backticks for databricks."""
+    """Test that field and model placeholders use backticks for databricks."""
     quality = DataQuality(type="sql", query="SELECT {field} FROM {model}")
-    quoting_config = QuotingConfig(quote_field_name_with_backticks=True)
+    server = Server(type="databricks")
 
-    result = prepare_query(quality, "my_table", "loc/dep", quoting_config, None)
+    result = prepare_query(quality, "my_table", "loc/dep", server)
 
-    assert result == "SELECT `loc/dep` FROM my_table"
+    assert result == "SELECT `loc/dep` FROM `my_table`"
 
 
 def test_check_property_required_backtick_quoting():
-    """Test that field names with special chars are backtick-quoted for databricks."""
-    quoting_config = QuotingConfig(quote_field_name_with_backticks=True)
-
-    check = check_property_required("my_table", "loc/dep", quoting_config)
+    """Test that field and model names are backtick-quoted for databricks."""
+    check = check_property_required("my_table", "loc/dep", Server(type="databricks"))
 
     impl = yaml.safe_load(check.implementation)
-    checks = impl["checks for my_table"]
+    checks = impl["checks for `my_table`"]
     assert any("missing_count(`loc/dep`) = 0" in str(c) for c in checks)
 
 
 def test_check_property_unique_backtick_quoting():
-    """Test that field names with special chars are backtick-quoted for unique checks."""
-    quoting_config = QuotingConfig(quote_field_name_with_backticks=True)
-
-    check = check_property_unique("my_table", "loc/dep", quoting_config)
+    """Test that field and model names are backtick-quoted for unique checks on databricks."""
+    check = check_property_unique("my_table", "loc/dep", Server(type="databricks"))
 
     impl = yaml.safe_load(check.implementation)
-    checks = impl["checks for my_table"]
+    checks = impl["checks for `my_table`"]
     assert any("duplicate_count(`loc/dep`) = 0" in str(c) for c in checks)
 
 
@@ -135,9 +128,7 @@ def test_check_property_is_present_no_backtick_quoting():
 
     Schema checks use metadata comparison, not SQL identifiers.
     """
-    quoting_config = QuotingConfig(quote_field_name_with_backticks=True)
-
-    check = check_property_is_present("my_table", "loc/dep", quoting_config)
+    check = check_property_is_present("my_table", "loc/dep", Server(type="databricks"))
 
     impl = yaml.safe_load(check.implementation)
     checks = impl["checks for my_table"]
@@ -150,9 +141,7 @@ def test_check_property_type_no_backtick_quoting():
 
     Schema checks use metadata comparison, not SQL identifiers.
     """
-    quoting_config = QuotingConfig(quote_field_name_with_backticks=True)
-
-    check = check_property_type("my_table", "loc/dep", "string", quoting_config)
+    check = check_property_type("my_table", "loc/dep", "string", Server(type="databricks"))
 
     impl = yaml.safe_load(check.implementation)
     checks = impl["checks for my_table"]
@@ -161,32 +150,28 @@ def test_check_property_type_no_backtick_quoting():
 
 
 def test_prepare_query_snowflake_field_quoting():
-    """Test that field placeholders use double quotes for snowflake."""
+    """Test that field placeholders are double-quoted for snowflake."""
     quality = DataQuality(type="sql", query="SELECT {field} FROM {model}")
-    quoting_config = QuotingConfig(quote_model_name=True)
     server = Server(**{"type": "snowflake", "schema": "my_schema"})
 
-    result = prepare_query(quality, "my_table", "name", quoting_config, server)
+    result = prepare_query(quality, "my_table", "name", server)
 
-    assert result == 'SELECT name FROM "my_table"'
+    assert result == 'SELECT "name" FROM "my_table"'
 
 
 def test_prepare_query_snowflake_schema_model_quoting():
     """Test that schema and model placeholders use double quotes for snowflake."""
     quality = DataQuality(type="sql", query="SELECT * FROM {schema}.{model}")
-    quoting_config = QuotingConfig(quote_field_name=True, quote_model_name=True)
     server = Server(**{"type": "snowflake", "schema": "my_schema"})
 
-    result = prepare_query(quality, "my_table", None, quoting_config, server)
+    result = prepare_query(quality, "my_table", None, server)
 
     assert result == 'SELECT * FROM "my_schema"."my_table"'
 
 
 def test_check_property_required_snowflake_quoting():
     """Test that field names are double-quoted for snowflake required checks."""
-    quoting_config = QuotingConfig(quote_field_name=True, quote_model_name=True)
-
-    check = check_property_required("my_table", "name", quoting_config)
+    check = check_property_required("my_table", "name", Server(type="snowflake"))
 
     impl = yaml.safe_load(check.implementation)
     checks = impl['checks for "my_table"']
@@ -195,9 +180,7 @@ def test_check_property_required_snowflake_quoting():
 
 def test_check_property_unique_snowflake_quoting():
     """Test that field names are double-quoted for snowflake unique checks."""
-    quoting_config = QuotingConfig(quote_field_name=True, quote_model_name=True)
-
-    check = check_property_unique("my_table", "name", quoting_config)
+    check = check_property_unique("my_table", "name", Server(type="snowflake"))
 
     impl = yaml.safe_load(check.implementation)
     checks = impl['checks for "my_table"']
@@ -209,9 +192,7 @@ def test_check_property_is_present_no_snowflake_quoting():
 
     Schema checks use metadata comparison, not SQL identifiers.
     """
-    quoting_config = QuotingConfig(quote_field_name=True, quote_model_name=True)
-
-    check = check_property_is_present("my_table", "name", quoting_config)
+    check = check_property_is_present("my_table", "name", Server(type="snowflake"))
 
     impl = yaml.safe_load(check.implementation)
     checks = impl['checks for "my_table"']
@@ -220,18 +201,16 @@ def test_check_property_is_present_no_snowflake_quoting():
 
 
 def test_check_property_required_duckdb_hyphenated_model_name():
-    """Test that model names with hyphens are double-quoted in required checks for DuckDB-backed sources (s3/gcs/azure/local)."""
-    quoting_config = QuotingConfig(quote_model_name=True)
-    check = check_property_required("test-1", "name", quoting_config)
+    """Test that hyphenated model names are double-quoted on ANSI-quoting dialects (s3/gcs/azure/local)."""
+    check = check_property_required("test-1", "name", Server(type="s3"))
     impl = yaml.safe_load(check.implementation)
     checks = impl['checks for "test-1"']
-    assert any("missing_count(name) = 0" in str(c) for c in checks)
+    assert any('missing_count("name") = 0' in str(c) for c in checks)
 
 
 def test_check_property_is_present_duckdb_hyphenated_model_name():
-    """Test that model names with hyphens are double-quoted for DuckDB-backed sources (s3/gcs/azure/local)."""
-    quoting_config = QuotingConfig(quote_model_name=True)
-    check = check_property_is_present("test-1", "name", quoting_config)
+    """Test that hyphenated model names are double-quoted on ANSI-quoting dialects (s3/gcs/azure/local)."""
+    check = check_property_is_present("test-1", "name", Server(type="s3"))
     impl = yaml.safe_load(check.implementation)
     checks = impl['checks for "test-1"']
     schema_check = checks[0]["schema"]
@@ -346,9 +325,8 @@ def test_prepare_query_schema_placeholder_backticks_databricks():
     """Test that {schema} and {model} placeholders use backticks for databricks."""
     quality = DataQuality(type="sql", query="SELECT * FROM {schema}.{model}")
     server = Server(**{"type": "databricks", "schema": "my_schema"})
-    quoting_config = QuotingConfig(quote_model_name_with_backticks=True)
 
-    result = prepare_query(quality, "my_table", None, quoting_config, server)
+    result = prepare_query(quality, "my_table", None, server)
 
     assert result == "SELECT * FROM `my_schema`.`my_table`"
 

--- a/tests/test_data_contract_checks.py
+++ b/tests/test_data_contract_checks.py
@@ -10,6 +10,7 @@ from open_data_contract_standard.model import (
 
 from datacontract.data_contract import DataContract
 from datacontract.engines.data_contract_checks import (
+    QuotingConfig,
     _escape_sql_string_values,
     check_property_enum,
     check_property_invalid_values,
@@ -27,11 +28,11 @@ from datacontract.engines.data_contract_checks import (
 
 
 def test_prepare_query_schema_placeholder():
-    """Test that {schema} placeholder is replaced with server schema (no-quoting dialect)."""
+    """Test that {schema} placeholder is replaced with server schema."""
     quality = DataQuality(type="sql", query="SELECT * FROM {schema}.{model}")
-    server = Server(**{"type": "duckdb", "schema": "my_schema"})
+    server = Server(**{"type": "postgres", "schema": "my_schema"})
 
-    result = prepare_query(quality, "my_table", None, server)
+    result = prepare_query(quality, "my_table", None, QuotingConfig(), server)
 
     assert result == "SELECT * FROM my_schema.my_table"
 
@@ -40,8 +41,9 @@ def test_prepare_query_schema_placeholder_quoted():
     """Test that {schema} placeholder is quoted for postgres/sqlserver."""
     quality = DataQuality(type="sql", query="SELECT * FROM {schema}.{model}")
     server = Server(**{"type": "postgres", "schema": "my_schema"})
+    quoting_config = QuotingConfig(quote_model_name=True)
 
-    result = prepare_query(quality, "my_table", None, server)
+    result = prepare_query(quality, "my_table", None, quoting_config, server)
 
     assert result == 'SELECT * FROM "my_schema"."my_table"'
 
@@ -50,8 +52,9 @@ def test_prepare_query_schema_placeholder_backticks():
     """Test that {schema} placeholder uses backticks for bigquery."""
     quality = DataQuality(type="sql", query="SELECT * FROM {schema}.{model}")
     server = Server(**{"type": "bigquery", "schema": "my_dataset"})
+    quoting_config = QuotingConfig(quote_model_name_with_backticks=True)
 
-    result = prepare_query(quality, "my_table", None, server)
+    result = prepare_query(quality, "my_table", None, quoting_config, server)
 
     assert result == "SELECT * FROM `my_dataset`.`my_table`"
 
@@ -60,17 +63,17 @@ def test_prepare_query_schema_placeholder_no_server():
     """Test that {schema} falls back to model name when server is None."""
     quality = DataQuality(type="sql", query="SELECT * FROM {schema}")
 
-    result = prepare_query(quality, "my_table", None, None)
+    result = prepare_query(quality, "my_table", None, QuotingConfig(), None)
 
     assert result == "SELECT * FROM my_table"
 
 
 def test_prepare_query_schema_placeholder_no_schema():
-    """Test that {schema} falls back to model name when server has no schema (no-quoting dialect)."""
+    """Test that {schema} falls back to model name when server has no schema."""
     quality = DataQuality(type="sql", query="SELECT * FROM {schema}")
-    server = Server(type="duckdb")
+    server = Server(type="postgres")
 
-    result = prepare_query(quality, "my_table", None, server)
+    result = prepare_query(quality, "my_table", None, QuotingConfig(), server)
 
     assert result == "SELECT * FROM my_table"
 
@@ -78,9 +81,9 @@ def test_prepare_query_schema_placeholder_no_schema():
 def test_prepare_query_schema_placeholder_with_dollar():
     """Test that ${schema} placeholder (with $) is replaced with server schema."""
     quality = DataQuality(type="sql", query="SELECT * FROM ${schema}.${model}")
-    server = Server(**{"type": "duckdb", "schema": "my_schema"})
+    server = Server(**{"type": "postgres", "schema": "my_schema"})
 
-    result = prepare_query(quality, "my_table", None, server)
+    result = prepare_query(quality, "my_table", None, QuotingConfig(), server)
 
     assert result == "SELECT * FROM my_schema.my_table"
 
@@ -88,38 +91,42 @@ def test_prepare_query_schema_placeholder_with_dollar():
 def test_prepare_query_all_placeholders_with_dollar():
     """Test that all placeholders work with $ prefix."""
     quality = DataQuality(type="sql", query="SELECT ${column} FROM ${schema}.${table}")
-    server = Server(**{"type": "duckdb", "schema": "my_schema"})
+    server = Server(**{"type": "postgres", "schema": "my_schema"})
 
-    result = prepare_query(quality, "my_table", "my_field", server)
+    result = prepare_query(quality, "my_table", "my_field", QuotingConfig(), server)
 
     assert result == "SELECT my_field FROM my_schema.my_table"
 
 
 def test_prepare_query_field_backtick_quoting():
-    """Test that field and model placeholders use backticks for databricks."""
+    """Test that field placeholders use backticks for databricks."""
     quality = DataQuality(type="sql", query="SELECT {field} FROM {model}")
-    server = Server(type="databricks")
+    quoting_config = QuotingConfig(quote_field_name_with_backticks=True)
 
-    result = prepare_query(quality, "my_table", "loc/dep", server)
+    result = prepare_query(quality, "my_table", "loc/dep", quoting_config, None)
 
-    assert result == "SELECT `loc/dep` FROM `my_table`"
+    assert result == "SELECT `loc/dep` FROM my_table"
 
 
 def test_check_property_required_backtick_quoting():
-    """Test that field and model names are backtick-quoted for databricks."""
-    check = check_property_required("my_table", "loc/dep", Server(type="databricks"))
+    """Test that field names with special chars are backtick-quoted for databricks."""
+    quoting_config = QuotingConfig(quote_field_name_with_backticks=True)
+
+    check = check_property_required("my_table", "loc/dep", quoting_config)
 
     impl = yaml.safe_load(check.implementation)
-    checks = impl["checks for `my_table`"]
+    checks = impl["checks for my_table"]
     assert any("missing_count(`loc/dep`) = 0" in str(c) for c in checks)
 
 
 def test_check_property_unique_backtick_quoting():
-    """Test that field and model names are backtick-quoted for unique checks on databricks."""
-    check = check_property_unique("my_table", "loc/dep", Server(type="databricks"))
+    """Test that field names with special chars are backtick-quoted for unique checks."""
+    quoting_config = QuotingConfig(quote_field_name_with_backticks=True)
+
+    check = check_property_unique("my_table", "loc/dep", quoting_config)
 
     impl = yaml.safe_load(check.implementation)
-    checks = impl["checks for `my_table`"]
+    checks = impl["checks for my_table"]
     assert any("duplicate_count(`loc/dep`) = 0" in str(c) for c in checks)
 
 
@@ -128,7 +135,9 @@ def test_check_property_is_present_no_backtick_quoting():
 
     Schema checks use metadata comparison, not SQL identifiers.
     """
-    check = check_property_is_present("my_table", "loc/dep", Server(type="databricks"))
+    quoting_config = QuotingConfig(quote_field_name_with_backticks=True)
+
+    check = check_property_is_present("my_table", "loc/dep", quoting_config)
 
     impl = yaml.safe_load(check.implementation)
     checks = impl["checks for my_table"]
@@ -141,7 +150,9 @@ def test_check_property_type_no_backtick_quoting():
 
     Schema checks use metadata comparison, not SQL identifiers.
     """
-    check = check_property_type("my_table", "loc/dep", "string", Server(type="databricks"))
+    quoting_config = QuotingConfig(quote_field_name_with_backticks=True)
+
+    check = check_property_type("my_table", "loc/dep", "string", quoting_config)
 
     impl = yaml.safe_load(check.implementation)
     checks = impl["checks for my_table"]
@@ -150,28 +161,32 @@ def test_check_property_type_no_backtick_quoting():
 
 
 def test_prepare_query_snowflake_field_quoting():
-    """Test that field placeholders are double-quoted for snowflake."""
+    """Test that field placeholders use double quotes for snowflake."""
     quality = DataQuality(type="sql", query="SELECT {field} FROM {model}")
+    quoting_config = QuotingConfig(quote_model_name=True)
     server = Server(**{"type": "snowflake", "schema": "my_schema"})
 
-    result = prepare_query(quality, "my_table", "name", server)
+    result = prepare_query(quality, "my_table", "name", quoting_config, server)
 
-    assert result == 'SELECT "name" FROM "my_table"'
+    assert result == 'SELECT name FROM "my_table"'
 
 
 def test_prepare_query_snowflake_schema_model_quoting():
     """Test that schema and model placeholders use double quotes for snowflake."""
     quality = DataQuality(type="sql", query="SELECT * FROM {schema}.{model}")
+    quoting_config = QuotingConfig(quote_field_name=True, quote_model_name=True)
     server = Server(**{"type": "snowflake", "schema": "my_schema"})
 
-    result = prepare_query(quality, "my_table", None, server)
+    result = prepare_query(quality, "my_table", None, quoting_config, server)
 
     assert result == 'SELECT * FROM "my_schema"."my_table"'
 
 
 def test_check_property_required_snowflake_quoting():
     """Test that field names are double-quoted for snowflake required checks."""
-    check = check_property_required("my_table", "name", Server(type="snowflake"))
+    quoting_config = QuotingConfig(quote_field_name=True, quote_model_name=True)
+
+    check = check_property_required("my_table", "name", quoting_config)
 
     impl = yaml.safe_load(check.implementation)
     checks = impl['checks for "my_table"']
@@ -180,7 +195,9 @@ def test_check_property_required_snowflake_quoting():
 
 def test_check_property_unique_snowflake_quoting():
     """Test that field names are double-quoted for snowflake unique checks."""
-    check = check_property_unique("my_table", "name", Server(type="snowflake"))
+    quoting_config = QuotingConfig(quote_field_name=True, quote_model_name=True)
+
+    check = check_property_unique("my_table", "name", quoting_config)
 
     impl = yaml.safe_load(check.implementation)
     checks = impl['checks for "my_table"']
@@ -192,7 +209,9 @@ def test_check_property_is_present_no_snowflake_quoting():
 
     Schema checks use metadata comparison, not SQL identifiers.
     """
-    check = check_property_is_present("my_table", "name", Server(type="snowflake"))
+    quoting_config = QuotingConfig(quote_field_name=True, quote_model_name=True)
+
+    check = check_property_is_present("my_table", "name", quoting_config)
 
     impl = yaml.safe_load(check.implementation)
     checks = impl['checks for "my_table"']
@@ -201,16 +220,18 @@ def test_check_property_is_present_no_snowflake_quoting():
 
 
 def test_check_property_required_duckdb_hyphenated_model_name():
-    """Test that hyphenated model names are double-quoted on ANSI-quoting dialects (s3/gcs/azure/local)."""
-    check = check_property_required("test-1", "name", Server(type="s3"))
+    """Test that model names with hyphens are double-quoted in required checks for DuckDB-backed sources (s3/gcs/azure/local)."""
+    quoting_config = QuotingConfig(quote_model_name=True)
+    check = check_property_required("test-1", "name", quoting_config)
     impl = yaml.safe_load(check.implementation)
     checks = impl['checks for "test-1"']
-    assert any('missing_count("name") = 0' in str(c) for c in checks)
+    assert any("missing_count(name) = 0" in str(c) for c in checks)
 
 
 def test_check_property_is_present_duckdb_hyphenated_model_name():
-    """Test that hyphenated model names are double-quoted on ANSI-quoting dialects (s3/gcs/azure/local)."""
-    check = check_property_is_present("test-1", "name", Server(type="s3"))
+    """Test that model names with hyphens are double-quoted for DuckDB-backed sources (s3/gcs/azure/local)."""
+    quoting_config = QuotingConfig(quote_model_name=True)
+    check = check_property_is_present("test-1", "name", quoting_config)
     impl = yaml.safe_load(check.implementation)
     checks = impl['checks for "test-1"']
     schema_check = checks[0]["schema"]
@@ -325,8 +346,9 @@ def test_prepare_query_schema_placeholder_backticks_databricks():
     """Test that {schema} and {model} placeholders use backticks for databricks."""
     quality = DataQuality(type="sql", query="SELECT * FROM {schema}.{model}")
     server = Server(**{"type": "databricks", "schema": "my_schema"})
+    quoting_config = QuotingConfig(quote_model_name_with_backticks=True)
 
-    result = prepare_query(quality, "my_table", None, server)
+    result = prepare_query(quality, "my_table", None, quoting_config, server)
 
     assert result == "SELECT * FROM `my_schema`.`my_table`"
 


### PR DESCRIPTION
## Summary

1. **fix:** SLA freshness checks now quote a column identifier only when the target dialect would reject the bare form. Athena pseudo-columns like `$file_modified_time` get ANSI-quoted, special-character names on Spark/Databricks/BigQuery/Kafka get backtick-quoted, and ordinary identifiers stay bare so dialect case-folding is preserved.
2. **refactor:** Lift the dialect lists in `to_schema_checks` into module-level constants `_BACKTICK_DIALECTS` and `_ANSI_QUOTING_DIALECTS` so each list has a single source of truth. Side effect: schema/quality checks on Impala, dataframe, and Kafka servers now backtick-quote identifiers (matching their existing behavior in the freshness path; closes a latent quoting gap on Spark/HMS-backed engines).

## Behavior

For the field name `$file_modified_time`:

| dialect | freshness output |
|---|---|
| postgres / snowflake / oracle / sqlserver | `freshness(col$ext) < 24h` (`$` valid bare; stays unquoted) |
| athena / trino | `freshness("$file_modified_time") < 24h` |
| databricks / bigquery / mysql / impala / dataframe / kafka | `` freshness(`$file_modified_time`) < 24h `` |

For ordinary identifiers (e.g. `order_timestamp`): bare on all dialects — no behavior change for the common case.

## Why "quote only when needed" instead of "always quote"

An earlier draft of this PR force-quoted every identifier per dialect. That introduced a breaking change: on case-folding dialects (Postgres folds to lowercase, Snowflake/Oracle to uppercase), every quote forces case-sensitivity that the bare form doesn't have. The conservative rule in the current commit avoids that — quoting is only emitted when the identifier literally cannot work bare on the target dialect.

## Known limitations (pre-existing, unchanged)

- Reserved-word column names (e.g. a column literally named `order`) are still emitted unquoted and would fail at SQL time. Out of scope for this PR; would need a per-dialect reserved-word list.
- The same special-character quoting fix would apply to SLA retention checks (`MIN({field_name})`), but is left for a follow-up.

## Test plan
- [x] `pytest tests/` (excluding heavy integration tests that require Java/external services) — 600 passed
- [x] New regression test: `test_freshness_check_quotes_dollar_field_on_athena`
- [x] Design-lock test: `test_freshness_check_leaves_dollar_field_bare_on_postgres` (defends the case-sensitivity-preservation principle)
- [x] Backtick branch: `test_freshness_check_backticks_special_field_on_databricks`

🤖 Generated with [Claude Code](https://claude.com/claude-code)