### PR TITLE
fix: Oracle test fails with ORA-00923 on releases before 23ai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `datacontract import unity` now imports struct and array columns as structured ODCS types instead of only a flat type string: structs get nested `properties`, arrays get `items` (parsed recursively from Unity's `type_json`, including descriptions on nested fields). Arrays also get the correct `logicalType: array` (previously `object`); this logical type fix applies to the `sql` and `snowflake` importers as well. Map columns and other unmappable SQL types now leave `logicalType` unset (instead of the invalid `object`) until ODCS v3.2 adds `logicalType: map` (RFC 0030). (#1280)
 - `datacontract export dcs` no longer crashes on data contracts with a structured description or a standard server.
+- `datacontract test` against Oracle releases before 23ai no longer fails every check with `ORA-00923: FROM keyword not found where expected` during schema introspection.
 
 ## [1.0.3] - 2026-06-15
 

--- a/datacontract/engines/ibis/connections/connect.py
+++ b/datacontract/engines/ibis/connections/connect.py
@@ -170,19 +170,23 @@ def connect_ibis(
         return _connect_sqlserver(ibis, server)
 
     if server_type == "oracle":
+        from datacontract.engines.ibis.connections.oracle_patch import apply_oracle_compatibility_patch
+
         service_name = server.serviceName or server.database
         oracle_client_dir = os.getenv("DATACONTRACT_ORACLE_CLIENT_DIR")
         if oracle_client_dir:
             import oracledb
 
             oracledb.init_oracle_client(lib_dir=oracle_client_dir)
-        return ibis.oracle.connect(
+        con = ibis.oracle.connect(
             host=server.host,
             port=int(server.port) if server.port else 1521,
             user=require_env("DATACONTRACT_ORACLE_USERNAME", server_type="oracle"),
             password=require_env("DATACONTRACT_ORACLE_PASSWORD", server_type="oracle"),
             service_name=service_name,
         )
+        apply_oracle_compatibility_patch(con)
+        return con
 
     if server_type == "trino":
         return _connect_trino(ibis, server)

--- a/datacontract/engines/ibis/connections/oracle_patch.py
+++ b/datacontract/engines/ibis/connections/oracle_patch.py
@@ -1,0 +1,169 @@
+"""Make ibis's Oracle schema introspection valid on Oracle releases before 23ai.
+
+ibis builds the column-metadata queries behind ``con.table(...)`` and
+``con.sql(...)`` with a bare boolean projection ``NULLABLE = 'Y'`` in the SELECT
+list (see ``ibis.backends.oracle.Backend.get_schema`` /
+``_get_schema_using_query``). Oracle only added a SQL boolean type in 23ai, so on
+every earlier release (19c, 21c, ...) that projection is a syntax error:
+
+    ORA-00923: FROM keyword not found where expected
+
+The 23ai test container (``gvenzl/oracle-free``) accepts it, which is why the
+bug stays invisible in CI but breaks against real-world Oracle databases.
+
+This module re-binds ``get_schema`` and ``_get_schema_using_query`` on a
+connected Oracle backend with equivalent queries that express the nullable flag
+as ``CASE WHEN NULLABLE = 'Y' THEN 1 ELSE 0 END``, which is valid on all
+supported Oracle versions. The override can be removed once a fixed ibis release
+is available.
+"""
+
+from __future__ import annotations
+
+import logging
+import types
+
+logger = logging.getLogger(__name__)
+
+
+def apply_oracle_compatibility_patch(con) -> None:
+    """Re-bind Oracle schema introspection to emit pre-23ai-compatible SQL.
+
+    Best-effort: if the backend internals differ from what we expect (e.g. a
+    future ibis refactor), the patch is skipped and the original methods stay in
+    place rather than breaking the connection.
+    """
+    try:
+        con.get_schema = types.MethodType(_get_schema, con)
+        con._get_schema_using_query = types.MethodType(_get_schema_using_query, con)
+    except Exception:  # pragma: no cover - defensive, never block a connection
+        logger.debug("Could not apply Oracle compatibility patch", exc_info=True)
+
+
+def _nullable_flag():
+    """``CASE WHEN NULLABLE = 'Y' THEN 1 ELSE 0 END`` as a sqlglot expression.
+
+    Replaces ibis's bare ``NULLABLE = 'Y'`` boolean projection, which is invalid
+    in an Oracle SELECT list before 23ai.
+    """
+    import sqlglot.expressions as sge
+    from ibis.backends.sql.compilers.base import C
+
+    return sge.Case(
+        ifs=[sge.If(this=C.nullable.eq(sge.convert("Y")), true=sge.convert(1))],
+        default=sge.convert(0),
+    )
+
+
+def _get_schema(self, name: str, *, catalog=None, database=None, **_):
+    """Drop-in for ``Backend.get_schema`` using a CASE-based nullable flag."""
+    import ibis.common.exceptions as exc
+    import ibis.expr.schema as sch
+    import sqlglot as sg
+    import sqlglot.expressions as sge
+    from ibis.backends.oracle import metadata_row_to_type
+    from ibis.backends.sql.compilers.base import C
+
+    if database is None:
+        database = self.con.username.upper()
+    stmt = (
+        sg.select(
+            C.column_name,
+            C.data_type,
+            C.data_precision,
+            C.data_scale,
+            _nullable_flag().as_("nullable"),
+        )
+        .from_(sg.table("all_tab_columns"))
+        .where(
+            C.table_name.eq(sge.convert(name)),
+            C.owner.eq(sge.convert(database)),
+        )
+        .order_by(C.column_id)
+    )
+    with self._safe_raw_sql(stmt) as cur:
+        results = cur.fetchall()
+
+    if not results:
+        raise exc.TableNotFound(name)
+
+    type_mapper = self.compiler.type_mapper
+    fields = {
+        col: metadata_row_to_type(
+            type_mapper=type_mapper,
+            type_string=type_string,
+            precision=precision,
+            scale=scale,
+            nullable=bool(nullable),
+        )
+        for col, type_string, precision, scale, nullable in results
+    }
+    return sch.Schema(fields)
+
+
+def _get_schema_using_query(self, query: str):
+    """Drop-in for ``Backend._get_schema_using_query`` using a CASE-based flag."""
+    import ibis.expr.schema as sch
+    import sqlglot as sg
+    import sqlglot.expressions as sge
+    from ibis import util
+    from ibis.backends.oracle import metadata_row_to_type
+    from ibis.backends.sql.compilers.base import STAR, C
+
+    name = util.gen_name("oracle_metadata")
+    dialect = self.name
+
+    try:
+        sg_expr = sg.parse_one(query, into=sg.exp.Table, dialect=dialect)
+    except sg.ParseError:
+        sg_expr = sg.parse_one(query, dialect=dialect)
+
+    if isinstance(sg_expr, sg.exp.Table):
+        sg_expr = sg.select(STAR).from_(sg_expr)
+
+    def transformer(node):
+        if isinstance(node, sg.exp.Table):
+            return sg.table(node.name, quoted=True)
+        elif isinstance(node, sg.exp.Column):
+            return sg.column(col=node.name, quoted=True)
+        return node
+
+    sg_expr = sg_expr.transform(transformer)
+
+    this = sg.table(name, quoted=True)
+    create_view = sg.exp.Create(kind="VIEW", this=this, expression=sg_expr).sql(dialect)
+    drop_view = sg.exp.Drop(kind="VIEW", this=this).sql(dialect)
+
+    metadata_query = (
+        sg.select(
+            C.column_name,
+            C.data_type,
+            C.data_precision,
+            C.data_scale,
+            _nullable_flag().as_("nullable"),
+        )
+        .from_("all_tab_columns")
+        .where(C.table_name.eq(sge.convert(name)))
+        .order_by(C.column_id)
+        .sql(dialect)
+    )
+
+    with self.begin() as con:
+        con.execute(create_view)
+        try:
+            results = con.execute(metadata_query).fetchall()
+        finally:
+            con.execute(drop_view)
+
+    type_mapper = self.compiler.type_mapper
+    schema = {}
+    for col, type_string, precision, scale, nullable in results:
+        schema[col] = metadata_row_to_type(
+            type_mapper=type_mapper,
+            type_string=type_string,
+            precision=precision,
+            scale=scale,
+            nullable=bool(nullable),
+        )
+
+    return sch.Schema(schema)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,8 +224,13 @@ override-dependencies = [
 ]
 
 [tool.pytest.ini_options]
-#addopts = "-n 8" # run tests in parallel, you can disable parallel test execution with "pytest -n0" command
+# Exclude slow tests by default; run them with `pytest -m slow` (or `-m "slow or not slow"` for everything).
+# Append parallel execution with "-n 8" if desired (disable with "-n0").
+addopts = "-m 'not slow'"
 testpaths = ["tests"]
+markers = [
+    "slow: tests that are slow to run (e.g. pull large containers); deselect with '-m \"not slow\"'",
+]
 log_level = "INFO"
 #log_cli = "true" #  activate live logging, do not use with -n 8 xdist option for parallel test execution: https://github.com/pytest-dev/pytest-xdist/issues/402
 log_cli_level = "INFO"

--- a/tests/test_oracle_patch.py
+++ b/tests/test_oracle_patch.py
@@ -1,0 +1,88 @@
+"""Regression tests for the Oracle pre-23ai schema-introspection patch.
+
+ibis renders the nullable flag in its column-metadata query as a bare
+``NULLABLE = 'Y'`` boolean projection. Oracle only added a SQL boolean type in
+23ai, so the unpatched query raises ``ORA-00923: FROM keyword not found where
+expected`` on 19c/21c. The CI test container runs 23ai and therefore cannot
+catch this, so these tests assert the patched query is boolean-free without
+needing a live database.
+"""
+
+import contextlib
+
+import pytest
+
+sc = pytest.importorskip("ibis.backends.sql.compilers")
+
+from datacontract.engines.ibis.connections import oracle_patch  # noqa: E402
+
+
+class _StubCursor:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def fetchall(self):
+        return self._rows
+
+
+class _StubOracleConnection:
+    """Minimal stand-in exposing what the patched introspection methods touch."""
+
+    name = "oracle"
+    compiler = sc.oracle.compiler
+
+    def __init__(self, rows):
+        self._rows = rows
+        self.captured_sql = None
+
+    @contextlib.contextmanager
+    def _safe_raw_sql(self, stmt):
+        # Render exactly as ibis's raw_sql does before executing.
+        self.captured_sql = stmt.sql(dialect=self.name)
+        yield _StubCursor(self._rows)
+
+
+def _assert_pre_23ai_compatible(sql: str):
+    assert "CASE WHEN" in sql
+    # The unpatched, pre-23ai-incompatible projection must not appear.
+    assert "= 'Y' AS" not in sql.upper().replace("NULLABLE = 'Y' THEN", "")
+
+
+def test_get_schema_query_is_boolean_free_and_typed():
+    rows = [
+        ("ID", "NUMBER", 10, 0, 1),
+        ("NAME", "VARCHAR2", None, None, 0),
+    ]
+    con = _StubOracleConnection(rows)
+
+    schema = oracle_patch._get_schema(con, "MY_TABLE", database="MY_OWNER")
+
+    _assert_pre_23ai_compatible(con.captured_sql)
+    # The 1/0 flag from CASE is coerced back to a Python bool on the field type.
+    assert schema["ID"].nullable is True
+    assert schema["NAME"].nullable is False
+    assert schema["ID"].is_integer()
+    assert schema["NAME"].is_string()
+
+
+def test_get_schema_raises_table_not_found_when_empty():
+    import ibis.common.exceptions as exc
+
+    con = _StubOracleConnection([])
+    with pytest.raises(exc.TableNotFound):
+        oracle_patch._get_schema(con, "MISSING", database="MY_OWNER")
+
+
+def test_apply_patch_rebinds_methods():
+    class _Backend:
+        def get_schema(self, *a, **k):  # pragma: no cover - replaced by the patch
+            return "original"
+
+        def _get_schema_using_query(self, *a, **k):  # pragma: no cover
+            return "original"
+
+    backend = _Backend()
+    oracle_patch.apply_oracle_compatibility_patch(backend)
+
+    assert backend.get_schema.__func__ is oracle_patch._get_schema
+    assert backend._get_schema_using_query.__func__ is oracle_patch._get_schema_using_query

--- a/tests/test_test_oracle_xe.py
+++ b/tests/test_test_oracle_xe.py
@@ -1,0 +1,93 @@
+"""End-to-end `datacontract test` against a pre-23ai Oracle.
+
+The main Oracle test (`test_test_oracle.py`) runs `gvenzl/oracle-free` (23ai).
+23ai is the first Oracle release with a SQL boolean type, so it silently accepts
+ibis's `NULLABLE = 'Y'` schema-introspection projection. Every earlier release
+(19c, 21c, ...) rejects it with `ORA-00923: FROM keyword not found where
+expected`, breaking every check.
+
+Oracle 19c has no freely pullable image (it lives behind Oracle's authenticated
+registry), so this test uses Oracle XE 21c — the newest free pre-23ai release —
+as the stand-in. It reproduces the same missing-boolean behaviour and therefore
+guards the compatibility patch in
+`datacontract.engines.ibis.connections.oracle_patch`.
+"""
+
+import pytest
+import sqlalchemy
+from oracledb import DatabaseError
+from testcontainers.oracle import OracleDbContainer
+
+from datacontract.data_contract import DataContract
+
+# XE 21c: pre-23ai (no SQL boolean type), and freely available unlike 19c.
+oracleContainer = OracleDbContainer("gvenzl/oracle-xe:21-slim-faststart")
+ORACLE_SERVER_PORT: int = 1521
+
+# XE's pluggable-database service name differs from oracle-free's FREEPDB1.
+_XE_SERVICE_NAME = "XEPDB1"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def oracle_container(request):
+    oracleContainer.start()
+
+    def remove_container():
+        oracleContainer.stop()
+
+    request.addfinalizer(remove_container)
+
+
+@pytest.mark.slow
+def test_test_oracle_xe_contract_dcs(oracle_container, monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_ORACLE_USERNAME", "SYSTEM")
+    monkeypatch.setenv("DATACONTRACT_ORACLE_PASSWORD", oracleContainer.oracle_password)
+
+    _init_sql("fixtures/oracle/data/testcase.sql")
+
+    data_contract_str = _setup_datacontract("fixtures/oracle/datacontract-oracle-dcs.yaml")
+    data_contract = DataContract(data_contract_str=data_contract_str)
+
+    run = data_contract.test()
+
+    print(run)
+    assert run.result == "passed"
+    assert all(check.result == "passed" for check in run.checks)
+
+
+@pytest.mark.slow
+def test_test_oracle_xe_contract_odcs(oracle_container, monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_ORACLE_USERNAME", "SYSTEM")
+    monkeypatch.setenv("DATACONTRACT_ORACLE_PASSWORD", oracleContainer.oracle_password)
+
+    _init_sql("fixtures/oracle/data/testcase.sql")
+
+    data_contract_str = _setup_datacontract("fixtures/oracle/datacontract-oracle-odcs.yaml")
+    data_contract = DataContract(data_contract_str=data_contract_str)
+
+    run = data_contract.test()
+
+    print(run)
+    assert run.result == "passed"
+    assert all(check.result == "passed" for check in run.checks)
+
+
+def _init_sql(sql_file_path):
+    with sqlalchemy.create_engine(oracleContainer.get_connection_url()).begin() as engine:
+        with engine.connection.cursor() as cursor:
+            with open(sql_file_path, "r") as sql_file:
+                for sql_command in sql_file.read().split(";"):
+                    try:
+                        cursor.execute(sql_command)
+                    except DatabaseError as e:
+                        print(f"Error executing SQL command: {e}", sql_command)
+
+
+def _setup_datacontract(datacontract):
+    with open(datacontract) as data_contract_file:
+        data_contract_str = data_contract_file.read()
+    port = oracleContainer.get_exposed_port(ORACLE_SERVER_PORT)
+    data_contract_str = data_contract_str.replace("__PORT__", str(port))
+    # The shared fixtures target oracle-free's FREEPDB1; XE serves XEPDB1.
+    data_contract_str = data_contract_str.replace("FREEPDB1", _XE_SERVICE_NAME)
+    return data_contract_str


### PR DESCRIPTION
## Problem

Running `datacontract test` against Oracle fails every check with:

```
Could not read model '...': ORA-00923: FROM keyword not found where expected
```

In the 1.x line testing runs on ibis. For each model it calls `con.table(model)`, which makes ibis introspect column metadata. ibis 12's Oracle backend builds that query (`Backend.get_schema`, and `_get_schema_using_query` for custom-SQL checks) with a bare boolean projection in the SELECT list:

```sql
SELECT column_name, data_type, data_precision, data_scale, nullable = 'Y' AS nullable
FROM all_tab_columns WHERE ...
```

Oracle only added a SQL boolean type in **23ai**. On every earlier release (19c, 21c, ...) `nullable = 'Y'` in a projection is a syntax error reported as `ORA-00923`. Because introspection fails before any data is read, every check fails.

This stayed invisible in CI because the existing Oracle test container is `gvenzl/oracle-free` (23ai), which accepts the boolean projection. It's an upstream ibis bug, and the latest ibis (`<13`) is still affected.

## Fix

Re-bind `get_schema` / `_get_schema_using_query` on the connected Oracle backend with equivalent queries that express the nullable flag as `CASE WHEN nullable = 'Y' THEN 1 ELSE 0 END` (valid on all supported Oracle versions), coercing the resulting `1`/`0` back to a Python bool. Best-effort: if ibis internals change, the patch is skipped rather than breaking the connection. Remove once a fixed ibis release is available.

## Tests

- `tests/test_oracle_patch.py` — DB-free unit test driving the patched method through a stub connection; asserts the emitted SQL is pre-23ai compatible (`CASE`, no boolean projection) and that nullable/types come back correct.
- `tests/test_test_oracle_xe.py` — end-to-end `datacontract test` against **Oracle XE 21c** (newest free pre-23ai release; 19c has no freely pullable image). Verified it fails with the exact `ORA-00923` error when the patch is disabled, and passes with it. Marked `@pytest.mark.slow`.
- `pyproject.toml` — registered the `slow` marker and excluded slow tests by default (`addopts = "-m 'not slow'"`); run them with `pytest -m slow`.

> Note: slow tests are now excluded from a bare `pytest`, including in CI. If CI should keep running the container test, add a step with `pytest -m slow`.