### PR TITLE
fix: surface WARNING/ERROR logs by default instead of suppressing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Schema type check no longer fails for `varchar(n)` columns on Databricks with PySpark 4.0+, and for `map` and `varchar` types nested inside `struct` columns; affected columns emit a warning and skip the type check instead
-- `WARNING`/`ERROR` log messages are now shown by default (on stderr) for `import`, `export`, `changelog`, `catalog`, `dbt`, and `publish`. Previously a `NullHandler` on the root logger suppressed all logging unless `--debug` was set, hiding diagnostics such as the `import sql` placeholder-connection warning. `test`/`ci`/`lint` keep stderr quiet since they already render these messages to the console.
+- `WARNING`/`ERROR` log messages are no longer hidden by default for `import`, `export`, `changelog`, `catalog`, `dbt`, and `publish`.
 
 ## [0.12.4] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Schema type check no longer fails for `varchar(n)` columns on Databricks with PySpark 4.0+, and for `map` and `varchar` types nested inside `struct` columns; affected columns emit a warning and skip the type check instead
+- `WARNING`/`ERROR` log messages are now shown by default (on stderr) for `import`, `export`, `changelog`, `catalog`, `dbt`, and `publish`. Previously a `NullHandler` on the root logger suppressed all logging unless `--debug` was set, hiding diagnostics such as the `import sql` placeholder-connection warning. `test`/`ci`/`lint` keep stderr quiet since they already render these messages to the console.
 
 ## [0.12.4] - 2026-05-21
 

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -122,15 +122,24 @@ def common(
     pass
 
 
-def enable_debug_logging(debug: bool):
-    root = logging.getLogger()
-    if debug:
-        logging.basicConfig(
-            level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", stream=sys.stderr
-        )
-    elif not root.handlers:
-        # Without a handler, Python's lastResort emits WARNING/ERROR messages
-        root.addHandler(logging.NullHandler())
+def enable_debug_logging(debug: bool, otherwise_disable_stderr: bool = False):
+    if not debug and otherwise_disable_stderr:
+        # some commands render run.logs to the console themselves; a NullHandler keeps
+        # the mirrored stdlib WARNING/ERROR (Run.log_*) off stderr so it isn't shown twice.
+        logging.basicConfig(handlers=[logging.NullHandler()], force=True)
+        return
+
+    logging.basicConfig(
+        level=logging.DEBUG if debug else logging.WARNING,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        stream=sys.stderr,
+        force=True,
+    )
+
+    if not debug:
+        # Keep noisy third-party loggers quiet
+        for noisy_logger in ("snowflake.connector", "py4j", "pyspark", "urllib3", "soda"):
+            logging.getLogger(noisy_logger).setLevel(logging.ERROR)
 
 
 def validate_publish_url(publish: str | None) -> None:

--- a/datacontract/command_ci.py
+++ b/datacontract/command_ci.py
@@ -71,7 +71,7 @@ def ci(
     """
     Run tests for CI/CD pipelines. Emits GitHub Actions annotations and step summary.
     """
-    enable_debug_logging(debug)
+    enable_debug_logging(debug, otherwise_disable_stderr=True)
     validate_publish_url(publish)
 
     if not locations:

--- a/datacontract/command_lint.py
+++ b/datacontract/command_lint.py
@@ -48,7 +48,7 @@ def lint(
     """
     Validate that the datacontract.yaml is correctly formatted.
     """
-    enable_debug_logging(debug)
+    enable_debug_logging(debug, otherwise_disable_stderr=True)
 
     run = DataContract(
         data_contract_file=location,

--- a/datacontract/command_test.py
+++ b/datacontract/command_test.py
@@ -79,7 +79,7 @@ def test(
     """
     Run schema and quality tests on configured servers.
     """
-    enable_debug_logging(debug)
+    enable_debug_logging(debug, otherwise_disable_stderr=True)
     validate_publish_url(publish)
 
     check_categories = None


### PR DESCRIPTION
## Problem

Every CLI command calls `enable_debug_logging(debug)` as its first action. When `--debug` is off, that function added a `logging.NullHandler` to the root logger, which disables Python's `lastResort` handler — so **all `logging.warning`/`logging.error` calls in the codebase were silent by default**.

The primary output of each command was unaffected (it goes through the rich `console` on stdout), but the `logging`-channel diagnostics were lost, e.g.:

```sh
datacontract import sql --source t.sql --dialect postgres            # no warning shown
datacontract import sql --source t.sql --dialect postgres --debug    # warning appears on stderr
```

The `sql_importer` "placeholder connection values" warning (and `resolve.py` / `excel_importer` / `spark_importer` warnings) only appeared with `--debug`.

## Fix

`enable_debug_logging` now defaults the root level to `WARNING` on **stderr** (so stdout stays clean for piped `import`/`export` YAML), and raises it to `DEBUG` with `--debug`. Noisy third-party loggers (`snowflake.connector`, `py4j`, `pyspark`, `urllib3`, `soda`) are pinned to `ERROR` to preserve the original intent of the `NullHandler` (muting library chatter) without blanket-suppressing everything.

### Why `test`/`ci`/`lint` are gated

`Run.log_info/warn/error` deliberately emit to **two** sinks: the structured `run.logs` record (rendered to the console, exported to JUnit, published) **and** stdlib `logging` (the live stream, and the only output for library callers of `DataContract(...).test()`). For `test`/`ci`/`lint`, which render `run.logs` to the console themselves, un-suppressing stderr would print the same WARNING/ERROR **twice**. Those three commands therefore pass `otherwise_disable_stderr=True` to keep the old `NullHandler` behavior. Commands that don't render `run.logs` (`import`, `export`, `changelog`, `catalog`, `dbt`, `publish`) get the WARNING-on-stderr default — a clean win with no duplication.

## Verification

Ran every command before/after, capturing stdout and stderr separately:

- `import sql`: warning now on **stderr**; piped stdout YAML stays clean (warning not in the file).
- `lint`/`test`/`ci`: failure/warnings shown **once** (on stdout, as before) — no doubling on stderr.
- `--debug`: WARNING/ERROR/DEBUG still on stderr for all commands.
- Test suite: `743 passed, 13 skipped` (the only errors are Docker-unavailable integration tests, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)