### PR TITLE
feat: load environment variables from a .env file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Environment variables (e.g., credentials for `datacontract test`) are now also loaded from a `.env` file in the current working directory, walking up parent directories until one is found. Already-set environment variables take precedence over `.env` values, so exported variables and CI secrets keep working unchanged. (#1295)
+
 ### Fixed
 - `datacontract test` no longer fails with `Compilation rule for RegexSearch operation is not defined` when a contract uses `logicalTypeOptions.pattern` (or `pattern`) against SQL Server. SQL Server has no native regex operator, so the ibis mssql backend cannot compile `re_search`; pattern checks now fall back to a `PATINDEX(...) > 0` LIKE match, restoring the behaviour of the former soda-core engine. Patterns that use real regex syntax (anchors, quantifiers, groups, `.`) cannot be expressed as a T-SQL LIKE pattern and now raise a clear error instead of failing cryptically. (#1284)
 

--- a/README.md
+++ b/README.md
@@ -477,6 +477,14 @@ Internally, it connects with DuckDB, Spark, or a native connection and executes 
 The `server` block in the datacontract.yaml is used to set up the connection.
 In addition, credentials, such as username and passwords, are provided with environment variables.
 
+Environment variables are also loaded from a `.env` file in the current working directory (or the nearest parent directory containing one, so you can run the CLI from a subfolder of your project). Already-set environment variables take precedence over values from the `.env` file.
+
+```bash
+# .env
+DATACONTRACT_POSTGRES_USERNAME=postgres
+DATACONTRACT_POSTGRES_PASSWORD=postgres
+```
+
 Feel free to create an [issue](https://github.com/datacontract/datacontract-cli/issues), if you need support for additional types and formats.
 
 <details markdown="1">

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -7,6 +7,7 @@ from typing import Iterable, Optional
 
 import typer
 from click import Context
+from dotenv import find_dotenv, load_dotenv
 from rich.console import Console
 from typer.core import TyperGroup
 from typing_extensions import Annotated
@@ -125,7 +126,10 @@ def common(
     connect to data sources and execute schema and quality tests,
     and export to different formats.
     """
-    pass
+    # Load environment variables (e.g., credentials) from a .env file in the
+    # current working directory, walking up parent directories until one is found.
+    # Already-set environment variables take precedence.
+    load_dotenv(dotenv_path=find_dotenv(usecwd=True), override=False)
 
 
 def enable_debug_logging(debug: bool, otherwise_disable_stderr: bool = False):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import os
 import re
 
 from typer.testing import CliRunner
@@ -35,6 +36,41 @@ def test_test_schema_name_option_in_help():
     assert result.exit_code == 0
     plain_output = re.sub(r"\x1b\[[0-9;]*m", "", result.stdout)
     assert "--schema-name" in plain_output
+
+
+def test_loads_env_file_from_current_working_directory(tmp_path, monkeypatch):
+    (tmp_path / ".env").write_text("DATACONTRACT_TEST_DOTENV_VAR=from-dotenv\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("DATACONTRACT_TEST_DOTENV_VAR", raising=False)
+    try:
+        result = runner.invoke(app, ["lint", "unknown.yaml"])
+        assert result.exit_code == 1  # file does not exist, but the app callback has run
+        assert os.environ.get("DATACONTRACT_TEST_DOTENV_VAR") == "from-dotenv"
+    finally:
+        os.environ.pop("DATACONTRACT_TEST_DOTENV_VAR", None)
+
+
+def test_loads_env_file_from_parent_directory(tmp_path, monkeypatch):
+    (tmp_path / ".env").write_text("DATACONTRACT_TEST_DOTENV_VAR=from-dotenv\n")
+    subdir = tmp_path / "sub" / "dir"
+    subdir.mkdir(parents=True)
+    monkeypatch.chdir(subdir)
+    monkeypatch.delenv("DATACONTRACT_TEST_DOTENV_VAR", raising=False)
+    try:
+        result = runner.invoke(app, ["lint", "unknown.yaml"])
+        assert result.exit_code == 1  # file does not exist, but the app callback has run
+        assert os.environ.get("DATACONTRACT_TEST_DOTENV_VAR") == "from-dotenv"
+    finally:
+        os.environ.pop("DATACONTRACT_TEST_DOTENV_VAR", None)
+
+
+def test_env_file_does_not_override_existing_environment_variables(tmp_path, monkeypatch):
+    (tmp_path / ".env").write_text("DATACONTRACT_TEST_DOTENV_VAR=from-dotenv\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("DATACONTRACT_TEST_DOTENV_VAR", "from-environment")
+    result = runner.invoke(app, ["lint", "unknown.yaml"])
+    assert result.exit_code == 1
+    assert os.environ.get("DATACONTRACT_TEST_DOTENV_VAR") == "from-environment"
 
 
 def test_changelog_help():


### PR DESCRIPTION
## What

Load environment variables from a `.env` file when the CLI starts (in the Typer app callback).

- The `.env` file is resolved from the current working directory, **walking up parent directories** until one is found (`find_dotenv(usecwd=True)`) — so the CLI can be run from any subfolder of a project.
- Already-set environment variables take precedence over values from the `.env` file (`override=False`).
- No new dependency: `python-dotenv` was already a core dependency in `pyproject.toml`.

## Why

Credentials for `datacontract test` (e.g. `DATACONTRACT_POSTGRES_USERNAME`) are provided via environment variables. With this change, projects can keep their connection settings in a local, gitignored `.env` file instead of exporting them manually in every shell session — same behavior as the Entropy Data CLI.

## Tests

- `.env` from the current working directory is loaded
- `.env` from a parent directory is found when running in a subfolder
- existing environment variables are not overridden

## Docs

README: documented `.env` support in the Supported Data Sources section.
