### PR TITLE
feat(dbt-sync): add --publish flag and dc:<type> check tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1144,23 +1144,37 @@ models:
 │                             `*.odcs.yaml` in the current directory and its subdirectories.       │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
-│ --project-dir                        PATH                 Path to the dbt project root (must     │
-│                                                           contain `dbt_project.yml`). Defaults   │
-│                                                           to the current directory.              │
-│ --schema-name                        TEXT                 Which ODCS schema object to sync, by   │
-│                                                           name.                                  │
-│                                                           [default: all]                         │
-│ --model-resolution                   [name|physicalName]  How to map an ODCS schema to a dbt     │
-│                                                           model name.                            │
-│                                                           [default: name]                        │
-│ --target                             TEXT                 Forwarded to `dbt test --target`.      │
-│ --profiles-dir                       PATH                 Forwarded to `dbt test                 │
-│                                                           --profiles-dir`.                       │
-│ --skip-tests          --run-tests                         Generate tests but skip running `dbt   │
-│                                                           test`.                                 │
-│                                                           [default: run-tests]                   │
-│ --debug               --no-debug                          Enable debug logging                   │
-│ --help                                                    Show this message and exit.            │
+│ --project-dir                                  PATH                 Path to the dbt project root │
+│                                                                     (must contain                │
+│                                                                     `dbt_project.yml`). Defaults │
+│                                                                     to the current directory.    │
+│ --schema-name                                  TEXT                 Which ODCS schema object to  │
+│                                                                     sync, by name.               │
+│                                                                     [default: all]               │
+│ --model-resolution                             [name|physicalName]  How to map an ODCS schema to │
+│                                                                     a dbt model name.            │
+│                                                                     [default: name]              │
+│ --target                                       TEXT                 Forwarded to `dbt test       │
+│                                                                     --target`.                   │
+│ --profiles-dir                                 PATH                 Forwarded to `dbt test       │
+│                                                                     --profiles-dir`.             │
+│ --skip-tests          --run-tests                                   Generate tests but skip      │
+│                                                                     running `dbt test`.          │
+│                                                                     [default: run-tests]         │
+│ --publish                                      TEXT                 The url to publish the       │
+│                                                                     results after the test.      │
+│ --server                                       TEXT                 ODCS server name for         │
+│                                                                     published test results.      │
+│                                                                     Auto-selected if the         │
+│                                                                     contract contains only one   │
+│                                                                     server. Otherwise defaults   │
+│                                                                     to --target.                 │
+│ --ssl-verification    --no-ssl-verification                         SSL verification when        │
+│                                                                     publishing the data          │
+│                                                                     contract.                    │
+│                                                                     [default: ssl-verification]  │
+│ --debug               --no-debug                                    Enable debug logging         │
+│ --help                                                              Show this message and exit.  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
                                                                                                     
  Example: datacontract dbt sync orders.odcs.yaml --project-dir ./warehouse                          
@@ -1177,7 +1191,7 @@ On each run, the command:
 - **Emits singular SQL tests** for all ODCS `quality` that can't be expressed as native YAML tests.
 - **Runs `dbt test --select tag:datacontract_cli`** to run the generated tests; pre-existing dbt tests are untouched. Pass `--skip-tests` to regenerate without invoking dbt.
 
-Prerequisites: `dbt-core` plus an adapter (e.g. `dbt-duckdb`, `dbt-postgres`) on `PATH`, [`dbt_utils`](https://github.com/dbt-labs/dbt-utils) installed in your dbt project's `packages.yml` (used for composite primary keys).
+Prerequisites: `dbt-core` plus an adapter (e.g. `dbt-duckdb`, `dbt-postgres`) on `PATH`, [`dbt_utils`](https://github.com/dbt-labs/dbt-utils) installed in your dbt project's `packages.yml`.
 
 ```bash
 # Auto-discover a contract named *.odcs.yaml in a dbt project
@@ -1186,8 +1200,11 @@ $ datacontract dbt sync
 # Explicit contract, run against a specific dbt target
 $ datacontract dbt sync orders.odcs.yaml --project-dir ./warehouse --target dev
 
-# Only generate tests, don't run them
+# Only generate dbt tests, don't run them
 $ datacontract dbt sync orders.odcs.yaml --skip-tests
+
+# Run and publish results to an Entropy Data instance
+$ datacontract dbt sync orders.odcs.yaml --publish https://api.entropy-data.com/api/test-results
 ```
 
 ### ci
@@ -2106,9 +2123,9 @@ Create a data contract based on the actual data. This is the fastest way to get 
 
 4. Set up a CI pipeline that executes daily for continuous quality checks. Use the [`ci`](#ci) command for
    CI-optimized output (GitHub Actions annotations and step summary, Azure DevOps annotations).
-   You can also report the test results to tools like [Data Mesh Manager](https://datamesh-manager.com).
+   You can also report the test results to tools like [Entropy Data](https://entropy-data.com).
    ```bash
-   $ datacontract ci --publish https://api.datamesh-manager.com/api/test-results
+   $ datacontract ci --publish https://api.entropy-data.com/api/test-results
    ```
 
 ### Contract-First

--- a/README.md
+++ b/README.md
@@ -1170,8 +1170,7 @@ models:
 │                                                                     server. Otherwise defaults   │
 │                                                                     to --target.                 │
 │ --ssl-verification    --no-ssl-verification                         SSL verification when        │
-│                                                                     publishing the data          │
-│                                                                     contract.                    │
+│                                                                     publishing test results.     │
 │                                                                     [default: ssl-verification]  │
 │ --debug               --no-debug                                    Enable debug logging         │
 │ --help                                                              Show this message and exit.  │

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -129,6 +129,13 @@ def enable_debug_logging(debug: bool):
         )
 
 
+def validate_publish_url(publish: str | None) -> None:
+    """Reject `--publish` values that aren't http/https before any real work runs."""
+    if publish is not None and not (publish.startswith("http://") or publish.startswith("https://")):
+        console.print(f"[red]--publish URL must start with http:// or https:// (got: {publish!r}).[/red]")
+        raise typer.Exit(code=1)
+
+
 def _print_logs(run, out=None):
     if out is None:
         out = console

--- a/datacontract/command_ci.py
+++ b/datacontract/command_ci.py
@@ -6,7 +6,7 @@ import typer
 from rich.console import Console
 from typing_extensions import Annotated
 
-from datacontract.cli import _print_logs, app, console, debug_option, enable_debug_logging
+from datacontract.cli import _print_logs, app, console, debug_option, enable_debug_logging, validate_publish_url
 from datacontract.data_contract import DataContract
 from datacontract.output.ci_output import write_ci_output, write_ci_summary, write_json_results
 from datacontract.output.output_format import OutputFormat
@@ -65,6 +65,7 @@ def ci(
     Run tests for CI/CD pipelines. Emits GitHub Actions annotations and step summary.
     """
     enable_debug_logging(debug)
+    validate_publish_url(publish)
 
     if not locations:
         locations = ["datacontract.yaml"]

--- a/datacontract/command_dbt.py
+++ b/datacontract/command_dbt.py
@@ -4,8 +4,15 @@ from typing import Optional
 import typer
 from typing_extensions import Annotated
 
-from datacontract.cli import OrderedCommandsWithMigrationHints, console, debug_option, enable_debug_logging
+from datacontract.cli import (
+    OrderedCommandsWithMigrationHints,
+    console,
+    debug_option,
+    enable_debug_logging,
+    validate_publish_url,
+)
 from datacontract.integration.dbt_sync import ModelResolution, check_dbt_on_path, generate_dbt_tests, run_tests
+from datacontract.integration.entropy_data import publish_test_results_to_entropy_data
 from datacontract.model.run import ResultEnum
 from datacontract.output.test_results_writer import print_test_results_table, to_field
 
@@ -46,6 +53,14 @@ def sync_command(
         bool,
         typer.Option("--skip-tests/--run-tests", help="Generate tests but skip running `dbt test`."),
     ] = False,
+    publish: Annotated[Optional[str], typer.Option(help="The url to publish the results after the test.")] = None,
+    server: Annotated[
+        Optional[str],
+        typer.Option(
+            help="ODCS server name for published test results. Auto-selected if the contract contains only one server. Otherwise defaults to --target.",
+        ),
+    ] = None,
+    ssl_verification: Annotated[bool, typer.Option(help="SSL verification when publishing the data contract.")] = True,
     debug: debug_option = None,
 ):
     """
@@ -54,6 +69,11 @@ def sync_command(
     Within the specified dbt project, this command wipes `<model-paths>/datacontract_cli/` and `<test-paths>/datacontract_cli/`, regenerates them from the contract, then runs `dbt test`.
     """
     enable_debug_logging(debug)
+
+    if publish is not None and skip_tests:
+        console.print("[red]--publish cannot be combined with --skip-tests (no run results to publish).[/red]")
+        raise typer.Exit(code=1)
+    validate_publish_url(publish)
 
     if not skip_tests:
         check_dbt_on_path()
@@ -65,6 +85,14 @@ def sync_command(
         model_resolution=model_resolution,
         console=console,
     )
+
+    if server is not None and gen.odcs.servers:
+        known = [s.server for s in gen.odcs.servers if s.server]
+        if server not in known:
+            console.print(
+                f"[red]--server {server!r} is not declared in the contract. Available: {', '.join(known) or '(none)'}[/red]"
+            )
+            raise typer.Exit(code=1)
 
     yaml_dir = gen.written_yaml[0].parent if gen.written_yaml else None
     sql_dir = gen.written_sql[0].parent if gen.written_sql else None
@@ -80,8 +108,23 @@ def sync_command(
         return
 
     run = run_tests(gen, target=target, profiles_dir=profiles_dir)
+    if server is not None:
+        run.server = server
+    elif gen.odcs.servers and len(gen.odcs.servers) == 1:
+        run.server = gen.odcs.servers[0].server
+    else:
+        run.server = target
+
+    publish_failed = False
+    if publish is not None:
+        initial_logs_length = len(run.logs)
+        publish_test_results_to_entropy_data(run, publish, ssl_verification)
+        publish_failed = any(log.level == "ERROR" for log in run.logs[initial_logs_length:])
+
     if not run.checks:
         console.print("[yellow]No test results parsed.[/yellow]")
+        if publish_failed:
+            raise typer.Exit(code=1)
         return
 
     print_test_results_table(run, console)
@@ -89,6 +132,8 @@ def sync_command(
     took = (run.timestampEnd - run.timestampStart).total_seconds()
     if run.result == ResultEnum.passed:
         console.print(f"🟢 dbt tests passed. Ran {total} tests. Took {took} seconds.")
+        if publish_failed:
+            raise typer.Exit(code=1)
         return
     if run.result == ResultEnum.warning:
         console.print("🟠 dbt tests have warnings:")
@@ -101,5 +146,5 @@ def sync_command(
             prefix = f"{field} " if field else ""
             console.print(f"{i}) {prefix}{check.name}: {check.reason}")
             i += 1
-    if run.result in (ResultEnum.failed, ResultEnum.error):
+    if run.result in (ResultEnum.failed, ResultEnum.error) or publish_failed:
         raise typer.Exit(code=1)

--- a/datacontract/command_dbt.py
+++ b/datacontract/command_dbt.py
@@ -117,9 +117,13 @@ def sync_command(
 
     publish_failed = False
     if publish is not None:
-        initial_logs_length = len(run.logs)
-        publish_test_results_to_entropy_data(run, publish, ssl_verification)
-        publish_failed = any(log.level == "ERROR" for log in run.logs[initial_logs_length:])
+        if server is None and not gen.odcs.servers:
+            console.print(
+                "[yellow]Skipping publish: no --server passed and the contract declares no servers. "
+                "Add a `servers:` block or pass --server to identify the run.[/yellow]"
+            )
+        else:
+            publish_failed = not publish_test_results_to_entropy_data(run, publish, ssl_verification)
 
     if not run.checks:
         console.print("[yellow]No test results parsed.[/yellow]")

--- a/datacontract/command_dbt.py
+++ b/datacontract/command_dbt.py
@@ -60,7 +60,7 @@ def sync_command(
             help="ODCS server name for published test results. Auto-selected if the contract contains only one server. Otherwise defaults to --target.",
         ),
     ] = None,
-    ssl_verification: Annotated[bool, typer.Option(help="SSL verification when publishing the data contract.")] = True,
+    ssl_verification: Annotated[bool, typer.Option(help="SSL verification when publishing test results.")] = True,
     debug: debug_option = None,
 ):
     """
@@ -117,11 +117,18 @@ def sync_command(
 
     publish_failed = False
     if publish is not None:
-        if server is None and not gen.odcs.servers:
-            console.print(
-                "[yellow]Skipping publish: no --server passed and the contract declares no servers. "
-                "Add a `servers:` block or pass --server to identify the run.[/yellow]"
-            )
+        if run.server is None:
+            if not gen.odcs.servers:
+                console.print(
+                    "[yellow]Skipping publish: the contract declares no servers. "
+                    "Add a `servers:` block or pass --server to identify the run.[/yellow]"
+                )
+            else:
+                known = ", ".join(s.server for s in gen.odcs.servers if s.server) or "(none)"
+                console.print(
+                    f"[yellow]Skipping publish: the contract declares multiple servers ({known}). "
+                    f"Pass --server to identify the run.[/yellow]"
+                )
         else:
             publish_failed = not publish_test_results_to_entropy_data(run, publish, ssl_verification)
 

--- a/datacontract/command_test.py
+++ b/datacontract/command_test.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import typer
 from typing_extensions import Annotated
 
-from datacontract.cli import _print_logs, app, console, debug_option, enable_debug_logging
+from datacontract.cli import _print_logs, app, console, debug_option, enable_debug_logging, validate_publish_url
 from datacontract.data_contract import DataContract
 from datacontract.lint.resolve import resolve_data_contract
 from datacontract.output.output_format import OutputFormat
@@ -73,6 +73,7 @@ def test(
     Run schema and quality tests on configured servers.
     """
     enable_debug_logging(debug)
+    validate_publish_url(publish)
 
     check_categories = None
     if checks is not None:

--- a/datacontract/integration/dbt_sync.py
+++ b/datacontract/integration/dbt_sync.py
@@ -216,21 +216,113 @@ def _normalize_severity(severity: Optional[str]) -> str:
     return "warn"
 
 
-def _attach_test_config(test: Any, severity: str) -> Any:
-    """Wrap a test entry with `config: { severity, tags }`.
+def _check_type_for_generic_test(test: Any) -> Optional[str]:
+    """Map a dbt generic test entry (string or `{name: args}` dict) to a `Check.type` value."""
+    dbt_test_name = None
+    if isinstance(test, str):
+        dbt_test_name = test
+    if isinstance(test, dict) and len(test) == 1:
+        ((name, _),) = test.items()
+        dbt_test_name = name
+
+    return {
+        "not_null": "field_required",
+        "unique": "field_unique",
+        "accepted_values": "field_enum",
+        "relationships": "field_relationships",
+        "dbt_utils.unique_combination_of_columns": "model_unique_combination",
+    }.get(dbt_test_name)
+
+
+def _attach_test_config(
+    test: Any,
+    severity: str,
+    description: Optional[str] = None,
+    check_type: Optional[str] = None,
+) -> Any:
+    """Wrap a test entry with `config: { severity, tags }` and an optional `description`.
 
     Strings (`"not_null"`) become single-key dicts so the config can ride along
     in the same form dbt accepts.
     """
-    config = {"severity": severity, "tags": [OUTPUT_TAG]}
+    tags = [OUTPUT_TAG]
+    if check_type:
+        tags.append(f"dc:{check_type}")
+    config = {"severity": severity, "tags": tags}
     if isinstance(test, str):
-        return {test: {"config": config}}
+        body: dict = {"config": config}
+        if description:
+            body["description"] = description
+        return {test: body}
     if isinstance(test, dict) and len(test) == 1:
         ((name, args),) = test.items()
         merged = dict(args) if isinstance(args, dict) else {"value": args}
         merged["config"] = config
+        if description:
+            merged["description"] = description
         return {name: merged}
     return test
+
+
+def _describe_dbt_test(test: Any, field_name: Optional[str], model_name: str) -> Optional[str]:
+    """Synthesize a human-readable description for a dbt test entry.
+
+    Similar to the check names in `datacontract/engines/data_contract_checks.py`, but for dbt.
+    """
+    if isinstance(test, str):
+        if test == "not_null":
+            return f"Check that field {field_name} has no missing values"
+        if test == "unique":
+            return f"Check that field {field_name} has no duplicate values"
+        return None
+    if isinstance(test, dict) and len(test) == 1:
+        ((name, args),) = test.items()
+        if not isinstance(args, dict):
+            return None
+        if name == "accepted_values":
+            values = args.get("values")
+            if isinstance(values, list) and len(values) == 1:
+                return f"Check that field {field_name} is equal to {values[0]}"
+            return f"Check that field {field_name} only contains enum values {values}"
+        if name == "relationships":
+            return f"Check that field {field_name} references {args.get('to')}.{args.get('field')}"
+        if name == "dbt_utils.unique_combination_of_columns":
+            cols = args.get("combination_of_columns") or []
+            return f"Check that model {model_name} has a unique combination of columns {', '.join(cols)}"
+    return None
+
+
+def _describe_field_bound(prop: "SchemaProperty", kind: str) -> Optional[str]:
+    """Human-readable descriptions for the singular SQL tests `_field_singular_tests` emits.
+
+    `kind` is one of `"length"`, `"pattern"`, `"range"`.
+    """
+    if kind == "length":
+        min_length = get_logical_type_option(prop, "minLength")
+        max_length = get_logical_type_option(prop, "maxLength")
+        if min_length is not None and max_length is not None:
+            return f"Check that field {prop.name} has a length between {min_length} and {max_length}"
+        if min_length is not None:
+            return f"Check that field {prop.name} has a length of at least {min_length}"
+        if max_length is not None:
+            return f"Check that field {prop.name} has a length of at most {max_length}"
+        return None
+    if kind == "pattern":
+        pattern = get_logical_type_option(prop, "pattern")
+        return f"Check that field {prop.name} matches regex pattern {pattern}"
+    if kind == "range":
+        parts = []
+        for key, label in (
+            ("minimum", "an inclusive minimum of"),
+            ("maximum", "an inclusive maximum of"),
+            ("exclusiveMinimum", "a strict minimum of"),
+            ("exclusiveMaximum", "a strict maximum of"),
+        ):
+            value = get_logical_type_option(prop, key)
+            if value is not None:
+                parts.append(f"{label} {value}")
+        return f"Check that field {prop.name} has " + " and ".join(parts) if parts else None
+    return None
 
 
 _REL_SOURCE_RE = re.compile(r'source\(\s*"[^"]*"\s*,\s*"([^"]+)"\s*\)')
@@ -331,6 +423,7 @@ def _singular_tests_for_qualities(
     run: Run,
     *,
     label_prefix: str = "",
+    field: Optional[str] = None,
 ) -> List[SingularTest]:
     """Generate singular tests for ODCS quality entries that have an associated `query` and bound."""
     out: List[SingularTest] = []
@@ -349,21 +442,50 @@ def _singular_tests_for_qualities(
         out.append(
             SingularTest(
                 filename=f"{filename}.sql",
-                sql=_build_singular_sql(quality.query, predicate, severity, contract_id, model),
+                sql=_build_singular_sql(
+                    quality.query,
+                    predicate,
+                    severity,
+                    contract_id,
+                    model,
+                    check_type="custom_sql",
+                    field=field,
+                    description=quality.description,
+                ),
                 description=quality.description,
             )
         )
     return out
 
 
-def _build_singular_sql(query: str, violation_predicate: str, severity: str, contract_id: str, model: str) -> str:
+def _format_dc_meta(model: str, field: Optional[str] = None, description: Optional[str] = None) -> str:
+    """Render the `meta={...}` arg for dbt `config()` so singular tests carry their contract model/field/description."""
+    meta: dict[str, str] = {"dc_model": model}
+    if field:
+        meta["dc_field"] = field
+    if description:
+        meta["dc_description"] = description
+    return f"meta={json.dumps(meta)}"
+
+
+def _build_singular_sql(
+    query: str,
+    violation_predicate: str,
+    severity: str,
+    contract_id: str,
+    model: str,
+    *,
+    check_type: str,
+    field: Optional[str] = None,
+    description: Optional[str] = None,
+) -> str:
     # The ODCS query is expected to yield a single-column scalar metric. We alias that
     # column to `metric_value` via the CTE column list, then return rows only when the
     # bound is violated — dbt singular-test semantics (rows returned = test failed).
     return (
         f"-- AUTO-GENERATED by `datacontract dbt sync`. Do not edit.\n"
         f"-- Source contract: {contract_id} (model: {model})\n"
-        f"{{{{ config(severity='{severity}', tags=['{OUTPUT_TAG}']) }}}}\n"
+        f"{{{{ config(severity='{severity}', tags=['{OUTPUT_TAG}', 'dc:{check_type}'], {_format_dc_meta(model, field, description)}) }}}}\n"
         f"WITH _dc_metric (metric_value) AS (\n"
         f"{query.rstrip()}\n"
         f")\n"
@@ -376,17 +498,43 @@ def _row_count_singular_test(quality: DataQuality, contract_id: str, model: str)
     predicate = _bound_violation_predicate(quality)
     if predicate is None:
         return None
-    severity = _normalize_severity(quality.severity)
-    label = _quality_label(quality, 1)
-    filename = f"{_slugify(contract_id)}__{_slugify(model)}__{_slugify(label)}.sql"
-    sql = _build_singular_sql(
-        f"SELECT COUNT(*) FROM {{{{ ref('{model}') }}}}",
-        predicate,
-        severity,
-        contract_id,
-        model,
+    description = quality.description or _describe_row_count_quality(quality, model)
+    return SingularTest(
+        filename=_slugify(f"{contract_id}__{model}__{_quality_label(quality, 1)}") + ".sql",
+        sql=_build_singular_sql(
+            f"SELECT COUNT(*) FROM {{{{ ref('{model}') }}}}",
+            predicate,
+            _normalize_severity(quality.severity),
+            contract_id,
+            model,
+            check_type="row_count",
+            description=description,
+        ),
+        description=description,
     )
-    return SingularTest(filename=filename, sql=sql, description=quality.description)
+
+
+def _describe_row_count_quality(quality: DataQuality, model: str) -> Optional[str]:
+    if quality.mustBe is not None:
+        return f"Check that model {model} has exactly {quality.mustBe} rows"
+    if quality.mustNotBe is not None:
+        return f"Check that model {model} does not have exactly {quality.mustNotBe} rows"
+    if quality.mustBeGreaterThan is not None:
+        return f"Check that model {model} has more than {quality.mustBeGreaterThan} rows"
+    if quality.mustBeGreaterOrEqualTo is not None:
+        return f"Check that model {model} has at least {quality.mustBeGreaterOrEqualTo} rows"
+    if quality.mustBeLessThan is not None:
+        return f"Check that model {model} has fewer than {quality.mustBeLessThan} rows"
+    if quality.mustBeLessOrEqualTo is not None:
+        return f"Check that model {model} has at most {quality.mustBeLessOrEqualTo} rows"
+    if quality.mustBeBetween is not None and len(quality.mustBeBetween) == 2:
+        return f"Check that model {model} has between {quality.mustBeBetween[0]} and {quality.mustBeBetween[1]} rows"
+    if quality.mustNotBeBetween is not None and len(quality.mustNotBeBetween) == 2:
+        return (
+            f"Check that model {model} has a row count outside "
+            f"{quality.mustNotBeBetween[0]} to {quality.mustNotBeBetween[1]}"
+        )
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -422,7 +570,7 @@ def _regex_violation_jinja(column: str, pattern: str) -> str:
 
 
 def _field_bound_predicates(prop: SchemaProperty) -> List[Tuple[str, str]]:
-    """For `prop`, yield `(label_suffix, sql_predicate)` for each declared bound.
+    """For `prop`, yield `(kind, sql_predicate)` for each declared bound, where `kind` is one of `"length"` / `"pattern"` / `"range"`.
 
     `sql_predicate` is TRUE only for rows that violate the bound. Length checks
     fire when the value is non-null but its length is out of range; numeric
@@ -469,16 +617,19 @@ def _field_bound_predicates(prop: SchemaProperty) -> List[Tuple[str, str]]:
 def _build_row_violation_sql(
     *,
     model: str,
+    field: str,
     column_null_filter: str,
     violation_predicate: str,
     severity: str,
     contract_id: str,
     label: str,
+    check_type: str,
+    description: Optional[str] = None,
 ) -> str:
     return (
         f"-- AUTO-GENERATED by `datacontract dbt sync`. Do not edit.\n"
         f"-- Source contract: {contract_id} (model: {model}, check: {label})\n"
-        f"{{{{ config(severity='{severity}', tags=['{OUTPUT_TAG}']) }}}}\n"
+        f"{{{{ config(severity='{severity}', tags=['{OUTPUT_TAG}', 'dc:{check_type}'], {_format_dc_meta(model, field, description)}) }}}}\n"
         f"SELECT *\n"
         f"FROM {{{{ ref('{model}') }}}}\n"
         f"WHERE {column_null_filter} IS NOT NULL\n"
@@ -490,18 +641,26 @@ def _field_singular_tests(prop: SchemaProperty, contract_id: str, model: str) ->
     """Singular SQL tests for `logicalTypeOptions` bounds on `prop` (length / regex / range)."""
     column = _quote_identifier(prop.name)
     out: List[SingularTest] = []
-    for suffix, predicate in _field_bound_predicates(prop):
-        label = f"{prop.name}__{suffix}"
-        filename = f"{_slugify(contract_id)}__{_slugify(model)}__{_slugify(label)}.sql"
-        sql = _build_row_violation_sql(
-            model=model,
-            column_null_filter=column,
-            violation_predicate=predicate,
-            severity="warn",
-            contract_id=contract_id,
-            label=label,
+    for kind, predicate in _field_bound_predicates(prop):
+        label = f"{prop.name}__{kind}"
+        description = _describe_field_bound(prop, kind)
+        out.append(
+            SingularTest(
+                filename=_slugify(f"{contract_id}__{model}__{label}") + ".sql",
+                sql=_build_row_violation_sql(
+                    model=model,
+                    field=prop.name,
+                    column_null_filter=column,
+                    violation_predicate=predicate,
+                    severity="warn",
+                    contract_id=contract_id,
+                    label=label,
+                    check_type={"length": "field_length", "pattern": "field_regex", "range": "field_range"}[kind],
+                    description=description,
+                ),
+                description=description,
+            )
         )
-        out.append(SingularTest(filename=filename, sql=sql, description=None))
     return out
 
 
@@ -518,10 +677,13 @@ def _model_data_tests(
     singular_tests: List[SingularTest] = []
     pk_cols = [p.name for p in (schema_obj.properties or []) if p.primaryKey]
     if len(pk_cols) > 1:
+        pk_test = {"dbt_utils.unique_combination_of_columns": {"combination_of_columns": pk_cols}}
         yaml_tests.append(
             _attach_test_config(
-                {"dbt_utils.unique_combination_of_columns": {"combination_of_columns": pk_cols}},
+                pk_test,
                 severity="warn",
+                description=_describe_dbt_test(pk_test, None, model),
+                check_type="model_unique_combination",
             )
         )
     for q in schema_obj.quality or []:
@@ -538,7 +700,9 @@ def _model_data_tests(
     return yaml_tests, singular_tests
 
 
-def _column_dict(prop: SchemaProperty, odcs: OpenDataContractStandard, single_pk_name: Optional[str], run: Run) -> dict:
+def _column_dict(
+    prop: SchemaProperty, odcs: OpenDataContractStandard, single_pk_name: Optional[str], model_name: str, run: Run
+) -> dict:
     column: dict = {"name": prop.name}
     base = field_to_data_tests(
         prop,
@@ -548,19 +712,33 @@ def _column_dict(prop: SchemaProperty, odcs: OpenDataContractStandard, single_pk
         source_name=odcs.id or "_source",
     )
     base = _rewrite_relationships_to_ref(base)
-    tests = [_attach_test_config(t, severity="warn") for t in base]
+    tests = [
+        _attach_test_config(
+            test,
+            severity="warn",
+            description=_describe_dbt_test(test, prop.name, model_name),
+            check_type=_check_type_for_generic_test(test),
+        )
+        for test in base
+    ]
 
-    for q in prop.quality or []:
-        if q.metric and q.metric.lower() == "invalidvalues":
+    for data_quality in prop.quality or []:
+        if data_quality.metric and data_quality.metric.lower() == "invalidvalues":
             continue
-        if q.query:
+        if data_quality.query:
             continue
-        if q.mustBe is not None:
+        if data_quality.mustBe is not None:
+            entry = {"accepted_values": {"values": [data_quality.mustBe]}}
             tests.append(
-                _attach_test_config({"accepted_values": {"values": [q.mustBe]}}, _normalize_severity(q.severity))
+                _attach_test_config(
+                    entry,
+                    _normalize_severity(data_quality.severity),
+                    description=data_quality.description or _describe_dbt_test(entry, prop.name, model_name),
+                    check_type="field_enum",
+                )
             )
             continue
-        run.log_warn(f"Skipping unsupported quality on `{prop.name}`: metric={q.metric!r}")
+        run.log_warn(f"Skipping unsupported quality on `{prop.name}`: metric={data_quality.metric!r}")
 
     if tests:
         column["data_tests"] = tests
@@ -588,7 +766,7 @@ def generate_dbt_tests_for_schema(
 
     columns: list = []
     for prop in schema_obj.properties or []:
-        columns.append(_column_dict(prop, odcs, single_pk_name, run))
+        columns.append(_column_dict(prop, odcs, single_pk_name, model_name, run))
     if columns:
         model_dict["columns"] = columns
 
@@ -599,7 +777,14 @@ def generate_dbt_tests_for_schema(
     # Existing `quality.query` singular tests (one CTE per scalar metric)
     for prop in schema_obj.properties or []:
         singulars.extend(
-            _singular_tests_for_qualities(prop.quality, contract_id, model_name, run, label_prefix=f"{prop.name}__")
+            _singular_tests_for_qualities(
+                prop.quality,
+                contract_id,
+                model_name,
+                run,
+                label_prefix=f"{prop.name}__",
+                field=prop.name,
+            )
         )
     singulars.extend(_singular_tests_for_qualities(schema_obj.quality, contract_id, model_name, run))
     _disambiguate_singular_filenames(singulars)
@@ -813,6 +998,23 @@ def _get_test_metadata(test_node: dict) -> Tuple[Optional[str], Optional[str], O
             if isinstance(dep, str) and dep.startswith("model."):
                 model = dep.split(".")[-1]
                 break
+
+    # Singular SQL tests have no `column_name` / `attached_node` in the manifest,
+    # therfore we stored them to `config(meta={...})`.
+    meta = (test_node.get("config") or {}).get("meta") or {}
+    if not column:
+        dc_field = meta.get("dc_field")
+        if isinstance(dc_field, str):
+            column = dc_field
+    if not model:
+        dc_model = meta.get("dc_model")
+        if isinstance(dc_model, str):
+            model = dc_model
+    if not description:
+        dc_description = meta.get("dc_description")
+        if isinstance(dc_description, str):
+            description = dc_description
+
     return model, column, description
 
 
@@ -853,6 +1055,10 @@ def parse_run_results(project_dir: Path, odcs: OpenDataContractStandard) -> Run:
         message = r.get("message")
         node = nodes.get(unique_id) or {}
         model, column, description = _get_test_metadata(node)
+        check_type = next(
+            (t.removeprefix("dc:") for t in (node.get("tags") or []) if isinstance(t, str) and t.startswith("dc:")),
+            "dbt_test",
+        )
         fallback_name = node.get("name")
         if not fallback_name:
             parts = unique_id.split(".")
@@ -864,7 +1070,7 @@ def parse_run_results(project_dir: Path, odcs: OpenDataContractStandard) -> Run:
             reason_parts.append(message)
         run.checks.append(
             Check(
-                type="dbt_test",
+                type=check_type,
                 name=description or fallback_name,
                 model=model,
                 field=column,
@@ -988,15 +1194,21 @@ def run_tests(
         target=target,
         profiles_dir=profiles_dir,
     )
-    if completed.stdout:
-        logger.info(completed.stdout)
-    if completed.stderr:
-        logger.info(completed.stderr)
+
+    gen_run = generated.generation_run
+    ansi = re.compile(r"\x1b\[[0-9;]*[mGKHF]")
+    for stream in (completed.stdout, completed.stderr):
+        if not stream:
+            continue
+        for line in ansi.sub("", stream).splitlines():
+            line = line.strip()
+            if line:
+                gen_run.log_info(line)
 
     parsed_run = parse_run_results(generated.project_dir, generated.odcs)
     # Stitch generation-time logs onto the parsed Run so warn-counts include
     # any generation-time skips.
-    parsed_run.logs = generated.generation_run.logs + parsed_run.logs
+    parsed_run.logs = gen_run.logs + parsed_run.logs
     parsed_run.timestampStart = generated.generation_run.timestampStart
     parsed_run.finish()
     return parsed_run

--- a/datacontract/integration/dbt_sync.py
+++ b/datacontract/integration/dbt_sync.py
@@ -292,7 +292,7 @@ def _describe_dbt_test(test: Any, field_name: Optional[str], model_name: str) ->
     return None
 
 
-def _describe_field_bound(prop: "SchemaProperty", kind: str) -> Optional[str]:
+def _describe_field_bound(prop: SchemaProperty, kind: str) -> Optional[str]:
     """Human-readable descriptions for the singular SQL tests `_field_singular_tests` emits.
 
     `kind` is one of `"length"`, `"pattern"`, `"range"`.
@@ -1000,7 +1000,7 @@ def _get_test_metadata(test_node: dict) -> Tuple[Optional[str], Optional[str], O
                 break
 
     # Singular SQL tests have no `column_name` / `attached_node` in the manifest,
-    # therfore we stored them to `config(meta={...})`.
+    # therefore we stored them to `config(meta={...})`.
     meta = (test_node.get("config") or {}).get("meta") or {}
     if not column:
         dc_field = meta.get("dc_field")

--- a/datacontract/integration/entropy_data.py
+++ b/datacontract/integration/entropy_data.py
@@ -9,7 +9,8 @@ from datacontract.model.run import Run
 RESPONSE_HEADER_LOCATION_HTML = "location-html"
 
 
-def publish_test_results_to_entropy_data(run: Run, publish_url: str, ssl_verification: bool):
+def publish_test_results_to_entropy_data(run: Run, publish_url: str, ssl_verification: bool) -> bool:
+    """Publish `run` to the Entropy Data instance. Returns True on success, False otherwise."""
     try:
         host = publish_url
         if publish_url is None:
@@ -38,15 +39,17 @@ def publish_test_results_to_entropy_data(run: Run, publish_url: str, ssl_verific
         if response.status_code != 200:
             display_host = _extract_hostname(host)
             run.log_error(f"Error publishing test results to {display_host}: {response.text}")
-            return
+            return False
         run.log_info("Published test results successfully")
 
         location_html = response.headers.get(RESPONSE_HEADER_LOCATION_HTML)
         if location_html is not None and len(location_html) > 0:
             print(f"🚀 Open {location_html}")
+        return True
 
     except Exception as e:
         run.log_error(f"Failed publishing test results. Error: {str(e)}")
+        return False
 
 
 def publish_data_contract_to_entropy_data(data_contract_dict: dict, ssl_verification: bool):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,15 +48,3 @@ def test_changelog_with_changes():
     assert "Removed" in result.output
     assert "Updated" in result.output
     assert "Added" in result.output
-
-
-def test_test_command_rejects_non_http_publish_url():
-    result = runner.invoke(app, ["test", "fixtures/lint/valid_datacontract.yaml", "--publish", "ftp://foo"])
-    assert result.exit_code == 1
-    assert "must start with http:// or https://" in result.stdout
-
-
-def test_ci_command_rejects_non_http_publish_url():
-    result = runner.invoke(app, ["ci", "fixtures/lint/valid_datacontract.yaml", "--publish", "ftp://foo"])
-    assert result.exit_code == 1
-    assert "must start with http:// or https://" in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,3 +48,15 @@ def test_changelog_with_changes():
     assert "Removed" in result.output
     assert "Updated" in result.output
     assert "Added" in result.output
+
+
+def test_test_command_rejects_non_http_publish_url():
+    result = runner.invoke(app, ["test", "fixtures/lint/valid_datacontract.yaml", "--publish", "ftp://foo"])
+    assert result.exit_code == 1
+    assert "must start with http:// or https://" in result.stdout
+
+
+def test_ci_command_rejects_non_http_publish_url():
+    result = runner.invoke(app, ["ci", "fixtures/lint/valid_datacontract.yaml", "--publish", "ftp://foo"])
+    assert result.exit_code == 1
+    assert "must start with http:// or https://" in result.stdout

--- a/tests/test_dbt_sync.py
+++ b/tests/test_dbt_sync.py
@@ -1203,9 +1203,7 @@ def test_cli_publish_rejects_non_http_url(tmp_path: Path):
 
 
 def test_cli_publish_skipped_when_no_server_resolvable(monkeypatch, tmp_path: Path):
-    """No --server and no `servers:` block in the contract → warn and skip publish.
-    The dbt --target name is a dbt concept, not an ODCS server identifier, so
-    falling back to it would mislabel the published run."""
+    """No --server, no --target, and no `servers:` block → warn and skip publish."""
     project = _copy_dbt_project(tmp_path)
     _stub_dbt_test(monkeypatch, project)
 
@@ -1221,8 +1219,6 @@ def test_cli_publish_skipped_when_no_server_resolvable(monkeypatch, tmp_path: Pa
             str(CONTRACT_PATH),
             "--project-dir",
             str(project),
-            "--target",
-            "dev",
             "--publish",
             "https://example.com",
         ],

--- a/tests/test_dbt_sync.py
+++ b/tests/test_dbt_sync.py
@@ -23,6 +23,7 @@ from datacontract.integration.dbt_sync import (
     _attach_test_config,
     _bound_violation_predicate,
     _build_singular_sql,
+    _describe_dbt_test,
     _disambiguate_singular_filenames,
     _ensure_dbt_project,
     _rewrite_relationships_to_ref,
@@ -285,14 +286,79 @@ def test_attach_config_string_test():
     }
 
 
+def test_attach_config_string_test_with_check_type():
+    assert _attach_test_config("not_null", "warn", check_type="field_required") == {
+        "not_null": {"config": {"severity": "warn", "tags": ["datacontract_cli", "dc:field_required"]}}
+    }
+
+
 def test_attach_config_dict_test():
-    result = _attach_test_config({"accepted_values": {"values": [1, 2]}}, "error")
+    result = _attach_test_config({"accepted_values": {"values": [1, 2]}}, "error", check_type="field_enum")
     assert result == {
         "accepted_values": {
             "values": [1, 2],
-            "config": {"severity": "error", "tags": ["datacontract_cli"]},
+            "config": {"severity": "error", "tags": ["datacontract_cli", "dc:field_enum"]},
         }
     }
+
+
+@pytest.mark.parametrize(
+    "test, expected",
+    [
+        ("not_null", "Check that field order_id has no missing values"),
+        ("unique", "Check that field order_id has no duplicate values"),
+        (
+            {"accepted_values": {"values": ["pending", "shipped"]}},
+            "Check that field order_id only contains enum values ['pending', 'shipped']",
+        ),
+        ({"accepted_values": {"values": ["X"]}}, "Check that field order_id is equal to X"),
+        (
+            {"relationships": {"to": "ref('customers')", "field": "id"}},
+            "Check that field order_id references ref('customers').id",
+        ),
+        (
+            {"dbt_utils.unique_combination_of_columns": {"combination_of_columns": ["order_id", "order_status"]}},
+            "Check that model orders has a unique combination of columns order_id, order_status",
+        ),
+    ],
+)
+def test_describe_dbt_test_templates(test, expected):
+    """Templates should read like the equivalent built-in check names so the published UI matches."""
+    assert _describe_dbt_test(test, "order_id", "orders") == expected
+
+
+def test_attach_test_config_embeds_description():
+    wrapped = _attach_test_config(
+        "not_null",
+        "warn",
+        description="Check that field order_id has no missing values",
+        check_type="field_required",
+    )
+    assert wrapped == {
+        "not_null": {
+            "config": {"severity": "warn", "tags": ["datacontract_cli", "dc:field_required"]},
+            "description": "Check that field order_id has no missing values",
+        }
+    }
+
+
+def test_generate_outputs_emits_descriptions_for_typed_field_tests():
+    """`not_null`, `unique`, `accepted_values` must carry a synthesized description
+    so the published Run.check name shows the human-readable form."""
+    odcs = resolve_data_contract(str(CONTRACT_PATH))
+    schema_obj = odcs.schema_[0]
+    model_dict, _ = generate_dbt_tests_for_schema(odcs, schema_obj, "orders", Run.create_run())
+
+    cols = {c["name"]: c for c in model_dict["columns"]}
+    descriptions_by_test_name = {}
+    for col_name, col in cols.items():
+        for entry in col.get("data_tests", []):
+            ((test_name, args),) = entry.items()
+            descriptions_by_test_name[(col_name, test_name)] = args.get("description")
+
+    assert descriptions_by_test_name[("order_id", "not_null")] == "Check that field order_id has no missing values"
+    assert descriptions_by_test_name[("order_id", "unique")] == "Check that field order_id has no duplicate values"
+    assert "only contains enum values" in descriptions_by_test_name[("order_status", "accepted_values")]
 
 
 def test_rewrite_relationships_to_ref():
@@ -321,12 +387,20 @@ def test_generate_outputs_wraps_tests_with_tag_and_emits_singulars():
     assert model_dict["name"] == "orders"
     assert model_dict["description"] == "Orders table"
 
-    # Sync-specific: every YAML test carries the datacontract_cli tag via inline config.
+    # Sync-specific: every YAML test carries the datacontract_cli tag plus a dc:<type> tag.
     cols = {c["name"]: c for c in model_dict["columns"]}
+    expected_dc_tag = {
+        "not_null": "dc:field_required",
+        "unique": "dc:field_unique",
+        "accepted_values": "dc:field_enum",
+        "relationships": "dc:field_relationships",
+    }
     for t in cols["order_id"]["data_tests"]:
         assert isinstance(t, dict)
-        (args,) = t.values()
-        assert args["config"]["tags"] == ["datacontract_cli"]
+        ((test_name, args),) = t.items()
+        tags = args["config"]["tags"]
+        assert tags[0] == "datacontract_cli"
+        assert tags[1] == expected_dc_tag[test_name]
 
     # Single-PK in this fixture → no model-level data_tests.
     assert "data_tests" not in model_dict
@@ -337,11 +411,10 @@ def test_generate_outputs_wraps_tests_with_tag_and_emits_singulars():
     assert all(s.filename.startswith("orders_sync_test__orders__") for s in singulars)
     assert all(s.filename.endswith(".sql") for s in singulars)
     assert any(s.description and "95%" in s.description for s in singulars)
-    # Field-level bound tests have no description (the source is `logicalTypeOptions`).
-    field_bounds = {s.filename for s in singulars if s.description is None}
-    assert "orders_sync_test__orders__order_id__length.sql" in field_bounds
-    assert "orders_sync_test__orders__order_id__pattern.sql" in field_bounds
-    assert "orders_sync_test__orders__order_total__range.sql" in field_bounds
+    by_name = {s.filename: s for s in singulars}
+    assert "length between 8 and 10" in by_name["orders_sync_test__orders__order_id__length.sql"].description
+    assert "matches regex pattern" in by_name["orders_sync_test__orders__order_id__pattern.sql"].description
+    assert "minimum of 0" in by_name["orders_sync_test__orders__order_total__range.sql"].description
 
 
 def test_generate_outputs_composite_pk_emits_model_level_unique():
@@ -406,7 +479,7 @@ def test_generate_outputs_singular_sql_carries_severity_and_tag():
     row_count = next(s for s in singulars if "row_count" in s.filename)
     # severity=error normalized from `severity: error` in the fixture
     assert "severity='error'" in row_count.sql
-    assert "tags=['datacontract_cli']" in row_count.sql
+    assert "tags=['datacontract_cli', 'dc:custom_sql']" in row_count.sql
 
 
 def test_build_singular_sql_wraps_query_with_violation_predicate():
@@ -416,13 +489,31 @@ def test_build_singular_sql_wraps_query_with_violation_predicate():
         "error",
         "my-contract",
         "orders",
+        check_type="row_count",
     )
     assert "AUTO-GENERATED" in sql
     assert "my-contract" in sql
-    assert "{{ config(severity='error', tags=['datacontract_cli']) }}" in sql
+    assert "severity='error'" in sql
+    assert "tags=['datacontract_cli', 'dc:row_count']" in sql
+    assert '"dc_model": "orders"' in sql  # Model is round-tripped through `meta`
+    assert "dc_field" not in sql  # model-level test, no field
     assert "WITH _dc_metric (metric_value) AS (" in sql
     assert "SELECT COUNT(*) FROM orders" in sql
     assert "WHERE metric_value IS NULL OR metric_value <= 1000" in sql
+
+
+def test_build_singular_sql_embeds_field_in_meta_when_provided():
+    sql = _build_singular_sql(
+        "SELECT 1",
+        "metric_value <> 1",
+        "warn",
+        "c",
+        "orders",
+        check_type="quality_custom",
+        field="order_id",
+    )
+    assert '"dc_model": "orders"' in sql
+    assert '"dc_field": "order_id"' in sql
 
 
 @pytest.mark.parametrize(
@@ -728,6 +819,140 @@ def test_parse_run_results_maps_status_and_failures(tmp_path: Path):
     assert statuses == {"passed", "failed", "warning", "error", "info"}
 
 
+def test_parse_run_results_derives_check_type_from_dc_tag(tmp_path: Path):
+    """`Check.type` is read from the `dc:<type>` tag attached to each test node.
+
+    Falls back to `dbt_test` when no `dc:*` tag is present.
+    """
+    project = _copy_dbt_project(tmp_path)
+    target_dir = project / "target"
+    target_dir.mkdir()
+
+    run_results = {
+        "results": [
+            {"unique_id": "test.proj.a", "status": "pass", "failures": 0, "message": None},
+            {"unique_id": "test.proj.b", "status": "pass", "failures": 0, "message": None},
+            {"unique_id": "test.proj.c", "status": "pass", "failures": 0, "message": None},
+        ]
+    }
+    (target_dir / "run_results.json").write_text(json.dumps(run_results))
+
+    manifest = {
+        "nodes": {
+            "test.proj.a": {"name": "a", "tags": ["datacontract_cli", "dc:field_required"]},
+            "test.proj.b": {"name": "b", "tags": ["datacontract_cli", "dc:row_count"]},
+            # Legacy artifact without a dc:* tag — must fall back to "dbt_test".
+            "test.proj.c": {"name": "c", "tags": ["datacontract_cli"]},
+        }
+    }
+    (target_dir / "manifest.json").write_text(json.dumps(manifest))
+
+    odcs = resolve_data_contract(str(CONTRACT_PATH))
+    parsed = parse_run_results(project, odcs)
+
+    by_name = {c.name: c for c in parsed.checks}
+    assert by_name["a"].type == "field_required"
+    assert by_name["b"].type == "row_count"
+    assert by_name["c"].type == "dbt_test"
+
+
+def test_parse_run_results_recovers_model_and_field_from_config_meta(tmp_path: Path):
+    """Singular SQL tests have no `column_name`/`attached_node` in the manifest.
+
+    `dbt sync` round-trips both names through `config(meta={...})`, which dbt
+    surfaces on `node.config.meta`. The parser must fall back to it.
+    """
+    project = _copy_dbt_project(tmp_path)
+    target_dir = project / "target"
+    target_dir.mkdir()
+    (target_dir / "run_results.json").write_text(
+        json.dumps(
+            {
+                "results": [
+                    {"unique_id": "test.proj.field_bound", "status": "fail", "failures": 2, "message": "boom"},
+                    {"unique_id": "test.proj.no_ref_quality", "status": "pass", "failures": 0, "message": None},
+                ]
+            }
+        )
+    )
+    (target_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "nodes": {
+                    # Singular SQL: no `column_name`, no `attached_node`. Meta supplies both.
+                    "test.proj.field_bound": {
+                        "name": "orders_sync_test__orders__order_id__length",
+                        "config": {"meta": {"dc_model": "orders", "dc_field": "order_id"}},
+                    },
+                    # User `quality.query` without `ref()` → `depends_on.nodes` is empty;
+                    # meta is the only signal we have for the model.
+                    "test.proj.no_ref_quality": {
+                        "name": "no_ref_quality",
+                        "config": {"meta": {"dc_model": "orders"}},
+                    },
+                }
+            }
+        )
+    )
+
+    odcs = resolve_data_contract(str(CONTRACT_PATH))
+    parsed = parse_run_results(project, odcs)
+
+    by_name = {c.name: c for c in parsed.checks}
+    field_bound = by_name["orders_sync_test__orders__order_id__length"]
+    assert field_bound.model == "orders"
+    assert field_bound.field == "order_id"
+
+    no_ref = by_name["no_ref_quality"]
+    assert no_ref.model == "orders"
+    assert no_ref.field is None
+
+
+def test_parse_run_results_recovers_description_from_config_meta(tmp_path: Path):
+    """dbt 1.11's manifest leaves `node.description == ''` for singular SQL tests even
+    when a description is set in the model YAML's top-level `data_tests:` block.
+    `dbt sync` round-trips the human-readable description through `config(meta={...})`
+    so `Check.name` reads "Check that field email matches…" instead of the SQL filename.
+    """
+    project = _copy_dbt_project(tmp_path)
+    target_dir = project / "target"
+    target_dir.mkdir()
+    (target_dir / "run_results.json").write_text(
+        json.dumps(
+            {
+                "results": [
+                    {"unique_id": "test.proj.email_pattern", "status": "warn", "failures": 1, "message": None},
+                ]
+            }
+        )
+    )
+    (target_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "nodes": {
+                    "test.proj.email_pattern": {
+                        "name": "orders_sync_test__customers__email__pattern",
+                        # Empty string (what dbt 1.11 actually writes), not None.
+                        "description": "",
+                        "config": {
+                            "meta": {
+                                "dc_model": "customers",
+                                "dc_field": "email",
+                                "dc_description": "Check that field email matches regex pattern ^[^@]+@[^@]+$",
+                            }
+                        },
+                    },
+                }
+            }
+        )
+    )
+
+    odcs = resolve_data_contract(str(CONTRACT_PATH))
+    parsed = parse_run_results(project, odcs)
+    assert len(parsed.checks) == 1
+    assert parsed.checks[0].name == "Check that field email matches regex pattern ^[^@]+@[^@]+$"
+
+
 def test_parse_run_results_honors_custom_target_path(tmp_path: Path):
     """When `target-path` is overridden, dbt writes artifacts to that dir — not `target/`."""
     project = _custom_paths_project(tmp_path, model_paths=["models"], test_paths=["tests"])
@@ -834,3 +1059,313 @@ def test_integration_end_to_end(tmp_path: Path):
     )
 
     assert result.run is not None
+
+
+# ---------------------------------------------------------------------------
+# --publish flag
+# ---------------------------------------------------------------------------
+
+
+def _stub_dbt_test(monkeypatch, project: Path) -> None:
+    """Replace `subprocess.run` so `dbt test` succeeds and leaves a minimal run_results.json."""
+    target_dir = project / "target"
+    target_dir.mkdir(exist_ok=True)
+
+    def fake_run(args, **kwargs):
+        (target_dir / "run_results.json").write_text(
+            json.dumps(
+                {"results": [{"unique_id": "test.proj.x.abc", "status": "pass", "failures": 0, "message": None}]}
+            )
+        )
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+
+def test_run_tests_forwards_dbt_output_to_run_logs(monkeypatch, tmp_path: Path):
+    """`run_tests` must surface `dbt test` stdout/stderr through `run.logs` so the
+    published Run carries the same context an operator would see locally — minus
+    ANSI codes and empty lines."""
+    project = _copy_dbt_project(tmp_path)
+    target_dir = project / "target"
+    target_dir.mkdir()
+
+    dbt_stdout = "\x1b[0m13:59:19  Running with dbt=1.11.7\n\x1b[0m13:59:19  \n13:59:20  Done. PASS=1\n"
+    dbt_stderr = "deprecation warning: foo\n"
+
+    def fake_run(args, **kwargs):
+        (target_dir / "run_results.json").write_text(
+            json.dumps(
+                {"results": [{"unique_id": "test.proj.x.abc", "status": "pass", "failures": 0, "message": None}]}
+            )
+        )
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout=dbt_stdout, stderr=dbt_stderr)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = sync(contract=str(CONTRACT_PATH), project_dir=project)
+    messages = [log.message for log in result.run.logs]
+    assert "13:59:19  Running with dbt=1.11.7" in messages
+    assert "13:59:20  Done. PASS=1" in messages
+    assert "deprecation warning: foo" in messages
+    # ANSI escape codes are stripped and empty lines dropped.
+    assert not any("\x1b[" in m for m in messages)
+    assert "" not in messages
+
+
+def test_publish_not_called_when_flag_absent(monkeypatch, tmp_path: Path):
+    project = _copy_dbt_project(tmp_path)
+    _stub_dbt_test(monkeypatch, project)
+
+    publish_mock = mock.MagicMock()
+    monkeypatch.setattr("datacontract.command_dbt.publish_test_results_to_entropy_data", publish_mock)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["dbt", "sync", str(CONTRACT_PATH), "--project-dir", str(project)])
+    assert result.exit_code == 0, result.output
+    publish_mock.assert_not_called()
+
+
+def test_publish_failure_exits_non_zero(monkeypatch, tmp_path: Path):
+    """Publish failure → exit 1 so CI scripts catch it. The error message itself
+    surfaces via stdlib logging (same path as every other `run.log_*` call); the
+    CLI doesn't double-print it on stdout."""
+    project = _copy_dbt_project(tmp_path)
+    _stub_dbt_test(monkeypatch, project)
+
+    def failing_publish(run, publish_url, ssl_verification):
+        run.log_error("Failed publishing test results. Error: boom")
+
+    monkeypatch.setattr("datacontract.command_dbt.publish_test_results_to_entropy_data", failing_publish)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "dbt",
+            "sync",
+            str(CONTRACT_PATH),
+            "--project-dir",
+            str(project),
+            "--publish",
+            "https://example.com/results",
+        ],
+    )
+    assert result.exit_code == 1, result.output
+
+
+def test_cli_publish_option_renders_in_help():
+    result = CliRunner().invoke(app, ["dbt", "sync", "--help"], terminal_width=200, color=False)
+    assert result.exit_code == 0
+    plain = re.sub(r"\s+", "", re.sub(r"\x1b\[[0-9;]*[mGKHF]", "", result.stdout))
+    assert "--publish" in plain
+    # --ssl-verification gets truncated
+    assert "--ssl-verific" in plain
+
+
+def test_cli_publish_flag_forwards_url_and_ssl(monkeypatch, tmp_path: Path):
+    project = _copy_dbt_project(tmp_path)
+    _stub_dbt_test(monkeypatch, project)
+
+    captured: dict = {}
+
+    def fake_publish(run, publish_url, ssl_verification):
+        captured["url"] = publish_url
+        captured["ssl"] = ssl_verification
+        run.log_info("Published test results successfully")
+
+    monkeypatch.setattr("datacontract.command_dbt.publish_test_results_to_entropy_data", fake_publish)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "dbt",
+            "sync",
+            str(CONTRACT_PATH),
+            "--project-dir",
+            str(project),
+            "--publish",
+            "https://example.com/results",
+            "--no-ssl-verification",
+        ],
+    )
+    if result.exit_code != 0:
+        sys.stderr.write(result.output)
+        if result.exception:
+            raise result.exception
+    assert result.exit_code == 0
+    assert captured["url"] == "https://example.com/results"
+    assert captured["ssl"] is False
+
+
+def test_cli_publish_with_skip_tests_rejected(tmp_path: Path):
+    project = _copy_dbt_project(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "dbt",
+            "sync",
+            str(CONTRACT_PATH),
+            "--project-dir",
+            str(project),
+            "--skip-tests",
+            "--publish",
+            "https://example.com",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "--publish cannot be combined with --skip-tests" in result.stdout
+
+
+def test_cli_publish_rejects_non_http_url(tmp_path: Path):
+    project = _copy_dbt_project(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "dbt",
+            "sync",
+            str(CONTRACT_PATH),
+            "--project-dir",
+            str(project),
+            "--publish",
+            "ftp://foo",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "must start with http:// or https://" in result.stdout
+
+
+def test_cli_server_defaults_to_target(monkeypatch, tmp_path: Path):
+    project = _copy_dbt_project(tmp_path)
+    _stub_dbt_test(monkeypatch, project)
+
+    captured: dict = {}
+
+    def fake_publish(run, publish_url, ssl_verification):
+        captured["server"] = run.server
+
+    monkeypatch.setattr("datacontract.command_dbt.publish_test_results_to_entropy_data", fake_publish)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "dbt",
+            "sync",
+            str(CONTRACT_PATH),
+            "--project-dir",
+            str(project),
+            "--target",
+            "dev",
+            "--publish",
+            "https://example.com",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["server"] == "dev"
+
+
+def test_cli_server_flag_overrides_target(monkeypatch, tmp_path: Path):
+    project = _copy_dbt_project(tmp_path)
+    _stub_dbt_test(monkeypatch, project)
+
+    captured: dict = {}
+
+    def fake_publish(run, publish_url, ssl_verification):
+        captured["server"] = run.server
+
+    monkeypatch.setattr("datacontract.command_dbt.publish_test_results_to_entropy_data", fake_publish)
+
+    # Contract declares a single server. Make it match what we'll pass via --server.
+    contract = tmp_path / "with-server.odcs.yaml"
+    contract.write_text(
+        CONTRACT_PATH.read_text()
+        + "\nservers:\n  - server: production\n    type: duckdb\n    database: warehouse\n    path: ./w.duckdb\n"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "dbt",
+            "sync",
+            str(contract),
+            "--project-dir",
+            str(project),
+            "--target",
+            "ci",
+            "--server",
+            "production",
+            "--publish",
+            "https://example.com",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["server"] == "production"
+
+
+def test_cli_server_defaults_to_single_contract_server(monkeypatch, tmp_path: Path):
+    """Single-server contracts are unambiguous; --target should be ignored for run.server."""
+    project = _copy_dbt_project(tmp_path)
+    _stub_dbt_test(monkeypatch, project)
+
+    captured: dict = {}
+
+    def fake_publish(run, publish_url, ssl_verification):
+        captured["server"] = run.server
+
+    monkeypatch.setattr("datacontract.command_dbt.publish_test_results_to_entropy_data", fake_publish)
+
+    contract = tmp_path / "with-server.odcs.yaml"
+    contract.write_text(
+        CONTRACT_PATH.read_text()
+        + "\nservers:\n  - server: production\n    type: duckdb\n    database: warehouse\n    path: ./w.duckdb\n"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "dbt",
+            "sync",
+            str(contract),
+            "--project-dir",
+            str(project),
+            "--target",
+            "ci",
+            "--publish",
+            "https://example.com",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["server"] == "production"
+
+
+def test_cli_server_rejects_unknown_name(tmp_path: Path):
+    project = _copy_dbt_project(tmp_path)
+    contract = tmp_path / "with-server.odcs.yaml"
+    contract.write_text(
+        CONTRACT_PATH.read_text()
+        + "\nservers:\n  - server: production\n    type: duckdb\n    database: warehouse\n    path: ./w.duckdb\n"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "dbt",
+            "sync",
+            str(contract),
+            "--project-dir",
+            str(project),
+            "--server",
+            "typo",
+            "--skip-tests",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "not declared in the contract" in result.stdout
+    assert "production" in result.stdout

--- a/tests/test_dbt_sync.py
+++ b/tests/test_dbt_sync.py
@@ -286,12 +286,6 @@ def test_attach_config_string_test():
     }
 
 
-def test_attach_config_string_test_with_check_type():
-    assert _attach_test_config("not_null", "warn", check_type="field_required") == {
-        "not_null": {"config": {"severity": "warn", "tags": ["datacontract_cli", "dc:field_required"]}}
-    }
-
-
 def test_attach_config_dict_test():
     result = _attach_test_config({"accepted_values": {"values": [1, 2]}}, "error", check_type="field_enum")
     assert result == {
@@ -325,21 +319,6 @@ def test_attach_config_dict_test():
 def test_describe_dbt_test_templates(test, expected):
     """Templates should read like the equivalent built-in check names so the published UI matches."""
     assert _describe_dbt_test(test, "order_id", "orders") == expected
-
-
-def test_attach_test_config_embeds_description():
-    wrapped = _attach_test_config(
-        "not_null",
-        "warn",
-        description="Check that field order_id has no missing values",
-        check_type="field_required",
-    )
-    assert wrapped == {
-        "not_null": {
-            "config": {"severity": "warn", "tags": ["datacontract_cli", "dc:field_required"]},
-            "description": "Check that field order_id has no missing values",
-        }
-    }
 
 
 def test_generate_outputs_emits_descriptions_for_typed_field_tests():
@@ -500,20 +479,6 @@ def test_build_singular_sql_wraps_query_with_violation_predicate():
     assert "WITH _dc_metric (metric_value) AS (" in sql
     assert "SELECT COUNT(*) FROM orders" in sql
     assert "WHERE metric_value IS NULL OR metric_value <= 1000" in sql
-
-
-def test_build_singular_sql_embeds_field_in_meta_when_provided():
-    sql = _build_singular_sql(
-        "SELECT 1",
-        "metric_value <> 1",
-        "warn",
-        "c",
-        "orders",
-        check_type="quality_custom",
-        field="order_id",
-    )
-    assert '"dc_model": "orders"' in sql
-    assert '"dc_field": "order_id"' in sql
 
 
 @pytest.mark.parametrize(
@@ -1079,6 +1044,7 @@ def _stub_dbt_test(monkeypatch, project: Path) -> None:
         )
         return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
 
+    monkeypatch.setattr(shutil, "which", lambda _: "/fake/dbt")
     monkeypatch.setattr(subprocess, "run", fake_run)
 
 
@@ -1101,6 +1067,7 @@ def test_run_tests_forwards_dbt_output_to_run_logs(monkeypatch, tmp_path: Path):
         )
         return subprocess.CompletedProcess(args=args, returncode=0, stdout=dbt_stdout, stderr=dbt_stderr)
 
+    monkeypatch.setattr(shutil, "which", lambda _: "/fake/dbt")
     monkeypatch.setattr(subprocess, "run", fake_run)
 
     result = sync(contract=str(CONTRACT_PATH), project_dir=project)
@@ -1135,6 +1102,7 @@ def test_publish_failure_exits_non_zero(monkeypatch, tmp_path: Path):
 
     def failing_publish(run, publish_url, ssl_verification):
         run.log_error("Failed publishing test results. Error: boom")
+        return False
 
     monkeypatch.setattr("datacontract.command_dbt.publish_test_results_to_entropy_data", failing_publish)
 
@@ -1147,20 +1115,13 @@ def test_publish_failure_exits_non_zero(monkeypatch, tmp_path: Path):
             str(CONTRACT_PATH),
             "--project-dir",
             str(project),
+            "--server",
+            "prod",
             "--publish",
             "https://example.com/results",
         ],
     )
     assert result.exit_code == 1, result.output
-
-
-def test_cli_publish_option_renders_in_help():
-    result = CliRunner().invoke(app, ["dbt", "sync", "--help"], terminal_width=200, color=False)
-    assert result.exit_code == 0
-    plain = re.sub(r"\s+", "", re.sub(r"\x1b\[[0-9;]*[mGKHF]", "", result.stdout))
-    assert "--publish" in plain
-    # --ssl-verification gets truncated
-    assert "--ssl-verific" in plain
 
 
 def test_cli_publish_flag_forwards_url_and_ssl(monkeypatch, tmp_path: Path):
@@ -1173,6 +1134,7 @@ def test_cli_publish_flag_forwards_url_and_ssl(monkeypatch, tmp_path: Path):
         captured["url"] = publish_url
         captured["ssl"] = ssl_verification
         run.log_info("Published test results successfully")
+        return True
 
     monkeypatch.setattr("datacontract.command_dbt.publish_test_results_to_entropy_data", fake_publish)
 
@@ -1185,6 +1147,8 @@ def test_cli_publish_flag_forwards_url_and_ssl(monkeypatch, tmp_path: Path):
             str(CONTRACT_PATH),
             "--project-dir",
             str(project),
+            "--server",
+            "prod",
             "--publish",
             "https://example.com/results",
             "--no-ssl-verification",
@@ -1238,16 +1202,15 @@ def test_cli_publish_rejects_non_http_url(tmp_path: Path):
     assert "must start with http:// or https://" in result.stdout
 
 
-def test_cli_server_defaults_to_target(monkeypatch, tmp_path: Path):
+def test_cli_publish_skipped_when_no_server_resolvable(monkeypatch, tmp_path: Path):
+    """No --server and no `servers:` block in the contract → warn and skip publish.
+    The dbt --target name is a dbt concept, not an ODCS server identifier, so
+    falling back to it would mislabel the published run."""
     project = _copy_dbt_project(tmp_path)
     _stub_dbt_test(monkeypatch, project)
 
-    captured: dict = {}
-
-    def fake_publish(run, publish_url, ssl_verification):
-        captured["server"] = run.server
-
-    monkeypatch.setattr("datacontract.command_dbt.publish_test_results_to_entropy_data", fake_publish)
+    publish_mock = mock.MagicMock(return_value=True)
+    monkeypatch.setattr("datacontract.command_dbt.publish_test_results_to_entropy_data", publish_mock)
 
     runner = CliRunner()
     result = runner.invoke(
@@ -1265,7 +1228,8 @@ def test_cli_server_defaults_to_target(monkeypatch, tmp_path: Path):
         ],
     )
     assert result.exit_code == 0, result.output
-    assert captured["server"] == "dev"
+    assert "Skipping publish" in result.stdout
+    publish_mock.assert_not_called()
 
 
 def test_cli_server_flag_overrides_target(monkeypatch, tmp_path: Path):
@@ -1276,6 +1240,7 @@ def test_cli_server_flag_overrides_target(monkeypatch, tmp_path: Path):
 
     def fake_publish(run, publish_url, ssl_verification):
         captured["server"] = run.server
+        return True
 
     monkeypatch.setattr("datacontract.command_dbt.publish_test_results_to_entropy_data", fake_publish)
 
@@ -1316,6 +1281,7 @@ def test_cli_server_defaults_to_single_contract_server(monkeypatch, tmp_path: Pa
 
     def fake_publish(run, publish_url, ssl_verification):
         captured["server"] = run.server
+        return True
 
     monkeypatch.setattr("datacontract.command_dbt.publish_test_results_to_entropy_data", fake_publish)
 


### PR DESCRIPTION
## Summary
- Adds `--publish`, `--server`, `--ssl-verification` to `datacontract dbt sync` so run results can be sent to an Entropy Data instance.
- Tags every generated dbt test (YAML and singular SQL) with `dc:<check_type>`; `parse_run_results` reads the tag back so published checks carry their original type (`field_required`, `row_count`, `custom_sql`, …) instead of a generic `dbt_test`.
- Singular SQL tests embed `model` / `field` / `description` in `config(meta={...})`, which `_get_test_metadata` then surfaces (the manifest doesn't otherwise expose these for singular tests).
- Adds human-readable descriptions for generated tests and streams `dbt test` stdout/stderr line-by-line into the run log (ANSI stripped).
- Shared `validate_publish_url` helper in `cli.py`, reused by `ci`, `test`, and `dbt sync`.

Builds on #1222.