### PR TITLE
refactor(dbt-export): extract field→test mapping helper

### DIFF
--- a/datacontract/export/dbt_exporter.py
+++ b/datacontract/export/dbt_exporter.py
@@ -5,6 +5,7 @@ from open_data_contract_standard.model import Description, OpenDataContractStand
 
 from datacontract.export.exporter import Exporter, _check_schema_name_for_export
 from datacontract.export.sql_type_converter import convert_to_sql_type
+from datacontract.integration.dbt_test_mapping import field_to_data_tests
 
 
 def _get_description_str(description: Union[str, Description, None]) -> Optional[str]:
@@ -37,50 +38,6 @@ class DbtStageExporter(Exporter):
             model_name,
             model_value,
         )
-
-
-def _get_custom_property_value(prop: SchemaProperty, key: str) -> Optional[str]:
-    """Get a custom property value."""
-    if prop.customProperties is None:
-        return None
-    for cp in prop.customProperties:
-        if cp.property == key:
-            return cp.value
-    return None
-
-
-def _get_logical_type_option(prop: SchemaProperty, key: str):
-    """Get a logical type option value."""
-    if prop.logicalTypeOptions is None:
-        return None
-    return prop.logicalTypeOptions.get(key)
-
-
-def _get_enum_values(prop: SchemaProperty):
-    """Get enum values from logicalTypeOptions, customProperties, or quality rules."""
-    import json
-
-    # First check logicalTypeOptions
-    enum_values = _get_logical_type_option(prop, "enum")
-    if enum_values:
-        return enum_values
-    # Then check customProperties
-    enum_str = _get_custom_property_value(prop, "enum")
-    if enum_str:
-        try:
-            if isinstance(enum_str, list):
-                return enum_str
-            return json.loads(enum_str)
-        except (json.JSONDecodeError, TypeError):
-            pass
-    # Finally check quality rules for invalidValues with validValues
-    if prop.quality:
-        for q in prop.quality:
-            if q.metric == "invalidValues" and q.arguments:
-                valid_values = q.arguments.get("validValues")
-                if valid_values:
-                    return valid_values
-    return None
 
 
 def _get_owner(data_contract: OpenDataContractStandard) -> Optional[str]:
@@ -251,13 +208,6 @@ def _to_columns(
     return columns
 
 
-def get_table_name_and_column_name(references: str) -> tuple:
-    parts = references.split(".")
-    if len(parts) < 2:
-        return None, parts[0]
-    return parts[-2], parts[-1]
-
-
 def _to_column(
     data_contract: OpenDataContractStandard,
     prop: SchemaProperty,
@@ -280,109 +230,28 @@ def _to_column(
     if prop.description is not None:
         column["description"] = prop.description.strip().replace("\n", " ")
 
-    # Handle required/not_null constraint
-    if prop.required or is_primary_key:
-        if supports_constraints:
+    # not_null / unique go into `constraints` on materializations that support them;
+    # otherwise the helper below emits them as data_tests.
+    if supports_constraints:
+        if prop.required or is_primary_key:
             column.setdefault("constraints", []).append({"type": "not_null"})
-        else:
-            column["data_tests"].append("not_null")
-
-    # Handle unique constraint
-    # For composite primary keys, uniqueness is handled at model level via unique_combination_of_columns
-    # Only add unique constraint for single-column primary keys or explicit unique fields
-    if prop.unique or (is_primary_key and is_single_pk):
-        if supports_constraints:
+        if prop.unique or (is_primary_key and is_single_pk):
             column.setdefault("constraints", []).append({"type": "unique"})
-        else:
-            column["data_tests"].append("unique")
-
-    enum_values = _get_enum_values(prop)
-    if enum_values and len(enum_values) > 0:
-        column["data_tests"].append({"accepted_values": {"values": enum_values}})
-
-    min_length = _get_logical_type_option(prop, "minLength")
-    max_length = _get_logical_type_option(prop, "maxLength")
-    if min_length is not None or max_length is not None:
-        length_test = {}
-        if min_length is not None:
-            length_test["min_value"] = min_length
-        if max_length is not None:
-            length_test["max_value"] = max_length
-        column["data_tests"].append({"dbt_expectations.expect_column_value_lengths_to_be_between": length_test})
 
     if prop.classification is not None:
         column.setdefault("meta", {})["classification"] = prop.classification
     if prop.tags is not None and len(prop.tags) > 0:
         column.setdefault("tags", []).extend(prop.tags)
 
-    pattern = _get_logical_type_option(prop, "pattern")
-    if pattern is not None:
-        # Beware, the data contract pattern is a regex, not a like pattern
-        column["data_tests"].append({"dbt_expectations.expect_column_values_to_match_regex": {"regex": pattern}})
-
-    minimum = _get_logical_type_option(prop, "minimum")
-    maximum = _get_logical_type_option(prop, "maximum")
-    exclusive_minimum = _get_logical_type_option(prop, "exclusiveMinimum")
-    exclusive_maximum = _get_logical_type_option(prop, "exclusiveMaximum")
-
-    if (minimum is not None or maximum is not None) and exclusive_minimum is None and exclusive_maximum is None:
-        range_test = {}
-        if minimum is not None:
-            range_test["min_value"] = minimum
-        if maximum is not None:
-            range_test["max_value"] = maximum
-        column["data_tests"].append({"dbt_expectations.expect_column_values_to_be_between": range_test})
-    elif (exclusive_minimum is not None or exclusive_maximum is not None) and minimum is None and maximum is None:
-        range_test = {}
-        if exclusive_minimum is not None:
-            range_test["min_value"] = exclusive_minimum
-        if exclusive_maximum is not None:
-            range_test["max_value"] = exclusive_maximum
-        range_test["strictly"] = True
-        column["data_tests"].append({"dbt_expectations.expect_column_values_to_be_between": range_test})
-    else:
-        if minimum is not None:
-            column["data_tests"].append({"dbt_expectations.expect_column_values_to_be_between": {"min_value": minimum}})
-        if maximum is not None:
-            column["data_tests"].append({"dbt_expectations.expect_column_values_to_be_between": {"max_value": maximum}})
-        if exclusive_minimum is not None:
-            column["data_tests"].append(
-                {
-                    "dbt_expectations.expect_column_values_to_be_between": {
-                        "min_value": exclusive_minimum,
-                        "strictly": True,
-                    }
-                }
-            )
-        if exclusive_maximum is not None:
-            column["data_tests"].append(
-                {
-                    "dbt_expectations.expect_column_values_to_be_between": {
-                        "max_value": exclusive_maximum,
-                        "strictly": True,
-                    }
-                }
-            )
-
-    # Handle references from relationships
-    references = None
-    if prop.relationships:
-        for rel in prop.relationships:
-            if hasattr(rel, "to") and rel.to:
-                references = rel.to
-                break
-    if references is not None:
-        ref_source_name = data_contract.id
-        table_name, column_name = get_table_name_and_column_name(references)
-        if table_name is not None and column_name is not None:
-            column["data_tests"].append(
-                {
-                    "relationships": {
-                        "to": f"""source("{ref_source_name}", "{table_name}")""",
-                        "field": f"{column_name}",
-                    }
-                }
-            )
+    column["data_tests"].extend(
+        field_to_data_tests(
+            prop,
+            is_primary_key=is_primary_key,
+            is_single_pk=is_single_pk,
+            supports_constraints=supports_constraints,
+            source_name=data_contract.id,
+        )
+    )
 
     if not column["data_tests"]:
         column.pop("data_tests")

--- a/datacontract/integration/dbt_test_mapping.py
+++ b/datacontract/integration/dbt_test_mapping.py
@@ -1,0 +1,163 @@
+"""Pure helpers that map ODCS field/model attributes to dbt data_tests.
+
+Shared between `datacontract export dbt` and (eventually) `datacontract dbt sync`
+so the two paths cannot drift while both emit dbt tests.
+"""
+
+import json
+from typing import Any, List, Optional
+
+from open_data_contract_standard.model import SchemaProperty
+
+
+def _get_custom_property_value(prop: SchemaProperty, key: str) -> Optional[str]:
+    if prop.customProperties is None:
+        return None
+    for cp in prop.customProperties:
+        if cp.property == key:
+            return cp.value
+    return None
+
+
+def _get_logical_type_option(prop: SchemaProperty, key: str) -> Any:
+    if prop.logicalTypeOptions is None:
+        return None
+    return prop.logicalTypeOptions.get(key)
+
+
+def _get_enum_values(prop: SchemaProperty) -> Optional[list]:
+    """Resolve enum values from logicalTypeOptions, customProperties, or quality.invalidValues."""
+
+    # First check logicalTypeOptions
+    enum_values = _get_logical_type_option(prop, "enum")
+    if enum_values:
+        return enum_values
+    # Then check customProperties
+    enum_str = _get_custom_property_value(prop, "enum")
+    if enum_str:
+        try:
+            if isinstance(enum_str, list):
+                return enum_str
+            return json.loads(enum_str)
+        except (json.JSONDecodeError, TypeError):
+            pass
+    # Finally check quality rules for invalidValues with validValues
+    if prop.quality:
+        for q in prop.quality:
+            if q.metric == "invalidValues" and q.arguments:
+                valid_values = q.arguments.get("validValues")
+                if valid_values:
+                    return valid_values
+    return None
+
+
+def get_table_name_and_column_name(references: str) -> tuple:
+    parts = references.split(".")
+    if len(parts) < 2:
+        return None, parts[0]
+    return parts[-2], parts[-1]
+
+
+def field_to_data_tests(
+    prop: SchemaProperty,
+    *,
+    is_primary_key: bool = False,
+    is_single_pk: bool = False,
+    supports_constraints: bool = False,
+    source_name: Optional[str] = None,
+) -> List[Any]:
+    """Build the list of dbt data_tests for an ODCS property.
+
+    When ``supports_constraints`` is True, the caller is expected to emit
+    ``not_null`` / ``unique`` as dbt column ``constraints`` instead, so they
+    are skipped here.
+    """
+    tests: List[Any] = []
+
+    if not supports_constraints:
+        if prop.required or is_primary_key:
+            tests.append("not_null")
+        if prop.unique or (is_primary_key and is_single_pk):
+            tests.append("unique")
+
+    enum_values = _get_enum_values(prop)
+    if enum_values and len(enum_values) > 0:
+        tests.append({"accepted_values": {"values": enum_values}})
+
+    min_length = _get_logical_type_option(prop, "minLength")
+    max_length = _get_logical_type_option(prop, "maxLength")
+    if min_length is not None or max_length is not None:
+        length_test = {}
+        if min_length is not None:
+            length_test["min_value"] = min_length
+        if max_length is not None:
+            length_test["max_value"] = max_length
+        tests.append({"dbt_expectations.expect_column_value_lengths_to_be_between": length_test})
+
+    pattern = _get_logical_type_option(prop, "pattern")
+    if pattern is not None:
+        tests.append({"dbt_expectations.expect_column_values_to_match_regex": {"regex": pattern}})
+
+    minimum = _get_logical_type_option(prop, "minimum")
+    maximum = _get_logical_type_option(prop, "maximum")
+    exclusive_minimum = _get_logical_type_option(prop, "exclusiveMinimum")
+    exclusive_maximum = _get_logical_type_option(prop, "exclusiveMaximum")
+
+    if (minimum is not None or maximum is not None) and exclusive_minimum is None and exclusive_maximum is None:
+        range_test = {}
+        if minimum is not None:
+            range_test["min_value"] = minimum
+        if maximum is not None:
+            range_test["max_value"] = maximum
+        tests.append({"dbt_expectations.expect_column_values_to_be_between": range_test})
+    elif (exclusive_minimum is not None or exclusive_maximum is not None) and minimum is None and maximum is None:
+        range_test = {}
+        if exclusive_minimum is not None:
+            range_test["min_value"] = exclusive_minimum
+        if exclusive_maximum is not None:
+            range_test["max_value"] = exclusive_maximum
+        range_test["strictly"] = True
+        tests.append({"dbt_expectations.expect_column_values_to_be_between": range_test})
+    else:
+        if minimum is not None:
+            tests.append({"dbt_expectations.expect_column_values_to_be_between": {"min_value": minimum}})
+        if maximum is not None:
+            tests.append({"dbt_expectations.expect_column_values_to_be_between": {"max_value": maximum}})
+        if exclusive_minimum is not None:
+            tests.append(
+                {
+                    "dbt_expectations.expect_column_values_to_be_between": {
+                        "min_value": exclusive_minimum,
+                        "strictly": True,
+                    }
+                }
+            )
+        if exclusive_maximum is not None:
+            tests.append(
+                {
+                    "dbt_expectations.expect_column_values_to_be_between": {
+                        "max_value": exclusive_maximum,
+                        "strictly": True,
+                    }
+                }
+            )
+
+    references = None
+    if prop.relationships:
+        for rel in prop.relationships:
+            if hasattr(rel, "to") and rel.to:
+                references = rel.to
+                break
+    if references is not None:
+        table_name, column_name = get_table_name_and_column_name(references)
+        if table_name is not None and column_name is not None:
+            tests.append(
+                {
+                    "relationships": {
+                        "to": f"""source("{source_name}", "{table_name}")""",
+                        "field": f"{column_name}",
+                    }
+                }
+            )
+
+    return tests


### PR DESCRIPTION
## Summary
- Pulls `_to_column`'s per-field test logic out of `datacontract/export/dbt_exporter.py` into a new `datacontract/integration/dbt_test_mapping.py` module exposing `field_to_data_tests()`.
- No behavior change — existing exporter golden-file tests (`tests/test_export_dbt*.py`) pass unchanged. The single shared function is now the home for ODCS quality → dbt `data_tests` mapping, ready to be reused by a future `datacontract dbt sync` command.

## Why
Without this, the upcoming sync command would either duplicate the exporter's mapping logic or import private helpers from it. Extracting first keeps the sync PR focused on its own surface.

## Test plan
- [x] `pytest tests/test_export_dbt_models.py tests/test_export_dbt_sources.py tests/test_export_dbt_staging_sql.py tests/test_import_dbt.py` — 19 passed, zero modifications
- [x] Full `pytest -n 8` suite — 644 passed, 13 skipped
- [x] PySpark-gated tests — 11 passed
- [x] `ruff check .` and `ruff format --check .` clean