### PR TITLE
Use Entropy Data branding in cli.datacontract.com footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,14 +39,14 @@
     </div>
     <footer class="footer">
       <p style="margin-top: 2em;">
-        <a href="https://www.innoq.com">
-          <img src="https://innoq.style/assets/logos/edition-02/svg/innoq-logo--petrolapricot.svg" class="footer-logo" />
+        <a href="https://entropy-data.com">
+          <img src="https://entropy-data.com/media/entropy-data-logo.svg" alt="Entropy Data" class="footer-logo" />
         </a>
       </p>
       <p>
-        <a href="https://www.innoq.com/en/impressum/">Legal Notice</a>
+        <a href="https://entropy-data.com/legal-notice">Legal Notice</a>
         |
-        <a href="https://www.innoq.com/en/datenschutz/">Privacy</a>
+        <a href="https://entropy-data.com/privacy-policy">Privacy</a>
       </p>
     </footer>
     <script src="{{ "assets/javascript/anchor-js/anchor.min.js" | relative_url }}"></script>


### PR DESCRIPTION
Swaps the INNOQ logo and impressum/datenschutz links in the Jekyll footer for the Entropy Data logo and entropy-data.com legal-notice/privacy-policy links, matching the README and docs site.