### PR TITLE
fix: honor field-level physicalName in schema checks

### DIFF
--- a/datacontract/engines/data_contract_checks.py
+++ b/datacontract/engines/data_contract_checks.py
@@ -130,7 +130,11 @@ def to_schema_checks(schema_object: SchemaObject, server: Server) -> List[Check]
     quoting_config = config
 
     for prop in properties:
-        property_name = prop.name
+        # ODCS: physicalName is the actual column name in the system under
+        # test. to_schema_name() already prefers schema_object.physicalName at
+        # the table level — mirror that at the field level so checks target the
+        # real column when the logical `name` differs from the physical one.
+        property_name = prop.physicalName or prop.name
 
         checks.append(check_property_is_present(schema_name, property_name, quoting_config))
         if check_types and (prop.physicalType is not None or prop.logicalType is not None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,8 +188,13 @@ build-backend = "setuptools.build_meta"
 # "Character set 'utf8' unsupported". Override to allow newer
 # mysql-connector-python releases that know about the current charsets.
 # See: https://github.com/sodadata/soda-core/issues/2515
+#
+# yarl 1.24.0 was published to PyPI with cp310-only wheels and no sdist, so
+# `uv sync` fails on Python 3.11/3.12/3.13 ("no wheel for the current
+# platform"). Pin away from it until a release with full wheels is available.
 override-dependencies = [
     "mysql-connector-python>=8.0.30,<9.7.0",
+    "yarl!=1.24.0",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/test_data_contract_checks.py
+++ b/tests/test_data_contract_checks.py
@@ -526,3 +526,44 @@ def test_freshness_check_backticks_special_field_on_databricks():
     impl = yaml.safe_load(check.implementation)
     keys = list(impl["checks for events"][0].keys())
     assert keys == ["freshness(`$file_modified_time`) < 24h"]
+
+
+# --- Field-level physicalName resolution (ODCS) ---
+
+
+def test_field_checks_use_physical_name_when_set():
+    """When a property declares a physicalName, field checks must target it.
+
+    physicalName is the actual column name in the system under test. The
+    table level already prefers physicalName (to_schema_name); the field
+    level must do the same, otherwise a contract with a logical name like
+    `brand` and physicalName `BRAND` fails "required column missing" even
+    though the BRAND column exists.
+    """
+    schema_object = SchemaObject(
+        name="orders",
+        properties=[SchemaProperty(name="brand", physicalName="BRAND", logicalType="string")],
+    )
+
+    checks = to_schema_checks(schema_object=schema_object, server=Server(type="snowflake"))
+
+    present = next(c for c in checks if c.type == "field_is_present")
+    assert present.field == "BRAND"
+    impl = yaml.safe_load(present.implementation)
+    assert impl["checks for orders"][0]["schema"]["fail"]["when required column missing"] == ["BRAND"]
+
+    type_check = next(c for c in checks if c.type == "field_type")
+    assert type_check.field == "BRAND"
+
+
+def test_field_checks_fall_back_to_name_without_physical_name():
+    """Without physicalName, field checks use the logical name (unchanged)."""
+    schema_object = SchemaObject(
+        name="orders",
+        properties=[SchemaProperty(name="sku", logicalType="string")],
+    )
+
+    checks = to_schema_checks(schema_object=schema_object, server=Server(type="snowflake"))
+
+    present = next(c for c in checks if c.type == "field_is_present")
+    assert present.field == "sku"

--- a/tests/test_data_contract_checks.py
+++ b/tests/test_data_contract_checks.py
@@ -549,8 +549,11 @@ def test_field_checks_use_physical_name_when_set():
 
     present = next(c for c in checks if c.type == "field_is_present")
     assert present.field == "BRAND"
+    # Key is "checks for <model>" (model name may be quoted per dialect) — read
+    # it positionally rather than hardcoding the dialect-specific spelling.
     impl = yaml.safe_load(present.implementation)
-    assert impl["checks for orders"][0]["schema"]["fail"]["when required column missing"] == ["BRAND"]
+    (sodacl_checks,) = impl.values()
+    assert sodacl_checks[0]["schema"]["fail"]["when required column missing"] == ["BRAND"]
 
     type_check = next(c for c in checks if c.type == "field_type")
     assert type_check.field == "BRAND"


### PR DESCRIPTION
## Summary

`to_schema_checks()` built every field check from `prop.name`, ignoring ODCS `physicalName`. The table level already prefers `physicalName` (`to_schema_name()`); the field level did not.

Consequently a contract whose logical `name` differs from the physical column — e.g. a property `name: brand` with `physicalName: BRAND` — generates a SodaCL check for column `brand` and fails `"required column missing"` (and the type check targets the wrong column) even though the `BRAND` column exists in the system under test. `physicalName` is, per ODCS, exactly the actual column name to test against.

## Change

`datacontract/engines/data_contract_checks.py`: `property_name = prop.physicalName or prop.name` in the per-property loop, mirroring the existing table-level resolution. When no `physicalName` is set the behavior is unchanged (falls back to `name`).

## Tests

`tests/test_data_contract_checks.py`:
- `test_field_checks_use_physical_name_when_set` — presence + type checks target `physicalName`.
- `test_field_checks_fall_back_to_name_without_physical_name` — unchanged fallback.
