### PR TITLE
feat: resolve authoritativeDefinitions[type=semantics] (REST URL or IRI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Resolve `authoritativeDefinitions[type=definition]` on schema properties: the referenced ODCS property is fetched from the configured entropy-data host (`ENTROPY_DATA_HOST`) and inlined into the property, filling fields the contract author left unset. The configured `x-api-key` is sent only when the resolved URL's host matches `ENTROPY_DATA_HOST` so a third-party `url:` cannot receive the user's key.
-- **Breaking:** Per default, any resolution failure of `authoritativeDefinitions[type=definition]` rejects the contract on `lint`, `test`, `ci`, `export`, and `changelog`.
+- Resolve `authoritativeDefinitions[type=semantics]` (and the legacy `type=semantic`) the same way. A `url:` that points at the configured entropy-data host is fetched directly; a `url:` that's an IRI (host doesn't match) is routed through `GET /api/semantics?iri=...` on the configured host, which uses the API key's organization to resolve. Precedence: a property with both a semantics and a definition reference resolves through the semantic one.
+- **Breaking:** Per default, any resolution failure of `authoritativeDefinitions[type in {definition, semantics}]` rejects the contract on `lint`, `test`, `ci`, `export`, and `changelog`.
 - `--no-inline-references` flag to skip the HTTP fetch above and leave each property as written. Useful for offline runs (e.g. CI without `ENTROPY_DATA_API_KEY`) and pure round-trip exports (e.g. `export excel`).
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -333,10 +333,11 @@ Commands
 │                                                                the first one.                    │
 │ --inline-references    --no-inline-references                  Resolve external references       │
 │                                                                (currently:                       │
-│                                                                authoritativeDefinitions[type=de… │
-│                                                                in the contract and inline the    │
-│                                                                fetched content from the          │
-│                                                                configured entropy-data host.     │
+│                                                                authoritativeDefinitions[type in  │
+│                                                                {definition, semantics}]) in the  │
+│                                                                contract and inline the fetched   │
+│                                                                content from the configured       │
+│                                                                entropy-data host.                │
 │                                                                [default: inline-references]      │
 │ --debug                --no-debug                              Enable debug logging              │
 │ --help                                                         Show this message and exit.       │
@@ -362,9 +363,10 @@ Commands
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --inline-references    --no-inline-references      Resolve external references (currently:       │
-│                                                    authoritativeDefinitions[type=definition]) in │
-│                                                    the contract and inline the fetched content   │
-│                                                    from the configured entropy-data host.        │
+│                                                    authoritativeDefinitions[type in {definition, │
+│                                                    semantics}]) in the contract and inline the   │
+│                                                    fetched content from the configured           │
+│                                                    entropy-data host.                            │
 │                                                    [default: inline-references]                  │
 │ --debug                --no-debug                  Enable debug logging                          │
 │ --help                                             Show this message and exit.                   │
@@ -434,9 +436,11 @@ $ datacontract changelog v1.odcs.yaml v2.odcs.yaml
 │ --inline-references       --no-inline-references                     Resolve external references │
 │                                                                      (currently:                 │
 │                                                                      authoritativeDefinitions[t… │
-│                                                                      in the contract and inline  │
-│                                                                      the fetched content from    │
-│                                                                      the configured entropy-data │
+│                                                                      in {definition,             │
+│                                                                      semantics}]) in the         │
+│                                                                      contract and inline the     │
+│                                                                      fetched content from the    │
+│                                                                      configured entropy-data     │
 │                                                                      host.                       │
 │                                                                      [default:                   │
 │                                                                      inline-references]          │
@@ -1329,9 +1333,10 @@ $ datacontract dbt sync orders.odcs.yaml --publish https://api.entropy-data.com/
 │ --inline-references    --no-inline-references                           Resolve external         │
 │                                                                         references (currently:   │
 │                                                                         authoritativeDefinition… │
-│                                                                         in the contract and      │
-│                                                                         inline the fetched       │
-│                                                                         content from the         │
+│                                                                         in {definition,          │
+│                                                                         semantics}]) in the      │
+│                                                                         contract and inline the  │
+│                                                                         fetched content from the │
 │                                                                         configured entropy-data  │
 │                                                                         host.                    │
 │                                                                         [default:                │

--- a/datacontract/command_changelog.py
+++ b/datacontract/command_changelog.py
@@ -16,7 +16,7 @@ def changelog(
     inline_references: Annotated[
         bool,
         typer.Option(
-            help="Resolve external references (currently: authoritativeDefinitions\\[type=definition]) in the "
+            help="Resolve external references (currently: authoritativeDefinitions\\[type in {definition, semantics}]) in the "
             "contract and inline the fetched content from the configured entropy-data host."
         ),
     ] = True,

--- a/datacontract/command_ci.py
+++ b/datacontract/command_ci.py
@@ -62,7 +62,7 @@ def ci(
     inline_references: Annotated[
         bool,
         typer.Option(
-            help="Resolve external references (currently: authoritativeDefinitions\\[type=definition]) in the "
+            help="Resolve external references (currently: authoritativeDefinitions\\[type in {definition, semantics}]) in the "
             "contract and inline the fetched content from the configured entropy-data host."
         ),
     ] = True,

--- a/datacontract/command_export.py
+++ b/datacontract/command_export.py
@@ -42,7 +42,7 @@ dialect_option = Annotated[
 inline_references_option = Annotated[
     bool,
     typer.Option(
-        help="Resolve external references (currently: authoritativeDefinitions\\[type=definition]) in the "
+        help="Resolve external references (currently: authoritativeDefinitions\\[type in {definition, semantics}]) in the "
         "contract and inline the fetched content from the configured entropy-data host."
     ),
 ]

--- a/datacontract/command_lint.py
+++ b/datacontract/command_lint.py
@@ -39,7 +39,7 @@ def lint(
     inline_references: Annotated[
         bool,
         typer.Option(
-            help="Resolve external references (currently: authoritativeDefinitions\\[type=definition]) in the "
+            help="Resolve external references (currently: authoritativeDefinitions\\[type in {definition, semantics}]) in the "
             "contract and inline the fetched content from the configured entropy-data host."
         ),
     ] = True,

--- a/datacontract/command_test.py
+++ b/datacontract/command_test.py
@@ -70,7 +70,7 @@ def test(
     inline_references: Annotated[
         bool,
         typer.Option(
-            help="Resolve external references (currently: authoritativeDefinitions\\[type=definition]) in the "
+            help="Resolve external references (currently: authoritativeDefinitions\\[type in {definition, semantics}]) in the "
             "contract and inline the fetched content from the configured entropy-data host."
         ),
     ] = True,

--- a/datacontract/lint/resolve.py
+++ b/datacontract/lint/resolve.py
@@ -1,7 +1,7 @@
 import importlib.resources as resources
 import logging
 from pathlib import Path
-from urllib.parse import urljoin, urlparse
+from urllib.parse import quote, urljoin, urlparse
 
 import fastjsonschema
 import requests
@@ -86,7 +86,11 @@ def resolve_data_contract_from_location(
     return _resolve_data_contract_from_str(data_contract_str, schema_location, inline_references, all_errors)
 
 
-DEFINITION_AUTHORITATIVE_TYPE = "definition"
+# Precedence-ordered: a property with both semantics and definition references
+# resolves through semantics (matches the editor's useInheritedDefinition).
+# "semantic" (singular) is accepted for back-compat with contracts written
+# before the entropy-data type migration.
+_RESOLVABLE_AUTHORITATIVE_TYPES = ("semantics", "semantic", "definition")
 
 # `name` and `id` are the property's own; `authoritativeDefinitions` is the link itself;
 # `properties`/`items` are the contract author's structure.
@@ -103,7 +107,8 @@ def clear_definition_cache() -> None:
 
 
 def inline_definitions_into_data_contract(data_contract: OpenDataContractStandard):
-    """Resolve `authoritativeDefinitions[type=definition]` on every property.
+    """Resolve `authoritativeDefinitions[type in {semantics, definition}]` on
+    every property.
 
     In-memory only. Inline values always win. Resolution failures raise
     `DataContractException` -- a broken reference rejects the contract.
@@ -125,44 +130,41 @@ def inline_definition_into_property(prop: SchemaProperty):
         for nested_prop in prop.properties:
             inline_definition_into_property(nested_prop)
 
-    url = _definition_reference_url(prop)
-    if url is None:
+    resolved = _resolvable_reference(prop)
+    if resolved is None:
         return
 
-    definition = _resolve_definition(url)
+    type_, url = resolved
+    definition = _resolve_definition(url, type_)
     _apply_definition_to_property(prop, definition)
 
 
-def _definition_reference_url(prop: SchemaProperty) -> str | None:
-    """URL of the property's first `authoritativeDefinitions[type=definition]`, or None."""
-    for authoritative_definition in prop.authoritativeDefinitions or []:
-        if authoritative_definition.type == DEFINITION_AUTHORITATIVE_TYPE and authoritative_definition.url:
-            return authoritative_definition.url
+def _resolvable_reference(prop: SchemaProperty) -> tuple[str, str] | None:
+    """`(type, url)` of the highest-precedence resolvable authoritativeDefinition
+    on `prop`, or None. Precedence: semantics > semantic > definition."""
+    for wanted_type in _RESOLVABLE_AUTHORITATIVE_TYPES:
+        for ad in prop.authoritativeDefinitions or []:
+            if ad.type == wanted_type and ad.url:
+                return wanted_type, ad.url
     return None
 
 
-def _resolve_definition(url: str) -> SchemaProperty:
-    """Fetch and parse the definition at `url`.
+def _resolve_definition(url: str, type_: str) -> SchemaProperty:
+    """Fetch and parse the definition or semantic concept at `url`.
 
-    The configured `x-api-key` is sent only when the resolved URL's host
-    matches the configured host -- a third-party `url:` never leaks the
-    key. Cached per URL after a successful fetch; failures aren't cached.
+    `type_` controls how an absolute URL on a different host is handled:
+    a `semantics`/`semantic` URL whose host differs from the configured
+    entropy-data host is treated as an IRI and routed through
+    `/api/semantics?iri=...`; a `definition` URL is fetched directly
+    (anonymously, so the API key never leaks). The `x-api-key` is only
+    ever sent to the configured host.
+
+    Cached per URL after a successful fetch; failures aren't cached.
     """
-    from datacontract.integration.entropy_data import _get_api_key_or_none, _get_host
-
     if url in _definition_cache:
         return _definition_cache[url]
 
-    configured_host = _get_host()
-    # urljoin keeps absolute URLs as-is and joins leading-slash paths onto
-    # the host -- covers both shapes ODCS allows for `url`.
-    target_url = urljoin(configured_host, url)
-
-    headers = {"Accept": "application/vnd.entropydata.odcs+json"}
-    if _hosts_match(target_url, configured_host):
-        api_key = _get_api_key_or_none()
-        if api_key is not None:
-            headers["x-api-key"] = api_key
+    target_url, headers = _build_request(url, type_)
 
     try:
         response = requests.get(target_url, headers=headers, timeout=10)
@@ -181,6 +183,52 @@ def _resolve_definition(url: str) -> SchemaProperty:
 
     _definition_cache[url] = definition
     return definition
+
+
+def _build_request(url: str, type_: str) -> tuple[str, dict[str, str]]:
+    """Return the URL to fetch and the headers to use for a given reference.
+
+    Three cases:
+      - URL on the configured host (relative path or matching absolute URL):
+        fetched directly, x-api-key sent when configured.
+      - Off-host `definition` URL: fetched directly and anonymously -- a
+        contract may legitimately reference a third-party REST URL, and the
+        API key must never leak across hosts.
+      - Off-host `semantics`/`semantic` URL: treated as an IRI and routed
+        through `/api/semantics?iri=...` on the configured host. Requires an
+        API key (that endpoint is API-key only).
+    """
+    from datacontract.integration.entropy_data import _get_api_key_or_none, _get_host
+
+    configured_host = _get_host()
+    # urljoin keeps absolute URLs as-is and joins leading-slash paths onto
+    # the host -- covers both shapes ODCS allows for `url`.
+    direct_url = urljoin(configured_host, url)
+    headers = {"Accept": "application/vnd.entropydata.odcs+json"}
+
+    if _hosts_match(direct_url, configured_host):
+        api_key = _get_api_key_or_none()
+        if api_key is not None:
+            headers["x-api-key"] = api_key
+        return direct_url, headers
+
+    if type_ == "definition":
+        # Third-party REST URL: fetch anonymously, no IRI fallback.
+        return direct_url, headers
+
+    # Off-host semantics reference: IRI lookup against the configured host.
+    api_key = _get_api_key_or_none()
+    if api_key is None:
+        raise _definition_resolution_error(
+            url,
+            f"{configured_host.rstrip('/')}/api/semantics",
+            "the reference looks like an IRI (host does not match the configured "
+            "entropy-data host); resolving an IRI goes through /api/semantics which "
+            "requires an API key (set ENTROPY_DATA_API_KEY)",
+        )
+    headers["x-api-key"] = api_key
+    lookup_url = f"{configured_host.rstrip('/')}/api/semantics?iri={quote(url, safe='')}"
+    return lookup_url, headers
 
 
 def _apply_definition_to_property(prop: SchemaProperty, definition: SchemaProperty):

--- a/tests/test_resolve_definitions.py
+++ b/tests/test_resolve_definitions.py
@@ -382,6 +382,121 @@ def test_malformed_body_raises(env):
     assert "/bad" in str(exc.value)
 
 
+# --- Semantics ------------------------------------------------------------
+#
+# `authoritativeDefinitions[type=semantics].url` resolves via the same path
+# as `type=definition` when the URL points at the configured entropy-data
+# host (REST URL). When the URL's host differs, it's treated as an IRI and
+# routed through `/api/semantics?iri=...` instead.
+
+
+def _semantics_prop(url: str, type_: str = "semantics", **inline) -> SchemaProperty:
+    return SchemaProperty(
+        name=inline.pop("name", "brand"),
+        authoritativeDefinitions=[AuthoritativeDefinition(type=type_, url=url)],
+        **inline,
+    )
+
+
+@responses.activate
+def test_semantics_rest_url_resolves_against_configured_host(env):
+    responses.add(
+        responses.GET,
+        f"{_HOST}/demo/semantics/main/product.brand",
+        body=_definition_body(logicalType="string", businessName="brand"),
+        status=200,
+    )
+
+    prop = _semantics_prop("/demo/semantics/main/product.brand")
+    inline_definitions_into_data_contract(_contract(prop))
+
+    assert prop.logicalType == "string"
+    assert prop.businessName == "brand"
+    assert responses.calls[0].request.headers["x-api-key"] == _API_KEY
+
+
+@responses.activate
+def test_semantics_iri_routes_through_api_semantics_lookup(env):
+    """An IRI is not directly fetchable; the resolver translates it to the
+    `/api/semantics?iri=...` lookup endpoint on the configured host."""
+    iri = "http://www.entropy-data.com/ns/main/Article"
+    responses.add(
+        responses.GET,
+        f"{_HOST}/api/semantics",
+        body=_definition_body(logicalType="string", businessName="Article"),
+        status=200,
+    )
+
+    prop = _semantics_prop(iri)
+    inline_definitions_into_data_contract(_contract(prop))
+
+    assert prop.logicalType == "string"
+    assert prop.businessName == "Article"
+    # The request must hit the configured host's lookup endpoint, NOT the
+    # IRI's host -- the latter doesn't serve this content.
+    call = responses.calls[0]
+    assert call.request.url.startswith(f"{_HOST}/api/semantics")
+    assert "iri=http" in call.request.url
+    assert call.request.headers["x-api-key"] == _API_KEY
+
+
+@responses.activate
+def test_semantics_iri_without_api_key_raises(env, monkeypatch):
+    """Resolving an IRI requires an API key; the lookup endpoint is API-key only."""
+    monkeypatch.delenv("ENTROPY_DATA_API_KEY", raising=False)
+    iri = "http://www.entropy-data.com/ns/main/Article"
+
+    prop = _semantics_prop(iri)
+    with pytest.raises(DataContractException) as exc:
+        inline_definitions_into_data_contract(_contract(prop))
+    assert "API key" in str(exc.value)
+    assert len(responses.calls) == 0
+
+
+@responses.activate
+def test_semantics_legacy_singular_type_is_resolved(env):
+    """Contracts written before the entropy-data type migration from
+    `"semantic"` to `"semantics"` still resolve."""
+    responses.add(
+        responses.GET,
+        f"{_HOST}/demo/semantics/main/x",
+        body=_definition_body(logicalType="string"),
+        status=200,
+    )
+
+    prop = _semantics_prop("/demo/semantics/main/x", type_="semantic")
+    inline_definitions_into_data_contract(_contract(prop))
+
+    assert prop.logicalType == "string"
+
+
+@responses.activate
+def test_semantics_wins_over_definition_when_both_present(env):
+    """Matches the editor's `useInheritedDefinition` convention: a property
+    that links to both a semantic concept and a definition resolves through
+    the semantic concept; only that one is fetched."""
+    responses.add(
+        responses.GET,
+        f"{_HOST}/sem",
+        body=_definition_body(logicalType="string", businessName="from-semantics"),
+        status=200,
+    )
+    # Definition URL not registered -- if the resolver picks it, the test
+    # fails with ConnectionError.
+
+    prop = SchemaProperty(
+        name="brand",
+        authoritativeDefinitions=[
+            AuthoritativeDefinition(type="definition", url="/def"),
+            AuthoritativeDefinition(type="semantics", url="/sem"),
+        ],
+    )
+    inline_definitions_into_data_contract(_contract(prop))
+
+    assert prop.businessName == "from-semantics"
+    assert len(responses.calls) == 1
+
+
 # --- CLI integration: --no-inline-references -----------------------------
 
 


### PR DESCRIPTION
## Summary

Stacked on #1261. Broadens the resolver from `"definition"` only to a precedence-ordered list (`"semantics"`, `"semantic"`, `"definition"`), and routes IRI-shaped semantic URLs through a new entropy-data endpoint instead of trying to GET them directly.

### Routing rules

| `url:` host | `type` | What happens |
|---|---|---|
| Matches configured entropy-data host (relative or absolute) | any | Fetched directly; `x-api-key` sent when configured |
| Off-host | `definition` | Fetched directly and anonymously — a contract may legitimately reference a third-party REST URL, and the API key must never leak across hosts (existing behaviour, unchanged) |
| Off-host | `semantics` / `semantic` | Treated as an IRI; routed through `GET /api/semantics?iri=...` on the configured entropy-data host (new endpoint in the entropy-data PR). Requires an API key — that endpoint is API-key only |

### Precedence

A property that links to both a semantics and a definition reference resolves through the **semantic** one — matches `useInheritedDefinition` in `datacontract-editor`. Legacy singular `"semantic"` is also accepted for contracts written before the entropy-data type migration.

### Tests

Five new tests in `test_resolve_definitions.py` (17 → 22): REST URL with api-key, IRI routed through `/api/semantics`, IRI without api-key raises with clear guidance, legacy `"semantic"` type resolves, semantics-wins-over-definition.

Verified end-to-end against a local entropy-data instance: contract with one REST-URL semantic and one IRI semantic — both resolve and inline correctly, no spurious requests to the IRI's host.