### PR TITLE
ci: run slow tests in a dedicated job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,6 +67,30 @@ jobs:
       - name: Run tests
         run: uv run pytest -n0
 
+  slow-tests:
+    name: "Slow tests (testcontainers)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java (required for Spark-based tests)
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Install system dependencies (msodbcsql18, protoc)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y msodbcsql18 protobuf-compiler
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.11'
+      - name: Install the project
+        run: uv sync --all-extras --dev
+      - name: Run slow tests
+        run: uv run pytest -n0 -m slow
+
   integration-tests:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5


### PR DESCRIPTION
## Why

#1323 marked the testcontainers-based tests `slow` and excluded slow tests from the default `pytest` run (`addopts = "-m 'not slow'"`). That means a bare `pytest` — including the CI `test` matrix — no longer runs them, so the pre-23ai Oracle XE regression test would silently stop executing in CI.

## Change

Add a dedicated `slow-tests` job that runs `pytest -m slow` once (Python 3.11; Docker is available on the `ubuntu-latest` runner), mirroring the `test` job's environment so full test collection succeeds. This keeps the slow container tests running in CI without multiplying them across the whole Python matrix.

Run locally with `pytest -m slow`.