### PR TITLE
feat(trino): support jwt and oauth2 authentication for Trino

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `datacontract import powerbi` imports a data contract from a Power BI semantic model (.pbit, .bim, or .json) (#1233)
+- `datacontract test` against Trino now supports `DATACONTRACT_TRINO_AUTHENTICATION=jwt` with `DATACONTRACT_TRINO_JWT_TOKEN`, and `DATACONTRACT_TRINO_AUTHENTICATION=oauth2` for the interactive browser flow.
 
 ### Changed
 - `datacontract edit` shows the edited filename in the editor header, no longer offers New/Load Example/Open, and Cancel reverts to the file on disk

--- a/README.md
+++ b/README.md
@@ -1160,10 +1160,12 @@ models:
 
 ##### Environment Variables
 
-| Environment Variable          | Example            | Description |
-|-------------------------------|--------------------|-------------|
-| `DATACONTRACT_TRINO_USERNAME` | `trino`            | Username    |
-| `DATACONTRACT_TRINO_PASSWORD` | `mysecretpassword` | Password    |
+| Environment Variable                 | Example            | Description                                                  |
+|--------------------------------------|--------------------|--------------------------------------------------------------|
+| `DATACONTRACT_TRINO_USERNAME`        | `trino`            | Username for `DATACONTRACT_TRINO_AUTHENTICATION=basic`       |
+| `DATACONTRACT_TRINO_PASSWORD`        | `mysecretpassword` | Password for `DATACONTRACT_TRINO_AUTHENTICATION=basic`       |
+| `DATACONTRACT_TRINO_AUTHENTICATION`  | `oauth2`           | Authentication mode: `basic` (default), `jwt`, or `oauth2`   |
+| `DATACONTRACT_TRINO_JWT_TOKEN`       | `eyJhbGciOi...`    | JWT bearer token for `DATACONTRACT_TRINO_AUTHENTICATION=jwt` |
 
 </details>
 

--- a/datacontract/engines/ibis/connections/connect.py
+++ b/datacontract/engines/ibis/connections/connect.py
@@ -185,21 +185,7 @@ def connect_ibis(
         )
 
     if server_type == "trino":
-        user = require_env("DATACONTRACT_TRINO_USERNAME", server_type="trino")
-        password = os.getenv("DATACONTRACT_TRINO_PASSWORD")
-        kwargs = dict(
-            host=server.host,
-            port=int(server.port) if server.port else 8080,
-            user=user,
-            database=server.catalog,
-            schema=server.schema_,
-        )
-        if password:
-            import trino as trino_pkg
-
-            kwargs["auth"] = trino_pkg.auth.BasicAuthentication(user, password)
-            kwargs["http_scheme"] = "https"
-        return ibis.trino.connect(**kwargs)
+        return _connect_trino(ibis, server)
 
     if server_type == "athena":
         return _connect_athena(ibis, server)
@@ -449,6 +435,54 @@ def _connect_athena(ibis, server: Server):
         region_name=os.getenv("DATACONTRACT_S3_REGION") or getattr(server, "region_name", None),
         schema_name=server.schema_,
     )
+
+
+def _connect_trino(ibis, server: Server):
+    authentication = os.getenv("DATACONTRACT_TRINO_AUTHENTICATION", "basic").strip().lower()
+
+    kwargs = dict(
+        host=server.host,
+        port=int(server.port) if server.port else 8080,
+        user=None,
+        database=server.catalog,
+        schema=server.schema_,
+    )
+
+    if authentication == "basic":
+        user = require_env("DATACONTRACT_TRINO_USERNAME", server_type="trino")
+        kwargs["user"] = user
+
+        password = os.getenv("DATACONTRACT_TRINO_PASSWORD")
+        if password:
+            import trino as trino_pkg
+
+            kwargs["auth"] = trino_pkg.auth.BasicAuthentication(user, password)
+            kwargs["http_scheme"] = "https"
+        return ibis.trino.connect(**kwargs)
+    elif authentication == "jwt":
+        import trino as trino_pkg
+
+        kwargs["auth"] = trino_pkg.auth.JWTAuthentication(
+            require_env("DATACONTRACT_TRINO_JWT_TOKEN", server_type="trino")
+        )
+        kwargs["http_scheme"] = "https"
+        return ibis.trino.connect(**kwargs)
+    elif authentication == "oauth2":
+        import trino as trino_pkg
+
+        kwargs["auth"] = trino_pkg.auth.OAuth2Authentication()
+        kwargs["http_scheme"] = "https"
+        return ibis.trino.connect(**kwargs)
+    else:
+        raise DataContractException(
+            type="trino-connection",
+            name="unsupported_authentication",
+            reason=(
+                "Unsupported DATACONTRACT_TRINO_AUTHENTICATION value "
+                f"{authentication!r}. Supported values are: basic, jwt, oauth2."
+            ),
+            engine="datacontract",
+        )
 
 
 def _get_custom_property(server: Server, name: str):

--- a/tests/test_connect_trino.py
+++ b/tests/test_connect_trino.py
@@ -1,0 +1,123 @@
+"""Unit tests for Trino auth-method selection in connect_ibis.
+
+These do not hit Trino: ``ibis.trino.connect`` is patched and we only assert
+which auth kwargs the dispatch passes for a given set of env vars.
+"""
+
+import ibis
+import pytest
+from open_data_contract_standard.model import Server
+
+from datacontract.engines.ibis.connections.connect import connect_ibis
+from datacontract.model.exceptions import DataContractException
+from datacontract.model.run import Run
+
+TRINO_ENV_VARS = [
+    "DATACONTRACT_TRINO_AUTHENTICATION",
+    "DATACONTRACT_TRINO_USERNAME",
+    "DATACONTRACT_TRINO_PASSWORD",
+    "DATACONTRACT_TRINO_JWT_TOKEN",
+]
+
+
+@pytest.fixture
+def env(monkeypatch):
+    for name in TRINO_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    return monkeypatch
+
+
+@pytest.fixture
+def captured_connect(monkeypatch):
+    calls = {}
+
+    def fake_connect(**kwargs):
+        calls.update(kwargs)
+        return "connection"
+
+    monkeypatch.setattr(ibis.trino, "connect", fake_connect)
+    return calls
+
+
+def _server(**kwargs):
+    defaults = dict(type="trino", host="localhost", port=8080, catalog="memory", schema="default")
+    defaults.update(kwargs)
+    return Server(**defaults)
+
+
+def _connect(server=None):
+    return connect_ibis(Run.create_run(), data_contract=None, server=server or _server())
+
+
+def test_basic_auth_is_default(env, captured_connect):
+    env.setenv("DATACONTRACT_TRINO_USERNAME", "my_user")
+    env.setenv("DATACONTRACT_TRINO_PASSWORD", "secret")
+
+    result = _connect()
+
+    assert result == "connection"
+    assert captured_connect["user"] == "my_user"
+    assert captured_connect["host"] == "localhost"
+    assert captured_connect["port"] == 8080
+    assert captured_connect["database"] == "memory"
+    assert captured_connect["schema"] == "default"
+    assert captured_connect["http_scheme"] == "https"
+    assert captured_connect["auth"].__class__.__name__ == "BasicAuthentication"
+
+
+def test_basic_auth_without_password(env, captured_connect):
+    env.setenv("DATACONTRACT_TRINO_USERNAME", "my_user")
+
+    _connect()
+
+    assert captured_connect["user"] == "my_user"
+    assert "auth" not in captured_connect
+    assert "http_scheme" not in captured_connect
+
+
+def test_jwt_auth(env, captured_connect):
+    env.setenv("DATACONTRACT_TRINO_AUTHENTICATION", "jwt")
+    env.setenv("DATACONTRACT_TRINO_JWT_TOKEN", "token-123")
+
+    _connect()
+
+    assert captured_connect["user"] is None
+    assert captured_connect["http_scheme"] == "https"
+    assert captured_connect["auth"].__class__.__name__ == "JWTAuthentication"
+    assert captured_connect["auth"].token == "token-123"
+
+
+def test_jwt_requires_token(env, captured_connect):
+    env.setenv("DATACONTRACT_TRINO_AUTHENTICATION", "jwt")
+
+    with pytest.raises(DataContractException) as exc:
+        _connect()
+
+    assert "DATACONTRACT_TRINO_JWT_TOKEN" in exc.value.reason
+
+
+def test_oauth2_auth(env, captured_connect):
+    env.setenv("DATACONTRACT_TRINO_AUTHENTICATION", "oauth2")
+
+    _connect()
+
+    assert captured_connect["user"] is None
+    assert captured_connect["http_scheme"] == "https"
+    assert captured_connect["auth"].__class__.__name__ == "OAuth2Authentication"
+
+
+def test_unsupported_authentication_raises(env, captured_connect):
+    env.setenv("DATACONTRACT_TRINO_AUTHENTICATION", "kerberos")
+
+    with pytest.raises(DataContractException) as exc:
+        _connect()
+
+    assert "DATACONTRACT_TRINO_AUTHENTICATION" in exc.value.reason
+    assert "basic, jwt, oauth2" in exc.value.reason
+
+
+def test_basic_auth_requires_username(env, captured_connect):
+    with pytest.raises(DataContractException) as exc:
+        _connect()
+
+    assert "DATACONTRACT_TRINO_USERNAME" in exc.value.reason


### PR DESCRIPTION
Add JWT and OAuth2 authentication support for Trino via DATACONTRACT_TRINO_AUTHENTICATION environment variable.

Fixes #1138

- [x] Tests pass (`uv run pytest`)
- [x] Code formatted (`uv run ruff check --fix && uv run ruff format`)
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added
