### PR TITLE
ci: build docs on PRs, deploy on main, skip Python CI for docs-only changes

### DIFF
--- a/.github/workflows/azure-static-web-apps-docs.yml
+++ b/.github/workflows/azure-static-web-apps-docs.yml
@@ -1,6 +1,7 @@
-name: Deploy Docs (Azure Static Web Apps)
+name: Docs
 
-# Publishes the Docusaurus documentation site in docs/ to docs.datacontract.com.
+# Builds the Docusaurus documentation site in docs/ on every PR
+# and deploys it to docs.datacontract.com on push to main.
 # Runs alongside the GitHub Pages site at cli.datacontract.com.
 
 on:
@@ -11,16 +12,31 @@ on:
       - 'docs/**'
       - '.github/workflows/azure-static-web-apps-docs.yml'
   pull_request:
-    types: [opened, synchronize, reopened, closed]
     paths:
       - 'docs/**'
       - '.github/workflows/azure-static-web-apps-docs.yml'
 
 jobs:
-  build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+  build:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    name: Build and Deploy
+    name: Build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+      - run: npm ci
+        working-directory: docs
+      - run: npm run build # docusaurus build, fails on broken links
+        working-directory: docs
+
+  deploy:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    name: Deploy
     steps:
       - uses: actions/checkout@v4
         with:
@@ -38,15 +54,3 @@ jobs:
           api_location: ""            # no API
           output_location: "build"   # Docusaurus build output (relative to app_location)
           ###### End of Repository/Build Configurations ######
-
-  close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    name: Close Pull Request
-    steps:
-      - name: Close Pull Request
-        id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_DATACONTRACT_CLI_DOCS }}
-          action: "close"

--- a/.github/workflows/azure-static-web-apps-docs.yml
+++ b/.github/workflows/azure-static-web-apps-docs.yml
@@ -16,6 +16,9 @@ on:
       - 'docs/**'
       - '.github/workflows/azure-static-web-apps-docs.yml'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: github.event_name == 'pull_request'
@@ -47,7 +50,6 @@ jobs:
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_DATACONTRACT_CLI_DOCS }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for GitHub integrations (i.e. PR comments)
           action: "upload"
           ###### Repository/Build Configurations ######
           app_location: "docs"        # Docusaurus project root

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - 'docs/**'
   workflow_call:
 
 permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,8 @@
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     branches: [ "main" ]
     paths-ignore:


### PR DESCRIPTION
- Docs workflow: build on every PR (secret-free, so it runs for forks too) and deploy to docs.datacontract.com only on push to `main`; restricted to `contents: read`.
- Skip the Python CI matrix for docs-only changes (PRs and pushes to `main`).