### PR TITLE
Bundle Spark Kafka/Avro connector JARs for air-gapped Kafka tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Container image now bundles the Spark Kafka and Avro connector JARs at build time, so `datacontract test` against a Kafka server runs fully offline (air-gapped). Previously the first run resolved `spark.jars.packages` from Maven Central (~60 MB of JARs), which required outbound network and added roughly a minute of startup. A warm Ivy cache is not enough: Spark hands the coordinates to Ivy on every session start, so with no network it fails with `UNRESOLVED DEPENDENCIES`. The JARs are now pre-fetched with the exact Spark/Scala version of the bundled PySpark and placed on the PySpark classpath, and `create_spark_session` skips the Maven resolve when they are already present (`connector_jars_already_on_classpath()`). Pip-installed users without the bundled JARs still download them on first use, so behaviour outside the image is unchanged.
+
 ## [1.0.0] - 2026-06-04
 
 ### Breaking Changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,51 @@ COPY --from=builder --chown=65532:65532 /opt/venv /opt/venv
 # those engines fail at SparkSession startup.
 COPY --from=dhi.io/eclipse-temurin:21-debian13 /opt/java/openjdk /opt/java/openjdk
 
+# Air-gap the Kafka/Spark engine: pre-fetch the Spark Kafka + Avro connector JARs
+# at build time and bundle them onto the PySpark classpath. Without this, the
+# first `datacontract test` against a Kafka server resolves `spark.jars.packages`
+# from Maven Central at runtime (~60 MB download, needs outbound network). The
+# JARs are resolved with the exact Spark/Scala version of the bundled PySpark, so
+# they always match the runtime; `connector_jars_already_on_classpath()` then
+# tells the engine to skip the Maven resolve and start offline.
+RUN <<'PY' python3
+import glob
+import os
+import shutil
+
+import pyspark
+from pyspark.sql import SparkSession
+
+from datacontract.engines.ibis.connections.kafka import spark_connector_packages
+
+ivy_home = "/tmp/ivyhome"
+spark = (
+    SparkSession.builder.appName("prefetch-connectors")
+    .config("spark.jars.ivy", ivy_home)
+    .config("spark.driver.bindAddress", "127.0.0.1")
+    .config("spark.driver.host", "127.0.0.1")
+    .config("spark.ui.enabled", "false")
+    .config("spark.jars.packages", spark_connector_packages())
+    .getOrCreate()
+)
+spark.stop()
+
+jars_dir = os.path.join(os.path.dirname(pyspark.__file__), "jars")
+jars = glob.glob(os.path.join(ivy_home, "jars", "*.jar"))
+assert jars, "no connector JARs were resolved"
+for jar in jars:
+    # Ivy retrieves as "<org>_<artifact>-<rev>.jar"; strip the org prefix so the
+    # bundled files use the canonical Maven name, matching the existing PySpark JARs.
+    name = os.path.basename(jar)
+    canonical = name.split("_", 1)[1] if "_" in name else name
+    shutil.copy2(jar, os.path.join(jars_dir, canonical))
+shutil.rmtree(ivy_home, ignore_errors=True)
+print(f"Bundled {len(jars)} connector JARs into {jars_dir}")
+PY
+
+# Keep the venv (incl. the freshly bundled JARs) owned by the nonroot runtime user.
+RUN chown -R 65532:65532 /opt/venv
+
 USER nonroot:nonroot
 WORKDIR /home/datacontract
 

--- a/datacontract/engines/ibis/connections/kafka.py
+++ b/datacontract/engines/ibis/connections/kafka.py
@@ -50,6 +50,32 @@ def spark_connector_packages() -> str:
     )
 
 
+def connector_jars_already_on_classpath() -> bool:
+    """True when the Kafka/Avro Spark connector JARs are already bundled into the
+    PySpark ``jars`` directory (i.e. on the classpath).
+
+    This is what makes an air-gapped runtime possible. ``spark.jars.packages``
+    always hands the coordinates to Ivy, which contacts a Maven resolver on every
+    session start; a warm Ivy cache is not enough, so with no network it fails
+    with ``UNRESOLVED DEPENDENCIES``. When the connectors are pre-fetched onto the
+    classpath at image build time, we can skip ``spark.jars.packages`` entirely
+    and start offline.
+    """
+    import pyspark
+
+    jars_dir = os.path.join(os.path.dirname(pyspark.__file__), "jars")
+    try:
+        names = os.listdir(jars_dir)
+    except OSError:
+        return False
+    # Match by substring so this holds whether the JARs use canonical Maven names
+    # (spark-sql-kafka-0-10_2.13-<v>.jar) or Ivy's org-prefixed retrieve names
+    # (org.apache.spark_spark-sql-kafka-0-10_2.13-<v>.jar).
+    has_kafka = any("spark-sql-kafka-0-10" in n and n.endswith(".jar") for n in names)
+    has_avro = any("spark-avro" in n and n.endswith(".jar") for n in names)
+    return has_kafka and has_avro
+
+
 def create_spark_session():
     """Create and configure a Spark session."""
 
@@ -77,16 +103,23 @@ def create_spark_session():
     os.environ.setdefault("PYSPARK_PYTHON", sys.executable)
     os.environ.setdefault("PYSPARK_DRIVER_PYTHON", sys.executable)
 
-    spark = (
+    builder = (
         SparkSession.builder.appName("datacontract")
         .config("spark.sql.warehouse.dir", f"{tmp_dir.name}/spark-warehouse")
         .config("spark.streaming.stopGracefullyOnShutdown", "true")
         .config("spark.ui.enabled", "false")
         .config("spark.driver.bindAddress", "127.0.0.1")
         .config("spark.driver.host", "127.0.0.1")
-        .config("spark.jars.packages", spark_connector_packages())
-        .getOrCreate()
     )
+
+    # Only resolve the connectors from Maven when they aren't already bundled on
+    # the classpath. The Docker image pre-fetches them at build time, so it can
+    # start offline; pip-installed users without the bundled JARs still get them
+    # downloaded on first use.
+    if not connector_jars_already_on_classpath():
+        builder = builder.config("spark.jars.packages", spark_connector_packages())
+
+    spark = builder.getOrCreate()
     spark.sparkContext.setLogLevel("WARN")
     print(f"Using PySpark version {spark.version}")
     return spark


### PR DESCRIPTION
## Problem

The first `datacontract test` against a Kafka server downloads the Spark Kafka + Avro connector JARs (~60 MB) from Maven Central at runtime, because `create_spark_session()` always sets `spark.jars.packages`. That needs outbound network and adds roughly a minute to startup, so the image is not air-gapped.

A warm Ivy cache does **not** fix this. Spark hands the coordinates to Ivy on every session start, and Ivy still contacts a resolver. With no network it fails:

```
:: UNRESOLVED DEPENDENCIES ::
:: org.apache.spark#spark-sql-kafka-0-10_2.13;4.0.2: not found
:: org.apache.spark#spark-avro_2.13;4.0.2: not found
```

## Fix

1. **Dockerfile**: pre-fetch the connectors at build time and bundle them onto the PySpark classpath. They are resolved with the exact Spark/Scala version of the bundled PySpark (`spark_connector_packages()`), so they always match the runtime, and renamed to their canonical Maven filenames.
2. **`kafka.py`**: `create_spark_session()` skips `spark.jars.packages` when the connectors are already on the classpath (`connector_jars_already_on_classpath()`). Pip-installed users without the bundled JARs keep the download-on-first-use behaviour, so nothing changes outside the image.

## Verification

Built a test image applying both changes on top of the published image (the real Dockerfile uses DHI base images that need `dhi.io` access).

- **Build** resolves and bundles 13 connector JARs onto the classpath.
- **Offline session**: `create_spark_session()` starts with `--network none` (no Maven route): `BUNDLED_JARS_DETECTED: True`, `SESSION_OK 4.0.2`.
- **End-to-end on an internal network with zero internet egress** (Maven unreachable), against a real KRaft Kafka broker: `🟢 data contract is valid. Run 16 checks. Took 5.4 seconds` (vs ~70s with the Maven download on the current image).

## Notes

- The prefetch step runs in the runtime stage because it needs the JRE that is copied there; it adds ~60 MB to the image (the connector JARs that were downloaded at runtime before).
- Image size grows by the connector JAR set; in exchange the Kafka engine starts offline and ~13x faster.
