### PR TITLE
chore: align README install extras with pyproject.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- `impala` extra (`pip install datacontract-cli[impala]`) — pulls in `soda-core-impala`. Impala engine support landed in #965 but the install extra was never added; users had to install `soda-core-impala` manually. Also included in `[all]`.
+
 ### Fixed
+- README install table: add missing `csv`, `excel`, and `oracle` extras. The matching `[project.optional-dependencies]` entries already existed but were undocumented.
 - `changelog` command help text now advertises `(url or path)` for V1/V2 arguments, clarifying that HTTP/HTTPS URLs are accepted (#1162)
 - **breaking:** `test` command now exits non-zero when a server is specified, but soda-core fails to connect or authenticate (#1181)
 - correct swapped `check_type` labels  `model_qualty_sql` and `field_quality_sql` (#1187)

--- a/README.md
+++ b/README.md
@@ -241,23 +241,26 @@ A list of available extras:
 | Amazon Athena           | `pip install datacontract-cli[athena]`     |
 | Avro Support            | `pip install datacontract-cli[avro]`       |
 | Google BigQuery         | `pip install datacontract-cli[bigquery]`   |
+| CSV                     | `pip install datacontract-cli[csv]`        |
 | Databricks Integration  | `pip install datacontract-cli[databricks]` |
+| dbt                     | `pip install datacontract-cli[dbt]`        |
+| DBML                    | `pip install datacontract-cli[dbml]`       |
 | DuckDB (local/S3/GCS/Azure file testing) | `pip install datacontract-cli[duckdb]` |
+| Excel                   | `pip install datacontract-cli[excel]`      |
 | Iceberg                 | `pip install datacontract-cli[iceberg]`    |
+| Impala                  | `pip install datacontract-cli[impala]`     |
 | Kafka Integration       | `pip install datacontract-cli[kafka]`      |
 | MySQL Integration       | `pip install datacontract-cli[mysql]`      |
+| Oracle                  | `pip install datacontract-cli[oracle]`     |
+| Parquet                 | `pip install datacontract-cli[parquet]`    |
 | PostgreSQL Integration  | `pip install datacontract-cli[postgres]`   |
+| protobuf                | `pip install datacontract-cli[protobuf]`   |
+| RDF                     | `pip install datacontract-cli[rdf]`        |
 | S3 Integration          | `pip install datacontract-cli[s3]`         |
 | Snowflake Integration   | `pip install datacontract-cli[snowflake]`  |
 | Microsoft SQL Server    | `pip install datacontract-cli[sqlserver]`  |
 | Trino                   | `pip install datacontract-cli[trino]`      |
-| Impala                  | `pip install datacontract-cli[impala]` 	   |
-| dbt                     | `pip install datacontract-cli[dbt]`        |
-| DBML                    | `pip install datacontract-cli[dbml]`       |
-| Parquet                 | `pip install datacontract-cli[parquet]`    |
-| RDF                     | `pip install datacontract-cli[rdf]`        |
 | API (run as web server) | `pip install datacontract-cli[api]`        |
-| protobuf                | `pip install datacontract-cli[protobuf]`   |
 
 
 ## Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,10 @@ trino = [
   "soda-core-trino>=3.3.20,<3.6.0"
 ]
 
+impala = [
+  "soda-core-impala>=3.3.20,<3.6.0"
+]
+
 dbt = [
   "dbt-core>=1.8.0"
 ]
@@ -137,7 +141,7 @@ protobuf = [
 ]
 
 all = [
-  "datacontract-cli[kafka,bigquery,csv,excel,snowflake,postgres,mysql,databricks,sqlserver,s3,athena,trino,dbt,dbml,duckdb,iceberg,parquet,rdf,api,protobuf,oracle]"
+  "datacontract-cli[kafka,bigquery,csv,excel,snowflake,postgres,mysql,databricks,sqlserver,s3,athena,trino,impala,dbt,dbml,duckdb,iceberg,parquet,rdf,api,protobuf,oracle]"
 ]
 
 # for development, we pin all libraries to an exact version


### PR DESCRIPTION
## Summary

Cross-checked the README install table against `[project.optional-dependencies]` in `pyproject.toml`. Found four discrepancies:

- **`impala` extra was advertised in README but didn't exist.** Engine support landed in #965 (Dec 2025), which added the README row and runtime code, but never added the `impala` extra to `pyproject.toml` or to `[all]`. Users running `pip install datacontract-cli[impala]` hit "WARNING: datacontract-cli does not provide the extra 'impala'", and `[all]` users didn't get `soda-core-impala` either. Added the extra (`soda-core-impala>=3.3.20,<3.6.0`) and included it in `[all]`.
- **`csv`, `excel`, `oracle` extras existed but were undocumented.** Added rows to the README install table.

Also resorted the table alphabetically by extra name (with the API row at the end since it's not a data source).

After this change: 23 extras in `pyproject.toml` ↔ 23 rows in the README install table, with zero orphans either way (verified via script).

## Test plan

- [x] Verified parity by parsing both files: `extras == in_readme_table` is True.
- [x] No code changes — install-metadata only.
- [ ] CI green