### PR TITLE
revert(dbt-export): restore dbt_expectations bound checks in `export dbt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - new `datacontract dbt sync` command: generate dbt tests from an ODCS contract, then run `dbt test` for them (#1222)
 
-### Changed
-- **breaking:** `export dbt` no longer emits `dbt_expectations` macros for length / regex / numeric-range / row-count bounds; those entries are dropped from the YAML output. `dbt sync` covers the same bounds via portable singular SQL, so the generated dbt project no longer requires `dbt_expectations` in `packages.yml`. `dbt_utils` is still used for composite-primary-key uniqueness only.
-
 ### Fixed
 - sql type converter: emit canonical `decimal`/`numeric` per dialect (Postgres → `numeric`, MySQL → `decimal`) so `test`'s column-type check matches `information_schema` (#1237)
 

--- a/datacontract/export/dbt_exporter.py
+++ b/datacontract/export/dbt_exporter.py
@@ -223,6 +223,10 @@ def _to_column(
     column["data_tests"] = []
     if dbt_type is not None:
         column["data_type"] = dbt_type
+    else:
+        column["data_tests"].append(
+            {"dbt_expectations.dbt_expectations.expect_column_values_to_be_of_type": {"column_type": dbt_type}}
+        )
     if prop.description is not None:
         column["description"] = prop.description.strip().replace("\n", " ")
 

--- a/datacontract/integration/dbt_sync.py
+++ b/datacontract/integration/dbt_sync.py
@@ -710,6 +710,7 @@ def _column_dict(
         is_single_pk=(prop.name == single_pk_name),
         supports_constraints=False,
         source_name=odcs.id or "_source",
+        include_dbt_expectations_bounds=False,
     )
     base = _rewrite_relationships_to_ref(base)
     tests = [

--- a/datacontract/integration/dbt_test_mapping.py
+++ b/datacontract/integration/dbt_test_mapping.py
@@ -65,6 +65,7 @@ def field_to_data_tests(
     is_single_pk: bool = False,
     supports_constraints: bool = False,
     source_name: Optional[str] = None,
+    include_dbt_expectations_bounds: bool = True,
 ) -> List[Any]:
     """Build the list of dbt data_tests for an ODCS property.
 
@@ -83,6 +84,65 @@ def field_to_data_tests(
     enum_values = _get_enum_values(prop)
     if enum_values and len(enum_values) > 0:
         tests.append({"accepted_values": {"values": enum_values}})
+
+    if include_dbt_expectations_bounds:
+        min_length = get_logical_type_option(prop, "minLength")
+        max_length = get_logical_type_option(prop, "maxLength")
+        if min_length is not None or max_length is not None:
+            length_test = {}
+            if min_length is not None:
+                length_test["min_value"] = min_length
+            if max_length is not None:
+                length_test["max_value"] = max_length
+            tests.append({"dbt_expectations.expect_column_value_lengths_to_be_between": length_test})
+
+        pattern = get_logical_type_option(prop, "pattern")
+        if pattern is not None:
+            tests.append({"dbt_expectations.expect_column_values_to_match_regex": {"regex": pattern}})
+
+        minimum = get_logical_type_option(prop, "minimum")
+        maximum = get_logical_type_option(prop, "maximum")
+        exclusive_minimum = get_logical_type_option(prop, "exclusiveMinimum")
+        exclusive_maximum = get_logical_type_option(prop, "exclusiveMaximum")
+
+        if (minimum is not None or maximum is not None) and exclusive_minimum is None and exclusive_maximum is None:
+            range_test = {}
+            if minimum is not None:
+                range_test["min_value"] = minimum
+            if maximum is not None:
+                range_test["max_value"] = maximum
+            tests.append({"dbt_expectations.expect_column_values_to_be_between": range_test})
+        elif (exclusive_minimum is not None or exclusive_maximum is not None) and minimum is None and maximum is None:
+            range_test = {}
+            if exclusive_minimum is not None:
+                range_test["min_value"] = exclusive_minimum
+            if exclusive_maximum is not None:
+                range_test["max_value"] = exclusive_maximum
+            range_test["strictly"] = True
+            tests.append({"dbt_expectations.expect_column_values_to_be_between": range_test})
+        else:
+            if minimum is not None:
+                tests.append({"dbt_expectations.expect_column_values_to_be_between": {"min_value": minimum}})
+            if maximum is not None:
+                tests.append({"dbt_expectations.expect_column_values_to_be_between": {"max_value": maximum}})
+            if exclusive_minimum is not None:
+                tests.append(
+                    {
+                        "dbt_expectations.expect_column_values_to_be_between": {
+                            "min_value": exclusive_minimum,
+                            "strictly": True,
+                        }
+                    }
+                )
+            if exclusive_maximum is not None:
+                tests.append(
+                    {
+                        "dbt_expectations.expect_column_values_to_be_between": {
+                            "max_value": exclusive_maximum,
+                            "strictly": True,
+                        }
+                    }
+                )
 
     references = None
     if prop.relationships:

--- a/tests/test_dbt_test_mapping.py
+++ b/tests/test_dbt_test_mapping.py
@@ -93,38 +93,51 @@ def test_enum_from_quality_invalid_values():
     assert {"accepted_values": {"values": ["a", "b"]}} in tests
 
 
-def test_length_bounds_emit_no_yaml_test():
-    """Length bounds previously emitted a `dbt_expectations` macro; they're now
-    handled as singular SQL by `datacontract dbt sync`."""
+def test_length_inclusive_range():
     tests = field_to_data_tests(
         _prop(name="x", logicalTypeOptions={"minLength": 3, "maxLength": 10}),
         supports_constraints=False,
     )
-    assert tests == []
+    assert {"dbt_expectations.expect_column_value_lengths_to_be_between": {"min_value": 3, "max_value": 10}} in tests
 
 
-def test_regex_emits_no_yaml_test():
+def test_regex():
     tests = field_to_data_tests(
         _prop(name="x", logicalTypeOptions={"pattern": "^[A-Z]+$"}),
         supports_constraints=False,
     )
-    assert tests == []
+    assert {"dbt_expectations.expect_column_values_to_match_regex": {"regex": "^[A-Z]+$"}} in tests
 
 
-def test_numeric_range_emits_no_yaml_test():
+def test_inclusive_range():
     tests = field_to_data_tests(
-        _prop(
-            name="x",
-            logicalTypeOptions={
-                "minimum": 0,
-                "maximum": 100,
-                "exclusiveMinimum": 0,
-                "exclusiveMaximum": 100,
-            },
-        ),
+        _prop(name="x", logicalTypeOptions={"minimum": 0, "maximum": 100}),
         supports_constraints=False,
     )
-    assert tests == []
+    assert {"dbt_expectations.expect_column_values_to_be_between": {"min_value": 0, "max_value": 100}} in tests
+
+
+def test_exclusive_range():
+    tests = field_to_data_tests(
+        _prop(name="x", logicalTypeOptions={"exclusiveMinimum": 0, "exclusiveMaximum": 100}),
+        supports_constraints=False,
+    )
+    assert {
+        "dbt_expectations.expect_column_values_to_be_between": {
+            "min_value": 0,
+            "max_value": 100,
+            "strictly": True,
+        }
+    } in tests
+
+
+def test_mixed_inclusive_and_exclusive_range():
+    tests = field_to_data_tests(
+        _prop(name="x", logicalTypeOptions={"minimum": 0, "exclusiveMaximum": 100}),
+        supports_constraints=False,
+    )
+    assert {"dbt_expectations.expect_column_values_to_be_between": {"min_value": 0}} in tests
+    assert {"dbt_expectations.expect_column_values_to_be_between": {"max_value": 100, "strictly": True}} in tests
 
 
 def test_relationships_uses_source_name():

--- a/tests/test_export_dbt_models.py
+++ b/tests/test_export_dbt_models.py
@@ -42,6 +42,12 @@ models:
         constraints:
           - type: not_null
           - type: unique
+        data_tests:
+          - dbt_expectations.expect_column_value_lengths_to_be_between:
+              min_value: 8
+              max_value: 10
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: ^B[0-9]+$
         meta:
           classification: sensitive
         tags:
@@ -51,6 +57,10 @@ models:
         constraints:
           - type: not_null
         description: The order_total field
+        data_tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+               min_value: 0
+               max_value: 1000000
       - name: order_status
         data_type: TEXT
         constraints:
@@ -93,6 +103,12 @@ models:
         constraints:
           - type: not_null
           - type: unique
+        data_tests:
+          - dbt_expectations.expect_column_value_lengths_to_be_between:
+              min_value: 8
+              max_value: 10
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: ^B[0-9]+$
         meta:
           classification: sensitive
         tags:
@@ -102,6 +118,10 @@ models:
         constraints:
           - type: not_null
         description: The order_total field
+        data_tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+               min_value: 0
+               max_value: 1000000
       - name: order_status
         data_type: STRING
         constraints:

--- a/tests/test_export_dbt_sources.py
+++ b/tests/test_export_dbt_sources.py
@@ -48,6 +48,11 @@ sources:
             data_tests:
               - not_null
               - unique
+              - dbt_expectations.expect_column_value_lengths_to_be_between:
+                  min_value: 8
+                  max_value: 10
+              - dbt_expectations.expect_column_values_to_match_regex:
+                  regex: ^B[0-9]+$
             meta:
               classification: sensitive
             tags:
@@ -57,6 +62,9 @@ sources:
             data_type: NUMBER
             data_tests:
               - not_null
+              - dbt_expectations.expect_column_values_to_be_between:
+                   min_value: 0
+                   max_value: 1000000
           - name: order_status
             data_type: TEXT
             data_tests:
@@ -93,6 +101,11 @@ sources:
             data_tests:
               - not_null
               - unique
+              - dbt_expectations.expect_column_value_lengths_to_be_between:
+                  min_value: 8
+                  max_value: 10
+              - dbt_expectations.expect_column_values_to_match_regex:
+                  regex: ^B[0-9]+$
             meta:
               classification: sensitive
             tags:
@@ -102,6 +115,9 @@ sources:
             data_type: INT64
             data_tests:
               - not_null
+              - dbt_expectations.expect_column_values_to_be_between:
+                   min_value: 0
+                   max_value: 1000000
           - name: order_status
             data_type: STRING
             data_tests:


### PR DESCRIPTION
Partial revert of 996cc98 (PR #1222). `export dbt` again emits `dbt_expectations.*` for length / regex / numeric-range bounds, matching behavior at 0.12.2.

`dbt sync` keeps its singular-SQL bound coverage from 996cc98 — it opts out of the restored mapping via a new `include_dbt_expectations_bounds` flag on the shared `field_to_data_tests` helper. #1235's `--publish` / `dc:<type>` machinery is untouched.

Drops the breaking-change CHANGELOG line, which no longer reflects what ships.