### PR TITLE
Fix: correct return type annotation on SparkExporter.export()

### DIFF
--- a/datacontract/export/spark_exporter.py
+++ b/datacontract/export/spark_exporter.py
@@ -20,7 +20,7 @@ class SparkExporter(Exporter):
         server,
         sql_server_type,
         export_args,
-    ) -> dict[str, types.StructType]:
+    ) -> str:
         """
         Export the given data contract to Spark schemas.
 
@@ -32,7 +32,7 @@ class SparkExporter(Exporter):
             export_args: Additional arguments for export.
 
         Returns:
-            dict[str, types.StructType]: A dictionary mapping model names to their corresponding Spark schemas.
+            str: A string representation of the Spark schema for each model.
         """
         return to_spark(data_contract)
 


### PR DESCRIPTION
## What this fixes

`SparkExporter.export()` was annotated as returning `dict[str, types.StructType]` but actually returns a `str`, consistent with every other exporter in the codebase and with `DataContract.export()`'s own `str | bytes` signature.

## Question for maintainers

While investigating this I noticed `to_spark_dict()` exists as a separate public function returning actual `StructType` objects, and is tested directly (not through `export()`). This suggests it's intentionally the way for Python API users to get live Spark objects.

However, this pattern isn't documented anywhere. A user calling `DataContract.export(ExportFormat.spark)` expecting a `StructType` (as the old annotation implied) would be confused. Would it be worth adding a note to the docstring or README pointing users to `to_spark_dict()` for programmatic use? Happy to include that in this PR if useful.

Haven't added any documentation yet, as I would like someone more familiar with the project to advise first.

- [x] Tests pass (`uv run pytest`)
- [x] Code formatted (`uv run ruff check --fix && uv run ruff format`)
- [ ] README.md updated (if relevant)
- [ ] CHANGELOG.md entry added
