### PR TITLE
fix: qualify Oracle tables with configured schema owner during test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract test` now only supports logicalTypes. Previously physicalType was preferrerd and used even if logicalType did not exist. 
 - `datacontract test` field type check now compares the full structured type tree for `object` and `array` logical types.
 - Unknown and unsupported types are silently ignored rather than failing the check. Specifically the `map` type is not supported until ODCS version v3.2.0 and is also ignored. 
+- `datacontract test` against Oracle now qualifies tables with the configured server `schema` (owner), fixing `Could not read model '<table>': <table>` when the login user differs from the table owner.
 
 
 

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -177,7 +177,7 @@ def _run_model(
     include_failed_samples: bool = False,
 ):
     try:
-        t = _resolve_table(con, model)
+        t = _resolve_table(con, model, _table_database(con, server))
     except Exception as e:
         logger.warning("Could not read model '%s': %s", model, e)
         _fail_all(run, specs, ResultEnum.failed, f"Could not read model '{model}': {e}")
@@ -848,21 +848,37 @@ def _resolve_col(columns: dict, field: str) -> str:
     return actual
 
 
-def _resolve_table(con, model: str):
+def _table_database(con, server: Optional[Server]) -> Optional[str]:
+    """The schema (owner) to qualify the table with, or ``None``.
+
+    Oracle logs in as one user but the tables may be owned by a different schema
+    (``server.schema``). ibis defaults the owner to the login user during
+    introspection, so an unqualified lookup raises ``TableNotFound``. Other
+    backends already pin the schema at connect time, so only Oracle needs this.
+    """
+    if server is None:
+        return None
+    if getattr(con, "name", None) == "oracle" and server.schema_:
+        return server.schema_
+    return None
+
+
+def _resolve_table(con, model: str, database: Optional[str] = None):
     """Resolve a table by name, tolerating case differences across dialects."""
     if getattr(con, "name", None) == "pyspark":
         return _pyspark_table_unconvertible_as_unknown(con, model)
+    kwargs = {"database": database} if database else {}
     try:
-        return con.table(model)
+        return con.table(model, **kwargs)
     except Exception:
         try:
-            available = con.list_tables()
+            available = con.list_tables(**kwargs)
         except Exception:
             raise
         match = next((name for name in available if name.lower() == model.lower()), None)
         if match is None:
             raise
-        return con.table(match)
+        return con.table(match, **kwargs)
 
 
 def _pyspark_table_unconvertible_as_unknown(con, name: str):

--- a/tests/test_ibis_oracle_schema.py
+++ b/tests/test_ibis_oracle_schema.py
@@ -1,0 +1,82 @@
+"""Unit tests for Oracle table resolution across schemas (owners).
+
+Oracle logs in as one user but the contract's tables may be owned by a different
+schema (``server.schema``). ibis defaults the owner to the login user during
+introspection, so an unqualified lookup raises ``TableNotFound``. The engine
+must qualify the table with the configured schema. See issue: cross-schema
+Oracle test fails with "Could not read model '<table>': <table>".
+"""
+
+from open_data_contract_standard.model import Server
+
+from datacontract.engines.ibis.ibis_check_execute import _resolve_table, _table_database
+
+
+class _FakeBackend:
+    """Minimal stand-in for an ibis backend that records how it is queried."""
+
+    def __init__(self, name, tables):
+        self.name = name
+        # tables: {database_or_None: {table_name: object}}
+        self._tables = tables
+        self.table_calls = []
+
+    def table(self, name, database=None):
+        self.table_calls.append((name, database))
+        try:
+            return self._tables[database][name]
+        except KeyError:
+            raise Exception(name)
+
+    def list_tables(self, database=None):
+        return list(self._tables.get(database, {}))
+
+
+def test_table_database_uses_server_schema_for_oracle():
+    server = Server(type="oracle", schema="PSD1_VERBIS")
+    con = _FakeBackend("oracle", {})
+    assert _table_database(con, server) == "PSD1_VERBIS"
+
+
+def test_table_database_none_for_oracle_without_schema():
+    server = Server(type="oracle")
+    con = _FakeBackend("oracle", {})
+    assert _table_database(con, server) is None
+
+
+def test_table_database_none_for_non_oracle_backend():
+    # Postgres/snowflake pin the schema at connect time, so no qualifier is added.
+    server = Server(type="postgres", schema="public")
+    con = _FakeBackend("postgres", {})
+    assert _table_database(con, server) is None
+
+
+def test_table_database_none_without_server():
+    con = _FakeBackend("oracle", {})
+    assert _table_database(con, None) is None
+
+
+def test_resolve_table_qualifies_with_schema():
+    sentinel = object()
+    con = _FakeBackend("oracle", {"PSD1_VERBIS": {"BERUF": sentinel}})
+
+    assert _resolve_table(con, "BERUF", "PSD1_VERBIS") is sentinel
+    assert ("BERUF", "PSD1_VERBIS") in con.table_calls
+
+
+def test_resolve_table_without_schema_does_not_pass_database():
+    sentinel = object()
+    con = _FakeBackend("oracle", {None: {"BERUF": sentinel}})
+
+    assert _resolve_table(con, "BERUF") is sentinel
+    assert con.table_calls == [("BERUF", None)]
+
+
+def test_resolve_table_case_insensitive_fallback_keeps_schema():
+    sentinel = object()
+    con = _FakeBackend("oracle", {"PSD1_VERBIS": {"BERUF": sentinel}})
+
+    # Contract uses lowercase; the actual table is uppercase in the schema.
+    assert _resolve_table(con, "beruf", "PSD1_VERBIS") is sentinel
+    # The successful resolution still targets the qualifying schema.
+    assert con.table_calls[-1] == ("BERUF", "PSD1_VERBIS")


### PR DESCRIPTION
## Problem

`datacontract test` against Oracle fails every schema check with a cryptic message when the table is owned by a different schema than the login user:

```
│ failed │ Check that field 'CTYP' is present │ CTYP │ Could not read model 'BERUF': BERUF │
...
```

The user connects as one Oracle user (`DATACONTRACT_ORACLE_USERNAME`) but the table `BERUF` is owned by schema `PSD1_VERBIS` (set as the server `schema`). The Oracle connect branch never sets the schema (unlike postgres/snowflake/redshift, which pass `schema=server.schema_`).

`con.table("BERUF")` triggers ibis schema introspection, which defaults the owner to the login user:

```python
# oracle_patch.py
if database is None:
    database = self.con.username.upper()
```

So it queries `all_tab_columns WHERE table_name='BERUF' AND owner=<login_user>`, finds nothing, and raises `TableNotFound("BERUF")` — the `: BERUF` in the message.

The existing Oracle tests connect as `SYSTEM` against `SYSTEM`-owned tables (owner == login user), so the gap was masked.

## Fix

- `_table_database()`: for Oracle backends, qualify the table with `server.schema` (the owner). Other backends return `None` — they already pin the schema at connect time.
- `_resolve_table()` passes `database=<schema>` to `con.table(...)` / `con.list_tables(...)`, so introspection looks in the configured schema. The case-insensitive fallback keeps the qualifier.

## Tests

- `tests/test_ibis_oracle_schema.py`: 7 fast unit tests with fake backends (no live Oracle required), covering the Oracle-qualifies / non-Oracle-skips / case-insensitive paths.
- ruff clean.

## Note

Custom `quality.type: sql` checks reference `{model}` unqualified, so a cross-schema contract that also uses SQL quality checks would need `{schema}.{model}` in the query. Out of scope here; the reported contract has no SQL quality checks.