### PR TITLE
fix: tolerate columns with types ibis cannot represent in test, e.g. VariantType (#1296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- `datacontract test` no longer fails on Spark/Databricks tables containing columns of types ibis cannot represent, such as VariantType (#1296)
+
 ## [1.0.1] - 2026-06-10
 
 ### Added

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -848,6 +848,8 @@ def _resolve_col(columns: dict, field: str) -> str:
 
 def _resolve_table(con, model: str):
     """Resolve a table by name, tolerating case differences across dialects."""
+    if getattr(con, "name", None) == "pyspark":
+        return _pyspark_table_unconvertible_as_unknown(con, model)
     try:
         return con.table(model)
     except Exception:
@@ -859,6 +861,32 @@ def _resolve_table(con, model: str):
         if match is None:
             raise
         return con.table(match)
+
+
+def _pyspark_table_unconvertible_as_unknown(con, name: str):
+    """Reflect a pyspark table, typing any column whose Spark type Ibis cannot
+    convert (e.g. Databricks `VariantType`) as `Unknown`.
+    """
+    import ibis
+    import ibis.expr.datatypes as dt
+    import ibis.expr.operations as ops
+    from ibis.backends.pyspark.datatypes import PySparkType
+
+    fields, unknown_columns = {}, []
+    for field in con._session.table(name).schema.fields:
+        try:
+            fields[field.name] = PySparkType.to_ibis(field.dataType)
+        except Exception:
+            fields[field.name] = dt.unknown
+            unknown_columns.append(f"{field.name} ({field.dataType.simpleString()})")
+    if not unknown_columns:
+        # Nothing unconvertible, resolve the table normally
+        return con.table(name)
+    logger.warning(
+        f"Model '{name}': column(s) {', '.join(unknown_columns)} have a type ibis cannot represent. "
+        f"Type checks for these columns will fail."
+    )
+    return ops.DatabaseTable(name, schema=ibis.schema(fields), source=con).to_expr()
 
 
 def _py(value):

--- a/tests/test_test_dataframe.py
+++ b/tests/test_test_dataframe.py
@@ -172,3 +172,29 @@ def _prepare_fail_dataframe(spark):
     # Create temporary view
     # Name must match the model name in the data contract
     df.createOrReplaceTempView("my_table")
+
+
+def test_pyspark_unconvertible_column_as_unknown(spark: SparkSession):
+    import ibis
+    import ibis.expr.datatypes as dt
+    from ibis.backends.pyspark.datatypes import PySparkType
+
+    from datacontract.engines.ibis.ibis_check_execute import _resolve_table
+
+    spark.sql("SELECT 1 AS id, INTERVAL '1-2' YEAR TO MONTH AS payload, 10 AS amount").createOrReplaceTempView(
+        "unconvertible_model"
+    )
+
+    # Sanity: the fixture column really is unconvertible for ibis
+    payload_type = spark.table("unconvertible_model").schema["payload"].dataType
+    with pytest.raises(Exception):
+        PySparkType.to_ibis(payload_type)
+
+    con = ibis.pyspark.connect(session=spark)
+    t = _resolve_table(con, "unconvertible_model")
+
+    assert set(t.columns) == {"id", "payload", "amount"}  # kept
+    assert isinstance(t.schema()["payload"], dt.Unknown)  # typed opaque
+    assert t.count().execute() == 1  # table is queryable
+    assert t.amount.isnull().sum().execute() == 0  # checks on other columns run
+    assert t.payload.isnull().sum().execute() == 0  # not-null still works on the opaque column


### PR DESCRIPTION
## Problem
Fixes #1296.

Since v1.0.0 (Soda → ibis engine), `datacontract test` against a Spark/Databricks server crashes when a table has a column whose Spark type ibis cannot convert — most notably Databricks `VariantType`:

```
Could not read model. Unable to convert type VariantType() to an ibis type.
```

`con.table(model)` reflects the *whole* table schema up front and maps every column to an ibis dtype all-or-nothing, so a single unrepresentable column fails **every** check on the model — even checks that never reference it.

## Fix

On the pyspark backend, reflect the schema ourselves and type any unconvertible column as `Unknown` instead of aborting — the same graceful fallback the SQL backends already apply to unmapped types. Such columns:

- stay present, so presence / not-null checks still run
- fail the checks that genuinely need the precise type

This restores the spirit of the old Soda engine, which never reflected a typed schema and so simply ignored columns it wasn't asked about.

The healthy path is unchanged: tables with no unconvertible columns still go through the public `con.table()`. The hand-built schema injection (a small reach into ibis internals) only runs when a column is actually unrepresentable.