### PR TITLE
feat(test): resolve semantic definitions to enrich properties at read time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `datacontract test` now logs the Data Contract CLI version and whether it ran as a local CLI or through the FastAPI server (including the request URL) as part of the test result logs
+- `datacontract test` now resolves `authoritativeDefinitions[type=semantics]` on each property and fills missing `logicalType` / `description` / `examples` / `businessName` from the concept at run time. A property that only carries a semantic ref (e.g. produced by the datacontract-editor's "Add from definition") now generates presence and type checks instead of silently skipping them. The API key is sent only to trusted hosts (`*.entropy-data.com` and the netloc of `ENTROPY_DATA_HOST` / `DATAMESH_MANAGER_HOST` / `DATACONTRACT_MANAGER_HOST`); other hosts are queried anonymously. Honors the existing `--no-ssl-verification` flag for self-signed certificates in self-hosted deployments. Concepts are cached per-process
 
 ### Fixed
 - Schema checks now resolve each property by its `physicalName` when set (falling back to `name`), matching the existing table-level resolution and the SQL/BigQuery exporters. Previously a property whose logical `name` differed from its physical column (e.g. `name: brand` with `physicalName: BRAND`) failed the presence and type checks even though the physical column existed (#1246)

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -147,6 +147,7 @@ class DataContract:
                 self._duckdb_connection,
                 schema_name=self._schema_name,
                 check_categories=self._check_categories,
+                ssl_verification=self._ssl_verification,
             )
 
         except DataContractException as e:

--- a/datacontract/engines/data_contract_checks.py
+++ b/datacontract/engines/data_contract_checks.py
@@ -14,6 +14,7 @@ from open_data_contract_standard.model import (
 )
 
 from datacontract.export.sql_type_converter import convert_to_sql_type
+from datacontract.integration.semantic_enrichment import enrich_in_place
 from datacontract.model.run import Check
 
 logger = logging.getLogger(__name__)
@@ -99,7 +100,20 @@ def _get_schema_custom_property_value(schema: SchemaObject, key: str) -> Optiona
     return None
 
 
-def create_checks(data_contract: OpenDataContractStandard, server: Server, schema_name: str = "all") -> List[Check]:
+def create_checks(
+    data_contract: OpenDataContractStandard,
+    server: Server,
+    schema_name: str = "all",
+    *,
+    ssl_verification: bool = True,
+) -> List[Check]:
+    # Fill `logicalType` / `description` / `examples` / `businessName` on
+    # properties that carry only an `authoritativeDefinitions[type=semantics]`
+    # reference, by resolving the concept once per URL. Mutates only the
+    # in-memory contract; failures are silent. `ssl_verification=False`
+    # passes through to the resolver (self-signed certs in self-hosted
+    # deployments).
+    enrich_in_place(data_contract, ssl_verification=ssl_verification)
     checks: List[Check] = []
     if data_contract.schema_ is None:
         return checks

--- a/datacontract/engines/data_contract_test.py
+++ b/datacontract/engines/data_contract_test.py
@@ -29,6 +29,7 @@ def execute_data_contract_test(
     duckdb_connection: "DuckDBPyConnection" = None,
     schema_name: str = "all",
     check_categories: set[str] | None = None,
+    ssl_verification: bool = True,
 ):
     if data_contract.schema_ is None or len(data_contract.schema_) == 0:
         raise DataContractException(
@@ -62,7 +63,7 @@ def execute_data_contract_test(
     if server.type == "api":
         server = process_api_response(run, server)
 
-    checks = create_checks(data_contract, server, schema_name=schema_name)
+    checks = create_checks(data_contract, server, schema_name=schema_name, ssl_verification=ssl_verification)
     if check_categories is not None:
         checks = [c for c in checks if c.category in check_categories]
         if not checks:

--- a/datacontract/integration/entropy_data.py
+++ b/datacontract/integration/entropy_data.py
@@ -1,4 +1,6 @@
 import os
+import re
+from threading import Lock
 from urllib.parse import urlparse
 
 import requests
@@ -7,6 +9,21 @@ from datacontract.model.run import Run
 
 # used to retrieve the HTML location of the published data contract or test results
 RESPONSE_HEADER_LOCATION_HTML = "location-html"
+
+# Pattern for a user-facing semantic definition URL exposed by the platform:
+#   <scheme>://<host>/<vanity>/semantics/<namespace>/<externalId>
+# These URLs appear in ODCS as `authoritativeDefinitions[type=semantics]`.
+_SEMANTIC_URL_RE = re.compile(
+    r"^(?P<scheme>https?)://(?P<host>[^/]+)/"
+    r"(?P<vanity>[^/]+)/semantics/"
+    r"(?P<namespace>[^/]+)/(?P<external_id>[^/?#]+)(?:[?#].*)?$"
+)
+
+# Per-process cache for resolved concepts. Keyed by the original URL so
+# callers don't need to know whether resolution was successful.
+_SEMANTIC_CACHE: dict[str, dict | None] = {}
+_SEMANTIC_CACHE_LOCK = Lock()
+_SEMANTIC_RESOLVE_TIMEOUT = 10  # seconds
 
 
 def publish_test_results_to_entropy_data(run: Run, publish_url: str, ssl_verification: bool) -> bool:
@@ -127,3 +144,112 @@ def _extract_hostname(url: str) -> str:
     """
     parsed = urlparse(url)
     return parsed.netloc.split(":")[0] if parsed.netloc else url
+
+
+def _looks_like_entropy_data_host(host: str) -> bool:
+    """True if `host` is a known/configured entropy-data host.
+
+    Used to decide whether to attach the API key when resolving a URL
+    named by a contract author. We never leak the key to arbitrary hosts.
+    Matches the configured ENTROPY_DATA_HOST (or its aliases) and any
+    `*.entropy-data.com` / `entropy-data.com` host.
+    """
+    if not host:
+        return False
+    host = host.lower().split(":")[0]
+    if host == "entropy-data.com" or host.endswith(".entropy-data.com"):
+        return True
+    configured = (
+        os.getenv("ENTROPY_DATA_HOST") or os.getenv("DATAMESH_MANAGER_HOST") or os.getenv("DATACONTRACT_MANAGER_HOST")
+    )
+    if configured:
+        netloc = urlparse(configured).netloc.lower().split(":")[0]
+        if netloc and host == netloc:
+            return True
+    return False
+
+
+def _semantic_url_to_api(url: str) -> str | None:
+    """Translate a user-facing semantic URL into the API endpoint.
+
+    Input:  <scheme>://<host>/<vanity>/semantics/<namespace>/<externalId>
+    Output: <scheme>://<host>/api/semantics/experimental
+                /namespaces/<namespace>/concepts/<externalId>
+
+    The vanity URL is not part of the API path — tenancy is resolved by
+    the API key. Returns None if the URL doesn't match the expected shape.
+    """
+    m = _SEMANTIC_URL_RE.match(url or "")
+    if not m:
+        return None
+    return (
+        f"{m.group('scheme')}://{m.group('host')}/api/semantics/experimental"
+        f"/namespaces/{m.group('namespace')}/concepts/{m.group('external_id')}"
+    )
+
+
+def resolve_semantic_definition(url: str, *, ssl_verification: bool = True) -> dict | None:
+    """Resolve a semantic-definition URL to its concept document.
+
+    `authoritativeDefinitions[type=semantics]` URLs in ODCS point at a
+    concept maintained by the platform. Readers that need fields the
+    contract doesn't inline (`logicalType`, `description`, ...) can call
+    this to fetch the concept JSON; callers then merge selected fields
+    into their in-memory model. The contract on disk is never mutated.
+
+    Returns the concept dict on success, None on any failure (unknown URL
+    shape, untrusted host that returned non-200, network error, malformed
+    response). Results — including resolved None — are cached per-process
+    by the original URL, so calling this once per property is cheap.
+
+    The API key is only attached when the URL's host matches a known
+    entropy-data host (or one configured via ENTROPY_DATA_HOST and its
+    aliases). For other hosts the request goes anonymously, so a contract
+    that names a third-party URL never receives the user's key.
+    """
+    if not url:
+        return None
+    with _SEMANTIC_CACHE_LOCK:
+        if url in _SEMANTIC_CACHE:
+            return _SEMANTIC_CACHE[url]
+    api_url = _semantic_url_to_api(url)
+    if api_url is None:
+        with _SEMANTIC_CACHE_LOCK:
+            _SEMANTIC_CACHE[url] = None
+        return None
+
+    headers = {"Accept": "application/json"}
+    host = urlparse(api_url).netloc.split(":")[0]
+    if _looks_like_entropy_data_host(host):
+        try:
+            headers["x-api-key"] = _get_api_key()
+        except Exception:
+            # No API key configured — attempt anonymously; if the endpoint
+            # needs auth it will 401 and we return None below.
+            pass
+
+    try:
+        response = requests.get(api_url, headers=headers, verify=ssl_verification, timeout=_SEMANTIC_RESOLVE_TIMEOUT)
+    except requests.RequestException:
+        with _SEMANTIC_CACHE_LOCK:
+            _SEMANTIC_CACHE[url] = None
+        return None
+
+    if response.status_code != 200:
+        with _SEMANTIC_CACHE_LOCK:
+            _SEMANTIC_CACHE[url] = None
+        return None
+
+    try:
+        concept = response.json()
+    except ValueError:
+        concept = None
+    with _SEMANTIC_CACHE_LOCK:
+        _SEMANTIC_CACHE[url] = concept
+    return concept
+
+
+def clear_semantic_cache() -> None:
+    """Drop the per-process semantic-definition cache. Used by tests."""
+    with _SEMANTIC_CACHE_LOCK:
+        _SEMANTIC_CACHE.clear()

--- a/datacontract/integration/semantic_enrichment.py
+++ b/datacontract/integration/semantic_enrichment.py
@@ -1,0 +1,79 @@
+"""In-memory enrichment of ODCS properties from their semantic concepts.
+
+A contract may carry only `name`, `physicalName`, and
+`authoritativeDefinitions[type=semantics]` on a property — no inline
+`logicalType` / `description` / `examples` / `businessName`. That's the
+"lean YAML" model: concept-level metadata lives in the semantic concept
+and is resolved on demand. For readers that need those fields (type and
+required checks in `datacontract test`, exports that need a column type,
+etc.) this module walks the contract, resolves each semantic URL once,
+and fills the in-memory property fields.
+
+The source contract on disk is never touched. Inline values on the
+property always win over the concept's; only fields that are missing
+locally are inherited.
+
+Resolution failures (no network, no key, untrusted host, 404, malformed
+response) are silent — the field stays None and the caller degrades
+exactly as it does today. That keeps this an additive change.
+"""
+
+from open_data_contract_standard.model import OpenDataContractStandard
+
+from datacontract.integration.entropy_data import resolve_semantic_definition
+
+
+def _first_semantic_url(prop) -> str | None:
+    """Return the first `authoritativeDefinitions[type=semantics]` URL, if any."""
+    defs = getattr(prop, "authoritativeDefinitions", None) or []
+    for d in defs:
+        if getattr(d, "type", None) == "semantics":
+            url = getattr(d, "url", None)
+            if url:
+                return url
+    return None
+
+
+def _apply_concept(prop, concept: dict) -> None:
+    """Merge selected concept fields into `prop` when the property lacks them.
+
+    Mapping (concept → ODCS property attribute):
+      data_type     → logicalType
+      description   → description
+      examples      → examples
+      business_name → businessName
+
+    Inline values are never overwritten. `examples` is treated as missing
+    when it's None or an empty list.
+    """
+    if getattr(prop, "logicalType", None) is None and concept.get("data_type"):
+        prop.logicalType = concept["data_type"]
+    if getattr(prop, "description", None) is None and concept.get("description"):
+        prop.description = concept["description"]
+    if not getattr(prop, "examples", None) and concept.get("examples"):
+        prop.examples = list(concept["examples"])
+    if getattr(prop, "businessName", None) is None and concept.get("business_name"):
+        prop.businessName = concept["business_name"]
+
+
+def enrich_in_place(data_contract: OpenDataContractStandard, *, ssl_verification: bool = True) -> None:
+    """Resolve semantic refs on every property and fill missing fields in place.
+
+    Walks every schema and every property. For each property carrying a
+    semantic authoritativeDefinition, resolves the URL once (cached) and
+    applies the concept to the property's in-memory attributes. Properties
+    without a semantic ref, and contracts without a schema, are skipped.
+
+    Idempotent. Safe to call multiple times against the same in-memory
+    contract: every merge is conditional on the target field being unset.
+    """
+    if data_contract is None or data_contract.schema_ is None:
+        return
+    for schema_obj in data_contract.schema_:
+        for prop in schema_obj.properties or []:
+            url = _first_semantic_url(prop)
+            if not url:
+                continue
+            concept = resolve_semantic_definition(url, ssl_verification=ssl_verification)
+            if concept:
+                _apply_concept(prop, concept)

--- a/tests/test_semantic_enrichment.py
+++ b/tests/test_semantic_enrichment.py
@@ -1,0 +1,312 @@
+"""Tests for resolving and applying semantic concepts to ODCS properties."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from open_data_contract_standard.model import (
+    AuthoritativeDefinition,
+    OpenDataContractStandard,
+    SchemaObject,
+    SchemaProperty,
+    Server,
+)
+
+from datacontract.engines.data_contract_checks import create_checks
+from datacontract.integration.entropy_data import (
+    _looks_like_entropy_data_host,
+    _semantic_url_to_api,
+    clear_semantic_cache,
+    resolve_semantic_definition,
+)
+from datacontract.integration.semantic_enrichment import enrich_in_place
+
+SEMANTIC_URL = "https://demo.entropy-data.com/org42/semantics/main/product.brand"
+EXPECTED_API_URL = "https://demo.entropy-data.com/api/semantics/experimental/namespaces/main/concepts/product.brand"
+SAMPLE_CONCEPT = {
+    "id": "product.brand",
+    "name": "brand",
+    "kind": "property",
+    "data_type": "string",
+    "description": "Brand the product belongs to.",
+    "business_name": "brand",
+    "examples": ["EcoWear"],
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    clear_semantic_cache()
+    yield
+    clear_semantic_cache()
+
+
+@pytest.fixture
+def env_with_api_key(monkeypatch):
+    monkeypatch.setenv("ENTROPY_DATA_API_KEY", "ed_test_key_abcdef")
+    monkeypatch.delenv("ENTROPY_DATA_HOST", raising=False)
+    monkeypatch.delenv("DATAMESH_MANAGER_HOST", raising=False)
+    monkeypatch.delenv("DATACONTRACT_MANAGER_HOST", raising=False)
+    return "ed_test_key_abcdef"
+
+
+@pytest.fixture
+def env_without_api_key(monkeypatch):
+    monkeypatch.delenv("ENTROPY_DATA_API_KEY", raising=False)
+    monkeypatch.delenv("DATAMESH_MANAGER_API_KEY", raising=False)
+    monkeypatch.delenv("DATACONTRACT_MANAGER_API_KEY", raising=False)
+    monkeypatch.delenv("ENTROPY_DATA_HOST", raising=False)
+    monkeypatch.delenv("DATAMESH_MANAGER_HOST", raising=False)
+    monkeypatch.delenv("DATACONTRACT_MANAGER_HOST", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# URL translation
+# ---------------------------------------------------------------------------
+
+
+def test_semantic_url_to_api_translates_known_shape():
+    assert _semantic_url_to_api(SEMANTIC_URL) == EXPECTED_API_URL
+
+
+def test_semantic_url_to_api_strips_query_and_fragment():
+    assert _semantic_url_to_api(SEMANTIC_URL + "?v=1#anchor") == EXPECTED_API_URL
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "",
+        "not a url",
+        "ftp://demo.entropy-data.com/org42/semantics/main/product.brand",
+        "https://demo.entropy-data.com/missing-semantics-segment/main/product.brand",
+        "https://demo.entropy-data.com/org42/semantics/main",  # missing externalId
+    ],
+)
+def test_semantic_url_to_api_rejects_unknown_shape(url):
+    assert _semantic_url_to_api(url) is None
+
+
+# ---------------------------------------------------------------------------
+# Host trust policy
+# ---------------------------------------------------------------------------
+
+
+def test_known_entropy_data_hosts_are_trusted(env_without_api_key):
+    assert _looks_like_entropy_data_host("entropy-data.com")
+    assert _looks_like_entropy_data_host("demo.entropy-data.com")
+    assert _looks_like_entropy_data_host("api.entropy-data.com")
+
+
+def test_arbitrary_host_is_not_trusted(env_without_api_key):
+    assert not _looks_like_entropy_data_host("example.com")
+    assert not _looks_like_entropy_data_host("evil.example.com")
+
+
+def test_configured_host_is_trusted(monkeypatch):
+    monkeypatch.setenv("ENTROPY_DATA_HOST", "https://datacontract.acme.internal:8443")
+    assert _looks_like_entropy_data_host("datacontract.acme.internal")
+    assert not _looks_like_entropy_data_host("other.acme.internal")
+
+
+# ---------------------------------------------------------------------------
+# resolve_semantic_definition
+# ---------------------------------------------------------------------------
+
+
+def _ok(json_body):
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = json_body
+    return response
+
+
+@patch("datacontract.integration.entropy_data.requests.get")
+def test_resolve_returns_concept_and_sends_api_key_for_entropy_host(mock_get, env_with_api_key):
+    mock_get.return_value = _ok(SAMPLE_CONCEPT)
+
+    concept = resolve_semantic_definition(SEMANTIC_URL)
+
+    assert concept == SAMPLE_CONCEPT
+    mock_get.assert_called_once()
+    called_url, called_kwargs = mock_get.call_args.args[0], mock_get.call_args.kwargs
+    assert called_url == EXPECTED_API_URL
+    assert called_kwargs["headers"]["x-api-key"] == env_with_api_key
+    assert called_kwargs["headers"]["Accept"] == "application/json"
+
+
+@patch("datacontract.integration.entropy_data.requests.get")
+def test_resolve_does_not_send_api_key_to_untrusted_hosts(mock_get, env_with_api_key):
+    mock_get.return_value = _ok(SAMPLE_CONCEPT)
+    foreign_url = "https://semantics.example.com/org/semantics/main/x"
+
+    resolve_semantic_definition(foreign_url)
+
+    headers = mock_get.call_args.kwargs["headers"]
+    assert "x-api-key" not in headers
+    assert headers["Accept"] == "application/json"
+
+
+@patch("datacontract.integration.entropy_data.requests.get")
+def test_resolve_caches_results_per_url(mock_get, env_with_api_key):
+    mock_get.return_value = _ok(SAMPLE_CONCEPT)
+
+    resolve_semantic_definition(SEMANTIC_URL)
+    resolve_semantic_definition(SEMANTIC_URL)
+    resolve_semantic_definition(SEMANTIC_URL)
+
+    assert mock_get.call_count == 1
+
+
+@patch("datacontract.integration.entropy_data.requests.get")
+def test_resolve_caches_negative_results(mock_get, env_with_api_key):
+    response = MagicMock()
+    response.status_code = 404
+    response.text = "not found"
+    mock_get.return_value = response
+
+    assert resolve_semantic_definition(SEMANTIC_URL) is None
+    assert resolve_semantic_definition(SEMANTIC_URL) is None
+    assert mock_get.call_count == 1
+
+
+@patch("datacontract.integration.entropy_data.requests.get")
+def test_resolve_returns_none_on_network_error(mock_get, env_with_api_key):
+    import requests as _requests
+
+    mock_get.side_effect = _requests.ConnectionError("boom")
+
+    assert resolve_semantic_definition(SEMANTIC_URL) is None
+
+
+@patch("datacontract.integration.entropy_data.requests.get")
+def test_resolve_returns_none_for_unknown_url_shape_without_calling_http(mock_get, env_with_api_key):
+    assert resolve_semantic_definition("not a url") is None
+    mock_get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# enrich_in_place — property-level merge
+# ---------------------------------------------------------------------------
+
+
+def _contract_with_semantic_brand():
+    return OpenDataContractStandard(
+        apiVersion="v3.1.0",
+        kind="DataContract",
+        id="orders-contract",
+        name="Orders",
+        version="1.0.0",
+        status="active",
+        schema=[
+            SchemaObject(
+                name="ORDERS",
+                physicalType="table",
+                properties=[
+                    SchemaProperty(name="ORDER_ID", logicalType="string", required=True, primaryKey=True),
+                    # Bare semantic-only property — what the editor's
+                    # "Add from definition" produces today.
+                    SchemaProperty(
+                        name="brand",
+                        physicalName="BRAND",
+                        authoritativeDefinitions=[AuthoritativeDefinition(type="semantics", url=SEMANTIC_URL)],
+                    ),
+                ],
+            )
+        ],
+    )
+
+
+@patch("datacontract.integration.entropy_data.requests.get")
+def test_enrich_fills_missing_fields_from_concept(mock_get, env_with_api_key):
+    mock_get.return_value = _ok(SAMPLE_CONCEPT)
+    contract = _contract_with_semantic_brand()
+    brand = contract.schema_[0].properties[1]
+    assert brand.logicalType is None and brand.description is None
+
+    enrich_in_place(contract)
+
+    assert brand.logicalType == "string"
+    assert brand.description == "Brand the product belongs to."
+    assert brand.examples == ["EcoWear"]
+    assert brand.businessName == "brand"
+    # Already-set fields are untouched.
+    assert brand.physicalName == "BRAND"
+
+
+@patch("datacontract.integration.entropy_data.requests.get")
+def test_enrich_does_not_overwrite_inline_fields(mock_get, env_with_api_key):
+    mock_get.return_value = _ok({**SAMPLE_CONCEPT, "data_type": "number"})
+    contract = _contract_with_semantic_brand()
+    brand = contract.schema_[0].properties[1]
+    brand.logicalType = "string"  # set inline by author — concept must not override
+
+    enrich_in_place(contract)
+
+    assert brand.logicalType == "string"
+
+
+@patch("datacontract.integration.entropy_data.requests.get")
+def test_enrich_is_a_noop_without_semantic_ref(mock_get, env_with_api_key):
+    contract = _contract_with_semantic_brand()
+    contract.schema_[0].properties[1].authoritativeDefinitions = []
+
+    enrich_in_place(contract)
+
+    mock_get.assert_not_called()
+
+
+def test_enrich_handles_contract_without_schema(env_without_api_key):
+    contract = OpenDataContractStandard(
+        apiVersion="v3.1.0",
+        kind="DataContract",
+        id="x",
+        name="x",
+        version="1.0.0",
+        status="active",
+    )
+    # Should not raise.
+    enrich_in_place(contract)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: create_checks now emits a type check for the brand property
+# ---------------------------------------------------------------------------
+
+
+@patch("datacontract.integration.entropy_data.requests.get")
+def test_create_checks_emits_type_check_after_enrichment(mock_get, env_with_api_key):
+    mock_get.return_value = _ok(SAMPLE_CONCEPT)
+    contract = _contract_with_semantic_brand()
+
+    checks = create_checks(contract, Server(type="snowflake"))
+
+    # Presence + type check now exist for BRAND (the physicalName), where
+    # previously the type check was silently skipped because the property
+    # had no inline logicalType/physicalType.
+    fields = {(c.type, c.field) for c in checks}
+    assert ("field_is_present", "BRAND") in fields
+    assert ("field_type", "BRAND") in fields
+
+
+@patch("datacontract.integration.entropy_data.requests.get")
+def test_ssl_verification_default_true_propagates_to_http_call(mock_get, env_with_api_key):
+    mock_get.return_value = _ok(SAMPLE_CONCEPT)
+    contract = _contract_with_semantic_brand()
+
+    create_checks(contract, Server(type="snowflake"))
+
+    assert mock_get.call_args.kwargs["verify"] is True
+
+
+@patch("datacontract.integration.entropy_data.requests.get")
+def test_ssl_verification_false_propagates_through_create_checks(mock_get, env_with_api_key):
+    """A self-hosted deployment with a self-signed certificate can pass
+    --no-ssl-verification to `datacontract test`; the same value must
+    reach the resolver's HTTP call so the concept can actually be
+    fetched and used to enrich the contract."""
+    mock_get.return_value = _ok(SAMPLE_CONCEPT)
+    contract = _contract_with_semantic_brand()
+
+    create_checks(contract, Server(type="snowflake"), ssl_verification=False)
+
+    assert mock_get.call_args.kwargs["verify"] is False


### PR DESCRIPTION
## Summary

Resolves `authoritativeDefinitions[type=semantics]` on each property at read time so `datacontract test` works against the *lean-YAML* model some editors adopt: a property carrying only a `name`, `physicalName`, and a semantic URL gets its `logicalType` / `description` / `examples` / `businessName` filled from the referenced concept just before checks are generated. The contract on disk is never modified.

Without this, properties produced by the datacontract-editor's "Add from definition" get a presence check but no type check — the schema validation silently degrades because `to_schema_checks` gates the type check on `prop.physicalType or prop.logicalType` being present, and neither is set inline.

## How it works

- `datacontract/integration/entropy_data.py` gains `resolve_semantic_definition(url)`: translates the URL `https://<host>/<vanity>/semantics/<namespace>/<externalId>` to the API path `https://<host>/api/semantics/experimental/namespaces/<namespace>/concepts/<externalId>`, fetches the concept JSON, and caches it per process. Sits alongside the existing `publish_*` helpers and reuses `_get_api_key()`.
- `datacontract/integration/semantic_enrichment.py` walks every property in the in-memory contract and merges the four concept fields above when (and only when) the property doesn't have them inline.
- `create_checks` calls `enrich_in_place(...)` before walking properties. No exporter call sites change; they remain at today's behavior and can opt in in a follow-up.

## Security

The API key is attached **only** when the URL's host matches `*.entropy-data.com` / `entropy-data.com` *or* the configured `ENTROPY_DATA_HOST` / `DATAMESH_MANAGER_HOST` / `DATACONTRACT_MANAGER_HOST`. Any other host (a third-party URL named by the contract author) is queried anonymously. A contract cannot redirect the resolver at an arbitrary host and exfiltrate the user's key. Covered by a unit test.

## Self-hosted deployments

Works out of the box for any standard self-hosted entropy-data instance (the same Spring app, the same URL layout). The user sets `ENTROPY_DATA_HOST=https://entropy.acme.internal` and `ENTROPY_DATA_API_KEY=ed_…` (the same plumbing the existing publish code uses), and contract URLs on that host resolve with the key attached. The existing `--no-ssl-verification` flag on `datacontract test` (and `ci`/`dbt`/`publish`) now threads through `create_checks` → `enrich_in_place` → `resolve_semantic_definition` to the underlying `requests.get`, supporting self-signed certificates.

## Failure behavior

Resolution failures — no network, no key, untrusted host returning non-200, network exception, malformed JSON, URL that doesn't match the expected shape — return `None` and the field stays unfilled. The resolver's per-process cache stores `None` too, so a single test run never makes the same failing request twice. The check set in that case is exactly today's, so the change is additive and never regresses behavior.

## Tests

`tests/test_semantic_enrichment.py` (23 tests) covers:
- URL translation: valid shapes, query/fragment-stripping, rejected shapes (empty, bad scheme, missing segments).
- Host-trust policy: `*.entropy-data.com` accepted, arbitrary hosts rejected, configured host accepted.
- Resolver: 200 returns concept; key sent to trusted host; key withheld from untrusted host; 200 caches; 404 caches negative; network error returns `None`; malformed URL short-circuits without HTTP.
- Enrichment: missing fields filled; inline fields not overwritten; no-op without a semantic ref; safe on contracts with no schema.
- End-to-end: `create_checks` emits a `field_type` check for a previously-bare semantic property.
- SSL verification: `ssl_verification=True` (default) and `ssl_verification=False` both propagate through `create_checks` to `requests.get(verify=…)`.

Existing `tests/test_data_contract_checks.py` (43 tests) is unchanged and still green.
