### PR TITLE
chore(deps): loosen uvicorn pin to a range in [api] extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,7 @@ rdf = [
 
 api = [
   "fastapi==0.136.1",
-  "uvicorn==0.44.0",
+  "uvicorn>=0.44.0,<0.47.0",
 ]
 
 protobuf = [


### PR DESCRIPTION
## Summary
- Replace exact pin `uvicorn==0.44.0` with `uvicorn>=0.44.0,<0.47.0` in the `api` extra.
- Avoids dependency-resolution failures when users install `datacontract-cli[api]` alongside other tools that depend on a different uvicorn version.
- Supersedes Dependabot PR #1210 (bump to `==0.46.0`); Dependabot will close that PR automatically once this lands.

## Why a range?
Our only uvicorn surface is `uvicorn.run(**args)` and `uvicorn.config.LOGGING_CONFIG` (used as a dict) in `datacontract/command_api.py` — stable APIs across the 0.44–0.46 range. The conservative upper bound `<0.47.0` keeps Dependabot tracking new minors.

## Test plan
- [x] `pip install -e '.[api]'` resolves (verified locally with uv; pulls uvicorn 0.46.0)
- [x] `datacontract api` starts as before (verified locally on uvicorn 0.46.0; `GET /openapi.json` → 200)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)