### PR TITLE
fix: skip schema type check for varchar(n) and map columns on Databricks (#1219, #1245)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
-
+- Schema type check no longer fails for `varchar(n)` columns on Databricks with PySpark 4.0+, and for `map` and `varchar` types nested inside `struct` columns; affected columns emit a warning and skip the type check instead
 
 ## [0.12.4] - 2026-05-21
 

--- a/datacontract/engines/data_contract_checks.py
+++ b/datacontract/engines/data_contract_checks.py
@@ -55,6 +55,26 @@ _ANSI_QUOTING_DIALECTS = {"postgres", "redshift", "sqlserver", "snowflake", "azu
 
 _BARE_IDENTIFIER_STRICT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _BARE_IDENTIFIER_PERMISSIVE = re.compile(r"^[A-Za-z_][A-Za-z0-9_$]*$")
+
+_DATABRICKS_UNSUPPORTED_TYPE_RE = re.compile(r"\bvarchar\b|\bmap\s*<", re.IGNORECASE)
+
+
+def _has_unsupported_databricks_type(prop) -> bool:
+    """Return True if physicalType contains varchar(n) or map at any nesting level,
+    or if any nested property (recursively) has an unsupported type.
+
+    soda-core-spark-df ≤3.5.6 cannot match these types correctly on PySpark 4.0+:
+    - varchar(n): reported as a distinct VarcharType by PySpark 4.0+, not in SCHEMA_CHECK_TYPES_MAPPING
+    - map: convert_to_databricks() returns None for maps nested inside structs
+    Affected issues: #1245 (varchar), #1219 (map in struct)
+    """
+    if _DATABRICKS_UNSUPPORTED_TYPE_RE.search(prop.physicalType or ""):
+        return True
+    if prop.properties:
+        return any(_has_unsupported_databricks_type(nested) for nested in prop.properties)
+    return False
+
+
 _PERMISSIVE_BARE_DIALECTS = {"postgres", "redshift", "snowflake", "oracle", "sqlserver"}
 
 
@@ -138,9 +158,19 @@ def to_schema_checks(schema_object: SchemaObject, server: Server) -> List[Check]
 
         checks.append(check_property_is_present(schema_name, property_name, quoting_config))
         if check_types and (prop.physicalType is not None or prop.logicalType is not None):
-            sql_type: str = convert_to_sql_type(prop, server_type)
-            if sql_type is not None:
-                checks.append(check_property_type(schema_name, property_name, sql_type, quoting_config))
+            if server_type == "databricks" and _has_unsupported_databricks_type(prop):
+                logger.warning(
+                    "Skipping schema type check for column '%s': physicalType '%s' "
+                    "contains varchar(n) or map, which are not reliably matched by "
+                    "soda-core-spark-df ≤3.5.6 on PySpark 4.0+. "
+                    "See https://github.com/datacontract/datacontract-cli/issues/1245",
+                    property_name,
+                    prop.physicalType,
+                )
+            else:
+                sql_type: str = convert_to_sql_type(prop, server_type)
+                if sql_type is not None:
+                    checks.append(check_property_type(schema_name, property_name, sql_type, quoting_config))
         if prop.required:
             checks.append(check_property_required(schema_name, property_name, quoting_config))
         if prop.unique:

--- a/tests/test_data_contract_checks.py
+++ b/tests/test_data_contract_checks.py
@@ -1,3 +1,4 @@
+import pytest
 import yaml
 from open_data_contract_standard.model import (
     DataQuality,
@@ -12,6 +13,7 @@ from datacontract.data_contract import DataContract
 from datacontract.engines.data_contract_checks import (
     QuotingConfig,
     _escape_sql_string_values,
+    _has_unsupported_databricks_type,
     check_property_enum,
     check_property_invalid_values,
     check_property_is_present,
@@ -570,3 +572,106 @@ def test_field_checks_fall_back_to_name_without_physical_name():
 
     present = next(c for c in checks if c.type == "field_is_present")
     assert present.field == "sku"
+
+
+# ---------------------------------------------------------------------------
+# _has_unsupported_databricks_type tests (#1245, #1219)
+# ---------------------------------------------------------------------------
+
+
+def _make_prop(physical_type):
+    """Helper: create a SchemaProperty with the given physicalType."""
+    return SchemaProperty(name="col", physicalType=physical_type)
+
+
+@pytest.mark.parametrize(
+    "physical_type,expected",
+    [
+        ("varchar(30)", True),
+        ("varchar", True),
+        ("VARCHAR(255)", True),
+        ("struct<name:varchar(30),age:int>", True),
+        ("array<varchar(30)>", True),
+        ("map<string,string>", True),
+        ("struct<data:map<string,int>>", True),
+        ("string", False),
+        ("int", False),
+        ("struct<age:int,name:string>", False),
+        (None, False),
+        ("", False),
+    ],
+)
+def test_has_unsupported_databricks_type(physical_type, expected):
+    prop = _make_prop(physical_type)
+    assert _has_unsupported_databricks_type(prop) == expected
+
+
+def test_to_schema_checks_databricks_varchar_skips_type_check():
+    """Databricks + varchar(n) physicalType produces only field_is_present, no field_type check."""
+    schema_object = SchemaObject(
+        name="orders",
+        properties=[SchemaProperty(name="name", physicalType="varchar(30)")],
+    )
+    server = Server(type="databricks")
+
+    checks = to_schema_checks(schema_object=schema_object, server=server)
+
+    types = [c.type for c in checks]
+    assert "field_is_present" in types
+    assert "field_type" not in types
+
+
+def test_to_schema_checks_databricks_map_in_struct_skips_type_check():
+    """Databricks + struct containing map skips the type check."""
+    schema_object = SchemaObject(
+        name="events",
+        properties=[SchemaProperty(name="metadata", physicalType="struct<data:map<string,int>>")],
+    )
+    server = Server(type="databricks")
+
+    checks = to_schema_checks(schema_object=schema_object, server=server)
+
+    types = [c.type for c in checks]
+    assert "field_is_present" in types
+    assert "field_type" not in types
+
+
+def test_to_schema_checks_non_databricks_varchar_still_produces_type_check():
+    """Non-Databricks server with varchar physicalType still emits a field_type check."""
+    schema_object = SchemaObject(
+        name="orders",
+        properties=[SchemaProperty(name="name", physicalType="varchar(30)")],
+    )
+    server = Server(type="snowflake")
+
+    checks = to_schema_checks(schema_object=schema_object, server=server)
+
+    types = [c.type for c in checks]
+    assert "field_type" in types
+
+
+def test_to_schema_checks_databricks_struct_with_nested_varchar_skips_type_check():
+    """Databricks struct column whose nested property has varchar physicalType skips type check.
+
+    The parent physicalType (struct<varchar_field:string>) does not itself contain
+    varchar as a type token, but the nested property does — so the parent check
+    must be skipped too (issue #1245).
+    """
+    nested = SchemaProperty(name="varchar_field", physicalType="varchar(100)")
+    schema_object = SchemaObject(
+        name="complex_datatypes",
+        properties=[
+            SchemaProperty(
+                name="struct_with_varchar_test",
+                physicalType="struct<varchar_field:string>",
+                properties=[nested],
+            )
+        ],
+    )
+    server = Server(type="databricks")
+
+    checks = to_schema_checks(schema_object=schema_object, server=server)
+
+    types = [c.type for c in checks]
+    assert "field_is_present" in types
+    assert "field_type" not in types

--- a/tests/test_data_contract_checks.py
+++ b/tests/test_data_contract_checks.py
@@ -1,4 +1,3 @@
-import pytest
 import yaml
 from open_data_contract_standard.model import (
     DataQuality,
@@ -13,7 +12,6 @@ from datacontract.data_contract import DataContract
 from datacontract.engines.data_contract_checks import (
     QuotingConfig,
     _escape_sql_string_values,
-    _has_unsupported_databricks_type,
     check_property_enum,
     check_property_invalid_values,
     check_property_is_present,
@@ -575,65 +573,8 @@ def test_field_checks_fall_back_to_name_without_physical_name():
 
 
 # ---------------------------------------------------------------------------
-# _has_unsupported_databricks_type tests (#1245, #1219)
+# Databricks varchar/map type-check skip (#1245, #1219)
 # ---------------------------------------------------------------------------
-
-
-def _make_prop(physical_type):
-    """Helper: create a SchemaProperty with the given physicalType."""
-    return SchemaProperty(name="col", physicalType=physical_type)
-
-
-@pytest.mark.parametrize(
-    "physical_type,expected",
-    [
-        ("varchar(30)", True),
-        ("varchar", True),
-        ("VARCHAR(255)", True),
-        ("struct<name:varchar(30),age:int>", True),
-        ("array<varchar(30)>", True),
-        ("map<string,string>", True),
-        ("struct<data:map<string,int>>", True),
-        ("string", False),
-        ("int", False),
-        ("struct<age:int,name:string>", False),
-        (None, False),
-        ("", False),
-    ],
-)
-def test_has_unsupported_databricks_type(physical_type, expected):
-    prop = _make_prop(physical_type)
-    assert _has_unsupported_databricks_type(prop) == expected
-
-
-def test_to_schema_checks_databricks_varchar_skips_type_check():
-    """Databricks + varchar(n) physicalType produces only field_is_present, no field_type check."""
-    schema_object = SchemaObject(
-        name="orders",
-        properties=[SchemaProperty(name="name", physicalType="varchar(30)")],
-    )
-    server = Server(type="databricks")
-
-    checks = to_schema_checks(schema_object=schema_object, server=server)
-
-    types = [c.type for c in checks]
-    assert "field_is_present" in types
-    assert "field_type" not in types
-
-
-def test_to_schema_checks_databricks_map_in_struct_skips_type_check():
-    """Databricks + struct containing map skips the type check."""
-    schema_object = SchemaObject(
-        name="events",
-        properties=[SchemaProperty(name="metadata", physicalType="struct<data:map<string,int>>")],
-    )
-    server = Server(type="databricks")
-
-    checks = to_schema_checks(schema_object=schema_object, server=server)
-
-    types = [c.type for c in checks]
-    assert "field_is_present" in types
-    assert "field_type" not in types
 
 
 def test_to_schema_checks_non_databricks_varchar_still_produces_type_check():


### PR DESCRIPTION
## Problem

`soda-core-spark-df` ≤3.5.6 (unmaintained) cannot match certain column types correctly on Databricks with PySpark 4.0+

- **`varchar(n)`** – PySpark 4.0+ preserves `VarcharType` as a distinct type, which is not in `SCHEMA_CHECK_TYPES_MAPPING`, causing every `varchar(n)` column to fail the type check
- **`map` nested inside a struct** – `convert_to_databricks()` returns `None` for nested maps, producing an invalid expected type like `STRUCT<...,field:None>`
- **struct columns containing `varchar(n)` in nested properties** – even when the parent struct's `physicalType` string does not directly contain `varchar`, soda-core compares against the real Databricks schema which uses `varchar(n)`, causing a mismatch

## Fix

Added `_has_unsupported_databricks_type()` which checks a column's `physicalType` and recurses into nested `properties` for any occurrence of `varchar` or `map<`. When a Databricks column matches, the schema type check is skipped and a `logger.warning()` is emitted instead of generating a failing check.

This is an interim fix until the Soda v3 dependency is removed entirely.

## Testing

- Manually verified against a real Databricks table with `varchar(30)`, `map<string,string>`, `struct<...:map<...>>`, and `struct<varchar_field:varchar(100)>` columns — all previously failing type checks now emit a warning and pass
- Unit tests added for `_has_unsupported_databricks_type` (11 parametrized cases) and for `to_schema_checks` behaviour on Databricks vs non-Databricks servers

Closes #1219
Closes #1245