### PR TITLE
feat: Recursive Validation of `logicalType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `datacontract test` now only supports logicalTypes. Previously physicalType was preferrerd and used even if logicalType did not exist. 
+- `datacontract test` field type check now compares the full structured type tree for `object` and `array` logical types.
+- Unknown and unsupported types are silently ignored rather than failing the check. Specifically the `map` type is not supported until ODCS version v3.2.0 and is also ignored. 
+
+
+
 ## [1.0.4] - 2026-06-22
 
 ### Added

--- a/datacontract/engines/checks/check_spec.py
+++ b/datacontract/engines/checks/check_spec.py
@@ -14,7 +14,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional
+
+if TYPE_CHECKING:
+    from open_data_contract_standard.model import SchemaProperty
 
 
 class MetricType(str, Enum):
@@ -116,8 +119,9 @@ class CheckSpec:
     valid_min_length: Optional[int] = None  # INVALID_COUNT
     valid_max_length: Optional[int] = None  # INVALID_COUNT
 
-    expected_category: Optional[str] = None  # FIELD_TYPE: normalized type category
+    expected_category: Optional[str] = None  # FIELD_TYPE: human-readable label (display only)
     expected_type_label: Optional[str] = None  # FIELD_TYPE: human-readable expected type
+    expected_schema_property: Optional["SchemaProperty"] = None  # FIELD_TYPE: structural comparison
 
     columns: Optional[List[str]] = None  # DUPLICATE_COUNT across multiple columns
 

--- a/datacontract/engines/checks/create_checks.py
+++ b/datacontract/engines/checks/create_checks.py
@@ -53,12 +53,6 @@ def to_schema_name(schema_object: SchemaObject, server_type: Optional[str]) -> s
     return schema_object.name
 
 
-def expected_type_category(prop: SchemaProperty) -> tuple[SchemaProperty, str]:
-    """Return (schema property for structural type comparison, human label)."""
-    label = prop.physicalType or prop.logicalType
-    return prop, (label or "")
-
-
 _PERCENT_UNITS = {"percent", "percentage", "%"}
 
 
@@ -177,8 +171,8 @@ def _to_schema_checks(schema_object: SchemaObject, server: Optional[Server]) -> 
             )
         )
 
-        if check_types and (prop.physicalType is not None or prop.logicalType is not None):
-            schema_prop, label = expected_type_category(prop)
+        if check_types and prop.logicalType is not None:
+            schema_prop, label = prop, prop.logicalType or ""
             checks.append(
                 CheckSpec(
                     key=f"{model}__{field}__field_type",

--- a/datacontract/engines/checks/create_checks.py
+++ b/datacontract/engines/checks/create_checks.py
@@ -22,7 +22,6 @@ from open_data_contract_standard.model import (
 )
 
 from datacontract.engines.checks.check_spec import CheckSpec, MetricType, Op, Threshold
-from datacontract.engines.checks.type_normalize import normalize_type_name
 
 logger = logging.getLogger(__name__)
 
@@ -54,10 +53,10 @@ def to_schema_name(schema_object: SchemaObject, server_type: Optional[str]) -> s
     return schema_object.name
 
 
-def expected_type_category(prop: SchemaProperty) -> tuple[str, str]:
-    """Return (normalized category, human label) for a property's declared type."""
+def expected_type_category(prop: SchemaProperty) -> tuple[SchemaProperty, str]:
+    """Return (schema property for structural type comparison, human label)."""
     label = prop.physicalType or prop.logicalType
-    return normalize_type_name(label), (label or "")
+    return prop, (label or "")
 
 
 _PERCENT_UNITS = {"percent", "percentage", "%"}
@@ -179,7 +178,7 @@ def _to_schema_checks(schema_object: SchemaObject, server: Optional[Server]) -> 
         )
 
         if check_types and (prop.physicalType is not None or prop.logicalType is not None):
-            category, label = expected_type_category(prop)
+            schema_prop, label = expected_type_category(prop)
             checks.append(
                 CheckSpec(
                     key=f"{model}__{field}__field_type",
@@ -189,8 +188,9 @@ def _to_schema_checks(schema_object: SchemaObject, server: Optional[Server]) -> 
                     model=model,
                     field=field,
                     metric=MetricType.FIELD_TYPE,
-                    expected_category=category,
+                    expected_category=label,
                     expected_type_label=label,
+                    expected_schema_property=schema_prop,
                 )
             )
 

--- a/datacontract/engines/checks/type_normalize.py
+++ b/datacontract/engines/checks/type_normalize.py
@@ -1,25 +1,29 @@
-"""Coarse type-category normalization for schema ``field_type`` checks.
+"""Type normalization and structural comparison for schema ``field_type`` checks.
 
-The legacy soda engine compared the data source's reported SQL type string
-against a per-dialect equivalence table (``SCHEMA_CHECK_TYPES_MAPPING``). The
-ibis engine instead normalizes both the contract's declared type and the actual
-column's ibis dtype into a small set of categories and compares those. This
-sidesteps dialect-specific type-name differences (``varchar`` vs ``text`` vs
-``string``) while still catching genuine mismatches (e.g. string vs integer).
+``normalize_type_name`` maps a raw type string (logical or physical) to one of
+the nine ODCS logical-type categories.
+
+``schema_property_matches`` compares two ``SchemaProperty`` trees — one from the
+contract, one reconstructed from the ibis-reported dtype — and returns True when
+the actual type is structurally compatible with the expected one.
 """
 
 from __future__ import annotations
 
 import re
 
-# Categories returned by normalization.
-NUMERIC = {"integer", "number", "decimal", "float"}
+from open_data_contract_standard.model import SchemaProperty
 
 
-def normalize_type_name(type_name: str | None) -> str:
-    """Map a contract type name (logical or physical) to a coarse category."""
+def normalize_type_name(type_name: str | None) -> str | None:
+    """Map a contract type name (logical or physical) to one of the 9 ODCS categories.
+
+    Returns ``None`` for types that are unsupported or unrecognized (binary,
+    map, null, interval …) so they can be silently ignored rather than
+    producing false type-check failures.
+    """
     if not type_name:
-        return "other"
+        return None
     name = type_name.strip().lower()
     # strip parameters like varchar(10) / decimal(10,2) and array<...> wrappers
     name = re.sub(r"\(.*\)", "", name)
@@ -62,11 +66,10 @@ def normalize_type_name(type_name: str | None) -> str:
         "byteint",
     }:
         return "integer"
-    if name in {"decimal", "numeric", "dec"}:
-        return "decimal"
-    if name in {"number"}:
-        return "number"
     if name in {
+        "decimal",
+        "numeric",
+        "dec",
         "float",
         "double",
         "double precision",
@@ -77,8 +80,9 @@ def normalize_type_name(type_name: str | None) -> str:
         "float64",
         "binary_float",
         "binary_double",
+        "number",
     }:
-        return "float"
+        return "number"
     if name in {"bool", "boolean", "bit", "logical"}:
         return "boolean"
     if name in {
@@ -98,40 +102,121 @@ def normalize_type_name(type_name: str | None) -> str:
         return "date"
     if name in {"time", "time without time zone", "time with time zone"}:
         return "time"
-    if name in {"bytes", "binary", "varbinary", "blob", "bytea", "raw"}:
-        return "binary"
-    if name in {"struct", "record", "object", "row", "json", "jsonb", "variant", "map", "interval"}:
-        # json/struct/object/map all collapse to a single nested category for matching
-        if name == "map":
-            return "map"
-        return "struct"
+    if name in {"struct", "record", "object", "row", "json", "jsonb", "variant"}:
+        return "object"
     if name in {"array", "list"}:
         return "array"
-    if name in {"null", "none", "void"}:
-        return "null"
-    return "other"
+    # binary, map, null, interval and other unrecognized types are not in the
+    # 9 allowed categories; return None so they are silently ignored.
+    return None
 
 
-def category_matches(expected: str, actual: str) -> bool:
-    """Return True if an actual column category satisfies the expected category.
+_NUMERIC = {"integer", "number"}
 
-    Lenient on purpose: unknown categories ("other") always match, and the
-    numeric family is treated as compatible to avoid false failures where a
-    contract says ``number`` but the engine reports ``decimal``/``float``/``int``.
+
+def schema_property_matches(
+    expected: SchemaProperty | None, actual: SchemaProperty | None
+) -> bool:
+    """Return True if ``actual`` is structurally compatible with ``expected``.
+
+    Lenient by design:
+
+    - If expected is ``None`` (unsupported/unrecognized type) always passes.
+    - ``integer`` and ``number`` are mutually compatible (ODCS "number" is
+      intentionally ambiguous across numeric storage classes).
+    - A bare ``object`` or ``array`` on the expected side (no nested detail)
+      matches any actual structure with the same base (underdeclared contract).
+    - Extra actual fields inside an ``object`` are ignored.
     """
-    if expected == actual:
+    if expected is None:
         return True
-    if expected == "other" or actual == "other":
+    if actual is None:
+        return False
+
+    expected_base = normalize_type_name(expected.logicalType or expected.physicalType)
+    actual_base = normalize_type_name(actual.logicalType or actual.physicalType)
+
+    if expected_base is None:
         return True
-    # ODCS "number" is intentionally ambiguous: accept any numeric storage.
-    if expected == "number" and actual in NUMERIC:
+    if actual_base is None:
+        return False
+        if not (expected_base in _NUMERIC and actual_base in _NUMERIC):
+            return False
+
+    if expected_base == "array":
+        if expected.items is None:
+            return True
+        return schema_property_matches(expected.items, actual.items)
+
+    if expected_base == "object":
+        if not expected.properties:
+            return True
+        actual_by_name = {
+            p.name.lower(): p for p in (actual.properties or []) if p.name
+        }
+        for exp_field in expected.properties:
+            if not exp_field.name:
+                continue
+            act_field = actual_by_name.get(exp_field.name.lower())
+            if act_field is None:
+                return False
+            if not schema_property_matches(exp_field, act_field):
+                return False
         return True
-    if actual == "number" and expected in NUMERIC:
-        return True
-    # decimal/float are routinely interchangeable across engines.
-    if expected in {"decimal", "float"} and actual in {"decimal", "float"}:
-        return True
-    # struct/object/json all collapse together.
-    if expected in {"struct"} and actual in {"struct"}:
-        return True
-    return False
+
+    return True
+
+
+def schema_property_mismatch_reason(
+    expected: SchemaProperty | None,
+    actual: SchemaProperty | None,
+    path: str = "",
+) -> str:
+    """Return a human-readable description of the first structural mismatch, or '' if none."""
+    if expected is None:
+        return ""
+    field_label = f"field '{path}'" if path else "column"
+    if actual is None:
+        exp_str = expected.logicalType or expected.physicalType
+        return f"{field_label}: expected type '{exp_str}' but the column type could not be determined"
+
+    expected_base = normalize_type_name(expected.logicalType or expected.physicalType)
+    actual_base = normalize_type_name(actual.logicalType or actual.physicalType)
+
+    if expected_base is None:
+        return ""
+
+    if expected_base != actual_base and not (
+        expected_base in _NUMERIC and actual_base in _NUMERIC
+    ):
+        exp_str = expected.logicalType or expected.physicalType
+        act_str = actual.logicalType or actual.physicalType
+        return f"{field_label}: expected type '{exp_str}' but got '{act_str}'"
+
+    if expected_base == "array":
+        if expected.items is not None:
+            child_path = f"{path}[]" if path else "[]"
+            return schema_property_mismatch_reason(
+                expected.items, actual.items, child_path
+            )
+        return ""
+
+    if expected_base == "object":
+        if not expected.properties:
+            return ""
+        actual_by_name = {
+            p.name.lower(): p for p in (actual.properties or []) if p.name
+        }
+        for exp_field in expected.properties:
+            if not exp_field.name:
+                continue
+            child_path = f"{path}.{exp_field.name}" if path else exp_field.name
+            act_field = actual_by_name.get(exp_field.name.lower())
+            if act_field is None:
+                return f"field '{child_path}' is missing"
+            reason = schema_property_mismatch_reason(exp_field, act_field, child_path)
+            if reason:
+                return reason
+        return ""
+
+    return ""

--- a/datacontract/engines/checks/type_normalize.py
+++ b/datacontract/engines/checks/type_normalize.py
@@ -116,9 +116,7 @@ def normalize_type_name(type_name: str | None) -> str | None:
 _NUMERIC = {"integer", "number"}
 
 
-def schema_property_matches(
-    expected: SchemaProperty | None, actual: SchemaProperty | None
-) -> bool:
+def schema_property_matches(expected: SchemaProperty | None, actual: SchemaProperty | None) -> bool:
     """Return True if ``actual`` is structurally compatible with ``expected``.
 
     Lenient by design:
@@ -142,9 +140,7 @@ def schema_property_matches(
         return True
     if actual_base is None:
         return False
-    if expected_base != actual_base and not (
-        expected_base in _NUMERIC and actual_base in _NUMERIC
-    ):
+    if expected_base != actual_base and not (expected_base in _NUMERIC and actual_base in _NUMERIC):
         return False
 
     if expected_base == "array":
@@ -155,9 +151,7 @@ def schema_property_matches(
     if expected_base == "object":
         if not expected.properties:
             return True
-        actual_by_name = {
-            p.name.lower(): p for p in (actual.properties or []) if p.name
-        }
+        actual_by_name = {p.name.lower(): p for p in (actual.properties or []) if p.name}
         for exp_field in expected.properties:
             if not exp_field.name:
                 continue
@@ -190,9 +184,7 @@ def schema_property_mismatch_reason(
     if expected_base is None:
         return ""
 
-    if expected_base != actual_base and not (
-        expected_base in _NUMERIC and actual_base in _NUMERIC
-    ):
+    if expected_base != actual_base and not (expected_base in _NUMERIC and actual_base in _NUMERIC):
         exp_str = expected.logicalType or expected.physicalType
         act_str = actual.logicalType or actual.physicalType
         return f"{field_label}: expected type '{exp_str}' but got '{act_str}'"
@@ -200,17 +192,13 @@ def schema_property_mismatch_reason(
     if expected_base == "array":
         if expected.items is not None:
             child_path = f"{path}[]" if path else "[]"
-            return schema_property_mismatch_reason(
-                expected.items, actual.items, child_path
-            )
+            return schema_property_mismatch_reason(expected.items, actual.items, child_path)
         return ""
 
     if expected_base == "object":
         if not expected.properties:
             return ""
-        actual_by_name = {
-            p.name.lower(): p for p in (actual.properties or []) if p.name
-        }
+        actual_by_name = {p.name.lower(): p for p in (actual.properties or []) if p.name}
         for exp_field in expected.properties:
             if not exp_field.name:
                 continue

--- a/datacontract/engines/checks/type_normalize.py
+++ b/datacontract/engines/checks/type_normalize.py
@@ -142,8 +142,10 @@ def schema_property_matches(
         return True
     if actual_base is None:
         return False
-        if not (expected_base in _NUMERIC and actual_base in _NUMERIC):
-            return False
+    if expected_base != actual_base and not (
+        expected_base in _NUMERIC and actual_base in _NUMERIC
+    ):
+        return False
 
     if expected_base == "array":
         if expected.items is None:

--- a/datacontract/engines/ibis/dtype_category.py
+++ b/datacontract/engines/ibis/dtype_category.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from ibis.expr.datatypes import DataType
+
 
 def ibis_dtype_category(dtype) -> str:
     """Return the normalized category for an ibis ``DataType``.
@@ -39,3 +41,47 @@ def ibis_dtype_category(dtype) -> str:
     except AttributeError:
         return "other"
     return "other"
+
+
+def ibis_dtype_to_logical_type(dtype: DataType) -> str | None:
+    """Map an ibis DataType to a flat logical type string.
+
+    Returns one of the 9 allowed base types (``boolean``, ``integer``, ``number``,
+    ``string``, ``timestamp``, ``date``, ``time``, ``object``, ``array``), with
+    recursive ``<...>`` details for struct and array types.
+
+    Returns ``None`` for unsupported types (binary, map, null, etc.) so the
+    caller can omit the field from comparisons rather than raising a false failure.
+    """
+    try:
+        if dtype.is_boolean():
+            return "boolean"
+        if dtype.is_integer():
+            return "integer"
+        if dtype.is_decimal() or dtype.is_floating():
+            return "number"
+        if dtype.is_string():
+            return "string"
+        if dtype.is_timestamp():
+            return "timestamp"
+        if dtype.is_date():
+            return "date"
+        if dtype.is_time():
+            return "time"
+        if dtype.is_struct():
+            field_parts = []
+            for name, ftype in dtype.fields.items():
+                mapped = ibis_dtype_to_logical_type(ftype)
+                if mapped is not None:
+                    field_parts.append(f"{name}:{mapped}")
+            if field_parts:
+                return "object<" + ",".join(field_parts) + ">"
+            return "object"
+        if dtype.is_array():
+            element = ibis_dtype_to_logical_type(dtype.value_type)
+            if element is not None:
+                return f"array<{element}>"
+            return "array"
+    except AttributeError:
+        return None
+    return None

--- a/datacontract/engines/ibis/dtype_category.py
+++ b/datacontract/engines/ibis/dtype_category.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ibis.expr.datatypes import DataType
+from open_data_contract_standard.model import SchemaProperty
 
 
 def ibis_dtype_category(dtype) -> str:
@@ -43,45 +44,48 @@ def ibis_dtype_category(dtype) -> str:
     return "other"
 
 
-def ibis_dtype_to_logical_type(dtype: DataType) -> str | None:
-    """Map an ibis DataType to a flat logical type string.
+def ibis_dtype_to_schema_property(dtype: DataType) -> SchemaProperty | None:
+    """Map an ibis DataType to a SchemaProperty for structural type comparison.
 
-    Returns one of the 9 allowed base types (``boolean``, ``integer``, ``number``,
-    ``string``, ``timestamp``, ``date``, ``time``, ``object``, ``array``), with
-    recursive ``<...>`` details for struct and array types.
-
-    Returns ``None`` for unsupported types (binary, map, null, etc.) so the
-    caller can omit the field from comparisons rather than raising a false failure.
+    Returns a ``SchemaProperty`` with ``logicalType`` set to one of the 9 ODCS
+    categories, recursively populating ``properties`` for structs and ``items``
+    for arrays. Returns ``None`` for unsupported types (binary, map, null, etc.)
+    so the caller can skip comparison rather than raising a false failure.
     """
     try:
         if dtype.is_boolean():
-            return "boolean"
+            return SchemaProperty(logicalType="boolean")
         if dtype.is_integer():
-            return "integer"
+            return SchemaProperty(logicalType="integer")
         if dtype.is_decimal() or dtype.is_floating():
-            return "number"
+            return SchemaProperty(logicalType="number")
         if dtype.is_string():
-            return "string"
+            return SchemaProperty(logicalType="string")
         if dtype.is_timestamp():
-            return "timestamp"
+            return SchemaProperty(logicalType="timestamp")
         if dtype.is_date():
-            return "date"
+            return SchemaProperty(logicalType="date")
         if dtype.is_time():
-            return "time"
+            return SchemaProperty(logicalType="time")
         if dtype.is_struct():
-            field_parts = []
-            for name, ftype in dtype.fields.items():
-                mapped = ibis_dtype_to_logical_type(ftype)
-                if mapped is not None:
-                    field_parts.append(f"{name}:{mapped}")
-            if field_parts:
-                return "object<" + ",".join(field_parts) + ">"
-            return "object"
+            properties = []
+            for field_name, ftype in dtype.fields.items():
+                child = ibis_dtype_to_schema_property(ftype)
+                if child is not None:
+                    properties.append(
+                        SchemaProperty(
+                            name=field_name,
+                            logicalType=child.logicalType,
+                            items=child.items,
+                            properties=child.properties,
+                        )
+                    )
+            return SchemaProperty(
+                logicalType="object", properties=properties if properties else None
+            )
         if dtype.is_array():
-            element = ibis_dtype_to_logical_type(dtype.value_type)
-            if element is not None:
-                return f"array<{element}>"
-            return "array"
+            element = ibis_dtype_to_schema_property(dtype.value_type)
+            return SchemaProperty(logicalType="array", items=element)
     except AttributeError:
         return None
     return None

--- a/datacontract/engines/ibis/dtype_category.py
+++ b/datacontract/engines/ibis/dtype_category.py
@@ -80,9 +80,7 @@ def ibis_dtype_to_schema_property(dtype: DataType) -> SchemaProperty | None:
                             properties=child.properties,
                         )
                     )
-            return SchemaProperty(
-                logicalType="object", properties=properties if properties else None
-            )
+            return SchemaProperty(logicalType="object", properties=properties if properties else None)
         if dtype.is_array():
             element = ibis_dtype_to_schema_property(dtype.value_type)
             return SchemaProperty(logicalType="array", items=element)

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -19,7 +19,7 @@ from open_data_contract_standard.model import OpenDataContractStandard, Server
 from datacontract.engines.checks.check_spec import CheckSpec, MetricType
 from datacontract.engines.checks.type_normalize import category_matches
 from datacontract.engines.ibis.connections.connect import connect_ibis
-from datacontract.engines.ibis.dtype_category import ibis_dtype_category
+from datacontract.engines.ibis.dtype_category import ibis_dtype_category, ibis_dtype_to_logical_type
 from datacontract.model.exceptions import DataContractException
 from datacontract.model.run import Check, ResultEnum, Run
 from datacontract.model.server import get_server_type
@@ -617,7 +617,7 @@ def _run_type(run: Run, schema, columns, spec: CheckSpec):
         _set_result(run, spec.key, ResultEnum.failed, f"Column '{spec.field}' is missing")
         return
     dtype = schema[actual_col]
-    actual_category = ibis_dtype_category(dtype)
+    actual_category = ibis_dtype_to_logical_type(dtype)
     _set_diagnostics(
         run,
         spec.key,

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -16,10 +16,12 @@ from typing import List, Optional
 
 from open_data_contract_standard.model import OpenDataContractStandard, Server
 
+from ibis.expr.datatypes import DataType
+
 from datacontract.engines.checks.check_spec import CheckSpec, MetricType
-from datacontract.engines.checks.type_normalize import category_matches
+from datacontract.engines.checks.type_normalize import schema_property_matches, schema_property_mismatch_reason
 from datacontract.engines.ibis.connections.connect import connect_ibis
-from datacontract.engines.ibis.dtype_category import ibis_dtype_category, ibis_dtype_to_logical_type
+from datacontract.engines.ibis.dtype_category import ibis_dtype_to_schema_property
 from datacontract.model.exceptions import DataContractException
 from datacontract.model.run import Check, ResultEnum, Run
 from datacontract.model.server import get_server_type
@@ -607,31 +609,30 @@ def _run_type(run: Run, schema, columns, spec: CheckSpec):
     _set_impl(
         run,
         spec.key,
-        f"type of '{spec.field}' is compatible with '{spec.expected_type_label}' ({spec.expected_category})",
+        f"type of '{spec.field}' is compatible with '{spec.expected_type_label}'",
         "introspection",
     )
-    expected_label = f"{spec.expected_type_label} ({spec.expected_category})"
     actual_col = columns.get(spec.field.lower())
     if actual_col is None:
-        _set_diagnostics(run, spec.key, _diag(metric="field_type", field=spec.field, expected=expected_label))
+        _set_diagnostics(run, spec.key, _diag(metric="field_type", field=spec.field, expected=spec.expected_type_label))
         _set_result(run, spec.key, ResultEnum.failed, f"Column '{spec.field}' is missing")
         return
     dtype = schema[actual_col]
-    actual_category = ibis_dtype_to_logical_type(dtype)
+    actual_prop = ibis_dtype_to_schema_property(dtype)
     _set_diagnostics(
         run,
         spec.key,
-        _diag(metric="field_type", field=spec.field, expected=expected_label, actual=f"{dtype} ({actual_category})"),
+        _diag(metric="field_type", field=spec.field, expected=spec.expected_type_label, actual=str(dtype)),
     )
-    if category_matches(spec.expected_category, actual_category):
+    if schema_property_matches(spec.expected_schema_property, actual_prop):
         _set_result(run, spec.key, ResultEnum.passed, None)
     else:
+        reason = schema_property_mismatch_reason(spec.expected_schema_property, actual_prop)
         _set_result(
             run,
             spec.key,
             ResultEnum.failed,
-            f"Expected type '{spec.expected_type_label}' ({spec.expected_category}) "
-            f"but column is '{dtype}' ({actual_category})",
+            reason or f"Expected type '{spec.expected_type_label}' but column is '{dtype}'",
         )
 
 

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -16,8 +16,6 @@ from typing import List, Optional
 
 from open_data_contract_standard.model import OpenDataContractStandard, Server
 
-from ibis.expr.datatypes import DataType
-
 from datacontract.engines.checks.check_spec import CheckSpec, MetricType
 from datacontract.engines.checks.type_normalize import schema_property_matches, schema_property_mismatch_reason
 from datacontract.engines.ibis.connections.connect import connect_ibis

--- a/datacontract/imports/dcs_importer.py
+++ b/datacontract/imports/dcs_importer.py
@@ -570,10 +570,10 @@ def _convert_field_to_property(
     return prop
 
 
-def _convert_type_to_logical_type(dcs_type: str) -> str:
+def _convert_type_to_logical_type(dcs_type: str) -> str | None:
     """Convert DCS type to ODCS logical type."""
     if dcs_type is None:
-        return "string"
+        return None
 
     t = dcs_type.lower()
 
@@ -598,19 +598,26 @@ def _convert_type_to_logical_type(dcs_type: str) -> str:
         "timestamp_tz": "timestamp",
         "timestamp_ntz": "timestamp",
         "date": "date",
-        "time": "string",  # not supported in ODCS
+        "time": None,  # not supported in ODCS
         "datetime": "timestamp",
         "array": "array",
         "object": "object",
         "record": "object",
         "struct": "object",
-        "map": "object",
-        "bytes": "string",  # not supported in ODCS
-        "binary": "string",  # not supported in ODCS
-        "null": "string",  # not supported in ODCS
+        "map": None,  # not supported in ODCS
+        "interval": None,  # not supported in ODCS
+        "bytes": None,  # not supported in ODCS
+        "binary": None,  # not supported in ODCS
+        "varbinary": None,  # not supported in ODCS
+        "blob": None,  # not supported in ODCS
+        "bytea": None,  # not supported in ODCS
+        "raw": None,  # not supported in ODCS
+        "null": None,  # not supported in ODCS
+        "none": None,  # not supported in ODCS
+        "void": None,  # not supported in ODCS
     }
 
-    return type_mapping.get(t, t)
+    return type_mapping.get(t, None)
 
 
 def _convert_quality_list(quality_list: list) -> List[DataQuality]:

--- a/tests/fixtures/oracle/datacontract-oracle-odcs.yaml
+++ b/tests/fixtures/oracle/datacontract-oracle-odcs.yaml
@@ -77,38 +77,33 @@ schema:
         physicalType: BINARY_DOUBLE
       - name: FIELD_TIMESTAMP
         description: Timestamp with fractional second precision of 6, no timezones
-        logicalType: date
+        logicalType: timestamp
         physicalType: TIMESTAMP(6)
       - name: FIELD_TIMESTAMP_TZ
         description: Timestamp with fractional second precision of 6, with timezones
             (TZ)
-        logicalType: date
+        logicalType: timestamp
         physicalType: TIMESTAMP(6) WITH TIME ZONE
       - name: FIELD_TIMESTAMP_LTZ
         description: Timestamp with fractional second precision of 6, with local timezone
             (LTZ)
-        logicalType: date
+        logicalType: timestamp
         physicalType: TIMESTAMP(6) WITH LOCAL TIME ZONE
       - name: FIELD_INTERVAL_YEAR
         description: Interval of time in years and months with default (2) precision
-        logicalType: integer
         physicalType: INTERVAL YEAR(2) TO MONTH
       - name: FIELD_INTERVAL_DAY
         description: Interval of time in days, hours, minutes and seconds with default
             (2 / 6) precision
-        logicalType: integer
         physicalType: INTERVAL DAY(2) TO SECOND(6)
       - name: FIELD_RAW
         description: Large raw binary data
-        logicalType: object
         physicalType: RAW
       - name: FIELD_ROWID
         description: Base 64 string representing a unique row address
-        logicalType: object
         physicalType: ROWID
       - name: FIELD_UROWID
         description: Base 64 string representing a unique row address
-        logicalType: object
         physicalType: UROWID
       - name: FIELD_CHAR
         description: Fixed-length string
@@ -126,15 +121,12 @@ schema:
         physicalType: CLOB
       - name: FIELD_NCLOB
         description: National character large object
-        logicalType: string
         physicalType: NCLOB
       - name: FIELD_BLOB
         description: Binary large object
-        logicalType: object
         physicalType: BLOB
       - name: FIELD_BFILE
         description: Binary file
-        logicalType: object
         physicalType: BFILE
     quality:
         - type: sql

--- a/tests/fixtures/postgres/odcs.yaml
+++ b/tests/fixtures/postgres/odcs.yaml
@@ -33,7 +33,7 @@ schema:
           FROM my_table
         mustBeLessThan: 5
   - name: field_three
-    logicalType: date
+    logicalType: timestamp
     physicalType: timestamptz
     isNullable: true
     isUnique: false

--- a/tests/fixtures/postgres/odcs_case_sensitive.odcs.yaml
+++ b/tests/fixtures/postgres/odcs_case_sensitive.odcs.yaml
@@ -26,7 +26,7 @@ schema:
     logicalTypeOptions:
       minimum: 10
   - name: Field_three
-    logicalType: date
+    logicalType: timestamp
     physicalType: timestamp
     isNullable: true
     isUnique: false

--- a/tests/test_test_diagnostics.py
+++ b/tests/test_test_diagnostics.py
@@ -8,6 +8,7 @@ report the validity rule they enforced.
 
 import ibis
 import pandas as pd
+from open_data_contract_standard.model import SchemaProperty
 
 from datacontract.data_contract import DataContract
 from datacontract.engines.checks.check_spec import CheckSpec, MetricType
@@ -89,8 +90,9 @@ def test_diagnostics_field_type_mismatch():
         model="m",
         metric=MetricType.FIELD_TYPE,
         field="amount",
-        expected_category="number",
+        expected_category="integer",
         expected_type_label="integer",
+        expected_schema_property=SchemaProperty(logicalType="integer"),
     )
     run = _run_with([spec])
 
@@ -99,7 +101,7 @@ def test_diagnostics_field_type_mismatch():
     check = run.checks[0]
     assert check.result == ResultEnum.failed
     assert check.diagnostics["metric"] == "field_type"
-    assert check.diagnostics["expected"] == "integer (number)"
+    assert check.diagnostics["expected"] == "integer"
     assert "string" in check.diagnostics["actual"]
 
 

--- a/tests/test_test_parquet.py
+++ b/tests/test_test_parquet.py
@@ -25,7 +25,7 @@ def test_valid():
     run = data_contract.test()
     print(run.pretty())
     assert run.result == "passed"
-    assert len(run.checks) == 26
+    assert len(run.checks) == 24
     assert all(check.result == "passed" for check in run.checks)
 
 

--- a/tests/test_type_normalize.py
+++ b/tests/test_type_normalize.py
@@ -1,4 +1,4 @@
-from datacontract.engines.checks.type_normalize import category_matches, normalize_type_name
+from datacontract.engines.checks.type_normalize import normalize_type_name
 
 
 def test_normalize_strips_length_parameters():
@@ -13,13 +13,3 @@ def test_normalize_oracle_string_types():
     assert normalize_type_name("VARCHAR2") == "string"
     assert normalize_type_name("NVARCHAR2") == "string"
     assert normalize_type_name("nvarchar2(100)") == "string"
-
-
-def test_parameterized_type_matches_unparameterized():
-    # A contract declaring VARCHAR2(4000) must match a column reported as VARCHAR2.
-    expected = normalize_type_name("VARCHAR2(4000)")
-    actual = normalize_type_name("VARCHAR2")
-    assert category_matches(expected, actual)
-
-    expected = normalize_type_name("NUMBER(4,0)")
-    assert category_matches(expected, "decimal")


### PR DESCRIPTION
- [x] Tests pass (`uv run pytest`)
- [x] Code formatted (`uv run ruff check --fix && uv run ruff format`)
- [x] README.md updated (if relevant)
- [x] CHANGELOG.md entry added

fixes: #1280

See context here: https://github.com/datacontract/datacontract-cli/issues/1280#issuecomment-4688175591
We have followed up and solved issue number 3 in the list:

> 3. Since v1.0.0 the test engine only compares top-level type categories, so element types of arrays, structs, and maps are not validated. Your observation is correct. This was a consequence of the soda-to-ibis migration. With the importer now emitting structured nested types, recursive type checking has something to validate against; I'll track that as a separate enhancement.

We have mapped ibis types to `SchemaProperty` objects in order to perform a deep type check on objects and arrays. 

> physicalType is an opaque platform-specific string, useful for documentation and platform-specific tooling, and is not the basis for nested validation.

This PR also addresses this point, please let us know if this should be addressed in a separate PR. 

> For maps: ODCS v3.1 has no structured map representation, which is why the flat map<k,v> string was the only option. ODCS v3.2 adds logicalType: map with map.key/map.value ([RFC 0030](https://github.com/bitol-io/tsc/blob/main/rfcs/approved/odcs-v3.2.0/0030-maps.md)). Once that lands in the model library, the importer will emit structured maps too; until then maps keep the flat physicalType string.

Finally we have mapped unsupported types to None for the logicalType field. This is a breaking change if anyone depends on this functionality, but we understood your comment that this should not be supported until v3.2.0 

## Further Clarifications

For objects and arrays we have changed the error message which is presented to the user to specify the first failed nested field type check. There are several ways to approach this: 

1. Show the first failed field in the nested structure
2. Show all failed fields in the nested structure
3. Show the first failed field and a count of the number of additional errors
4. Show a flat string representation of the object as shown in  #1280 

We would recommend approach number 3, since the other approaches become quite impractical for large nested structures. See the example below

```
╭────────┬────────────────────────────────────────────┬───────────┬────────────────────────────────────────────────────╮
│ Result │ Check                                      │ Field     │ Details                                            │
├────────┼────────────────────────────────────────────┼───────────┼────────────────────────────────────────────────────┤
│ failed │ Check that field example has type array    │ example   │ field '[].metadata.item[]': expected type          │
│        │                                            │           │ 'integer' but got 'string' (and 1 other type error)│
│ passed │ Check that field 'example' is present      │ example   │                                                    │
╰────────┴────────────────────────────────────────────┴───────────┴────────────────────────────────────────────────────╯
```

Here is an example of a very complex structure. We have added an error in the `example.metadata.item` and the `example.updated.timestamp` field as shown above. 

```
schema:
- name: abc
  physicalType: table
  physicalName: inconsistency_example
  properties:
  - name: example
    logicalType: array
    items:
      logicalType: object
      properties:
      - name: codeId
        logicalType: object
        properties:
        - name: value
          physicalType: bigint
          logicalType: integer
      - name: id
        physicalType: bigint
        logicalType: integer
      - name: metadata
        logicalType: object
        properties:
        - name: item
          logicalType: array
          items:
            physicalType: string
            logicalType: integer
      - name: updated
        logicalType: object
        properties:
        - name: timestamp
          physicalType: string
          logicalType: integer
      - name: updatedBy
        physicalType: string
        logicalType: string
      - name: originCodeId
        logicalType: object
        properties:
        - name: value
          physicalType: bigint
          logicalType: integer
      - name: uuid
        logicalType: object
        properties:
        - name: namespace
          physicalType: string
          logicalType: string
        - name: uuid
          physicalType: string
          logicalType: string
      - name: versionId
        physicalType: bigint
        logicalType: integer
```