### PR TITLE
feat: use Docker Hardened Image for container builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,6 +121,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to Docker Hardened Images (dhi.io)
+        uses: docker/login-action@v3
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -188,6 +188,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to Docker Hardened Images (dhi.io)
+        uses: docker/login-action@v3
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Changed
-- Container image is now based on [Docker Hardened Images](https://hub.docker.com/hardened-images/catalog/dhi/python): signed, ships SBOM/VEX, and has tighter CVE patch SLAs than upstream Debian. The runtime stage uses the minimal hardened image — nonroot (uid 65532), no shell, no `apt`, only Python runtime libs — for a smaller attack surface. `pip` / `uv` installs at build time are routed through Socket Firewall Free, which blocks malicious dependencies. End users pulling `datacontract/cli` are unaffected. (#1275, #1277)
+- Container image is now based on [Docker Hardened Images](https://hub.docker.com/hardened-images/catalog/dhi/python): signed, ships SBOM/VEX, and has tighter CVE patch SLAs than upstream Debian. Runs as nonroot (uid 65532) instead of root. `pip` / `uv` installs at build time are routed through Socket Firewall Free, which blocks malicious dependencies. (#1275, #1277)
+- Container image now ships Eclipse Temurin JRE 17, so PySpark-backed engines (Kafka, Spark) actually run inside the image — previously they failed at `SparkSession` startup because the base image had no JVM. End users pulling `datacontract/cli` are unaffected by the build-side changes. (#1277)
 
 ## [0.12.5] - 2026-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Container image is now based on [Docker Hardened Images](https://hub.docker.com/hardened-images/catalog/dhi/python): signed, ships SBOM/VEX, and has tighter CVE patch SLAs than upstream Debian. The runtime stage uses the minimal hardened image — nonroot (uid 65532), no shell, no `apt`, only Python runtime libs — for a smaller attack surface. `pip` / `uv` installs at build time are routed through Socket Firewall Free, which blocks malicious dependencies. End users pulling `datacontract/cli` are unaffected. (#1275, #1277)
+
 ## [0.12.5] - 2026-05-30
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,8 @@ RUN sfw uv pip install --no-cache-dir ".[all]"
 # We picked `-dev` over the minimal `3.11-debian13` (no shell, no apt) because
 # PySpark's `spark-submit` is a bash script. Without bash, Kafka/Spark engines
 # can't even start. The `-dev` variant adds bash + coreutils + apt at ~60 MB
-# cost and lets us drop a /opt/protoc shared-lib copy hack. Default user is
-# root; switched to nonroot via the USER directive at the bottom.
+# cost. Default user is root; switched to nonroot via the USER directive at
+# the bottom.
 FROM dhi.io/python:3.11-debian13-dev AS runtime
 
 ENV PYTHONUNBUFFERED=1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,12 @@ ENV PYTHONUNBUFFERED=1 \
 # install uv (build-time only)
 COPY --from=ghcr.io/astral-sh/uv:0.11.15 /uv /uvx /bin/
 
+# protoc is required by `datacontract import protobuf` — install here and copy
+# the binary + its shared libs into the runtime below
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
 # create the venv that we'll copy into the runtime image
 RUN python3 -m venv "$VIRTUAL_ENV"
 
@@ -39,13 +45,13 @@ ENV PYTHONUNBUFFERED=1 \
     JAVA_HOME=/opt/java/openjdk/17-jre \
     PATH=/opt/venv/bin:/opt/java/openjdk/17-jre/bin:$PATH
 
-# protoc is required by `datacontract import protobuf`
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends protobuf-compiler \
-    && rm -rf /var/lib/apt/lists/*
-
 # copy the pre-built venv (readable+executable by the nonroot user)
 COPY --from=builder --chown=65532:65532 /opt/venv /opt/venv
+
+# copy protoc + its shared libs from the builder. The library glob handles
+# both linux/amd64 and linux/arm64 (Debian multi-arch lib paths).
+COPY --from=builder /usr/bin/protoc /usr/bin/protoc
+COPY --from=builder /usr/lib/*-linux-gnu/libproto*.so* /usr/lib/
 
 # Eclipse Temurin JRE 17 — required by PySpark-backed engines (Kafka, Spark).
 # Without Java, those engines fail at SparkSession startup. Adding the JRE here

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,6 @@ ENV PYTHONUNBUFFERED=1 \
 # install uv (build-time only)
 COPY --from=ghcr.io/astral-sh/uv:0.11.15 /uv /uvx /bin/
 
-# install protoc here so we can copy it into the minimal runtime
-# (the runtime image has no apt and no shell)
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends protobuf-compiler \
-    && rm -rf /var/lib/apt/lists/*
-
 # create the venv that we'll copy into the runtime image
 RUN python3 -m venv "$VIRTUAL_ENV"
 
@@ -35,23 +29,29 @@ RUN sfw uv pip install --no-cache-dir ".[all]"
 
 
 # ---------- Runtime ----------
-# Minimal Docker Hardened Image: signed, SBOM/VEX, nonroot (uid 65532), no
-# shell, no apt. Only the artifacts copied below from the builder are present.
-FROM dhi.io/python:3.11-debian13 AS runtime
+# Docker Hardened Image (dev variant): signed, SBOM/VEX, DHI patch SLAs.
+# Switched to nonroot via the USER directive below.
+FROM dhi.io/python:3.11-debian13-dev AS runtime
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     VIRTUAL_ENV=/opt/venv \
-    PATH=/opt/venv/bin:/opt/protoc/bin:$PATH \
-    LD_LIBRARY_PATH=/opt/protoc/lib:$LD_LIBRARY_PATH
+    JAVA_HOME=/opt/java/openjdk/17-jre \
+    PATH=/opt/venv/bin:/opt/java/openjdk/17-jre/bin:$PATH
 
-# copy the pre-built venv (readable+executable by nonroot)
+# protoc is required by `datacontract import protobuf`
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+# copy the pre-built venv (readable+executable by the nonroot user)
 COPY --from=builder --chown=65532:65532 /opt/venv /opt/venv
 
-# copy protoc + its shared libs so `datacontract import protobuf` works in the
-# runtime. Glob matches the Debian multi-arch lib path for amd64 and arm64.
-COPY --from=builder /usr/bin/protoc /opt/protoc/bin/protoc
-COPY --from=builder /usr/lib/*-linux-gnu/libproto*.so* /opt/protoc/lib/
+# Eclipse Temurin JRE 17 — required by PySpark-backed engines (Kafka, Spark).
+# Without Java, those engines fail at SparkSession startup. Adding the JRE here
+# means `datacontract test` against a kafka/spark server works in the image
+# without users having to extend it.
+COPY --from=dhi.io/eclipse-temurin:17-debian13 /opt/java/openjdk /opt/java/openjdk
 
 USER nonroot:nonroot
 WORKDIR /home/datacontract

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # ---------- Builder ----------
 # Docker Hardened Image (DHI) with Socket Firewall Free: signed, SBOM/VEX,
-# tighter CVE patch SLAs than upstream Debian, and `pip`/`uv` installs are
+# tighter CVE patch SLAs than upstream Debian, and `pip` / `uv` installs are
 # proxied through Socket Firewall to block malicious dependencies at build time.
 # Requires `docker login dhi.io` with a Docker Hub account that has DHI access.
 FROM dhi.io/python:3.11-debian13-sfw-dev AS builder
@@ -17,6 +17,12 @@ ENV PYTHONUNBUFFERED=1 \
 # install uv (build-time only)
 COPY --from=ghcr.io/astral-sh/uv:0.11.15 /uv /uvx /bin/
 
+# install protoc here so we can copy it into the minimal runtime
+# (the runtime image has no apt and no shell)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
 # create the venv that we'll copy into the runtime image
 RUN python3 -m venv "$VIRTUAL_ENV"
 
@@ -29,23 +35,25 @@ RUN sfw uv pip install --no-cache-dir ".[all]"
 
 
 # ---------- Runtime ----------
-FROM dhi.io/python:3.11-debian13-sfw-dev AS runtime
+# Minimal Docker Hardened Image: signed, SBOM/VEX, nonroot (uid 65532), no
+# shell, no apt. Only the artifacts copied below from the builder are present.
+FROM dhi.io/python:3.11-debian13 AS runtime
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     VIRTUAL_ENV=/opt/venv \
-    PATH=/opt/venv/bin:$PATH
+    PATH=/opt/venv/bin:/opt/protoc/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/protoc/lib:$LD_LIBRARY_PATH
 
-# install protoc — required by `datacontract import protobuf` (the CLI shells out
-# to the system protoc to compile .proto files into FileDescriptorSets)
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends protobuf-compiler \
-    && rm -rf /var/lib/apt/lists/*
+# copy the pre-built venv (readable+executable by nonroot)
+COPY --from=builder --chown=65532:65532 /opt/venv /opt/venv
 
-# copy the pre-built venv from the builder stage
-COPY --from=builder /opt/venv /opt/venv
+# copy protoc + its shared libs so `datacontract import protobuf` works in the
+# runtime. Glob matches the Debian multi-arch lib path for amd64 and arm64.
+COPY --from=builder /usr/bin/protoc /opt/protoc/bin/protoc
+COPY --from=builder /usr/lib/*-linux-gnu/libproto*.so* /opt/protoc/lib/
 
-RUN mkdir -p /home/datacontract
+USER 65532:65532
 WORKDIR /home/datacontract
 
 ENTRYPOINT ["datacontract"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 # syntax=docker/dockerfile:1.7
 
 # ---------- Builder ----------
-FROM python:3.11-slim-trixie AS builder
+# Docker Hardened Image (DHI) with Socket Firewall Free: signed, SBOM/VEX,
+# tighter CVE patch SLAs than upstream Debian, and `pip`/`uv` installs are
+# proxied through Socket Firewall to block malicious dependencies at build time.
+# Requires `docker login dhi.io` with a Docker Hub account that has DHI access.
+FROM dhi.io/python:3.11-debian13-sfw-dev AS builder
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
@@ -14,18 +18,18 @@ ENV PYTHONUNBUFFERED=1 \
 COPY --from=ghcr.io/astral-sh/uv:0.11.15 /uv /uvx /bin/
 
 # create the venv that we'll copy into the runtime image
-RUN python -m venv "$VIRTUAL_ENV"
+RUN python3 -m venv "$VIRTUAL_ENV"
 
 WORKDIR /app
 
-# install dependencies into the venv
+# install dependencies into the venv, routed through Socket Firewall
 COPY pyproject.toml MANIFEST.in /app/
 COPY datacontract/ /app/datacontract/
-RUN uv pip install --no-cache-dir ".[all]"
+RUN sfw uv pip install --no-cache-dir ".[all]"
 
 
 # ---------- Runtime ----------
-FROM python:3.11-slim-trixie AS runtime
+FROM dhi.io/python:3.11-debian13-sfw-dev AS runtime
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,12 +35,16 @@ RUN sfw uv pip install --no-cache-dir ".[all]"
 
 
 # ---------- Runtime ----------
-# Docker Hardened Image (dev variant): signed, SBOM/VEX, DHI patch SLAs.
-# Dev (not the minimal `3.11-debian13`) because PySpark's `spark-submit` is a
-# bash script — the minimal image ships no shell, so Kafka/Spark engines can't
-# even start there. Dev adds bash + coreutils + apt at ~60 MB cost and lets us
-# drop the manual /opt/protoc lib gymnastics. Default user is root; switched to
-# nonroot via the USER directive at the bottom.
+# NOTE: the `-dev` suffix is intentional. In Docker Hardened Images, `-dev`
+# names a hardened production variant that ships bash + coreutils + apt — it is
+# NOT a development-only image. It's signed, ships SBOM/VEX, and is on the same
+# DHI patch SLAs as the minimal variant.
+#
+# We picked `-dev` over the minimal `3.11-debian13` (no shell, no apt) because
+# PySpark's `spark-submit` is a bash script. Without bash, Kafka/Spark engines
+# can't even start. The `-dev` variant adds bash + coreutils + apt at ~60 MB
+# cost and lets us drop a /opt/protoc shared-lib copy hack. Default user is
+# root; switched to nonroot via the USER directive at the bottom.
 FROM dhi.io/python:3.11-debian13-dev AS runtime
 
 ENV PYTHONUNBUFFERED=1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,11 @@ RUN sfw uv pip install --no-cache-dir ".[all]"
 
 # ---------- Runtime ----------
 # Docker Hardened Image (dev variant): signed, SBOM/VEX, DHI patch SLAs.
-# Switched to nonroot via the USER directive below.
+# Dev (not the minimal `3.11-debian13`) because PySpark's `spark-submit` is a
+# bash script — the minimal image ships no shell, so Kafka/Spark engines can't
+# even start there. Dev adds bash + coreutils + apt at ~60 MB cost and lets us
+# drop the manual /opt/protoc lib gymnastics. Default user is root; switched to
+# nonroot via the USER directive at the bottom.
 FROM dhi.io/python:3.11-debian13-dev AS runtime
 
 ENV PYTHONUNBUFFERED=1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY --from=builder --chown=65532:65532 /opt/venv /opt/venv
 COPY --from=builder /usr/bin/protoc /opt/protoc/bin/protoc
 COPY --from=builder /usr/lib/*-linux-gnu/libproto*.so* /opt/protoc/lib/
 
-USER 65532:65532
+USER nonroot:nonroot
 WORKDIR /home/datacontract
 
 ENTRYPOINT ["datacontract"]


### PR DESCRIPTION
## Summary

Move the container image to Docker Hardened Images (DHI), and bundle Eclipse Temurin JRE 17 so PySpark-backed engines actually run inside the published image.

- **Builder**: `dhi.io/python:3.11-debian13-sfw-dev` (Python 3.11.15, Debian 13). DHI is signed, ships SBOM/VEX, and has tighter CVE patch SLAs than upstream Debian. The `sfw-dev` variant routes `pip` / `uv` installs through Socket Firewall Free, which blocks malicious dependencies at install time. Installs are wrapped as `sfw uv pip install …` so `uv` is covered.
- **Runtime**: `dhi.io/python:3.11-debian13-dev`. Same DHI hardening (signed, SBOM/VEX, patch SLAs). Switched to **nonroot** (uid 65532) via the `USER` directive. The dev variant ships `bash` and `apt`, which the minimal hardened image (`dhi.io/python:3.11-debian13`) does not — and PySpark's `spark-submit` is a bash script, so the minimal image breaks PySpark-backed engines even with Java present. Dev variant is also free.
- **Java 17**: `dhi.io/eclipse-temurin:17-debian13` multi-stage copied into `/opt/java/openjdk`, `JAVA_HOME` and `PATH` adjusted. PySpark 3.5.8 supports Java 17. **This is the first time the published image can actually run Kafka or Spark engines without users extending it themselves.**

Closes #1275.

## Notable changes

- Switched `python -m venv` → `python3 -m venv` (DHI ships only the `python3` name).
- `COPY --chown=65532:65532 /opt/venv` so the nonroot user owns the venv.
- `apt-get install protobuf-compiler` runs in the runtime stage (dev has apt) — same as the previous slim-trixie image, no manual lib copy needed.
- `USER nonroot:nonroot` pins runtime identity to uid 65532.
- CI: added a `Login to Docker Hardened Images (dhi.io)` step to the `docker` job in both `ci.yaml` (snapshot publish) and `release.yaml` (versioned publish), reusing the existing `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets — DHI uses Docker Hub auth.

## Operational note

The Docker Hub account behind the existing `DOCKERHUB_*` secrets needs DHI access enabled (one-time setup at hub.docker.com — the free Socket Firewall tier is sufficient, no paid subscription). Without that, the new `dhi.io` login step will succeed but the base-image pull will 401.

End users pulling `datacontract/cli` from Docker Hub are unaffected — they don't need any new auth.

## Image comparison

| | Before (`python:3.11-slim-trixie`) | After (DHI dev + JRE 17) |
|---|---|---|
| Builder base | python:3.11-slim-trixie | dhi.io/python:3.11-debian13-sfw-dev |
| Runtime base | python:3.11-slim-trixie | dhi.io/python:3.11-debian13-dev |
| Runs as | root | **nonroot (uid 65532)** |
| Signed / SBOM / VEX | no | **yes** |
| Supply-chain check at install | no | **yes (Socket Firewall)** |
| JVM bundled (Kafka/Spark engines work) | **no** | **yes (Temurin JRE 17)** |
| Image size | ~1.97 GB | 2.13 GB (+8%) |

## Test plan (verified locally)

- [x] `docker build .` end-to-end (apt protobuf-compiler in builder, sfw uv pip install, multi-stage venv + JRE copy, USER switch)
- [x] `datacontract --version` returns `0.12.5`
- [x] `datacontract --help` lists all commands
- [x] `protoc --version` returns `libprotoc 3.21.12`
- [x] `java -version` returns Temurin 17.0.19
- [x] Container runs as uid 65532 / gid 65532 (nonroot)
- [x] `datacontract lint` against real fixtures (postgres, csv, avro)
- [x] `datacontract export` to: html, sql, jsonschema, dbt-models, markdown, odcs, avro, protobuf, spark
- [x] `datacontract import protobuf` against a real `.proto` file
- [x] `datacontract test` against local CSV (duckdb engine)
- [x] `datacontract test` against kafka contract: PySpark loads (`Using PySpark version 3.5.8`), JVM starts, query execution reaches the Kafka layer and fails on the missing server — not on Java/spark-submit. **This was never possible in the previous image.**
- [x] Direct `SparkSession.builder.master('local[1]').getOrCreate()` + `createDataFrame` + `count()` runs cleanly inside the container
- [x] `datacontract changelog` between two contract versions
- [ ] CI `docker` job runs cleanly once DHI access is enabled on the Docker Hub account
- [ ] CI release `docker` job runs cleanly on the next versioned release

## What this does NOT change

- `datacontract dbt sync` still requires the user to install `dbt-core` themselves (unchanged — `dbt` is not declared in `pyproject.toml`).
- MS SQL Server engine still requires the ODBC driver (unchanged — `msodbcsql18` is not in the image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)