### PR TITLE
feat(quality): support {object} placeholder in SQL quality queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+- quality: support `{object}` and `${object}` placeholder in SQL quality queries as the ODCS-spec name for the current schema object (alias for `{model}`/`{table}`) (#676)
 - `changelog` command help text now advertises `(url or path)` for V1/V2 arguments, clarifying that HTTP/HTTPS URLs are accepted (#1162)
 - **breaking:** `test` command now exits non-zero when a server is specified, but soda-core fails to connect or authenticate (#1181)
 - correct swapped `check_type` labels  `model_qualty_sql` and `field_quality_sql` (#1187)

--- a/datacontract/engines/data_contract_checks.py
+++ b/datacontract/engines/data_contract_checks.py
@@ -896,6 +896,7 @@ def prepare_query(
 
     query = re.sub(r'["\']?\$?\{model}["\']?', model_name_for_soda, query)
     query = re.sub(r'["\']?\$?\{table}["\']?', model_name_for_soda, query)
+    query = re.sub(r'["\']?\$?\{object}["\']?', model_name_for_soda, query)
 
     if server and server.schema_:
         if quoting_config.quote_model_name:

--- a/tests/test_data_contract_checks.py
+++ b/tests/test_data_contract_checks.py
@@ -98,6 +98,24 @@ def test_prepare_query_all_placeholders_with_dollar():
     assert result == "SELECT my_field FROM my_schema.my_table"
 
 
+def test_prepare_query_object_placeholder():
+    """Test that {object} and ${object} placeholders are replaced with the model name (ODCS spec terminology)."""
+    quality = DataQuality(type="sql", query="SELECT COUNT(*) FROM {object} WHERE ${object} IS NOT NULL")
+
+    result = prepare_query(quality, "my_table", None, QuotingConfig(), None)
+
+    assert result == "SELECT COUNT(*) FROM my_table WHERE my_table IS NOT NULL"
+
+
+def test_prepare_query_object_and_property_placeholders():
+    """Test the canonical ODCS-spec example: SELECT COUNT(*) FROM {object} WHERE {property} IS NOT NULL."""
+    quality = DataQuality(type="sql", query="SELECT COUNT(*) FROM {object} WHERE {property} IS NOT NULL")
+
+    result = prepare_query(quality, "my_table", "my_field", QuotingConfig(), None)
+
+    assert result == "SELECT COUNT(*) FROM my_table WHERE my_field IS NOT NULL"
+
+
 def test_prepare_query_field_backtick_quoting():
     """Test that field placeholders use backticks for databricks."""
     quality = DataQuality(type="sql", query="SELECT {field} FROM {model}")


### PR DESCRIPTION
## Summary

- Adds `{object}` / `${object}` substitution to `prepare_query` in `data_contract_checks.py` as an alias for `{model}`/`{table}`. Picks up the same dialect-aware quoting.
- Brings the CLI in line with the [ODCS spec](https://bitol-io.github.io/open-data-contract-standard/latest/#valid-properties-for-operator), which documents `{object}` and `{property}` as the canonical SQL-quality placeholders.
- Closes #676. Also makes `datacontract-editor`'s existing `Use {object} and {property} as placeholders` hint correct end-to-end.

### Why now

Found while debugging why `{object}` leaks unreplaced into quality SQL. `{object}` was never substituted in any released version of the CLI (verified across all 24 historical revisions of `prepare_query`). Asymmetry crept in with #783, which added `{property}` (the ODCS-spec property alias) but missed adding `{object}` alongside `{model}`/`{table}`.

## Test plan

- [x] `pytest tests/test_data_contract_checks.py` — 41/41 pass
- [x] `ruff check` / `ruff format --check` clean
- [x] New tests cover bare `{object}`, `${object}`, and the canonical ODCS example `SELECT COUNT(*) FROM {object} WHERE {property} IS NOT NULL`
- [ ] CI green