### PR TITLE
chore(docker): use Docker Hardened Image base

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -188,6 +188,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to Docker Hardened Images
+        uses: docker/login-action@v3
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v5
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 # syntax=docker/dockerfile:1.7
 
 # ---------- Builder ----------
-FROM python:3.11-slim-trixie AS builder
+# Docker Hardened Image (DHI), -dev variant: includes a shell and apt-get,
+# so we can install build-time deps and copy the resulting venv into the
+# minimal runtime image below.
+FROM dhi.io/python:3.11-debian13-dev AS builder
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
@@ -10,8 +13,17 @@ ENV PYTHONUNBUFFERED=1 \
     VIRTUAL_ENV=/opt/venv \
     PATH=/opt/venv/bin:$PATH
 
+USER root
+
 # install uv (build-time only)
 COPY --from=ghcr.io/astral-sh/uv:0.11.15 /uv /uvx /bin/
+
+# install protoc — required by `datacontract import protobuf` (the CLI shells
+# out to the system protoc to compile .proto files into FileDescriptorSets).
+# The binary and well-known-types headers are copied into the runtime stage.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
 
 # create the venv that we'll copy into the runtime image
 RUN python -m venv "$VIRTUAL_ENV"
@@ -23,25 +35,28 @@ COPY pyproject.toml MANIFEST.in /app/
 COPY datacontract/ /app/datacontract/
 RUN uv pip install --no-cache-dir ".[all]"
 
+# pre-create a writable workdir owned by the nonroot user, to be copied into
+# the runtime image (the runtime is distroless — no shell, no mkdir/chown).
+RUN install -d -o nonroot -g nonroot /workdir
+
 
 # ---------- Runtime ----------
-FROM python:3.11-slim-trixie AS runtime
+# Docker Hardened Image (DHI): distroless, nonroot by default, no shell,
+# no package manager. Only what's copied in is present.
+FROM dhi.io/python:3.11-debian13 AS runtime
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     VIRTUAL_ENV=/opt/venv \
     PATH=/opt/venv/bin:$PATH
 
-# install protoc — required by `datacontract import protobuf` (the CLI shells out
-# to the system protoc to compile .proto files into FileDescriptorSets)
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends protobuf-compiler \
-    && rm -rf /var/lib/apt/lists/*
-
-# copy the pre-built venv from the builder stage
+# copy the pre-built venv and the system protoc + well-known-types headers
 COPY --from=builder /opt/venv /opt/venv
+COPY --from=builder /usr/bin/protoc /usr/bin/protoc
+COPY --from=builder /usr/include/google /usr/include/google
 
-RUN mkdir -p /home/datacontract
+# nonroot-owned workdir (host volume mounts overlay this at runtime)
+COPY --from=builder /workdir /home/datacontract
 WORKDIR /home/datacontract
 
 ENTRYPOINT ["datacontract"]

--- a/README.md
+++ b/README.md
@@ -224,6 +224,12 @@ You can create an alias for the Docker command to make it easier to use:
 alias datacontract='docker run --rm -v "${PWD}:/home/datacontract" datacontract/cli:latest'
 ```
 
+The image is built on a [Docker Hardened Image](https://docs.docker.com/dhi/) (DHI) base, which is distroless and runs as a non-root user (`nonroot`) by default. If the CLI needs to write back to the mounted directory (e.g. via `--output`), pass your host UID/GID so that file ownership matches:
+
+```bash
+docker run --rm -u "$(id -u):$(id -g)" -v "${PWD}:/home/datacontract" datacontract/cli export html datacontract.yaml --output datacontract.html
+```
+
 _Note:_ The output of Docker command line messages is limited to 80 columns and may include line breaks. Don't pipe docker output to files if you want to export code. Use the `--output` option instead.
 
 


### PR DESCRIPTION
## Summary
- Switches the Dockerfile base from `python:3.11-slim-trixie` to [Docker Hardened Images](https://docs.docker.com/dhi/): `dhi.io/python:3.11-debian13-dev` for the builder stage and `dhi.io/python:3.11-debian13` (distroless, nonroot) for the runtime stage.
- `protoc` (needed by `datacontract import protobuf`) is installed in the dev image; the binary and well-known-types headers are copied into the runtime.
- Adds a `docker login dhi.io` step to the release workflow — DHI requires authentication even for the free Community tier.
- README mentions the hardened base and shows how to pass `-u "$(id -u):$(id -g)"` when the CLI needs to write back to a mounted directory.

Closes #1275.

## Prerequisites before merge / release
- The Docker Hub org used in CI (`secrets.DOCKERHUB_USERNAME`) must be **enrolled in Docker Hardened Images** so it can pull from `dhi.io`. Free Community tier is sufficient; no Select/Enterprise subscription needed. Without enrollment, the build will fail at the first `FROM dhi.io/...` line.

## Notes
- The runtime image runs as `nonroot` by default. For the typical `docker run -v "${PWD}:/home/datacontract" datacontract/cli` invocation, reads work fine; writes to host-mounted files require `-u "$(id -u):$(id -g)"`.
- Multi-arch (`linux/amd64,linux/arm64`) is preserved — both arches are published in the DHI catalog.

## Test plan
- [ ] CI: docker job builds and pushes successfully on a tagged release.
- [ ] Manual: `docker run --rm datacontract/cli:<tag> --version` prints the version.
- [ ] Manual: `docker run --rm -v "${PWD}:/home/datacontract" datacontract/cli lint datacontract.yaml` works for a sample contract.
- [ ] Manual: `docker run --rm -v "${PWD}:/home/datacontract" datacontract/cli import protobuf --source schema.proto` confirms protoc is present and works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)