### PR TITLE
Fix: correct return type annotations on exporter export() methods

### DIFF
--- a/datacontract/export/avro_exporter.py
+++ b/datacontract/export/avro_exporter.py
@@ -7,7 +7,7 @@ from datacontract.export.exporter import Exporter, _check_schema_name_for_export
 
 
 class AvroExporter(Exporter):
-    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> dict:
+    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> str:
         model_name, model_value = _check_schema_name_for_export(data_contract, schema_name, self.export_format)
         return to_avro_schema_json(model_name, model_value)
 

--- a/datacontract/export/avro_idl_exporter.py
+++ b/datacontract/export/avro_idl_exporter.py
@@ -88,7 +88,7 @@ avro_primitive_physical_types = {
 
 
 class AvroIdlExporter(Exporter):
-    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> dict:
+    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> str:
         return to_avro_idl(data_contract)
 
 

--- a/datacontract/export/data_caterer_exporter.py
+++ b/datacontract/export/data_caterer_exporter.py
@@ -12,7 +12,7 @@ class DataCatererExporter(Exporter):
     Creates a YAML file, based on the data contract, for Data Caterer to generate synthetic data.
     """
 
-    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> dict:
+    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> str:
         return to_data_caterer_generate_yaml(data_contract, server)
 
 

--- a/datacontract/export/dbml_exporter.py
+++ b/datacontract/export/dbml_exporter.py
@@ -11,7 +11,7 @@ from datacontract.model.exceptions import DataContractException
 
 
 class DbmlExporter(Exporter):
-    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> dict:
+    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> str:
         found_server = _get_server_by_name(data_contract, server) if server else None
         return to_dbml_diagram(data_contract, found_server)
 

--- a/datacontract/export/dbt_exporter.py
+++ b/datacontract/export/dbt_exporter.py
@@ -21,17 +21,17 @@ def _get_description_str(description: Union[str, Description, None]) -> Optional
 
 
 class DbtModelsExporter(Exporter):
-    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> dict:
+    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> str:
         return to_dbt_models_yaml(data_contract, server)
 
 
 class DbtSourceExporter(Exporter):
-    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> dict:
+    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> str:
         return to_dbt_sources_yaml(data_contract, server)
 
 
 class DbtStageExporter(Exporter):
-    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> dict:
+    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> str:
         model_name, model_value = _check_schema_name_for_export(data_contract, schema_name, self.export_format)
         return to_dbt_staging_sql(
             data_contract,

--- a/datacontract/export/dcs_exporter.py
+++ b/datacontract/export/dcs_exporter.py
@@ -28,7 +28,7 @@ from datacontract.export.exporter import Exporter
 
 
 class DcsExporter(Exporter):
-    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> dict:
+    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> str:
         return to_dcs_yaml(data_contract)
 
 

--- a/datacontract/export/go_exporter.py
+++ b/datacontract/export/go_exporter.py
@@ -7,7 +7,7 @@ from datacontract.export.exporter import Exporter
 
 
 class GoExporter(Exporter):
-    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> dict:
+    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> str:
         return to_go_types(data_contract)
 
 

--- a/datacontract/export/html_exporter.py
+++ b/datacontract/export/html_exporter.py
@@ -12,7 +12,7 @@ from datacontract.export.mermaid_exporter import to_mermaid
 
 
 class HtmlExporter(Exporter):
-    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> dict:
+    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> str:
         return to_html(data_contract)
 
 

--- a/datacontract/export/iceberg_exporter.py
+++ b/datacontract/export/iceberg_exporter.py
@@ -19,7 +19,7 @@ class IcebergExporter(Exporter):
         server,
         sql_server_type,
         export_args,
-    ):
+    ) -> str:
         """
         Export the given data contract to an Iceberg schema.
 

--- a/datacontract/export/jsonschema_exporter.py
+++ b/datacontract/export/jsonschema_exporter.py
@@ -7,7 +7,7 @@ from datacontract.export.exporter import Exporter, _check_schema_name_for_export
 
 
 class JsonSchemaExporter(Exporter):
-    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> dict:
+    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> str:
         model_name, model_value = _check_schema_name_for_export(data_contract, schema_name, self.export_format)
         return to_jsonschema_json(model_name, model_value)
 

--- a/datacontract/export/mermaid_exporter.py
+++ b/datacontract/export/mermaid_exporter.py
@@ -4,7 +4,7 @@ from datacontract.export.exporter import Exporter
 
 
 class MermaidExporter(Exporter):
-    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> dict:
+    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> str | None:
         return to_mermaid(data_contract)
 
 

--- a/datacontract/export/odcs_v3_exporter.py
+++ b/datacontract/export/odcs_v3_exporter.py
@@ -6,7 +6,7 @@ from datacontract.export.exporter import Exporter
 
 
 class OdcsV3Exporter(Exporter):
-    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> dict:
+    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> str:
         return to_odcs_v3_yaml(data_contract)
 
 

--- a/datacontract/export/protobuf_exporter.py
+++ b/datacontract/export/protobuf_exporter.py
@@ -8,7 +8,7 @@ OBJECT_TYPES: set = {"object", "record", "struct"}
 
 
 class ProtoBufExporter(Exporter):
-    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> dict:
+    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> str:
         """Exports data contract to Protobuf format."""
         proto = to_protobuf(data_contract)
         return proto

--- a/datacontract/export/pydantic_exporter.py
+++ b/datacontract/export/pydantic_exporter.py
@@ -8,7 +8,7 @@ from datacontract.export.exporter import Exporter
 
 
 class PydanticExporter(Exporter):
-    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> dict:
+    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> str:
         return to_pydantic_model_str(data_contract)
 
 

--- a/datacontract/export/rdf_exporter.py
+++ b/datacontract/export/rdf_exporter.py
@@ -6,7 +6,7 @@ from datacontract.export.exporter import Exporter
 
 
 class RdfExporter(Exporter):
-    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> dict:
+    def export(self, data_contract, schema_name, server, sql_server_type, export_args) -> str:
         self.dict_args = export_args
         rdf_base = self.dict_args.get("rdf_base")
         return to_rdf_n3(data_contract=data_contract, base=rdf_base)

--- a/datacontract/export/sqlalchemy_exporter.py
+++ b/datacontract/export/sqlalchemy_exporter.py
@@ -10,7 +10,7 @@ from datacontract.export.exporter import Exporter, _determine_sql_server_type
 class SQLAlchemyExporter(Exporter):
     def export(
         self, data_contract: OpenDataContractStandard, schema_name, server, sql_server_type, export_args
-    ) -> dict:
+    ) -> str:
         sql_server_type = _determine_sql_server_type(data_contract, sql_server_type, server)
         return to_sqlalchemy_model_str(data_contract, sql_server_type, server)
 

--- a/datacontract/export/sqlalchemy_exporter.py
+++ b/datacontract/export/sqlalchemy_exporter.py
@@ -8,9 +8,7 @@ from datacontract.export.exporter import Exporter, _determine_sql_server_type
 
 
 class SQLAlchemyExporter(Exporter):
-    def export(
-        self, data_contract: OpenDataContractStandard, schema_name, server, sql_server_type, export_args
-    ) -> str:
+    def export(self, data_contract: OpenDataContractStandard, schema_name, server, sql_server_type, export_args) -> str:
         sql_server_type = _determine_sql_server_type(data_contract, sql_server_type, server)
         return to_sqlalchemy_model_str(data_contract, sql_server_type, server)
 


### PR DESCRIPTION
As flagged in #1240 and confirmed by @jschoedl, several exporters were annotated as `dict` but actually return `str`. This PR fixes all of them.

This was identified during review of PR #1240

- [ ] Tests pass (`uv run pytest`)
- [ ] Code formatted (`uv run ruff check --fix && uv run ruff format`)
- [ ] README.md updated (if relevant)
- [ ] CHANGELOG.md entry added
