### PR TITLE
feat(test): add Redshift support via soda-core-redshift

### DIFF
--- a/README.md
+++ b/README.md
@@ -976,13 +976,25 @@ models:
 ```
 
 ##### Environment Variables
+All [parameters supported by Soda](https://docs.soda.io/soda/connect-redshift.html), uppercased and prepended by `DATACONTRACT_REDSHIFT_` prefix.
+For example:
 
-| Environment Variable             | Example            | Description |
-|----------------------------------|--------------------|-------------|
-| `DATACONTRACT_REDSHIFT_USERNAME` | `admin`            | Username    |
-| `DATACONTRACT_REDSHIFT_PASSWORD` | `mysecretpassword` | Password    |
+| Soda parameter        | Environment Variable                       |
+|-----------------------|--------------------------------------------|
+| `username`            | `DATACONTRACT_REDSHIFT_USERNAME`           |
+| `password`            | `DATACONTRACT_REDSHIFT_PASSWORD`           |
+| `region`              | `DATACONTRACT_REDSHIFT_REGION`             |
+| `access_key_id`       | `DATACONTRACT_REDSHIFT_ACCESS_KEY_ID`      |
+| `secret_access_key`   | `DATACONTRACT_REDSHIFT_SECRET_ACCESS_KEY`  |
+| `role_arn`            | `DATACONTRACT_REDSHIFT_ROLE_ARN`           |
 
-Any additional `DATACONTRACT_REDSHIFT_*` environment variable is forwarded to the Soda data source configuration (key lower-cased, prefix stripped). For example, `DATACONTRACT_REDSHIFT_REGION=us-east-1` becomes `region: us-east-1`, which lets you supply IAM-based credentials (`access_key_id`, `secret_access_key`, `region`, ...) without changes here.
+Beware, that parameters:
+* `host`
+* `port`
+* `database`
+* `schema`
+
+are obtained from the `servers` section of the YAML-file.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ A list of available extras:
 | PostgreSQL Integration  | `pip install datacontract-cli[postgres]`   |
 | protobuf                | `pip install datacontract-cli[protobuf]`   |
 | RDF                     | `pip install datacontract-cli[rdf]`        |
+| Amazon Redshift         | `pip install datacontract-cli[redshift]`   |
 | S3 Integration          | `pip install datacontract-cli[s3]`         |
 | Snowflake Integration   | `pip install datacontract-cli[snowflake]`  |
 | Microsoft SQL Server    | `pip install datacontract-cli[sqlserver]`  |
@@ -947,6 +948,41 @@ models:
 |----------------------------------|--------------------|-------------|
 | `DATACONTRACT_POSTGRES_USERNAME` | `postgres`         | Username    |
 | `DATACONTRACT_POSTGRES_PASSWORD` | `mysecretpassword` | Password    |
+
+</details>
+
+<details markdown="1">
+<summary><strong>Amazon Redshift</strong></summary>
+
+Data Contract CLI can test data in Amazon Redshift (both provisioned clusters and Redshift Serverless).
+
+##### Example
+
+datacontract.yaml
+```yaml
+servers:
+  redshift:
+    type: redshift
+    host: my-workgroup.123456789012.us-east-1.redshift-serverless.amazonaws.com
+    port: 5439
+    database: dev
+    schema: analytics
+models:
+  my_table_1: # corresponds to a table
+    type: table
+    fields:
+      my_column_1: # corresponds to a column
+        type: varchar
+```
+
+##### Environment Variables
+
+| Environment Variable             | Example            | Description |
+|----------------------------------|--------------------|-------------|
+| `DATACONTRACT_REDSHIFT_USERNAME` | `admin`            | Username    |
+| `DATACONTRACT_REDSHIFT_PASSWORD` | `mysecretpassword` | Password    |
+
+Any additional `DATACONTRACT_REDSHIFT_*` environment variable is forwarded to the Soda data source configuration (key lower-cased, prefix stripped). For example, `DATACONTRACT_REDSHIFT_REGION=us-east-1` becomes `region: us-east-1`, which lets you supply IAM-based credentials (`access_key_id`, `secret_access_key`, `region`, ...) without changes here.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -998,7 +998,12 @@ are obtained from the `servers` section of the YAML-file.
 
 ##### IAM Authentication
 
-Set `DATACONTRACT_REDSHIFT_USERNAME` (the database user) and AWS credentials (`DATACONTRACT_REDSHIFT_ACCESS_KEY_ID` + `DATACONTRACT_REDSHIFT_SECRET_ACCESS_KEY` + `DATACONTRACT_REDSHIFT_REGION`, or `DATACONTRACT_REDSHIFT_ROLE_ARN`), and leave `DATACONTRACT_REDSHIFT_PASSWORD` unset. soda-core-redshift will call `GetClusterCredentials` to obtain a temporary password.
+Set `DATACONTRACT_REDSHIFT_USERNAME` (the database user that exists in the cluster) and leave `DATACONTRACT_REDSHIFT_PASSWORD` unset. soda-core-redshift will then call `GetClusterCredentials` to obtain a temporary password. AWS credentials can be supplied in two ways:
+
+1. **Explicit keys** — set `DATACONTRACT_REDSHIFT_ACCESS_KEY_ID`, `DATACONTRACT_REDSHIFT_SECRET_ACCESS_KEY`, `DATACONTRACT_REDSHIFT_REGION` (and `DATACONTRACT_REDSHIFT_SESSION_TOKEN` for temporary credentials, or `DATACONTRACT_REDSHIFT_ROLE_ARN` to assume a role).
+2. **AWS_PROFILE** — set `AWS_PROFILE` in your shell to a profile defined in `~/.aws/credentials`. boto3's default credential chain picks it up. Also set `DATACONTRACT_REDSHIFT_REGION` so soda routes to the right Redshift endpoint.
+
+> `DATACONTRACT_REDSHIFT_PROFILE_NAME` is accepted by soda-core-redshift but only consulted when assuming a role. For direct IAM access, use `AWS_PROFILE` in the shell instead.
 
 **Limitation:** IAM authentication is supported only for **provisioned** Redshift clusters. Redshift Serverless requires username/password — the upstream soda-core-redshift driver doesn't call the Serverless `GetCredentials` API.
 

--- a/README.md
+++ b/README.md
@@ -996,6 +996,12 @@ Beware, that parameters:
 
 are obtained from the `servers` section of the YAML-file.
 
+##### IAM Authentication
+
+Set `DATACONTRACT_REDSHIFT_USERNAME` (the database user) and AWS credentials (`DATACONTRACT_REDSHIFT_ACCESS_KEY_ID` + `DATACONTRACT_REDSHIFT_SECRET_ACCESS_KEY` + `DATACONTRACT_REDSHIFT_REGION`, or `DATACONTRACT_REDSHIFT_ROLE_ARN`), and leave `DATACONTRACT_REDSHIFT_PASSWORD` unset. soda-core-redshift will call `GetClusterCredentials` to obtain a temporary password.
+
+**Limitation:** IAM authentication is supported only for **provisioned** Redshift clusters. Redshift Serverless requires username/password — the upstream soda-core-redshift driver doesn't call the Serverless `GetCredentials` API.
+
 </details>
 
 <details markdown="1">

--- a/README.md
+++ b/README.md
@@ -979,33 +979,21 @@ models:
 All [parameters supported by Soda](https://docs.soda.io/soda/connect-redshift.html), uppercased and prepended by `DATACONTRACT_REDSHIFT_` prefix.
 For example:
 
-| Soda parameter        | Environment Variable                       |
-|-----------------------|--------------------------------------------|
-| `username`            | `DATACONTRACT_REDSHIFT_USERNAME`           |
-| `password`            | `DATACONTRACT_REDSHIFT_PASSWORD`           |
-| `region`              | `DATACONTRACT_REDSHIFT_REGION`             |
-| `access_key_id`       | `DATACONTRACT_REDSHIFT_ACCESS_KEY_ID`      |
-| `secret_access_key`   | `DATACONTRACT_REDSHIFT_SECRET_ACCESS_KEY`  |
-| `role_arn`            | `DATACONTRACT_REDSHIFT_ROLE_ARN`           |
+| Soda parameter      | Environment Variable                      | Details             |
+|---------------------|-------------------------------------------|---------------------|
+| `username`          | `DATACONTRACT_REDSHIFT_USERNAME`          |                     |
+| `password`          | `DATACONTRACT_REDSHIFT_PASSWORD`          | leave unset for IAM |
+| `region`            | `DATACONTRACT_REDSHIFT_REGION`            | for IAM             |
+| `access_key_id`     | `DATACONTRACT_REDSHIFT_ACCESS_KEY_ID`     | for IAM             |
+| `secret_access_key` | `DATACONTRACT_REDSHIFT_SECRET_ACCESS_KEY` | for IAM             |
+| `role_arn`          | `DATACONTRACT_REDSHIFT_ROLE_ARN`          | for IAM             |
 
-Beware, that parameters:
-* `host`
-* `port`
-* `database`
-* `schema`
+IAM credentials can be supplied in two ways:
 
-are obtained from the `servers` section of the YAML-file.
+1. **AWS_PROFILE** — set `AWS_PROFILE` in your shell to a profile defined in `~/.aws/credentials` and `DATACONTRACT_REDSHIFT_REGION`.
+2. **Explicit keys** — set `DATACONTRACT_REDSHIFT_REGION`, `..._ACCESS_KEY_ID`, `..._SECRET_ACCESS_KEY`, and `..._SESSION_TOKEN` for temporary credentials, or `..._ROLE_ARN` to assume a role.
 
-##### IAM Authentication
-
-Set `DATACONTRACT_REDSHIFT_USERNAME` (the database user that exists in the cluster) and leave `DATACONTRACT_REDSHIFT_PASSWORD` unset. soda-core-redshift will then call `GetClusterCredentials` to obtain a temporary password. AWS credentials can be supplied in two ways:
-
-1. **Explicit keys** — set `DATACONTRACT_REDSHIFT_ACCESS_KEY_ID`, `DATACONTRACT_REDSHIFT_SECRET_ACCESS_KEY`, `DATACONTRACT_REDSHIFT_REGION` (and `DATACONTRACT_REDSHIFT_SESSION_TOKEN` for temporary credentials, or `DATACONTRACT_REDSHIFT_ROLE_ARN` to assume a role).
-2. **AWS_PROFILE** — set `AWS_PROFILE` in your shell to a profile defined in `~/.aws/credentials`. boto3's default credential chain picks it up. Also set `DATACONTRACT_REDSHIFT_REGION` so soda routes to the right Redshift endpoint.
-
-> `DATACONTRACT_REDSHIFT_PROFILE_NAME` is accepted by soda-core-redshift but only consulted when assuming a role. For direct IAM access, use `AWS_PROFILE` in the shell instead.
-
-**Limitation:** IAM authentication is supported only for **provisioned** Redshift clusters. Redshift Serverless requires username/password — the upstream soda-core-redshift driver doesn't call the Serverless `GetCredentials` API.
+>IAM authentication is supported only for **provisioned** Redshift clusters.
 
 </details>
 

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -129,8 +129,7 @@ def enable_debug_logging(debug: bool):
             level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", stream=sys.stderr
         )
     elif not root.handlers:
-        # Without a handler, Python's lastResort emits WARNING/ERROR messages with the raw
-        # "ERROR:root:..." format, leaking past the CLI's rich tables. Suppress.
+        # Without a handler, Python's lastResort emits WARNING/ERROR messages
         root.addHandler(logging.NullHandler())
 
 

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -123,10 +123,15 @@ def common(
 
 
 def enable_debug_logging(debug: bool):
+    root = logging.getLogger()
     if debug:
         logging.basicConfig(
             level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", stream=sys.stderr
         )
+    elif not root.handlers:
+        # Without a handler, Python's lastResort emits WARNING/ERROR messages with the raw
+        # "ERROR:root:..." format, leaking past the CLI's rich tables. Suppress.
+        root.addHandler(logging.NullHandler())
 
 
 def validate_publish_url(publish: str | None) -> None:

--- a/datacontract/engines/data_contract_checks.py
+++ b/datacontract/engines/data_contract_checks.py
@@ -51,11 +51,11 @@ def _quote_field_name(field_name: str, quoting_config: QuotingConfig) -> str:
 
 
 _BACKTICK_DIALECTS = {"databricks", "bigquery", "mysql", "impala", "dataframe", "kafka"}
-_ANSI_QUOTING_DIALECTS = {"postgres", "sqlserver", "snowflake", "azure", "s3", "gcs", "local"}
+_ANSI_QUOTING_DIALECTS = {"postgres", "redshift", "sqlserver", "snowflake", "azure", "s3", "gcs", "local"}
 
 _BARE_IDENTIFIER_STRICT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _BARE_IDENTIFIER_PERMISSIVE = re.compile(r"^[A-Za-z_][A-Za-z0-9_$]*$")
-_PERMISSIVE_BARE_DIALECTS = {"postgres", "snowflake", "oracle", "sqlserver"}
+_PERMISSIVE_BARE_DIALECTS = {"postgres", "redshift", "snowflake", "oracle", "sqlserver"}
 
 
 def _quote_identifier_if_needed(identifier: str, server: Optional[Server]) -> str:

--- a/datacontract/engines/soda/check_soda_execute.py
+++ b/datacontract/engines/soda/check_soda_execute.py
@@ -18,6 +18,7 @@ from datacontract.engines.soda.connections.impala import to_impala_soda_configur
 from datacontract.engines.soda.connections.kafka import create_spark_session, read_kafka_topic
 from datacontract.engines.soda.connections.mysql import to_mysql_soda_configuration
 from datacontract.engines.soda.connections.postgres import to_postgres_soda_configuration
+from datacontract.engines.soda.connections.redshift import to_redshift_soda_configuration
 from datacontract.engines.soda.connections.snowflake import to_snowflake_soda_configuration
 from datacontract.engines.soda.connections.sqlserver import to_sqlserver_soda_configuration
 from datacontract.engines.soda.connections.trino import to_trino_soda_configuration
@@ -74,6 +75,10 @@ def check_soda_execute(
         scan.set_data_source_name(server.type)
     elif server.type == "postgres":
         soda_configuration_str = to_postgres_soda_configuration(server)
+        scan.add_configuration_yaml_str(soda_configuration_str)
+        scan.set_data_source_name(server.type)
+    elif server.type == "redshift":
+        soda_configuration_str = to_redshift_soda_configuration(server)
         scan.add_configuration_yaml_str(soda_configuration_str)
         scan.set_data_source_name(server.type)
     elif server.type == "mysql":

--- a/datacontract/engines/soda/connections/redshift.py
+++ b/datacontract/engines/soda/connections/redshift.py
@@ -8,18 +8,18 @@ from datacontract.model.exceptions import require_env
 def to_redshift_soda_configuration(server):
     prefix = "DATACONTRACT_REDSHIFT_"
     extra = {
-        k.replace(prefix, "").lower(): v
+        k.removeprefix(prefix).lower(): v
         for k, v in os.environ.items()
         if k.startswith(prefix) and k not in {"DATACONTRACT_REDSHIFT_USERNAME", "DATACONTRACT_REDSHIFT_PASSWORD"}
     }
     data_source = {
+        **extra,
         "type": "redshift",
         "host": server.host,
         "port": str(server.port),
         "username": require_env("DATACONTRACT_REDSHIFT_USERNAME", server_type="redshift"),
         "database": server.database,
         "schema": server.schema_,
-        **extra,
     }
     # Password is optional: when absent, soda-core-redshift enters IAM mode and
     # derives temporary credentials from access_key_id / secret_access_key / region.

--- a/datacontract/engines/soda/connections/redshift.py
+++ b/datacontract/engines/soda/connections/redshift.py
@@ -1,0 +1,29 @@
+import os
+
+import yaml
+
+from datacontract.model.exceptions import require_env
+
+_PASSTHROUGH_EXCLUDED = {"DATACONTRACT_REDSHIFT_USERNAME", "DATACONTRACT_REDSHIFT_PASSWORD"}
+
+
+def to_redshift_soda_configuration(server):
+    prefix = "DATACONTRACT_REDSHIFT_"
+    extra = {
+        k.replace(prefix, "").lower(): v
+        for k, v in os.environ.items()
+        if k.startswith(prefix) and k not in _PASSTHROUGH_EXCLUDED
+    }
+    soda_configuration = {
+        f"data_source {server.type}": {
+            "type": "redshift",
+            "host": server.host,
+            "port": str(server.port),
+            "username": require_env("DATACONTRACT_REDSHIFT_USERNAME", server_type="redshift"),
+            "password": require_env("DATACONTRACT_REDSHIFT_PASSWORD", server_type="redshift"),
+            "database": server.database,
+            "schema": server.schema_,
+            **extra,
+        }
+    }
+    return yaml.dump(soda_configuration)

--- a/datacontract/engines/soda/connections/redshift.py
+++ b/datacontract/engines/soda/connections/redshift.py
@@ -4,26 +4,26 @@ import yaml
 
 from datacontract.model.exceptions import require_env
 
-_PASSTHROUGH_EXCLUDED = {"DATACONTRACT_REDSHIFT_USERNAME", "DATACONTRACT_REDSHIFT_PASSWORD"}
-
 
 def to_redshift_soda_configuration(server):
     prefix = "DATACONTRACT_REDSHIFT_"
     extra = {
         k.replace(prefix, "").lower(): v
         for k, v in os.environ.items()
-        if k.startswith(prefix) and k not in _PASSTHROUGH_EXCLUDED
+        if k.startswith(prefix) and k not in {"DATACONTRACT_REDSHIFT_USERNAME", "DATACONTRACT_REDSHIFT_PASSWORD"}
     }
-    soda_configuration = {
-        f"data_source {server.type}": {
-            "type": "redshift",
-            "host": server.host,
-            "port": str(server.port),
-            "username": require_env("DATACONTRACT_REDSHIFT_USERNAME", server_type="redshift"),
-            "password": require_env("DATACONTRACT_REDSHIFT_PASSWORD", server_type="redshift"),
-            "database": server.database,
-            "schema": server.schema_,
-            **extra,
-        }
+    data_source = {
+        "type": "redshift",
+        "host": server.host,
+        "port": str(server.port),
+        "username": require_env("DATACONTRACT_REDSHIFT_USERNAME", server_type="redshift"),
+        "database": server.database,
+        "schema": server.schema_,
+        **extra,
     }
-    return yaml.dump(soda_configuration)
+    # Password is optional: when absent, soda-core-redshift enters IAM mode and
+    # derives temporary credentials from access_key_id / secret_access_key / region.
+    password = os.getenv("DATACONTRACT_REDSHIFT_PASSWORD")
+    if password:
+        data_source["password"] = password
+    return yaml.dump({f"data_source {server.type}": data_source})

--- a/datacontract/export/sql_type_converter.py
+++ b/datacontract/export/sql_type_converter.py
@@ -190,7 +190,7 @@ def _convert_base_to_sql_type(field: Union[SchemaProperty, FieldLike], server_ty
     if server_type == "snowflake":
         return convert_to_snowflake(field)
     elif server_type == "postgres" or server_type == "redshift":
-        return convert_type_to_postgres(field)
+        return convert_type_to_postgres(field)  # Redshift is Postgres-compatible
     elif server_type == "mysql":
         return convert_type_to_mysql(field)
     elif server_type == "dataframe":

--- a/datacontract/export/sql_type_converter.py
+++ b/datacontract/export/sql_type_converter.py
@@ -189,7 +189,7 @@ def _convert_base_to_sql_type(field: Union[SchemaProperty, FieldLike], server_ty
     """Route a field to the server-specific converter."""
     if server_type == "snowflake":
         return convert_to_snowflake(field)
-    elif server_type == "postgres":
+    elif server_type == "postgres" or server_type == "redshift":
         return convert_type_to_postgres(field)
     elif server_type == "mysql":
         return convert_type_to_mysql(field)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,10 @@ postgres = [
   "soda-core-postgres>=3.3.20,<3.6.0"
 ]
 
+redshift = [
+  "soda-core-redshift>=3.3.20,<3.6.0"
+]
+
 s3 = [
   "s3fs>=2025.2.0,<2027.0.0",
   "aiobotocore>=2.17.0,<3.8.0",
@@ -146,7 +150,7 @@ protobuf = [
 ]
 
 all = [
-  "datacontract-cli[kafka,bigquery,csv,excel,snowflake,postgres,mysql,databricks,sqlserver,s3,athena,trino,impala,dbml,duckdb,iceberg,parquet,rdf,api,protobuf,oracle]"
+  "datacontract-cli[kafka,bigquery,csv,excel,snowflake,postgres,redshift,mysql,databricks,sqlserver,s3,athena,trino,impala,dbml,duckdb,iceberg,parquet,rdf,api,protobuf,oracle]"
 ]
 
 # for development, we pin all libraries to an exact version

--- a/tests/test_redshift_soda_configuration.py
+++ b/tests/test_redshift_soda_configuration.py
@@ -1,0 +1,56 @@
+import pytest
+import yaml
+from open_data_contract_standard.model import Server
+
+from datacontract.engines.soda.connections.redshift import to_redshift_soda_configuration
+from datacontract.model.exceptions import DataContractException
+
+
+def _server() -> Server:
+    return Server(
+        type="redshift",
+        host="my-wg.123456789012.us-east-1.redshift-serverless.amazonaws.com",
+        port=5439,
+        database="dev",
+        schema="analytics",
+    )
+
+
+def test_to_redshift_soda_configuration_minimal(monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_USERNAME", "admin")
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_PASSWORD", "secret")
+
+    yaml_str = to_redshift_soda_configuration(_server())
+    config = yaml.safe_load(yaml_str)["data_source redshift"]
+
+    assert config == {
+        "type": "redshift",
+        "host": "my-wg.123456789012.us-east-1.redshift-serverless.amazonaws.com",
+        "port": "5439",
+        "username": "admin",
+        "password": "secret",
+        "database": "dev",
+        "schema": "analytics",
+    }
+
+
+def test_to_redshift_soda_configuration_passes_through_extra_env_vars(monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_USERNAME", "admin")
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_PASSWORD", "secret")
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_REGION", "us-east-1")
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_ACCESS_KEY_ID", "AKIA...")
+
+    yaml_str = to_redshift_soda_configuration(_server())
+    config = yaml.safe_load(yaml_str)["data_source redshift"]
+
+    assert config["region"] == "us-east-1"
+    assert config["access_key_id"] == "AKIA..."
+
+
+def test_to_redshift_soda_configuration_missing_username_raises(monkeypatch):
+    monkeypatch.delenv("DATACONTRACT_REDSHIFT_USERNAME", raising=False)
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_PASSWORD", "secret")
+
+    with pytest.raises(DataContractException) as exc_info:
+        to_redshift_soda_configuration(_server())
+    assert exc_info.value.type == "redshift-connection"

--- a/tests/test_redshift_soda_configuration.py
+++ b/tests/test_redshift_soda_configuration.py
@@ -54,3 +54,22 @@ def test_to_redshift_soda_configuration_missing_username_raises(monkeypatch):
     with pytest.raises(DataContractException) as exc_info:
         to_redshift_soda_configuration(_server())
     assert exc_info.value.type == "redshift-connection"
+
+
+def test_to_redshift_soda_configuration_iam_mode_omits_password(monkeypatch):
+    # IAM mode: username + AWS creds set, password unset. soda-core-redshift triggers
+    # IAM only when the password key is absent from the config, so we must omit it.
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_USERNAME", "admin")
+    monkeypatch.delenv("DATACONTRACT_REDSHIFT_PASSWORD", raising=False)
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_ACCESS_KEY_ID", "AKIA...")
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_SECRET_ACCESS_KEY", "secret-key")
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_REGION", "eu-central-1")
+
+    yaml_str = to_redshift_soda_configuration(_server())
+    config = yaml.safe_load(yaml_str)["data_source redshift"]
+
+    assert "password" not in config
+    assert config["username"] == "admin"
+    assert config["access_key_id"] == "AKIA..."
+    assert config["secret_access_key"] == "secret-key"
+    assert config["region"] == "eu-central-1"


### PR DESCRIPTION
## Summary

Adds a new \`redshift\` server type to \`datacontract test\`, routing through \`soda-core-redshift\` (latest 3.5.6, brings \`psycopg2-binary\` + \`boto3\` for optional IAM auth). Redshift is wire-compatible with Postgres but the dedicated Soda driver gives us IAM auth and tracks Redshift-specific SQL dialect quirks.

Touch points (~134 lines):
- **New connector** \`datacontract/engines/soda/connections/redshift.py\` — mirrors the Postgres connector for required fields, mirrors the Snowflake connector for \`DATACONTRACT_REDSHIFT_*\` env-var passthrough (so IAM keys / region flow through without code changes).
- **Dispatch** \`datacontract/engines/soda/check_soda_execute.py\` — import + \`elif server.type == "redshift":\` branch after the Postgres case.
- **Dialect sets** \`datacontract/engines/data_contract_checks.py\` — \`"redshift"\` added to \`_ANSI_QUOTING_DIALECTS\` and \`_PERMISSIVE_BARE_DIALECTS\` (same quoting rules as Postgres).
- **SQL type converter** \`datacontract/export/sql_type_converter.py\` — Redshift routed through \`convert_type_to_postgres\` so field-type checks emit valid SQL types.
- **Optional dependency** \`pyproject.toml\` — new \`redshift\` extra (\`soda-core-redshift>=3.3.20,<3.6.0\`); appended to the \`all\` bundle.
- **Unit tests** \`tests/test_redshift_soda_configuration.py\` — three tests covering minimal config, env-var passthrough, and missing-env error.
- **README** — extras-table row + new Redshift \`<details>\` block after the Postgres section.

No integration test with a container (no maintained Redshift testcontainer exists — same precedent as Snowflake).