### PR TITLE
Docs+README: use Entropy Data wordmark logo in footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ Created by [Stefan Negele](https://www.linkedin.com/in/stefan-negele-573153112/)
 ---
 
 <p align="center">
-  <a href="https://entropy-data.com" target="_blank"><img src="https://entropy-data.com/media/logo_fuchsia_v2.png" alt="Entropy Data" height="48"></a>
+  <a href="https://entropy-data.com" target="_blank"><img src="https://entropy-data.com/media/entropy-data-logo.svg" alt="Entropy Data" height="36"></a>
 </p>
 <p align="center">
   <a href="https://entropy-data.com/legal-notice">Legal Notice</a> · <a href="https://entropy-data.com/privacy-policy">Privacy Policy</a>

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -134,10 +134,10 @@ const config: Config = {
       ],
       logo: {
         alt: 'Entropy Data',
-        src: 'https://entropy-data.com/media/logo_fuchsia_v2.png',
+        src: 'https://entropy-data.com/media/entropy-data-logo.svg',
         href: 'https://entropy-data.com',
-        width: 44,
-        height: 44,
+        width: 148,
+        height: 36,
       },
       copyright: `Copyright © ${new Date().getFullYear()} Data Contract CLI authors. Built with Docusaurus.`,
     },


### PR DESCRIPTION
Switches the footer logo to https://entropy-data.com/media/entropy-data-logo.svg with proportional sizing for the horizontal wordmark.