### PR TITLE
Docs: show required extra at top of each connection page

### DIFF
--- a/docs/docs/connect/api.md
+++ b/docs/docs/connect/api.md
@@ -8,6 +8,10 @@ description: "Test JSON HTTP APIs (GET only)."
 
 # HTTP API
 
+:::info Required extra
+This connection needs **no additional extra**. See [Installation](../installation.md).
+:::
+
 Test APIs that return data in JSON format. Currently, only GET requests are supported.
 
 ## Server
@@ -25,3 +29,4 @@ servers:
 | Variable | Example | Description |
 |---|---|---|
 | `DATACONTRACT_API_HEADER_AUTHORIZATION` | `Bearer <token>` | Value for the `authorization` header (optional) |
+

--- a/docs/docs/connect/athena.md
+++ b/docs/docs/connect/athena.md
@@ -8,6 +8,10 @@ description: "Test data in AWS Athena stored in S3."
 
 # Amazon Athena
 
+:::info Required extra
+This connection requires the `athena` extra. See [Installation](../installation.md).
+:::
+
 Test data in AWS Athena stored in S3. Supports formats such as Iceberg, Parquet, JSON, and CSV.
 
 ## Server
@@ -31,4 +35,3 @@ servers:
 | `DATACONTRACT_S3_SECRET_ACCESS_KEY` | `93S7LRrJ...` | AWS Secret Access Key |
 | `DATACONTRACT_S3_SESSION_TOKEN` | `AQoDYXdzEJr...` | AWS temporary session token (optional) |
 
-Requires the `athena` extra.

--- a/docs/docs/connect/azure.md
+++ b/docs/docs/connect/azure.md
@@ -8,6 +8,10 @@ description: "Test data on Azure Blob storage or Azure Data Lake Storage Gen2."
 
 # Azure Blob / ADLS
 
+:::info Required extra
+This connection requires the `azure` and `duckdb` extras. See [Installation](../installation.md).
+:::
+
 Test data stored in Azure Blob storage or Azure Data Lake Storage Gen2 (ADLS) in various formats.
 
 ## Server
@@ -30,4 +34,3 @@ Authentication uses an Azure Service Principal (App Registration) with a secret.
 | `DATACONTRACT_AZURE_CLIENT_ID` | `3cf7ce49-...` | The Application/Client ID of the app registration |
 | `DATACONTRACT_AZURE_CLIENT_SECRET` | `yZK8Q~GWO1M...` | The client secret value |
 
-Requires the `azure` / `duckdb` extra.

--- a/docs/docs/connect/bigquery.md
+++ b/docs/docs/connect/bigquery.md
@@ -8,6 +8,10 @@ description: "Test data in Google BigQuery tables and views."
 
 # Google BigQuery
 
+:::info Required extra
+This connection requires the `bigquery` extra. See [Installation](../installation.md).
+:::
+
 Test data in Google BigQuery. Authentication uses a Service Account Key or Application Default Credentials (ADC) — including Workload Identity Federation (WIF), the GCE metadata server, and `gcloud auth application-default login`. The service account should have the **BigQuery Job User** and **BigQuery Data Viewer** roles.
 
 When `DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH` is not set, the CLI falls back to ADC automatically.
@@ -30,4 +34,3 @@ servers:
 | `DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT` | `sa@project.iam.gserviceaccount.com` | Optional. Service account to impersonate (works with key file or ADC). |
 | `DATACONTRACT_BIGQUERY_BILLING_PROJECT` | `my-compute-project` | Optional. Project to bill query jobs to. Requires `bigquery.jobUser` on the billing project and `bigquery.dataViewer` on the data project. |
 
-Requires the `bigquery` extra.

--- a/docs/docs/connect/databricks.md
+++ b/docs/docs/connect/databricks.md
@@ -8,6 +8,10 @@ description: "Test data in Databricks (Unity Catalog or Hive metastore)."
 
 # Databricks
 
+:::info Required extra
+This connection requires the `databricks` extra. See [Installation](../installation.md).
+:::
+
 Test data in Databricks. Works with Unity Catalog and the Hive metastore. Needs a running SQL warehouse or compute cluster.
 
 ## Server
@@ -52,4 +56,3 @@ run.result
 On Databricks LTS ML runtimes (15.4, 16.4), installing via `%pip install` in notebooks can cause issues. Instead, add `datacontract-cli[databricks]` as a **PyPI library** on the cluster (Compute → your cluster → Libraries → Install new → PyPI), then restart the cluster.
 :::
 
-Requires the `databricks` extra.

--- a/docs/docs/connect/dataframe.md
+++ b/docs/docs/connect/dataframe.md
@@ -8,6 +8,10 @@ description: "Test in-memory Spark DataFrames in a pipeline (programmatic)."
 
 # Spark DataFrame
 
+:::info Required extra
+This connection needs **no additional extra**. See [Installation](../installation.md).
+:::
+
 Test Spark DataFrames in a pipeline before writing them to a data source. DataFrames are registered as named temporary views; multiple views are supported if the contract has multiple schemas.
 
 ## Server
@@ -32,3 +36,4 @@ data_contract = DataContract(
 run = data_contract.test()
 assert run.result == "passed"
 ```
+

--- a/docs/docs/connect/gcs.md
+++ b/docs/docs/connect/gcs.md
@@ -8,6 +8,10 @@ description: "Test files on Google Cloud Storage via S3 interoperability."
 
 # Google Cloud Storage (GCS)
 
+:::info Required extra
+This connection requires the `gcs` and `duckdb` extras. See [Installation](../installation.md).
+:::
+
 The [Amazon S3](./s3.md) integration also works with files on Google Cloud Storage through its [interoperability](https://cloud.google.com/storage/docs/interoperability). Use `https://storage.googleapis.com` as the endpoint URL and the `s3://` scheme for the location.
 
 ## Server
@@ -29,4 +33,3 @@ servers:
 | `DATACONTRACT_S3_ACCESS_KEY_ID` | `GOOG1EZZZ...` | The GCS [HMAC Key](https://cloud.google.com/storage/docs/authentication/hmackeys) ID |
 | `DATACONTRACT_S3_SECRET_ACCESS_KEY` | `PDWWpb...` | The GCS [HMAC Key](https://cloud.google.com/storage/docs/authentication/hmackeys) secret |
 
-Requires the `gcs` / `duckdb` extra.

--- a/docs/docs/connect/impala.md
+++ b/docs/docs/connect/impala.md
@@ -8,6 +8,10 @@ description: "Run checks against an Apache Impala cluster."
 
 # Apache Impala
 
+:::info Required extra
+This connection requires the `impala` extra. See [Installation](../installation.md).
+:::
+
 Run checks against an Apache Impala cluster.
 
 ## Server
@@ -32,4 +36,3 @@ servers:
 | `DATACONTRACT_IMPALA_USE_HTTP_TRANSPORT` | `true` | Whether to use HTTP transport (defaults to true) |
 | `DATACONTRACT_IMPALA_HTTP_PATH` | `cliservice` | HTTP path for the Impala service (defaults to cliservice) |
 
-Requires the `impala` extra.

--- a/docs/docs/connect/kafka.md
+++ b/docs/docs/connect/kafka.md
@@ -8,6 +8,10 @@ description: "Test data in Kafka topics (experimental)."
 
 # Kafka
 
+:::info Required extra
+This connection requires the `kafka` extra. See [Installation](../installation.md).
+:::
+
 Test data in Kafka topics. Kafka support is currently considered **experimental**.
 
 ## Server
@@ -29,4 +33,3 @@ servers:
 | `DATACONTRACT_KAFKA_SASL_PASSWORD` | `xxx` | The SASL password (secret) |
 | `DATACONTRACT_KAFKA_SASL_MECHANISM` | `PLAIN` | Default `PLAIN`; also `SCRAM-SHA-256`, `SCRAM-SHA-512` |
 
-Requires the `kafka` extra.

--- a/docs/docs/connect/local.md
+++ b/docs/docs/connect/local.md
@@ -8,6 +8,10 @@ description: "Test local files in Parquet, JSON, CSV, or Delta format."
 
 # Local files
 
+:::info Required extra
+This connection requires the `duckdb` extra. See [Installation](../installation.md).
+:::
+
 Test local files in Parquet, JSON, CSV, or Delta format.
 
 ## Server
@@ -20,4 +24,3 @@ servers:
     format: parquet
 ```
 
-Requires the `duckdb` extra.

--- a/docs/docs/connect/mysql.md
+++ b/docs/docs/connect/mysql.md
@@ -8,6 +8,10 @@ description: "Test data in MySQL and MySQL-compatible databases."
 
 # MySQL
 
+:::info Required extra
+This connection requires the `mysql` extra. See [Installation](../installation.md).
+:::
+
 Test data in MySQL or MySQL-compatible databases (e.g. MariaDB).
 
 ## Server
@@ -28,4 +32,3 @@ servers:
 | `DATACONTRACT_MYSQL_USERNAME` | `root` | Username |
 | `DATACONTRACT_MYSQL_PASSWORD` | `mysecretpassword` | Password |
 
-Requires the `mysql` extra.

--- a/docs/docs/connect/oracle.md
+++ b/docs/docs/connect/oracle.md
@@ -8,6 +8,10 @@ description: "Test data in Oracle Database."
 
 # Oracle
 
+:::info Required extra
+This connection requires the `oracle` extra. See [Installation](../installation.md).
+:::
+
 Test data in Oracle Database.
 
 ## Server
@@ -30,4 +34,3 @@ servers:
 | `DATACONTRACT_ORACLE_PASSWORD` | `0x162e53` | Password |
 | `DATACONTRACT_ORACLE_CLIENT_DIR` | `C:\oracle\client` | Path to an Oracle Instant Client installation (required for thick mode) |
 
-Requires the `oracle` extra.

--- a/docs/docs/connect/postgres.md
+++ b/docs/docs/connect/postgres.md
@@ -8,6 +8,10 @@ description: "Test data in Postgres and Postgres-compatible databases."
 
 # Postgres
 
+:::info Required extra
+This connection requires the `postgres` extra. See [Installation](../installation.md).
+:::
+
 Test data in Postgres or Postgres-compatible databases (e.g. RisingWave).
 
 ## Server
@@ -29,4 +33,3 @@ servers:
 | `DATACONTRACT_POSTGRES_USERNAME` | `postgres` | Username |
 | `DATACONTRACT_POSTGRES_PASSWORD` | `mysecretpassword` | Password |
 
-Requires the `postgres` extra.

--- a/docs/docs/connect/redshift.md
+++ b/docs/docs/connect/redshift.md
@@ -8,6 +8,10 @@ description: "Test data in Amazon Redshift."
 
 # Amazon Redshift
 
+:::info Required extra
+This connection requires the `redshift` extra. See [Installation](../installation.md).
+:::
+
 Test data in Amazon Redshift (both provisioned clusters and Redshift Serverless). Redshift is reached over the PostgreSQL wire protocol via the ibis Postgres backend, using username/password authentication.
 
 ## Server
@@ -33,4 +37,3 @@ servers:
 IAM-based authentication (region / access key / role ARN) is not currently supported for Redshift, because ibis connects through the generic Postgres backend rather than a Redshift-specific driver.
 :::
 
-Requires the `redshift` extra.

--- a/docs/docs/connect/s3.md
+++ b/docs/docs/connect/s3.md
@@ -8,6 +8,10 @@ description: "Test data stored in S3 buckets or S3-compatible storage."
 
 # Amazon S3
 
+:::info Required extra
+This connection requires the `s3` and `duckdb` extras. See [Installation](../installation.md).
+:::
+
 Test data stored in S3 buckets or any S3-compatible endpoint, in CSV, JSON, Delta, or Parquet format.
 
 ## Server (JSON)
@@ -42,4 +46,3 @@ servers:
 | `DATACONTRACT_S3_SECRET_ACCESS_KEY` | `93S7LRrJ...` | AWS Secret Access Key |
 | `DATACONTRACT_S3_SESSION_TOKEN` | `AQoDYXdzEJr...` | AWS temporary session token (optional) |
 
-Requires the `s3` / `duckdb` extra.

--- a/docs/docs/connect/snowflake.md
+++ b/docs/docs/connect/snowflake.md
@@ -8,6 +8,10 @@ description: "Test data in Snowflake."
 
 # Snowflake
 
+:::info Required extra
+This connection requires the `snowflake` extra. See [Installation](../installation.md).
+:::
+
 Test data in Snowflake.
 
 ## Server
@@ -39,4 +43,3 @@ Any `DATACONTRACT_SNOWFLAKE_`-prefixed variable is passed (lowercased, prefix st
 | `private_key_passphrase` | `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE` |
 | `private_key_path` | `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_PATH` |
 
-Requires the `snowflake` extra.

--- a/docs/docs/connect/sqlserver.md
+++ b/docs/docs/connect/sqlserver.md
@@ -8,6 +8,10 @@ description: "Test data in SQL Server, Azure SQL, Synapse, and Fabric."
 
 # Microsoft SQL Server
 
+:::info Required extra
+This connection requires the `sqlserver` extra. See [Installation](../installation.md).
+:::
+
 Test data in MS SQL Server, including Azure SQL, Synapse Analytics SQL Pool, and Microsoft Fabric.
 
 ## Server
@@ -38,4 +42,3 @@ servers:
 
 The `cli` mode reuses an `az login` session through the Azure default credential chain and requires ODBC Driver 18.1 or newer.
 
-Requires the `sqlserver` extra.

--- a/docs/docs/connect/trino.md
+++ b/docs/docs/connect/trino.md
@@ -8,6 +8,10 @@ description: "Test data in Trino with basic, JWT, or OAuth2 auth."
 
 # Trino
 
+:::info Required extra
+This connection requires the `trino` extra. See [Installation](../installation.md).
+:::
+
 Test data in Trino.
 
 ## Server
@@ -31,4 +35,3 @@ servers:
 | `DATACONTRACT_TRINO_AUTHENTICATION` | `oauth2` | `basic` (default), `jwt`, or `oauth2` |
 | `DATACONTRACT_TRINO_JWT_TOKEN` | `eyJhbGciOi...` | JWT bearer token for `jwt` auth |
 
-Requires the `trino` extra.


### PR DESCRIPTION
Adds a prominent 'Required extra' admonition under the title of every Connect your Data page (no install command), linking to the Installation page.