### PR TITLE
fix: recognize Oracle VARCHAR2/NVARCHAR2 as string in field type check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract import unity` now imports struct and array columns as structured ODCS types instead of only a flat type string: structs get nested `properties`, arrays get `items` (parsed recursively from Unity's `type_json`, including descriptions on nested fields). Arrays also get the correct `logicalType: array` (previously `object`); this logical type fix applies to the `sql` and `snowflake` importers as well. Map columns and other unmappable SQL types now leave `logicalType` unset (instead of the invalid `object`) until ODCS v3.2 adds `logicalType: map` (RFC 0030). (#1280)
 - `datacontract export dcs` no longer crashes on data contracts with a structured description or a standard server.
 - `datacontract test` against Oracle releases before 23ai no longer fails every check with `ORA-00923: FROM keyword not found where expected` during schema introspection.
+- `datacontract test` now recognizes Oracle `VARCHAR2`/`NVARCHAR2` (with or without a length, e.g. `VARCHAR2(4000)`) as string types in the field type check.
 
 ## [1.0.3] - 2026-06-15
 

--- a/datacontract/engines/checks/type_normalize.py
+++ b/datacontract/engines/checks/type_normalize.py
@@ -27,10 +27,12 @@ def normalize_type_name(type_name: str | None) -> str:
 
     if name in {
         "varchar",
+        "varchar2",
         "char",
         "character",
         "character varying",
         "nvarchar",
+        "nvarchar2",
         "nchar",
         "text",
         "string",

--- a/tests/test_type_normalize.py
+++ b/tests/test_type_normalize.py
@@ -1,0 +1,25 @@
+from datacontract.engines.checks.type_normalize import category_matches, normalize_type_name
+
+
+def test_normalize_strips_length_parameters():
+    assert normalize_type_name("VARCHAR2(4000)") == "string"
+    assert normalize_type_name("VARCHAR2(40)") == "string"
+    assert normalize_type_name("NUMBER(4,0)") == "number"
+    assert normalize_type_name("CHAR(10)") == "string"
+
+
+def test_normalize_oracle_string_types():
+    # Oracle VARCHAR2/NVARCHAR2 (with or without length) are strings, not "other".
+    assert normalize_type_name("VARCHAR2") == "string"
+    assert normalize_type_name("NVARCHAR2") == "string"
+    assert normalize_type_name("nvarchar2(100)") == "string"
+
+
+def test_parameterized_type_matches_unparameterized():
+    # A contract declaring VARCHAR2(4000) must match a column reported as VARCHAR2.
+    expected = normalize_type_name("VARCHAR2(4000)")
+    actual = normalize_type_name("VARCHAR2")
+    assert category_matches(expected, actual)
+
+    expected = normalize_type_name("NUMBER(4,0)")
+    assert category_matches(expected, "decimal")


### PR DESCRIPTION
## Problem

A user reported that an Oracle data contract with length-annotated physical types (e.g. `physicalType: VARCHAR2(4000)`, `NUMBER(4,0)`) failed every type check during `datacontract test`:

```
failed │ Check that field FIELD1 has type VARCHAR2(4000) │ Type Mismatch, Expected Type: VARCHAR2(4000); Actual Type: VARCHAR2
failed │ Check that field FIELD2 has type NUMBER(4,0) │ Type Mismatch, Expected Type: NUMBER(4,0); Actual Type: NUMBER
```

That `Type Mismatch` message comes from the old soda-core engine (pre-1.0.0), which compared the declared `physicalType` string literally against the type Oracle reports. Oracle metadata returns `VARCHAR2`/`NUMBER` without the length/precision, so length-annotated forms never matched. The soda engine was replaced by the ibis engine in #1279, which normalizes both sides to coarse categories — so this case already passes on 1.0.x (verified against a live Oracle container for `VARCHAR2(4000)`, `VARCHAR2(256)`, `VARCHAR2(40)`, `NUMBER(4,0)`).

## Change

On current code, `VARCHAR2`/`NVARCHAR2` were not in the recognized string set, so they fell through to the lenient `"other"` category that matches any actual type — passing by accident and unable to catch a genuine mismatch (e.g. `VARCHAR2` declared for a numeric column). This adds `varchar2`/`nvarchar2` to the string set so the check is intentional. Length-annotated forms continue to work because parameters are stripped before lookup.

## Tests

Added `tests/test_type_normalize.py`.