### PR TITLE
fix(test): support Redshift introspection (avoid bare current_schema)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `datacontract test` against Redshift no longer fails with `column "current_schema" does not exist`. Redshift rides the Postgres ibis backend, whose introspection resolved the active schema with `SELECT current_schema` (no parentheses) — valid on PostgreSQL but rejected by Redshift, which only supports `current_schema()`. The configured server `schema` is now passed explicitly during introspection, skipping that query.
+
 ## [1.0.5] - 2026-06-24
 
 ### Fixed

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -849,16 +849,31 @@ def _resolve_col(columns: dict, field: str) -> str:
 
 
 def _table_database(con, server: Optional[Server]) -> Optional[str]:
-    """The schema (owner) to qualify the table with, or ``None``.
+    """The schema to qualify the table with during introspection, or ``None``.
 
-    Oracle logs in as one user but the tables may be owned by a different schema
-    (``server.schema``). ibis defaults the owner to the login user during
-    introspection, so an unqualified lookup raises ``TableNotFound``. Other
-    backends already pin the schema at connect time, so only Oracle needs this.
+    Two backends need the contract's ``server.schema`` passed explicitly instead
+    of relying on ibis's default:
+
+    - **Oracle** logs in as one user but the tables may be owned by a different
+      schema (``server.schema``). ibis defaults the owner to the login user, so
+      an unqualified lookup raises ``TableNotFound``.
+    - **Redshift** has no dedicated ibis backend and goes through the Postgres
+      backend (``con.name == "postgres"``). When no schema is passed, ibis's
+      Postgres introspection resolves the active schema with ``SELECT
+      current_schema`` (no parentheses) — valid on PostgreSQL but rejected by
+      Redshift with ``column "current_schema" does not exist``, since Redshift
+      only supports the parenthesized ``current_schema()``. Passing the schema
+      explicitly skips that query.
+
+    Other backends pin the schema at connect time and need no qualifier.
     """
-    if server is None:
+    if server is None or not server.schema_:
         return None
-    if getattr(con, "name", None) == "oracle" and server.schema_:
+    if getattr(con, "name", None) == "oracle":
+        return server.schema_
+    # Redshift rides the Postgres backend, so detect it by the contract's server
+    # type rather than con.name.
+    if get_server_type(server) == "redshift":
         return server.schema_
     return None
 

--- a/tests/test_ibis_oracle_schema.py
+++ b/tests/test_ibis_oracle_schema.py
@@ -51,6 +51,22 @@ def test_table_database_none_for_non_oracle_backend():
     assert _table_database(con, server) is None
 
 
+def test_table_database_uses_server_schema_for_redshift():
+    # Redshift rides the Postgres ibis backend (con.name == "postgres"). Without
+    # an explicit schema, ibis introspects via `SELECT current_schema` (no
+    # parens), which Redshift rejects ("column current_schema does not exist").
+    # Passing the schema explicitly avoids that query.
+    server = Server(type="redshift", schema="dwh_academic")
+    con = _FakeBackend("postgres", {})
+    assert _table_database(con, server) == "dwh_academic"
+
+
+def test_table_database_none_for_redshift_without_schema():
+    server = Server(type="redshift")
+    con = _FakeBackend("postgres", {})
+    assert _table_database(con, server) is None
+
+
 def test_table_database_none_without_server():
     con = _FakeBackend("oracle", {})
     assert _table_database(con, None) is None


### PR DESCRIPTION
## What & why

`datacontract test` against Amazon Redshift fails with:

```
column "current_schema" does not exist
```

Redshift has no dedicated ibis backend, so it rides the **Postgres** backend (`ibis.postgres.connect(...)`). During table introspection, when no schema is passed, ibis resolves the active schema with `SELECT current_schema` (no parentheses). PostgreSQL accepts the bare niladic form; Redshift parses `current_schema` as a column reference and rejects it — Redshift only supports the parenthesized `current_schema()`.

The query originates in ibis's `Backend.current_database` (`sg.select(sg.func("current_schema")).sql(dialect)`), reached via `get_schema(...)` → `dbs = [database or self.current_database]` when the table is looked up without an explicit schema. sqlglot renders `current_schema` without parens for the Redshift dialect (same as Postgres), so the dialect alone doesn't save us.

This affects **both** `type: redshift` and `type: postgres` servers pointed at a Redshift endpoint, since both take the Postgres backend path.

## How it works

`_table_database()` already passes the configured `server.schema` explicitly for Oracle (which has the same "introspection ignores the configured schema" problem). This extends the same treatment to Redshift: when the contract's server type is `redshift` and a `schema` is set, the schema is passed into `con.table(...)`, so `get_schema` uses it directly and never calls `current_database` / `SELECT current_schema`.

Redshift is detected by the **contract server type** (`get_server_type(server) == "redshift"`), not `con.name`, because the ibis backend reports `con.name == "postgres"` for Redshift.

## Testing

- New unit tests in `tests/test_ibis_oracle_schema.py`:
  - `test_table_database_uses_server_schema_for_redshift` — redshift + schema → schema is returned (and thus passed to `con.table`, bypassing `current_schema`).
  - `test_table_database_none_for_redshift_without_schema` — no schema → `None` (unchanged).
- Existing `test_table_database_none_for_non_oracle_backend` (plain Postgres → `None`) still passes, so PostgreSQL behavior is unchanged.
- Verified end-to-end against a real Postgres testcontainer (same wire protocol as Redshift) by recording every SQL the backend issues: the unqualified path emits one `SELECT current_schema`; with the fix it emits zero.
- `ruff format --check` and `ruff check` clean.

## Notes / out of scope

- sqlglot rendering `current_schema` without parentheses for the Redshift dialect (while `current_database()` gets parens) is arguably an upstream bug; this change works around it at the engine level and does not depend on a sqlglot fix.
