### PR TITLE
fix: bundle DuckDB cloud extensions to support air-gapped tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Schema type check no longer fails for `varchar(n)` columns on Databricks with PySpark 4.0+, and for `map` and `varchar` types nested inside `struct` columns; affected columns emit a warning and skip the type check instead
 - `WARNING`/`ERROR` log messages are no longer hidden by default for `import`, `export`, `changelog`, `catalog`, `dbt`, and `publish`.
+- `datacontract test` against S3, GCS, and Azure no longer fails with `Failed to download extension` in air-gapped containers. The required DuckDB extensions are now bundled via the `s3`/`gcs`/`azure` install extras (#1191)
 
 ## [0.12.4] - 2026-05-21
 

--- a/README.md
+++ b/README.md
@@ -239,31 +239,33 @@ uv tool install --python python3.11 --upgrade 'datacontract-cli[all]'
 
 A list of available extras:
 
-| Dependency              | Installation Command                       |
-|-------------------------|--------------------------------------------|
-| Amazon Athena           | `pip install datacontract-cli[athena]`     |
-| Avro Support            | `pip install datacontract-cli[avro]`       |
-| Google BigQuery         | `pip install datacontract-cli[bigquery]`   |
-| CSV                     | `pip install datacontract-cli[csv]`        |
-| Databricks Integration  | `pip install datacontract-cli[databricks]` |
-| DBML                    | `pip install datacontract-cli[dbml]`       |
-| DuckDB (local/S3/GCS/Azure file testing) | `pip install datacontract-cli[duckdb]` |
-| Excel                   | `pip install datacontract-cli[excel]`      |
-| Iceberg                 | `pip install datacontract-cli[iceberg]`    |
-| Impala                  | `pip install datacontract-cli[impala]`     |
-| Kafka Integration       | `pip install datacontract-cli[kafka]`      |
-| MySQL Integration       | `pip install datacontract-cli[mysql]`      |
-| Oracle                  | `pip install datacontract-cli[oracle]`     |
-| Parquet                 | `pip install datacontract-cli[parquet]`    |
-| PostgreSQL Integration  | `pip install datacontract-cli[postgres]`   |
-| protobuf                | `pip install datacontract-cli[protobuf]`   |
-| RDF                     | `pip install datacontract-cli[rdf]`        |
-| Amazon Redshift         | `pip install datacontract-cli[redshift]`   |
-| S3 Integration          | `pip install datacontract-cli[s3]`         |
-| Snowflake Integration   | `pip install datacontract-cli[snowflake]`  |
-| Microsoft SQL Server    | `pip install datacontract-cli[sqlserver]`  |
-| Trino                   | `pip install datacontract-cli[trino]`      |
-| API (run as web server) | `pip install datacontract-cli[api]`        |
+| Dependency                               | Installation Command                       |
+|------------------------------------------|--------------------------------------------|
+| Amazon Athena                            | `pip install datacontract-cli[athena]`     |
+| Avro Support                             | `pip install datacontract-cli[avro]`       |
+| Azure Integration                        | `pip install datacontract-cli[azure]`      |
+| Google BigQuery                          | `pip install datacontract-cli[bigquery]`   |
+| CSV                                      | `pip install datacontract-cli[csv]`        |
+| Databricks Integration                   | `pip install datacontract-cli[databricks]` |
+| DBML                                     | `pip install datacontract-cli[dbml]`       |
+| DuckDB (local/S3/GCS/Azure file testing) | `pip install datacontract-cli[duckdb]`     |
+| Excel                                    | `pip install datacontract-cli[excel]`      |
+| GCS Integration                          | `pip install datacontract-cli[gcs]`        |
+| Iceberg                                  | `pip install datacontract-cli[iceberg]`    |
+| Impala                                   | `pip install datacontract-cli[impala]`     |
+| Kafka Integration                        | `pip install datacontract-cli[kafka]`      |
+| MySQL Integration                        | `pip install datacontract-cli[mysql]`      |
+| Oracle                                   | `pip install datacontract-cli[oracle]`     |
+| Parquet                                  | `pip install datacontract-cli[parquet]`    |
+| PostgreSQL Integration                   | `pip install datacontract-cli[postgres]`   |
+| protobuf                                 | `pip install datacontract-cli[protobuf]`   |
+| RDF                                      | `pip install datacontract-cli[rdf]`        |
+| Amazon Redshift                          | `pip install datacontract-cli[redshift]`   |
+| S3 Integration                           | `pip install datacontract-cli[s3]`         |
+| Snowflake Integration                    | `pip install datacontract-cli[snowflake]`  |
+| Microsoft SQL Server                     | `pip install datacontract-cli[sqlserver]`  |
+| Trino                                    | `pip install datacontract-cli[trino]`      |
+| API (run as web server)                  | `pip install datacontract-cli[api]`        |
 
 
 ## Documentation

--- a/datacontract/engines/soda/check_soda_execute.py
+++ b/datacontract/engines/soda/check_soda_execute.py
@@ -35,10 +35,22 @@ def check_soda_execute(
     schema_name: str = "all",
     check_categories: set[str] | None = None,
 ):
-    from soda.common.config_helper import ConfigHelper
+    try:
+        from soda.common.config_helper import ConfigHelper
 
-    ConfigHelper.get_instance().upsert_value("send_anonymous_usage_stats", False)
-    from soda.scan import Scan
+        ConfigHelper.get_instance().upsert_value("send_anonymous_usage_stats", False)
+        from soda.scan import Scan
+    except ImportError as e:
+        if server.type == "s3":
+            extra = "s3,duckdb"
+        elif server.type == "local":
+            extra = "duckdb"
+        else:
+            extra = server.type
+        raise ImportError(
+            f"soda-core is required to test '{server.type}' servers. "
+            f"Install with: pip install 'datacontract-cli[{extra}]'"
+        ) from e
 
     if data_contract is None:
         run.log_warn("Cannot run engine soda-core, as data contract is invalid")

--- a/datacontract/engines/soda/check_soda_execute.py
+++ b/datacontract/engines/soda/check_soda_execute.py
@@ -41,6 +41,7 @@ def check_soda_execute(
         ConfigHelper.get_instance().upsert_value("send_anonymous_usage_stats", False)
         from soda.scan import Scan
     except ImportError as e:
+        # soda-core is not installed
         if server.type == "s3":
             extra = "s3,duckdb"
         elif server.type == "local":
@@ -48,7 +49,7 @@ def check_soda_execute(
         else:
             extra = server.type
         raise ImportError(
-            f"soda-core is required to test '{server.type}' servers. "
+            f"soda-core is required to test '{server.type}' servers.\n"
             f"Install with: pip install 'datacontract-cli[{extra}]'"
         ) from e
 

--- a/datacontract/engines/soda/connections/duckdb_connection.py
+++ b/datacontract/engines/soda/connections/duckdb_connection.py
@@ -188,7 +188,45 @@ def add_nested_views(con: "duckdb.DuckDBPyConnection", model_name: str, properti
             add_nested_views(con, nested_model_name, prop.properties)
 
 
+def _load_extension(con, name: str, extra: str) -> None:
+    import gzip
+    import importlib.resources
+    import pathlib
+    import shutil
+
+    # first try to use locally bundled wheel to support air-gapped environments
+    try:
+        ext_module = importlib.import_module(f"duckdb_extension_{name}")
+        if ext_module is not None:
+            module_path = pathlib.Path(str(importlib.resources.files(ext_module)))
+            duckdb_version = con.sql("PRAGMA version;").fetchone()[0]
+            extension_dir = module_path / "extensions" / duckdb_version
+            extension_file_gz = extension_dir / f"{name}.duckdb_extension.gz"
+            extension_file = extension_dir / f"{name}.duckdb_extension"
+
+            if not extension_file.exists() and extension_file_gz.exists():
+                with gzip.open(extension_file_gz, "rb") as src, open(extension_file, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+
+            if extension_file.exists():
+                con.sql(f"LOAD '{extension_file}'")
+                return
+    except ImportError:
+        ext_module = None
+
+    try:
+        con.install_extension(name)
+        con.load_extension(name)
+    except Exception as e:
+        raise RuntimeError(
+            f"Failed to install the '{name}' DuckDB extension. "
+            f"Please install the extension wheel via: pip install 'datacontract-cli[{extra}]'"
+        ) from e
+
+
 def setup_s3_connection(con, server: Server):
+    _load_extension(con, "httpfs", "s3")
+    _load_extension(con, "aws", "s3")
     s3_region = os.getenv("DATACONTRACT_S3_REGION")
     s3_access_key_id = os.getenv("DATACONTRACT_S3_ACCESS_KEY_ID")
     s3_secret_access_key = os.getenv("DATACONTRACT_S3_SECRET_ACCESS_KEY")
@@ -233,6 +271,7 @@ def setup_s3_connection(con, server: Server):
 
 
 def setup_gcs_connection(con, server: Server):
+    _load_extension(con, "httpfs", "gcs")
     key_id = require_env("DATACONTRACT_GCS_KEY_ID", server_type="gcs")
     secret = require_env("DATACONTRACT_GCS_SECRET", server_type="gcs")
 
@@ -253,8 +292,7 @@ def setup_azure_connection(con, server: Server):
         to_azure_storage_account(server.location) if server.type == "azure" and "://" in server.location else None
     )
 
-    con.install_extension("azure")
-    con.load_extension("azure")
+    _load_extension(con, "azure", "azure")
 
     if storage_account is not None:
         con.sql(f"""

--- a/datacontract/engines/soda/connections/duckdb_connection.py
+++ b/datacontract/engines/soda/connections/duckdb_connection.py
@@ -193,26 +193,28 @@ def _load_extension(con, name: str, extra: str) -> None:
     import importlib.resources
     import pathlib
     import shutil
+    import tempfile
 
-    # first try to use locally bundled wheel to support air-gapped environments
+    # first try to use locally bundled wheel to support air-gapped environments.
+    # Decompress to a tempfile rather than the wheel dir, which may be read-only
+    # (system installs, read-only Docker layers).
     try:
         ext_module = importlib.import_module(f"duckdb_extension_{name}")
-        if ext_module is not None:
-            module_path = pathlib.Path(str(importlib.resources.files(ext_module)))
-            duckdb_version = con.sql("PRAGMA version;").fetchone()[0]
-            extension_dir = module_path / "extensions" / duckdb_version
-            extension_file_gz = extension_dir / f"{name}.duckdb_extension.gz"
-            extension_file = extension_dir / f"{name}.duckdb_extension"
+        module_path = pathlib.Path(str(importlib.resources.files(ext_module)))
+        duckdb_version = con.sql("PRAGMA version;").fetchone()[0]
+        extension_file_gz = module_path / "extensions" / duckdb_version / f"{name}.duckdb_extension.gz"
 
-            if not extension_file.exists() and extension_file_gz.exists():
-                with gzip.open(extension_file_gz, "rb") as src, open(extension_file, "wb") as dst:
-                    shutil.copyfileobj(src, dst)
-
-            if extension_file.exists():
-                con.sql(f"LOAD '{extension_file}'")
-                return
+        if extension_file_gz.exists():
+            # DuckDB derives the extension's init-symbol name from the file basename,
+            # so the file must be named "{name}.duckdb_extension" — not a random tempname.
+            tmpdir = pathlib.Path(tempfile.mkdtemp(prefix=f"datacontract-{name}-"))
+            extension_file = tmpdir / f"{name}.duckdb_extension"
+            with gzip.open(extension_file_gz, "rb") as src, open(extension_file, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+            con.sql(f"LOAD '{extension_file}'")
+            return
     except ImportError:
-        ext_module = None
+        pass
 
     try:
         con.install_extension(name)

--- a/datacontract/engines/soda/connections/duckdb_connection.py
+++ b/datacontract/engines/soda/connections/duckdb_connection.py
@@ -195,9 +195,7 @@ def _load_extension(con, name: str, extra: str) -> None:
     import shutil
     import tempfile
 
-    # first try to use locally bundled wheel to support air-gapped environments.
-    # Decompress to a tempfile rather than the wheel dir, which may be read-only
-    # (system installs, read-only Docker layers).
+    # first try to use locally bundled wheel to support air-gapped environments
     try:
         ext_module = importlib.import_module(f"duckdb_extension_{name}")
         module_path = pathlib.Path(str(importlib.resources.files(ext_module)))
@@ -205,8 +203,6 @@ def _load_extension(con, name: str, extra: str) -> None:
         extension_file_gz = module_path / "extensions" / duckdb_version / f"{name}.duckdb_extension.gz"
 
         if extension_file_gz.exists():
-            # DuckDB derives the extension's init-symbol name from the file basename,
-            # so the file must be named "{name}.duckdb_extension" — not a random tempname.
             tmpdir = pathlib.Path(tempfile.mkdtemp(prefix=f"datacontract-{name}-"))
             extension_file = tmpdir / f"{name}.duckdb_extension"
             with gzip.open(extension_file_gz, "rb") as src, open(extension_file, "wb") as dst:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,8 +92,7 @@ redshift = [
 ]
 
 # DuckDB extension wheels are skipped on Linux/aarch64 — no 1.0.x manylinux2014_aarch64 build exists.
-# ARM Linux users fall back to DuckDB's online auto-install (pre-PR behavior); air-gapped use is
-# unsupported on that platform until soda-core-duckdb allows a newer duckdb minor with aarch64 wheels.
+# ARM Linux users fall back to DuckDB's online auto-install (does not work in air-gapped environments)
 s3 = [
   "s3fs>=2025.2.0,<2027.0.0",
   "aiobotocore>=2.17.0,<3.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,16 @@ redshift = [
 s3 = [
   "s3fs>=2025.2.0,<2027.0.0",
   "aiobotocore>=2.17.0,<3.8.0",
+  "duckdb-extension-httpfs>=1.0.1,<1.1.0",
+  "duckdb-extension-aws>=1.0.3,<1.1.0",
+]
+
+gcs = [
+  "duckdb-extension-httpfs>=1.0.1,<1.1.0",
+]
+
+azure = [
+  "duckdb-extension-azure>=1.0.3,<1.1.0",
 ]
 
 snowflake = [
@@ -150,7 +160,7 @@ protobuf = [
 ]
 
 all = [
-  "datacontract-cli[kafka,bigquery,csv,excel,snowflake,postgres,redshift,mysql,databricks,sqlserver,s3,athena,trino,impala,dbml,duckdb,iceberg,parquet,rdf,api,protobuf,oracle]"
+  "datacontract-cli[kafka,bigquery,csv,excel,snowflake,postgres,redshift,mysql,databricks,sqlserver,s3,gcs,azure,athena,trino,impala,dbml,duckdb,iceberg,parquet,rdf,api,protobuf,oracle]"
 ]
 
 # for development, we pin all libraries to an exact version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,10 +99,12 @@ s3 = [
 ]
 
 gcs = [
+  "datacontract-cli[duckdb]",
   "duckdb-extension-httpfs>=1.0.1,<1.1.0",
 ]
 
 azure = [
+  "datacontract-cli[duckdb]",
   "duckdb-extension-azure>=1.0.3,<1.1.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,21 +91,24 @@ redshift = [
   "soda-core-redshift>=3.3.20,<3.6.0"
 ]
 
+# DuckDB extension wheels are skipped on Linux/aarch64 — no 1.0.x manylinux2014_aarch64 build exists.
+# ARM Linux users fall back to DuckDB's online auto-install (pre-PR behavior); air-gapped use is
+# unsupported on that platform until soda-core-duckdb allows a newer duckdb minor with aarch64 wheels.
 s3 = [
   "s3fs>=2025.2.0,<2027.0.0",
   "aiobotocore>=2.17.0,<3.8.0",
-  "duckdb-extension-httpfs>=1.0.1,<1.1.0",
-  "duckdb-extension-aws>=1.0.3,<1.1.0",
+  'duckdb-extension-httpfs>=1.0.1,<1.1.0; platform_system != "Linux" or platform_machine != "aarch64"',
+  'duckdb-extension-aws>=1.0.3,<1.1.0; platform_system != "Linux" or platform_machine != "aarch64"',
 ]
 
 gcs = [
   "datacontract-cli[duckdb]",
-  "duckdb-extension-httpfs>=1.0.1,<1.1.0",
+  'duckdb-extension-httpfs>=1.0.1,<1.1.0; platform_system != "Linux" or platform_machine != "aarch64"',
 ]
 
 azure = [
   "datacontract-cli[duckdb]",
-  "duckdb-extension-azure>=1.0.3,<1.1.0",
+  'duckdb-extension-azure>=1.0.3,<1.1.0; platform_system != "Linux" or platform_machine != "aarch64"',
 ]
 
 snowflake = [


### PR DESCRIPTION
## Summary

Fixes #1191. `datacontract test` against S3, GCS, or Azure used to fail in air-gapped containers because DuckDB tried to auto-download the required extensions (`httpfs`, `aws`, `azure`) from `extensions.duckdb.org` on first use.

- Bundle the extension binaries via PyPI wheels: `s3` extra now also pulls in `duckdb-extension-httpfs` + `duckdb-extension-aws`; new `gcs` and `azure` extras pull in the matching wheels.
- A single `_ensure_extension` helper in `duckdb_connection.py` loads the bundled binary via `LOAD '<path>'` when available; otherwise it falls back to DuckDB's auto-install. If auto-install also fails, the error is re-raised with a hint pointing at the relevant extra (`pip install 'datacontract-cli[<extra>]'`).
- Azure's previous eager `con.install_extension("azure")` is replaced by the same helper.

## Test plan

- [x] Existing online tests pass: `pytest tests/test_test_s3_csv.py tests/test_test_s3_json.py`
- [x] End-to-end air-gap reproduction (fake `HOME`, dead `extensions.duckdb.org` URL):
  - S3 (real minio): baseline reproduces #1191, fix passes
  - GCS (no real backend): baseline reproduces #1191, fix loads extension (only the remaining error is HTTP 403 from the fake bucket)
  - Azure (no real backend): baseline reproduces #1191, fix completes setup
- [x] Friendly-error path verified: with the wheel absent and air-gap, each cloud path raises `RuntimeError` pointing at the correct `[extra]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)