### PR TITLE
feat: accept extra top-level fields when --json-schema is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolve `authoritativeDefinitions[type=semantics]` (and the legacy `type=semantic`) the same way. A `url:` that points at the configured entropy-data host is fetched directly; a `url:` that's an IRI (host doesn't match) is routed through `GET /api/semantics?iri=...` on the configured host, which uses the API key's organization to resolve. Precedence: a property with both a semantics and a definition reference resolves through the semantic one.
 - **Breaking:** Per default, any resolution failure of `authoritativeDefinitions[type in {definition, semantics}]` rejects the contract on `lint`, `test`, `ci`, `export`, and `changelog`.
 - `--no-inline-references` flag to skip the HTTP fetch above and leave each property as written. Useful for offline runs (e.g. CI without `ENTROPY_DATA_API_KEY`) and pure round-trip exports (e.g. `export excel`).
+- When `--json-schema` points at a custom JSON Schema, the ODCS Pydantic step now accepts extra top-level fields the schema allows (instead of rejecting them with `extra='forbid'`), so teams can extend ODCS with their own root-level fields (e.g. `change_management`) and still validate with `lint`, `test`, `export`, etc.
 
 ### Fixed
 - Schema type check no longer fails for `varchar(n)` columns on Databricks with PySpark 4.0+, and for `map` and `varchar` types nested inside `struct` columns; affected columns emit a warning and skip the type check instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolve `authoritativeDefinitions[type=semantics]` (and the legacy `type=semantic`) the same way. A `url:` that points at the configured entropy-data host is fetched directly; a `url:` that's an IRI (host doesn't match) is routed through `GET /api/semantics?iri=...` on the configured host, which uses the API key's organization to resolve. Precedence: a property with both a semantics and a definition reference resolves through the semantic one.
 - **Breaking:** Per default, any resolution failure of `authoritativeDefinitions[type in {definition, semantics}]` rejects the contract on `lint`, `test`, `ci`, `export`, and `changelog`.
 - `--no-inline-references` flag to skip the HTTP fetch above and leave each property as written. Useful for offline runs (e.g. CI without `ENTROPY_DATA_API_KEY`) and pure round-trip exports (e.g. `export excel`).
-- When `--json-schema` points at a custom JSON Schema, the ODCS Pydantic step now accepts extra top-level fields the schema allows (instead of rejecting them with `extra='forbid'`), so teams can extend ODCS with their own root-level fields (e.g. `change_management`) and still validate with `lint`, `test`, `export`, etc.
+- When `--json-schema` points at a custom JSON Schema, the ODCS Pydantic step now accepts extra top-level fields the schema allows
 
 ### Fixed
 - Schema type check no longer fails for `varchar(n)` columns on Databricks with PySpark 4.0+, and for `map` and `varchar` types nested inside `struct` columns; affected columns emit a warning and skip the type check instead

--- a/datacontract/lint/resolve.py
+++ b/datacontract/lint/resolve.py
@@ -9,12 +9,24 @@ import yaml
 from fastjsonschema import JsonSchemaValueException
 from jsonschema import validators
 from open_data_contract_standard.model import OpenDataContractStandard, SchemaProperty
+from pydantic import ConfigDict
 
 from datacontract.lint.resources import read_resource
 from datacontract.lint.schema import fetch_schema
 from datacontract.model.exceptions import DataContractException, DataContractValidationErrors
 from datacontract.model.odcs import is_open_data_contract_standard, is_open_data_product_standard
 from datacontract.model.run import ResultEnum
+
+
+class _LaxOpenDataContractStandard(OpenDataContractStandard):
+    """ODCS variant that accepts unknown top-level fields.
+
+    Used when the contract is validated against a user-supplied JSON schema
+    (`--json-schema`): the custom schema is the source of truth, so the
+    Pydantic step must not re-reject extras the schema already accepted.
+    """
+
+    model_config = ConfigDict(extra="allow")
 
 
 class _SafeLoaderNoTimestamp(yaml.SafeLoader):
@@ -281,13 +293,15 @@ def _resolve_data_contract_from_str(
 
     if is_open_data_contract_standard(yaml_dict):
         logging.info("Importing ODCS v3")
-        # Validate the ODCS schema
+        # When a custom JSON schema is provided, treat it as the source of
+        # truth and accept extra top-level fields the standard ODCS Pydantic
+        # class would reject.
+        custom_schema = schema_location is not None
         if schema_location is None:
             schema_location = resources.files("datacontract").joinpath("schemas", "odcs-3.1.0.schema.json")
         _validate_json_schema(yaml_dict, schema_location, all_errors=all_errors)
 
-        # Parse ODCS directly
-        odcs = _parse_odcs_from_dict(yaml_dict)
+        odcs = _parse_odcs_from_dict(yaml_dict, lax=custom_schema)
         if inline_references:
             inline_definitions_into_data_contract(odcs)
         return odcs
@@ -303,10 +317,11 @@ def _resolve_data_contract_from_str(
     return odcs
 
 
-def _parse_odcs_from_dict(yaml_dict: dict) -> OpenDataContractStandard:
+def _parse_odcs_from_dict(yaml_dict: dict, lax: bool = False) -> OpenDataContractStandard:
     """Parse ODCS from a dictionary."""
+    cls = _LaxOpenDataContractStandard if lax else OpenDataContractStandard
     try:
-        return OpenDataContractStandard(**yaml_dict)
+        return cls(**yaml_dict)
     except Exception as e:
         raise DataContractException(
             type="schema",

--- a/tests/fixtures/lint/odcs_with_extra_top_level.schema.json
+++ b/tests/fixtures/lint/odcs_with_extra_top_level.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["apiVersion", "kind", "id"],
+  "properties": {
+    "apiVersion": { "type": "string" },
+    "kind": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/tests/fixtures/lint/odcs_with_extra_top_level.yaml
+++ b/tests/fixtures/lint/odcs_with_extra_top_level.yaml
@@ -1,0 +1,11 @@
+apiVersion: "v3.1.0"
+kind: "DataContract"
+id: "extra-fields-test"
+name: "Contract with extra top-level fields"
+version: "1.0.0"
+status: "draft"
+change_management:
+  process: "GitOps"
+  reviewers:
+    - "alice"
+    - "bob"

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -37,6 +37,28 @@ def test_lint_custom_schema():
     assert run.result == "passed"
 
 
+def test_lint_extra_top_level_field_rejected_without_custom_schema():
+    """Without --json-schema, extra top-level fields must fail (default ODCS is strict)."""
+    data_contract_file = "fixtures/lint/odcs_with_extra_top_level.yaml"
+    data_contract = DataContract(data_contract_file=data_contract_file)
+
+    run = data_contract.lint()
+
+    assert run.result == "failed"
+
+
+def test_lint_extra_top_level_field_allowed_with_custom_schema():
+    """With --json-schema, the custom schema is the source of truth and the
+    Pydantic step must accept extra top-level fields it allows."""
+    data_contract_file = "fixtures/lint/odcs_with_extra_top_level.yaml"
+    schema_file = "fixtures/lint/odcs_with_extra_top_level.schema.json"
+    data_contract = DataContract(data_contract_file=data_contract_file, schema_location=schema_file)
+
+    run = data_contract.lint()
+
+    assert run.result == "passed"
+
+
 def test_lint_valid_odcs_schema():
     data_contract_file = "fixtures/lint/valid.odcs.yaml"
     data_contract = DataContract(data_contract_file=data_contract_file)


### PR DESCRIPTION
## Summary
- When `--json-schema` is provided, parse the contract with a `_LaxOpenDataContractStandard(extra="allow")` subclass so the Pydantic step no longer re-rejects extra top-level fields the custom schema already accepted. Applies to all callers of `resolve_data_contract` (`lint`, `test`, `export`, `get_data_contract`).
- Default behaviour (no `--json-schema`) is unchanged — strict ODCS, extras are still rejected.

## Test plan
- [x] `tests/test_lint.py::test_lint_extra_top_level_field_rejected_without_custom_schema` — extra top-level field is still rejected without `--json-schema` (regression guard)
- [x] `tests/test_lint.py::test_lint_extra_top_level_field_allowed_with_custom_schema` — same contract passes with a permissive `--json-schema`
- [x] Existing 79 tests in `test_lint.py` + `test_resolve_definitions.py` + `test_data_contract_checks.py` still pass
- [x] Manual CLI: `datacontract lint <contract-with-extras>` fails; same with `--json-schema <permissive>` passes
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)