### PR TITLE
fix: bundle libpq via psycopg[binary] in the postgres and redshift extras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- The `postgres` and `redshift` extras now install `psycopg[binary]`, whose wheels bundle the libpq client library. Previously, `datacontract test` against PostgreSQL/Redshift failed on machines without PostgreSQL client libraries installed (`couldn't import psycopg: no pq wrapper available`).
+
 ## [1.0.1] - 2026-06-10
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,12 +86,18 @@ mysql = [
 ]
 
 postgres = [
-  "ibis-framework[postgres]>=10.0.0,<13.0.0"
+  "ibis-framework[postgres]>=10.0.0,<13.0.0",
+  # psycopg's binary wheels bundle libpq, so the extra works without
+  # PostgreSQL client libraries installed on the system.
+  "psycopg[binary]>=3.1,<4.0",
 ]
 
 redshift = [
   # Redshift speaks the postgres wire protocol; ibis has no dedicated backend.
-  "ibis-framework[postgres]>=10.0.0,<13.0.0"
+  "ibis-framework[postgres]>=10.0.0,<13.0.0",
+  # psycopg's binary wheels bundle libpq, so the extra works without
+  # PostgreSQL client libraries installed on the system.
+  "psycopg[binary]>=3.1,<4.0",
 ]
 
 # DuckDB extension wheels are bundled for air-gapped installs. The 1.5.x line


### PR DESCRIPTION
## Problem

`pip install datacontract-cli[postgres]` installs `ibis-framework[postgres]`, which depends on plain `psycopg` (v3). Plain `psycopg` loads the **libpq** C library from the system at runtime. On a machine without PostgreSQL client libraries installed (no `libpq5`/`brew install libpq`), `datacontract test` fails with:

```
couldn't import psycopg: no pq wrapper available
```

even though the pip install succeeded.

## Fix

Add `psycopg[binary]` to the `postgres` and `redshift` extras. The binary wheels bundle libpq inside the wheel, so the extras work out of the box with zero system dependencies. psycopg automatically prefers the binary implementation when it is present (`psycopg.pq.__impl__ == 'binary'`), and users who need to link against a system libpq can still do so by uninstalling `psycopg-binary`.

Binary wheels are available for all mainstream platforms (macOS arm64/x86, Linux including aarch64/musl, Windows).