### PR TITLE
fix: pass DATACONTRACT_S3_SESSION_TOKEN to the Athena connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `datacontract test` no longer aborts remaining quality checks after a SQL quality check falls back to native execution on DuckDB-backed sources (#1302)
+- Athena: pass `DATACONTRACT_S3_SESSION_TOKEN` to the connection again, fixing `UnrecognizedClientException` with temporary AWS credentials
 
 ## [1.0.2] - 2026-06-11
 

--- a/datacontract/engines/ibis/connections/connect.py
+++ b/datacontract/engines/ibis/connections/connect.py
@@ -428,6 +428,7 @@ def _sqlserver_connection_kwargs(server: Server) -> dict:
 def _connect_athena(ibis, server: Server):
     s3_access_key_id = os.getenv("DATACONTRACT_S3_ACCESS_KEY_ID")
     s3_secret_access_key = os.getenv("DATACONTRACT_S3_SECRET_ACCESS_KEY")
+    s3_session_token = os.getenv("DATACONTRACT_S3_SESSION_TOKEN")
     if not server.schema_:
         raise DataContractException(
             type="athena-connection",
@@ -446,6 +447,7 @@ def _connect_athena(ibis, server: Server):
         s3_staging_dir=server.stagingDir,
         aws_access_key_id=s3_access_key_id,
         aws_secret_access_key=s3_secret_access_key,
+        aws_session_token=s3_session_token,
         region_name=os.getenv("DATACONTRACT_S3_REGION") or getattr(server, "region_name", None),
         schema_name=server.schema_,
     )


### PR DESCRIPTION
The ibis Athena connection dropped `DATACONTRACT_S3_SESSION_TOKEN`, so temporary AWS credentials failed with `UnrecognizedClientException: The security token included in the request is invalid`. Pass the session token through again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)