### PR TITLE
Remove duplicate Entropy Data footer on cli.datacontract.com

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -37,18 +37,6 @@
       </div>
       {% endif %}
     </div>
-    <footer class="footer">
-      <p style="margin-top: 2em;">
-        <a href="https://entropy-data.com">
-          <img src="https://entropy-data.com/media/entropy-data-logo.svg" alt="Entropy Data" class="footer-logo" />
-        </a>
-      </p>
-      <p>
-        <a href="https://entropy-data.com/legal-notice">Legal Notice</a>
-        |
-        <a href="https://entropy-data.com/privacy-policy">Privacy</a>
-      </p>
-    </footer>
     <script src="{{ "assets/javascript/anchor-js/anchor.min.js" | relative_url }}"></script>
     <script>anchors.add();</script>
     {% if site.google_analytics %}


### PR DESCRIPTION
The README content already renders the Entropy Data logo + legal/privacy footer (used on GitHub and PyPI). Removing the duplicate template <footer> so cli.datacontract.com shows it once.