### PR TITLE
fix: support logicalTypeOptions.pattern on SQL Server via PATINDEX (#1284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- `datacontract test` no longer fails with `Compilation rule for RegexSearch operation is not defined` when a contract uses `logicalTypeOptions.pattern` (or `pattern`) against SQL Server. SQL Server has no native regex operator, so the ibis mssql backend cannot compile `re_search`; pattern checks now fall back to a `PATINDEX(...) > 0` LIKE match, restoring the behaviour of the former soda-core engine. Patterns that use real regex syntax (anchors, quantifiers, groups, `.`) cannot be expressed as a T-SQL LIKE pattern and now raise a clear error instead of failing cryptically. (#1284)
+
 ## [1.0.0] - 2026-06-04
 
 ### Breaking Changes

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -409,13 +409,87 @@ def _as_string(column, dtype):
     return column.cast("string")
 
 
+def _backend_name(t) -> str:
+    """Backend name (e.g. ``mssql``, ``duckdb``) behind a bound table, or ``""``."""
+    try:
+        return getattr(t.get_backend(), "name", "") or ""
+    except Exception:
+        return ""
+
+
+# Regex metacharacters with no T-SQL LIKE/PATINDEX equivalent. Inside a bracket
+# class (``[...]``) these are literal and allowed; encountered outside one they
+# signal a real regex we cannot translate to a LIKE pattern.
+_MSSQL_UNSUPPORTED_REGEX_CHARS = set(".^$*+?(){}|\\")
+
+
+def _mssql_like_pattern(pattern: str) -> str:
+    """Validate that a contract ``pattern`` is expressible as a T-SQL LIKE pattern.
+
+    SQL Server has no native regex operator, so the mssql backend cannot compile
+    ``re_search`` ("Compilation rule for RegexSearch operation is not defined").
+    PATINDEX instead matches LIKE wildcards (``%``, ``_``, ``[...]`` classes).
+    Patterns built from literals and ``[...]`` classes (the common case, e.g.
+    ``[0-9][0-9][0-9][0-9][0-9]``) map directly. Patterns using real regex syntax
+    (anchors, quantifiers, groups, ``.``) cannot be expressed and raise here,
+    rather than silently matching the wrong rows.
+    """
+    in_class = False
+    for ch in pattern:
+        if in_class:
+            if ch == "]":
+                in_class = False
+            continue
+        if ch == "[":
+            in_class = True
+            continue
+        if ch in _MSSQL_UNSUPPORTED_REGEX_CHARS:
+            raise ValueError(
+                f"SQL Server does not support general regular expressions for pattern checks. "
+                f"The pattern {pattern!r} uses regex syntax ({ch!r}) that cannot be translated "
+                f"to a T-SQL LIKE/PATINDEX pattern. Only LIKE-compatible patterns (literals, "
+                f"'%', '_', and [...] character classes) are supported on SQL Server."
+            )
+    return pattern
+
+
+def _mssql_pattern_search(column, pattern: str):
+    """``PATINDEX(pattern, column) > 0`` for the mssql backend (unanchored match).
+
+    Mirrors the former soda-core SQL Server behaviour, where ``valid regex`` was
+    compiled to ``PATINDEX('<pattern>', expr) > 0``. The pattern is passed as a
+    bound literal, so it is escaped rather than string-interpolated.
+    """
+    import ibis
+
+    like = _mssql_like_pattern(pattern)
+
+    @ibis.udf.scalar.builtin
+    def patindex(pattern: str, expression: str) -> int:  # -> PATINDEX(pattern, expression)
+        ...
+
+    return patindex(like, column) > 0
+
+
+def _regex_search_expr(t, column, pattern: str):
+    """Unanchored regex/pattern match, portable across backends.
+
+    Most ibis backends compile ``re_search`` to a native regex operator. SQL
+    Server has none, so fall back to a PATINDEX-based LIKE match for the mssql
+    backend.
+    """
+    if _backend_name(t) == "mssql":
+        return _mssql_pattern_search(column, pattern)
+    return column.re_search(pattern)
+
+
 def _valid_expr(t, col, dtype, spec: CheckSpec):
     """Boolean: a non-missing value satisfies all configured validity constraints."""
     conds = []
     if spec.valid_values is not None:
         conds.append(t[col].isin(spec.valid_values))
     if spec.valid_regex is not None:
-        conds.append(_as_string(t[col], dtype).re_search(spec.valid_regex))
+        conds.append(_regex_search_expr(t, _as_string(t[col], dtype), spec.valid_regex))
     if spec.valid_min is not None:
         conds.append(t[col] >= spec.valid_min)
     if spec.valid_max is not None:

--- a/tests/fixtures/sqlserver/datacontract.yaml
+++ b/tests/fixtures/sqlserver/datacontract.yaml
@@ -20,6 +20,7 @@ models:
         type: varchar
         required: true
         unique: true
+        pattern: "[A-Z][A-Z]-[0-9][0-9][0-9]-[A-Z][A-Z]"
       field_two:
         type: int
         minimum: 10

--- a/tests/test_ibis_mssql_pattern.py
+++ b/tests/test_ibis_mssql_pattern.py
@@ -1,0 +1,48 @@
+"""Unit tests for the SQL Server (mssql) pattern-check fallback.
+
+SQL Server has no native regex operator, so the ibis mssql backend cannot
+compile ``re_search`` and raises "Compilation rule for RegexSearch operation is
+not defined". For pattern checks we fall back to a PATINDEX-based LIKE match,
+matching the former soda-core behaviour. See issue #1284.
+"""
+
+import ibis
+import pytest
+
+from datacontract.engines.ibis.ibis_check_execute import (
+    _mssql_like_pattern,
+    _mssql_pattern_search,
+)
+
+
+def test_like_compatible_pattern_passes_through():
+    pattern = "[0-9][0-9][0-9][0-9][0-9]"
+    assert _mssql_like_pattern(pattern) == pattern
+
+
+def test_like_compatible_pattern_with_literals_and_classes():
+    pattern = "[A-Z][A-Z]-[0-9][0-9][0-9]-[A-Z][A-Z]"
+    assert _mssql_like_pattern(pattern) == pattern
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        "^[0-9]{5}$",  # anchors + quantifier
+        ".+@.+",  # wildcard + quantifier
+        "[0-9]+",  # quantifier
+        r"\d\d\d",  # escape
+        "(a|b)",  # group + alternation
+    ],
+)
+def test_real_regex_patterns_are_rejected(pattern):
+    with pytest.raises(ValueError, match="SQL Server does not support general regular expressions"):
+        _mssql_like_pattern(pattern)
+
+
+def test_pattern_search_compiles_to_patindex_for_mssql():
+    t = ibis.table({"postal_code": "string"}, name="USER")
+    predicate = _mssql_pattern_search(t.postal_code, "[0-9][0-9][0-9][0-9][0-9]")
+    sql = ibis.to_sql(t.filter(predicate).count(), dialect="mssql")
+    assert "PATINDEX('[0-9][0-9][0-9][0-9][0-9]'" in sql
+    assert "REGEXP" not in sql.upper()

--- a/tests/test_test_sqlserver.py
+++ b/tests/test_test_sqlserver.py
@@ -7,8 +7,11 @@ from datacontract.data_contract import DataContract
 
 # logging.basicConfig(level=logging.DEBUG, force=True)
 
-datacontract = "fixtures/sqlserver/datacontract.yaml"
-sql_file_path = "fixtures/sqlserver/data/data.sql"
+# Absolute paths so the module-scoped container fixture (which runs before the
+# function-scoped change_test_dir chdir) can find the fixtures from any cwd.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+datacontract = os.path.join(_HERE, "fixtures/sqlserver/datacontract.yaml")
+sql_file_path = os.path.join(_HERE, "fixtures/sqlserver/data/data.sql")
 
 sql_server = SqlServerContainer()
 SQL_SERVER_PORT: int = 1433

--- a/tests/test_test_sqlserver.py
+++ b/tests/test_test_sqlserver.py
@@ -17,11 +17,19 @@ SQL_SERVER_PORT: int = 1433
 @pytest.fixture(scope="module", autouse=True)
 def mssql_container(request):
     sql_server.start()
+    _init_sql()
 
     def remove_container():
         sql_server.stop()
 
     request.addfinalizer(remove_container)
+
+
+def _set_sqlserver_env(monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_SQLSERVER_USERNAME", sql_server.username)
+    monkeypatch.setenv("DATACONTRACT_SQLSERVER_PASSWORD", sql_server.password)
+    monkeypatch.setenv("DATACONTRACT_SQLSERVER_TRUST_SERVER_CERTIFICATE", "True")
+    monkeypatch.setenv("DATACONTRACT_SQLSERVER_DRIVER", "ODBC Driver 18 for SQL Server")
 
 
 # To run this on ARM macs, run these commands (https://github.com/pymssql/pymssql/issues/769)
@@ -33,12 +41,7 @@ def mssql_container(request):
 # pip install pymssql==2.2.8 --no-binary :all:
 @pytest.mark.skipif(not os.getenv("CI"), reason="Skipping test outside CI/CD environment")
 def test_test_sqlserver(mssql_container, monkeypatch):
-    monkeypatch.setenv("DATACONTRACT_SQLSERVER_USERNAME", sql_server.username)
-    monkeypatch.setenv("DATACONTRACT_SQLSERVER_PASSWORD", sql_server.password)
-    monkeypatch.setenv("DATACONTRACT_SQLSERVER_TRUST_SERVER_CERTIFICATE", "True")
-    monkeypatch.setenv("DATACONTRACT_SQLSERVER_DRIVER", "ODBC Driver 18 for SQL Server")
-
-    _init_sql()
+    _set_sqlserver_env(monkeypatch)
 
     data_contract_str = _setup_datacontract()
     data_contract = DataContract(data_contract_str=data_contract_str)
@@ -48,6 +51,35 @@ def test_test_sqlserver(mssql_container, monkeypatch):
     print(run)
     assert run.result == "passed"
     assert all(check.result == "passed" for check in run.checks)
+
+
+@pytest.mark.skipif(not os.getenv("CI"), reason="Skipping test outside CI/CD environment")
+def test_test_sqlserver_pattern_detects_violations(mssql_container, monkeypatch):
+    # Regression for #1284: a logicalTypeOptions.pattern check must run on SQL
+    # Server (no native regex) via the PATINDEX fallback and actually evaluate
+    # the data, rather than failing with "Compilation rule for RegexSearch
+    # operation is not defined". field_one values look like "CX-263-DU", so a
+    # pattern requiring four consecutive digits matches none of them.
+    _set_sqlserver_env(monkeypatch)
+
+    data_contract_str = _setup_datacontract().replace(
+        "[A-Z][A-Z]-[0-9][0-9][0-9]-[A-Z][A-Z]",
+        "[0-9][0-9][0-9][0-9]",
+    )
+    data_contract = DataContract(data_contract_str=data_contract_str)
+
+    run = data_contract.test()
+
+    print(run)
+    assert run.result == "failed"
+    pattern_checks = [c for c in run.checks if c.field == "field_one" and "pattern" in (c.name or "").lower()]
+    assert pattern_checks, "expected a pattern check on field_one"
+    for check in pattern_checks:
+        # The check must fail because rows violate the pattern, not because the
+        # backend could not compile the regex.
+        assert check.result == "failed"
+        assert "RegexSearch" not in (check.reason or "")
+        assert "Compilation rule" not in (check.reason or "")
 
 
 def _setup_datacontract():


### PR DESCRIPTION
## Problem

Closes #1284.

In 0.12.5 (soda-core backend) a `pattern` / `logicalTypeOptions.pattern` constraint worked against SQL Server. After the 1.0.0 switch to ibis, any contract with a pattern constraint fails:

```
Compilation rule for RegexSearch operation is not defined
```

SQL Server has no native regex operator, so the ibis `mssql` backend cannot compile `re_search`.

## Fix

Pattern checks now fall back to a `PATINDEX(...) > 0` LIKE match for the `mssql` backend, mirroring what the former soda-core SQL Server data source did (`PATINDEX('<pattern>', expr) > 0`). The pattern is passed as a bound literal (escaped), avoiding the string interpolation the old soda code used.

Patterns that use real regex syntax (anchors, quantifiers, groups, `.`) cannot be expressed as a T-SQL LIKE pattern. Rather than silently matching the wrong rows (which is what soda-core actually did for such patterns), these now raise a clear error.

## Changes

- `datacontract/engines/ibis/ibis_check_execute.py`: `_valid_expr` routes the regex condition through a new `_regex_search_expr`, which uses `_mssql_pattern_search` (PATINDEX builtin UDF) for the `mssql` backend and the unchanged `re_search` path otherwise. `_mssql_like_pattern` validates LIKE-compatibility.
- `tests/test_ibis_mssql_pattern.py`: container-free unit tests for pass-through, rejection of real regex, and PATINDEX SQL rendering.
- `tests/test_test_sqlserver.py`: refactored init into the module fixture; added `test_test_sqlserver_pattern_detects_violations` confirming the PATINDEX fallback evaluates data (and does not error with the compilation message).
- `tests/fixtures/sqlserver/datacontract.yaml`: added a LIKE-compatible pattern to `field_one` so the existing CI integration test exercises the happy path.
- `CHANGELOG.md`: Fixed entry.

## Testing

- New unit tests pass (8).
- `test_test_diagnostics.py` passes, confirming non-mssql backends still use `re_search`.
- `ruff check` clean.
- The SQL Server integration tests require a testcontainer and run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)