### PR TITLE
fix: represent dataframe server as ODCS type: custom (#1282)

### DIFF
--- a/datacontract/engines/ibis/connections/connect.py
+++ b/datacontract/engines/ibis/connections/connect.py
@@ -19,6 +19,7 @@ from open_data_contract_standard.model import OpenDataContractStandard, Server
 from datacontract.engines.ibis.connections.duckdb_connection import get_duckdb_connection
 from datacontract.model.exceptions import DataContractException, require_env
 from datacontract.model.run import Check, ResultEnum, Run
+from datacontract.model.server import get_server_type
 
 if typing.TYPE_CHECKING:
     import ibis
@@ -56,7 +57,7 @@ def connect_ibis(
     appended to ``run`` (mirroring the previous soda behaviour).
     """
     ibis = _import_ibis()
-    server_type = server.type
+    server_type = get_server_type(server)
 
     if server_type in _FILE_SERVER_TYPES:
         if server.format not in _SUPPORTED_FILE_FORMATS:

--- a/datacontract/imports/dcs_importer.py
+++ b/datacontract/imports/dcs_importer.py
@@ -22,6 +22,7 @@ from open_data_contract_standard.model import (
 )
 
 from datacontract.imports.importer import Importer
+from datacontract.model.server import to_odcs_server_type
 
 logger = logging.getLogger(__name__)
 
@@ -140,10 +141,15 @@ def _convert_servers(dcs_servers: Dict[str, DCSServer]) -> List[ODCSServer]:
     """Convert DCS servers dict to ODCS servers list."""
     servers = []
     for server_name, dcs_server in dcs_servers.items():
+        # Map non-ODCS server types (e.g. dataframe) to a standard-compliant
+        # `type: custom` with the real type in a `customType` custom property.
+        odcs_type, type_custom_properties = to_odcs_server_type(dcs_server.type)
         odcs_server = ODCSServer(
             server=server_name,
-            type=dcs_server.type,
+            type=odcs_type,
         )
+        if type_custom_properties:
+            odcs_server.customProperties = type_custom_properties
 
         # Copy common attributes
         if dcs_server.environment:

--- a/datacontract/imports/odcs_helper.py
+++ b/datacontract/imports/odcs_helper.py
@@ -10,6 +10,8 @@ from open_data_contract_standard.model import (
     Server,
 )
 
+from datacontract.model.server import to_odcs_server_type
+
 
 def create_odcs(
     id: str = None,
@@ -157,8 +159,16 @@ def create_server(
     topic: str = None,
     format: str = None,
 ) -> Server:
-    """Create a Server object."""
-    server = Server(server=name, type=server_type)
+    """Create a Server object.
+
+    Server types outside the ODCS enum (e.g. ``dataframe``) are written in a
+    standard-compliant way as ``type: custom`` with the real type carried in a
+    ``customType`` custom property.
+    """
+    odcs_type, custom_properties = to_odcs_server_type(server_type)
+    server = Server(server=name, type=odcs_type)
+    if custom_properties:
+        server.customProperties = custom_properties
     if environment:
         server.environment = environment
     if host:

--- a/datacontract/model/server.py
+++ b/datacontract/model/server.py
@@ -1,0 +1,50 @@
+from typing import List, Optional, Tuple
+
+from open_data_contract_standard.model import CustomProperty, Server
+
+# datacontract-CLI supports server types that are not part of the ODCS
+# `Server.type` enum (e.g. a Spark `dataframe`). To stay compliant with the
+# ODCS standard, such a server is written as `type: custom` and the real
+# datacontract-CLI type is carried in this custom property.
+CUSTOM_SERVER_TYPE_PROPERTY = "customType"
+
+# Server types datacontract-CLI supports but ODCS does not define.
+NON_ODCS_SERVER_TYPES = {"dataframe"}
+
+
+def to_odcs_server_type(server_type: Optional[str]) -> Tuple[Optional[str], Optional[List[CustomProperty]]]:
+    """Map a datacontract-CLI server type to a standard-compliant ODCS server.
+
+    Types outside the ODCS enum become ``custom`` with the real type stored in
+    the ``customType`` custom property. ODCS-native types pass through unchanged.
+
+    Returns a ``(type, customProperties)`` tuple; ``customProperties`` is
+    ``None`` for native types.
+    """
+    if server_type in NON_ODCS_SERVER_TYPES:
+        return "custom", [CustomProperty(property=CUSTOM_SERVER_TYPE_PROPERTY, value=server_type)]
+    return server_type, None
+
+
+def get_server_type(server: Optional[Server]) -> Optional[str]:
+    """Return the effective datacontract-CLI server type.
+
+    Resolves the standard-compliant ``type: custom`` + ``customType`` custom
+    property back to the real datacontract-CLI type (e.g. ``dataframe``).
+    Servers carrying a literal type (the in-memory object path that bypasses
+    JSON-schema validation) are returned unchanged.
+    """
+    if server is None:
+        return None
+    if server.type == "custom":
+        custom_type = _get_custom_property(server, CUSTOM_SERVER_TYPE_PROPERTY)
+        if custom_type:
+            return custom_type
+    return server.type
+
+
+def _get_custom_property(server: Server, name: str) -> Optional[str]:
+    for prop in server.customProperties or []:
+        if prop.property == name:
+            return prop.value
+    return None

--- a/tests/fixtures/spark/import/users_datacontract_desc.yml
+++ b/tests/fixtures/spark/import/users_datacontract_desc.yml
@@ -6,7 +6,10 @@ name: My Data Contract
 status: draft
 servers:
 - server: local
-  type: dataframe
+  type: custom
+  customProperties:
+  - property: customType
+    value: dataframe
 schema:
 - name: users
   physicalType: table

--- a/tests/fixtures/spark/import/users_datacontract_no_desc.yml
+++ b/tests/fixtures/spark/import/users_datacontract_no_desc.yml
@@ -6,7 +6,10 @@ name: My Data Contract
 status: draft
 servers:
 - server: local
-  type: dataframe
+  type: custom
+  customProperties:
+  - property: customType
+    value: dataframe
 schema:
 - name: users
   physicalType: table

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,6 +1,7 @@
 import tempfile
 
 from datacontract.lint.resolve import resolve_data_contract
+from datacontract.model.server import get_server_type
 
 # logging.basicConfig(level=logging.INFO, force=True)
 
@@ -223,3 +224,55 @@ def test_resolve_data_contract_relative_refrence():
         orders_schema = next(s for s in odcs.schema_ if s.name == "orders")
         order_id_prop = next(p for p in orders_schema.properties if p.name == "order_id")
         assert order_id_prop.logicalType == "string"
+
+
+def test_resolve_odcs_custom_dataframe_server():
+    # `dataframe` is not an ODCS server type, so it is expressed standard-compliantly
+    # as `type: custom` with the real type in the `customType` custom property.
+    # Resolving (which runs JSON-schema validation) must not reject it. See issue #1282.
+    odcs = resolve_data_contract(
+        data_contract_str="""
+    kind: DataContract
+    apiVersion: v3.1.0
+    id: repro
+    version: 1.0.0
+    status: active
+    servers:
+      - server: production
+        type: custom
+        customProperties:
+          - property: customType
+            value: dataframe
+    schema:
+      - name: my_table
+        properties:
+          - name: c
+            logicalType: string
+    """,
+    )
+    assert odcs.servers[0].type == "custom"
+    assert get_server_type(odcs.servers[0]) == "dataframe"
+
+
+def test_resolve_dcs_dataframe_server_converted_to_custom():
+    # The DCS -> ODCS converter must emit a standard-compliant `type: custom`
+    # server for the non-ODCS `dataframe` type. See issue #1282.
+    odcs = resolve_data_contract(
+        data_contract_str="""
+    dataContractSpecification: 1.2.1
+    id: my-id
+    info:
+      title: My Title
+      version: 1.0.0
+    servers:
+      unittest:
+        type: dataframe
+    models:
+      my_table:
+        fields:
+          c:
+            type: string
+    """,
+    )
+    assert odcs.servers[0].type == "custom"
+    assert get_server_type(odcs.servers[0]) == "dataframe"


### PR DESCRIPTION
Fixes #1282.

## Problem

ODCS contracts with a `dataframe` server fail JSON-schema validation:

```
data.servers[0].type must be one of ['api', 'athena', ... 'zen', 'custom']
```

`dataframe` is a datacontract-CLI extension that is **not** part of the upstream ODCS `Server.type` enum. The bundled `schemas/odcs-3.1.0.schema.json` is a verbatim copy of the standard and must not diverge from it, so widening that enum is not an option.

At the same time the CLI itself produces this invalid type:
- the Spark importer emits `type: dataframe`
- the DCS→ODCS converter (`_convert_servers`) copies `type: dataframe` through

So `datacontract import` could generate a contract that `datacontract test` then rejected. The inconsistency was only visible on the string path (which validates); the in-memory object path skips validation and worked.

## Fix

Represent `dataframe` the standard-compliant ODCS way: `type: custom` with the real type in a `customType` custom property.

```yaml
servers:
  - server: production
    type: custom
    customProperties:
      - property: customType
        value: dataframe
```

- New helper `datacontract/model/odcs.py`: `to_odcs_server_type()` (CLI type → standard ODCS `type` + customProperties) and `get_server_type()` (resolve the effective type back).
- `create_server` and the DCS server converter now emit `type: custom`.
- The ibis connection resolves the effective type via `get_server_type`, so a dataframe contract still connects via the Spark backend. The legacy in-memory object path (`type: dataframe`, validation skipped) keeps working.
- Updated Spark-import fixtures; added regression tests in `tests/test_resolve.py` for ODCS string validation and the DCS→ODCS conversion.

## Behavior note

A hand-written ODCS string contract using the literal `type: dataframe` still fails validation (it is genuinely invalid ODCS). Use the `type: custom` + `customType: dataframe` form above, or let the importer produce it. The object path is unchanged.

## Tests

`test_resolve` (9), `test_import_spark` (6), `test_test_dataframe` (2, Java 21), ODCS round-trip + sql-type-converter + spark-export (48), other importers (28) — all pass. ruff check + format clean.