### PR TITLE
fix: make ibis import optional so `datacontract --help` works without extras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract test` now only supports logicalTypes. Previously physicalType was preferrerd and used even if logicalType did not exist. 
 - `datacontract test` field type check now compares the full structured type tree for `object` and `array` logical types.
 - Unknown and unsupported types are silently ignored rather than failing the check. Specifically the `map` type is not supported until ODCS version v3.2.0 and is also ignored. 
+- `datacontract --help` no longer fails with `ModuleNotFoundError: No module named 'ibis'` when the optional `ibis` extra is not installed.
 
 
 

--- a/datacontract/engines/ibis/dtype_category.py
+++ b/datacontract/engines/ibis/dtype_category.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
-from ibis.expr.datatypes import DataType
+from typing import TYPE_CHECKING
+
 from open_data_contract_standard.model import SchemaProperty
+
+if TYPE_CHECKING:
+    from ibis.expr.datatypes import DataType
 
 
 def ibis_dtype_category(dtype) -> str:


### PR DESCRIPTION
## Problem

CI on `main` is red. The `integration-tests` job fails at the `Test datacontract --help` step:

```
File ".../datacontract/engines/ibis/dtype_category.py", line 5, in <module>
    from ibis.expr.datatypes import DataType
ModuleNotFoundError: No module named 'ibis'
```

PR #1331 added a module-level `from ibis.expr.datatypes import DataType` to `datacontract/engines/ibis/dtype_category.py`. That module is in the eager import chain that runs on every CLI invocation (`cli.py` → `command_catalog.py` → `catalog.py` → `data_contract.py` → `engines/data_contract_test.py` → `engines/ibis/ibis_check_execute.py` → `dtype_category.py`).

`ibis` is an optional extra, not a base dependency. The `integration-tests` job installs only the base package and runs `datacontract --help`, which now fails at import time. The full `test` jobs install the extras, so only this job is affected.

## Fix

`DataType` is used only as a type annotation. With `from __future__ import annotations` already in place, annotations are lazy strings, so the import can move under `TYPE_CHECKING`. This removes the runtime `ibis` requirement while keeping the type hint.

## Verification

- `datacontract.cli` imports cleanly with `ibis` simulated as absent (the exact CI scenario).
- `ruff check` and `ruff format --check` pass.