### PR TITLE
fix: declare click as explicit dependency, bump typer to <0.27

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ classifiers = [
 ]
 requires-python = ">=3.10,<3.15"
 dependencies = [
-  "typer>=0.18.0,<0.26",
+  "typer>=0.18.0,<0.27",
+  "click>=8.1.0,<9.0.0",
   "pydantic>=2.8.2,<2.14.0",
   "pyyaml~=6.0.1",
   "requests>=2.31,<2.35",


### PR DESCRIPTION
typer 0.26 dropped `click` from its dependency tree, but `datacontract/cli.py` imports `from click import Context`. Declare `click` explicitly and widen the typer ceiling to `<0.27`. Supersedes #1308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)