### PR TITLE
fix: support versioned dbt schemas in `import dbt` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Schema checks now resolve each property by its `physicalName` when set (falling back to `name`), matching the existing table-level resolution and the SQL/BigQuery exporters. Previously a property whose logical `name` differed from its physical column (e.g. `name: brand` with `physicalName: BRAND`) failed the presence and type checks even though the physical column existed (#1246)
+- `import dbt --model <name>.vN` now correctly imports the specified version of a versioned dbt model. Previously the filter compared the full `name.vN` string against `node["name"]` (which is always the bare base name), producing a silent empty contract (#1249)
 
 ## [0.12.3] - 2026-05-18
 

--- a/README.md
+++ b/README.md
@@ -1867,6 +1867,8 @@ datacontract import unity --table <table_full_name>
 Importing from dbt manifest file.
 You may give the `--model` parameter to enumerate the tables that should be imported. If no tables are given, _all_ available tables of the database will be imported.
 
+For [versioned dbt models](https://docs.getdbt.com/docs/collaborate/govern/model-versions), use the `name.vN` convention to target a specific version. Omitting the version suffix imports all versions of that model.
+
 Examples:
 
 ```bash
@@ -1877,6 +1879,11 @@ datacontract import dbt --source <manifest_path> --model <model_name_1> --model 
 ```bash
 # Example import from dbt manifest importing all tables in the database
 datacontract import dbt --source <manifest_path>
+```
+
+```bash
+# Import a specific version of a versioned dbt model
+datacontract import dbt --source <manifest_path> --model mart_orders.v1
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -1881,11 +1881,6 @@ datacontract import dbt --source <manifest_path> --model <model_name_1> --model 
 datacontract import dbt --source <manifest_path>
 ```
 
-```bash
-# Import a specific version of a versioned dbt model
-datacontract import dbt --source <manifest_path> --model mart_orders.v1
-```
-
 </details>
 
 <details markdown="1">

--- a/datacontract/imports/dbt_importer.py
+++ b/datacontract/imports/dbt_importer.py
@@ -174,20 +174,31 @@ def _get_references(manifest: dict, node: dict) -> dict[str, str]:
     return references
 
 
+_VERSION_SUFFIX_RE = re.compile(r"^v?(\d+)$")
+
+
 def _matches_dbt_node_filter(node: dict, dbt_nodes: list[str]) -> bool:
     """Return True if *node* matches any entry in *dbt_nodes*.
 
     Entries may be plain model names (``my_model``) or versioned names using
     dbt's ``name.vN`` convention (``my_model.v1``).  A plain name matches any
     version of that model; a versioned name matches only the specific version.
+
+    Model names that contain dots but whose final segment does not look like a
+    version suffix (``v<digits>`` or bare ``<digits>``) are treated as plain
+    names so that names such as ``schema.my_model`` are matched correctly.
     """
     for filter_name in dbt_nodes:
         if "." in filter_name:
-            base, _, version_str = filter_name.rpartition(".")
-            version_num = version_str.lstrip("v")
-            if node.get("name") == base and str(node.get("version", "")) == version_num:
-                return True
-        elif node.get("name") == filter_name:
+            base, _, suffix = filter_name.rpartition(".")
+            m = _VERSION_SUFFIX_RE.match(suffix)
+            if m:
+                # Versioned filter — match base name and version number only.
+                if node.get("name") == base and str(node.get("version", "")) == m.group(1):
+                    return True
+                continue  # versioned filter didn't match; try next entry
+            # Suffix doesn't look like a version — fall through to plain-name match.
+        if node.get("name") == filter_name:
             return True
     return False
 

--- a/datacontract/imports/dbt_importer.py
+++ b/datacontract/imports/dbt_importer.py
@@ -174,6 +174,24 @@ def _get_references(manifest: dict, node: dict) -> dict[str, str]:
     return references
 
 
+def _matches_dbt_node_filter(node: dict, dbt_nodes: list[str]) -> bool:
+    """Return True if *node* matches any entry in *dbt_nodes*.
+
+    Entries may be plain model names (``my_model``) or versioned names using
+    dbt's ``name.vN`` convention (``my_model.v1``).  A plain name matches any
+    version of that model; a versioned name matches only the specific version.
+    """
+    for filter_name in dbt_nodes:
+        if "." in filter_name:
+            base, _, version_str = filter_name.rpartition(".")
+            version_num = version_str.lstrip("v")
+            if node.get("name") == base and str(node.get("version", "")) == version_num:
+                return True
+        elif node.get("name") == filter_name:
+            return True
+    return False
+
+
 def import_dbt_manifest(
     manifest: dict,
     dbt_nodes: list[str],
@@ -193,7 +211,7 @@ def import_dbt_manifest(
         if node.get("resource_type") not in resource_types:
             continue
 
-        if dbt_nodes and node.get("name") not in dbt_nodes:
+        if dbt_nodes and not _matches_dbt_node_filter(node, dbt_nodes):
             continue
 
         model_unique_id = node["unique_id"]

--- a/tests/fixtures/dbt/import/manifest_versioned_models.json
+++ b/tests/fixtures/dbt/import/manifest_versioned_models.json
@@ -1,0 +1,173 @@
+{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+    "dbt_version": "1.8.0",
+    "generated_at": "2024-07-09T00:33:06.822862Z",
+    "invocation_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    "env": {},
+    "project_name": "test_project",
+    "project_id": "test_project_id",
+    "user_id": null,
+    "send_anonymous_usage_stats": false,
+    "adapter_type": "duckdb"
+  },
+  "nodes": {
+    "model.test_project.mart_orders.v1": {
+      "database": "test_project",
+      "schema": "main",
+      "name": "mart_orders",
+      "resource_type": "model",
+      "package_name": "test_project",
+      "path": "mart_orders_v1.sql",
+      "original_file_path": "models/mart_orders_v1.sql",
+      "unique_id": "model.test_project.mart_orders.v1",
+      "fqn": ["test_project", "mart_orders", "v1"],
+      "alias": "mart_orders_v1",
+      "checksum": {"name": "sha256", "checksum": "aabbcc"},
+      "config": {
+        "enabled": true,
+        "materialized": "table",
+        "tags": [],
+        "contract": {"enforced": false, "alias_types": true},
+        "access": "protected"
+      },
+      "tags": [],
+      "description": "Orders mart version 1",
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "description": "Primary key",
+          "meta": {},
+          "data_type": "integer",
+          "constraints": [{"type": "primary_key"}],
+          "quote": null,
+          "tags": []
+        },
+        "amount": {
+          "name": "amount",
+          "description": "Order amount",
+          "meta": {},
+          "data_type": "numeric",
+          "constraints": [],
+          "quote": null,
+          "tags": []
+        }
+      },
+      "version": 1,
+      "constraints": [],
+      "meta": {},
+      "depends_on": {"macros": [], "nodes": []},
+      "refs": [],
+      "sources": []
+    },
+    "model.test_project.mart_orders.v2": {
+      "database": "test_project",
+      "schema": "main",
+      "name": "mart_orders",
+      "resource_type": "model",
+      "package_name": "test_project",
+      "path": "mart_orders_v2.sql",
+      "original_file_path": "models/mart_orders_v2.sql",
+      "unique_id": "model.test_project.mart_orders.v2",
+      "fqn": ["test_project", "mart_orders", "v2"],
+      "alias": "mart_orders_v2",
+      "checksum": {"name": "sha256", "checksum": "ddeeff"},
+      "config": {
+        "enabled": true,
+        "materialized": "table",
+        "tags": [],
+        "contract": {"enforced": false, "alias_types": true},
+        "access": "protected"
+      },
+      "tags": [],
+      "description": "Orders mart version 2",
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "description": "Primary key",
+          "meta": {},
+          "data_type": "integer",
+          "constraints": [{"type": "primary_key"}],
+          "quote": null,
+          "tags": []
+        },
+        "amount": {
+          "name": "amount",
+          "description": "Order amount",
+          "meta": {},
+          "data_type": "numeric",
+          "constraints": [],
+          "quote": null,
+          "tags": []
+        },
+        "currency": {
+          "name": "currency",
+          "description": "Currency code, added in v2",
+          "meta": {},
+          "data_type": "varchar",
+          "constraints": [],
+          "quote": null,
+          "tags": []
+        }
+      },
+      "version": 2,
+      "constraints": [],
+      "meta": {},
+      "depends_on": {"macros": [], "nodes": []},
+      "refs": [],
+      "sources": []
+    },
+    "model.test_project.dim_customers": {
+      "database": "test_project",
+      "schema": "main",
+      "name": "dim_customers",
+      "resource_type": "model",
+      "package_name": "test_project",
+      "path": "dim_customers.sql",
+      "original_file_path": "models/dim_customers.sql",
+      "unique_id": "model.test_project.dim_customers",
+      "fqn": ["test_project", "dim_customers"],
+      "alias": "dim_customers",
+      "checksum": {"name": "sha256", "checksum": "112233"},
+      "config": {
+        "enabled": true,
+        "materialized": "table",
+        "tags": [],
+        "contract": {"enforced": false, "alias_types": true},
+        "access": "protected"
+      },
+      "tags": [],
+      "description": "Customer dimension",
+      "columns": {
+        "customer_id": {
+          "name": "customer_id",
+          "description": "Primary key",
+          "meta": {},
+          "data_type": "integer",
+          "constraints": [],
+          "quote": null,
+          "tags": []
+        }
+      },
+      "version": null,
+      "constraints": [],
+      "meta": {},
+      "depends_on": {"macros": [], "nodes": []},
+      "refs": [],
+      "sources": []
+    }
+  },
+  "sources": {},
+  "exposures": {},
+  "metrics": {},
+  "groups": {},
+  "selectors": {},
+  "parent_map": {},
+  "child_map": {
+    "model.test_project.mart_orders.v1": [],
+    "model.test_project.mart_orders.v2": [],
+    "model.test_project.dim_customers": []
+  },
+  "group_map": {},
+  "docs": {}
+}

--- a/tests/test_import_dbt.py
+++ b/tests/test_import_dbt.py
@@ -10,6 +10,7 @@ from datacontract.imports.dbt_importer import read_dbt_manifest
 dbt_manifest = "fixtures/dbt/import/manifest_jaffle_duckdb.json"
 dbt_manifest_bigquery = "fixtures/dbt/import/manifest_jaffle_bigquery.json"
 dbt_manifest_empty_columns = "fixtures/dbt/import/manifest_empty_columns.json"
+dbt_manifest_versioned = "fixtures/dbt/import/manifest_versioned_models.json"
 
 
 def test_read_dbt_manifest_():
@@ -97,3 +98,59 @@ def test_import_dbt_manifest_with_filter():
     with open("fixtures/dbt/import/expected/manifest_jaffle_duckdb_filtered.odcs.yaml") as file:
         expected = file.read()
     assert yaml.safe_load(result.to_yaml()) == yaml.safe_load(expected)
+
+
+# --- Versioned model filter tests ---
+
+
+def test_import_versioned_dbt_manifest_unversioned_filter_returns_all_versions():
+    """A plain model name (no .vN suffix) should import every version of that model."""
+    result = DataContract.import_from_source("dbt", dbt_manifest_versioned, dbt_model=["mart_orders"])
+
+    schema_names = [s.name for s in result.schema_]
+    assert "mart_orders" in schema_names
+    assert len([s for s in result.schema_ if s.name == "mart_orders"]) == 2, (
+        "Expected both v1 and v2 of mart_orders to be imported"
+    )
+
+
+def test_import_versioned_dbt_manifest_v1_filter():
+    """--model mart_orders.v1 should import only the v1 model, not v2."""
+    result = DataContract.import_from_source("dbt", dbt_manifest_versioned, dbt_model=["mart_orders.v1"])
+
+    assert result.schema_, "Expected at least one schema but got an empty contract"
+    assert len(result.schema_) == 1, f"Expected exactly 1 schema, got {len(result.schema_)}"
+    assert result.schema_[0].name == "mart_orders"
+    # v1 has 2 columns; v2 has 3 (adds 'currency')
+    field_names = [p.name for p in result.schema_[0].properties]
+    assert "currency" not in field_names, "currency is a v2-only column; v1 should not contain it"
+
+
+def test_import_versioned_dbt_manifest_v2_filter():
+    """--model mart_orders.v2 should import only the v2 model, not v1."""
+    result = DataContract.import_from_source("dbt", dbt_manifest_versioned, dbt_model=["mart_orders.v2"])
+
+    assert result.schema_, "Expected at least one schema but got an empty contract"
+    assert len(result.schema_) == 1, f"Expected exactly 1 schema, got {len(result.schema_)}"
+    assert result.schema_[0].name == "mart_orders"
+    field_names = [p.name for p in result.schema_[0].properties]
+    assert "currency" in field_names, "currency is a v2-only column and should be present"
+
+
+def test_cli_versioned_filter_v1():
+    """CLI: --model mart_orders.v1 should exit 0 and produce non-empty output."""
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "import",
+            "dbt",
+            "--source",
+            dbt_manifest_versioned,
+            "--model",
+            "mart_orders.v1",
+        ],
+    )
+    assert result.exit_code == 0
+    parsed = yaml.safe_load(result.output)
+    assert parsed.get("schema"), "Expected non-empty schema in CLI output for mart_orders.v1"

--- a/tests/test_import_dbt.py
+++ b/tests/test_import_dbt.py
@@ -3,7 +3,7 @@ from typer.testing import CliRunner
 
 from datacontract.cli import app
 from datacontract.data_contract import DataContract
-from datacontract.imports.dbt_importer import read_dbt_manifest
+from datacontract.imports.dbt_importer import _matches_dbt_node_filter, read_dbt_manifest
 
 # logging.basicConfig(level=logging.DEBUG, force=True)
 
@@ -154,3 +154,51 @@ def test_cli_versioned_filter_v1():
     assert result.exit_code == 0
     parsed = yaml.safe_load(result.output)
     assert parsed.get("schema"), "Expected non-empty schema in CLI output for mart_orders.v1"
+
+
+# --- _matches_dbt_node_filter unit tests ---
+
+
+def test_matches_plain_name():
+    node = {"name": "orders", "version": None}
+    assert _matches_dbt_node_filter(node, ["orders"]) is True
+
+
+def test_matches_versioned_v_prefix():
+    node = {"name": "orders", "version": 1}
+    assert _matches_dbt_node_filter(node, ["orders.v1"]) is True
+
+
+def test_matches_versioned_no_v_prefix():
+    node = {"name": "orders", "version": 2}
+    assert _matches_dbt_node_filter(node, ["orders.2"]) is True
+
+
+def test_does_not_match_wrong_version():
+    node = {"name": "orders", "version": 1}
+    assert _matches_dbt_node_filter(node, ["orders.v2"]) is False
+
+
+def test_plain_name_matches_all_versions():
+    node_v1 = {"name": "orders", "version": 1}
+    node_v2 = {"name": "orders", "version": 2}
+    assert _matches_dbt_node_filter(node_v1, ["orders"]) is True
+    assert _matches_dbt_node_filter(node_v2, ["orders"]) is True
+
+
+def test_dotted_plain_name_not_misread_as_versioned():
+    """A name like 'schema.orders' with no version suffix must match as a plain name."""
+    node = {"name": "schema.orders", "version": None}
+    assert _matches_dbt_node_filter(node, ["schema.orders"]) is True
+
+
+def test_dotted_plain_name_does_not_match_wrong_node():
+    node = {"name": "schema.other", "version": None}
+    assert _matches_dbt_node_filter(node, ["schema.orders"]) is False
+
+
+def test_empty_filter_list():
+    node = {"name": "orders", "version": 1}
+    # Empty list means no filter — the caller should not invoke the helper,
+    # but it should be safe to call and return False.
+    assert _matches_dbt_node_filter(node, []) is False

--- a/tests/test_import_dbt.py
+++ b/tests/test_import_dbt.py
@@ -3,7 +3,7 @@ from typer.testing import CliRunner
 
 from datacontract.cli import app
 from datacontract.data_contract import DataContract
-from datacontract.imports.dbt_importer import _matches_dbt_node_filter, read_dbt_manifest
+from datacontract.imports.dbt_importer import read_dbt_manifest
 
 # logging.basicConfig(level=logging.DEBUG, force=True)
 
@@ -154,51 +154,3 @@ def test_cli_versioned_filter_v1():
     assert result.exit_code == 0
     parsed = yaml.safe_load(result.output)
     assert parsed.get("schema"), "Expected non-empty schema in CLI output for mart_orders.v1"
-
-
-# --- _matches_dbt_node_filter unit tests ---
-
-
-def test_matches_plain_name():
-    node = {"name": "orders", "version": None}
-    assert _matches_dbt_node_filter(node, ["orders"]) is True
-
-
-def test_matches_versioned_v_prefix():
-    node = {"name": "orders", "version": 1}
-    assert _matches_dbt_node_filter(node, ["orders.v1"]) is True
-
-
-def test_matches_versioned_no_v_prefix():
-    node = {"name": "orders", "version": 2}
-    assert _matches_dbt_node_filter(node, ["orders.2"]) is True
-
-
-def test_does_not_match_wrong_version():
-    node = {"name": "orders", "version": 1}
-    assert _matches_dbt_node_filter(node, ["orders.v2"]) is False
-
-
-def test_plain_name_matches_all_versions():
-    node_v1 = {"name": "orders", "version": 1}
-    node_v2 = {"name": "orders", "version": 2}
-    assert _matches_dbt_node_filter(node_v1, ["orders"]) is True
-    assert _matches_dbt_node_filter(node_v2, ["orders"]) is True
-
-
-def test_dotted_plain_name_not_misread_as_versioned():
-    """A name like 'schema.orders' with no version suffix must match as a plain name."""
-    node = {"name": "schema.orders", "version": None}
-    assert _matches_dbt_node_filter(node, ["schema.orders"]) is True
-
-
-def test_dotted_plain_name_does_not_match_wrong_node():
-    node = {"name": "schema.other", "version": None}
-    assert _matches_dbt_node_filter(node, ["schema.orders"]) is False
-
-
-def test_empty_filter_list():
-    node = {"name": "orders", "version": 1}
-    # Empty list means no filter — the caller should not invoke the helper,
-    # but it should be safe to call and return False.
-    assert _matches_dbt_node_filter(node, []) is False


### PR DESCRIPTION
### Problem

Importing a specific version of a dbt model using the `name.vN` convention produced an empty contract with no error:

```bash
# Silent empty output
datacontract import dbt --source target/manifest.json --model mart_orders.v1
datacontract import dbt --source target/manifest.json --model mart_orders.v2
```

In `manifest.json`, dbt always stores the base name in `node["name"]` and the version number separately in `node["version"]`. The filter compared the user-supplied string (`"mart_orders.v1"`) directly against `node["name"]` (`"mart_orders"`), so every node was skipped.

### Fix

Added `_matches_dbt_node_filter()` in `dbt_importer.py` which understands the `name.vN` convention:

- `--model mart_orders` → imports all versions (unchanged behaviour)
- `--model mart_orders.v1` → imports only the v1 node
- `--model mart_orders.v2` → imports only the v2 node

### Tests

Added a versioned manifest fixture (`manifest_versioned_models.json`) and four new tests covering the above cases.

### Checklist

- [x] Tests pass (uv run pytest)
- [x] Code formatted (uv run ruff check --fix && uv run ruff format)
- [x] CHANGELOG.md entry added