### PR TITLE
chore!: switch protobuf import to external protoc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,10 +41,10 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - name: Install msodbcsql18
+      - name: Install system dependencies (msodbcsql18, protoc)
         run: |
           sudo apt-get update
-          sudo apt-get install -y msodbcsql18
+          sudo apt-get install -y msodbcsql18 protobuf-compiler
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** `test` command now exits non-zero when a server is specified, but soda-core fails to connect or authenticate (#1181)
 - correct swapped `check_type` labels  `model_qualty_sql` and `field_quality_sql` (#1187)
 - `import spark` now emits a native Spark SQL physicalType (e.g. `string`) instead of Python repr (e.g. `StringType()`). Contracts imported using Spark in v0.11.0–v0.12.1 did not perform type checks and must be re-imported. (#1048)
-- Remove unnecessary `setuptools` dependency from `pyproject.toml` (temporary workaround for soda-core#2091 resolved) (#1199)
+- Re-add `setuptools` as a base dependency. soda-core's `env_helper.py` imports `from distutils.util import strtobool`; `distutils` was removed from stdlib in Python 3.12 and stripped from python-build-standalone 3.11 builds. `setuptools` provides the `distutils` shim. Previously pulled in transitively via `grpcio-tools`; now required explicitly. Reverts #1199 — see soda-core#2091.
 - SLA freshness checks now quote column identifiers with special characters (#1202)
 - update field / model quotation for Impala, dataframe, and Kafka (#1202)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **breaking:** drop the `dbt` extra and the `dbt-core` dependency. `import dbt` now reads `manifest.json` directly with no third-party dependency, and works without installing any extra. Minimum supported manifest schema version is v9 (dbt 1.5+). Users who installed `datacontract-cli[dbt]` should switch to plain `datacontract-cli`.
+- **breaking:** the `protobuf` extra now requires the `protoc` compiler installed on the system. Replaces the bundled `grpcio-tools` (~50 MB of platform-specific protoc binaries) with the lighter `protobuf` runtime (`>=3.20,<7.0`). `import protobuf` raises a clear error with platform-specific install hints if `protoc` is not on `PATH`. Install with `brew install protobuf` (macOS), `sudo apt install protobuf-compiler` (Debian/Ubuntu), etc. — see README.
 
 ### Fixed
 - README install table: add missing `csv`, `excel`, and `oracle` extras. The matching `[project.optional-dependencies]` entries already existed but were undocumented.

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,12 @@ ENV UV_COMPILE_BYTECODE=1
 # install uv
 COPY --from=ghcr.io/astral-sh/uv:0.6.9 /uv /uvx /bin/
 
+# install protoc — required by `datacontract import protobuf` (the CLI shells out
+# to the system protoc to compile .proto files into FileDescriptorSets)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
 # copy resources
 COPY pyproject.toml /app/.
 COPY MANIFEST.in /app/.

--- a/README.md
+++ b/README.md
@@ -1870,7 +1870,17 @@ datacontract import csv --source "test.csv"
 <details markdown="1">
 <summary><strong>protobuf</strong></summary>
 
-Importing from protobuf File. Specify file in `source` parameter. 
+Importing from protobuf File. Specify file in `source` parameter.
+
+Requires the `protoc` compiler installed on the system. Install with:
+
+| Platform       | Command                              |
+|----------------|--------------------------------------|
+| macOS          | `brew install protobuf`              |
+| Debian/Ubuntu  | `sudo apt install protobuf-compiler` |
+| Fedora/RHEL    | `sudo dnf install protobuf-compiler` |
+| Arch           | `sudo pacman -S protobuf`            |
+| Windows        | `choco install protoc` (or [download a release](https://github.com/protocolbuffers/protobuf/releases)) |
 
 Example:
 

--- a/datacontract/imports/protobuf_importer.py
+++ b/datacontract/imports/protobuf_importer.py
@@ -1,10 +1,11 @@
 import os
 import re
+import shutil
+import subprocess
 import tempfile
 from typing import List
 
 from google.protobuf import descriptor_pb2
-from grpc_tools import protoc
 from open_data_contract_standard.model import OpenDataContractStandard, SchemaProperty
 
 from datacontract.imports.importer import Importer
@@ -14,6 +15,19 @@ from datacontract.imports.odcs_helper import (
     create_schema_object,
 )
 from datacontract.model.exceptions import DataContractException
+
+_PROTOC_INSTALL_HINT = """\
+The 'protoc' compiler is required to import .proto files but was not found on your PATH.
+
+Install it with your platform's package manager:
+  macOS         : brew install protobuf
+  Debian/Ubuntu : sudo apt install protobuf-compiler
+  Fedora/RHEL   : sudo dnf install protobuf-compiler
+  Arch          : sudo pacman -S protobuf
+  Windows       : choco install protoc
+                  or download from https://github.com/protocolbuffers/protobuf/releases
+
+After installing, verify with: protoc --version"""
 
 
 def map_type_from_protobuf(field_type: int) -> str:
@@ -55,7 +69,17 @@ def parse_imports_raw(proto_file: str) -> list:
 
 
 def compile_proto_to_binary(proto_files: list, output_file: str, proto_root: str = None):
-    """Compile the provided proto files into a single descriptor set."""
+    """Compile the provided proto files into a single FileDescriptorSet using the system `protoc`."""
+    protoc_path = shutil.which("protoc")
+    if protoc_path is None:
+        raise DataContractException(
+            type="schema",
+            name="Compile proto files",
+            reason=_PROTOC_INSTALL_HINT,
+            engine="datacontract",
+            original_exception=None,
+        )
+
     if proto_root:
         proto_dirs = {proto_root}
     else:
@@ -63,17 +87,43 @@ def compile_proto_to_binary(proto_files: list, output_file: str, proto_root: str
     proto_paths = [f"--proto_path={d}" for d in proto_dirs]
 
     abs_proto_files = [os.path.abspath(proto) for proto in proto_files]
+    args = [protoc_path, *proto_paths, f"--descriptor_set_out={output_file}", *abs_proto_files]
 
-    args = [""] + proto_paths + [f"--descriptor_set_out={output_file}"] + abs_proto_files
-    ret = protoc.main(args)
-    if ret != 0:
+    try:
+        result = subprocess.run(args, capture_output=True, text=True, check=False)
+    except OSError as e:
         raise DataContractException(
             type="schema",
             name="Compile proto files",
-            reason=f"grpc_tools.protoc failed with exit code {ret}",
+            reason=f"Failed to invoke protoc at {protoc_path}: {e}",
+            engine="datacontract",
+            original_exception=e,
+        )
+
+    if result.returncode != 0:
+        version = _safe_protoc_version(protoc_path)
+        stderr = (result.stderr or "").strip()
+        details = stderr if stderr else f"protoc exited with code {result.returncode} and no error output"
+        raise DataContractException(
+            type="schema",
+            name="Compile proto files",
+            reason=(
+                f"protoc failed to compile the proto files (exit code {result.returncode}).\n"
+                f"protoc: {protoc_path} ({version})\n\n"
+                f"protoc output:\n{details}"
+            ),
             engine="datacontract",
             original_exception=None,
         )
+
+
+def _safe_protoc_version(protoc_path: str) -> str:
+    """Best-effort `protoc --version` for inclusion in error messages."""
+    try:
+        result = subprocess.run([protoc_path, "--version"], capture_output=True, text=True, check=False, timeout=5)
+        return (result.stdout or result.stderr or "").strip() or "unknown version"
+    except (OSError, subprocess.TimeoutExpired):
+        return "unknown version"
 
 
 def extract_enum_values_from_fds(fds: descriptor_pb2.FileDescriptorSet, enum_name: str) -> dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,13 @@ dependencies = [
   "datacontract-specification>=1.2.3,<2.0.0",
   "open-data-contract-standard>=3.1.2,<4.0.0",
   "deepdiff>=6.0.0,<10.0.0",
+  # setuptools provides the distutils shim that soda-core's env_helper.py
+  # imports (`from distutils.util import strtobool`). distutils was removed
+  # from stdlib in Python 3.12 (and stripped from python-build-standalone
+  # 3.11 builds), so without setuptools, soda-core blows up on import.
+  # See soda-core#2091. Was previously pulled in transitively via
+  # grpcio-tools; required explicitly now that we use external protoc.
+  "setuptools>=70",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,11 +170,6 @@ datacontract = "datacontract.cli:main"
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.uv]
-override-dependencies = [
-    "mysql-connector-python>=8.0.30,<9.7.0",
-]
-
 [tool.pytest.ini_options]
 #addopts = "-n 8" # run tests in parallel, you can disable parallel test execution with "pytest -n0" command
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,9 @@ api = [
 ]
 
 protobuf = [
-  "grpcio-tools>=1.53",
+  # `protoc` (the compiler) must be installed separately on the system; see README.
+  # Wide range: only `descriptor_pb2.FileDescriptorSet` is used, stable since 3.x.
+  "protobuf>=3.20,<7.0",
 ]
 
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,17 @@ datacontract = "datacontract.cli:main"
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.uv]
+# soda-core-mysql exact-pins mysql-connector-python==8.0.30 (from 2022),
+# which doesn't recognize the charset IDs returned by modern MySQL server
+# images (used by our testcontainers-based MySQL tests) and raises
+# "Character set 'utf8' unsupported". Override to allow newer
+# mysql-connector-python releases that know about the current charsets.
+# See: https://github.com/sodadata/soda-core/issues/2515
+override-dependencies = [
+    "mysql-connector-python>=8.0.30,<9.7.0",
+]
+
 [tool.pytest.ini_options]
 #addopts = "-n 8" # run tests in parallel, you can disable parallel test execution with "pytest -n0" command
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

The `protobuf` extra previously bundled `grpcio-tools` — a ~50 MB dep that ships platform-specific `protoc` binaries — purely to call `grpc_tools.protoc.main()` once inside `compile_proto_to_binary`. Replace with an external `protoc` invocation via `subprocess` and a much lighter runtime (`protobuf>=3.20,<7.0`, used only for `descriptor_pb2.FileDescriptorSet` parsing).

### Behavior

- `compile_proto_to_binary` shells out to the system `protoc` discovered via `shutil.which`.
- **protoc-not-found error**: clear `DataContractException` with platform-specific install hints (brew / apt / dnf / pacman / choco + GitHub releases link).
- **protoc-failed error**: surfaces protoc's stderr verbatim, plus the resolved protoc path and `--version` output.
- README's `import protobuf` section documents the new install requirement.

### Breaking change

`pip install datacontract-cli[protobuf]` no longer installs a bundled protoc. Users must install `protoc` separately. The error message walks them through it on first failure.

### Verified

End-to-end `datacontract import protobuf` produces identical ODCS output across the full pinned protobuf-runtime range:

| protobuf runtime | matches expected output |
|---|---|
| 3.20.3 (floor) | ✅ |
| 4.21.12 | ✅ |
| 6.33.5 / 6.33.6 (latest pre-7) | ✅ |

Also verified: `uv pip install --dry-run '.[all]'` resolves cleanly (no conflicts); `--dry-run '.[protobuf]' 'protobuf==3.20.3'` resolves to the floor without conflicts; `pytest tests/test_*protobuf*.py` 6/6 pass; ruff clean.

## Test plan

- [x] All protobuf import/export tests pass on system protoc (libprotoc 34.1).
- [x] Floor / mid-range / top-of-range protobuf runtimes all produce matching ODCS output.
- [x] protoc-not-found error verified (PATH clobbered).
- [x] protoc-failed error verified (malformed .proto — surfaces protoc's stderr).
- [ ] CI green