### PR TITLE
Pin duckdb-extension-azure to the 1.5.x line for duckdb lockstep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ gcs = [
 
 azure = [
   "datacontract-cli[duckdb]",
-  'duckdb-extension-azure>=1.0.3,<1.1.0; platform_system != "Linux" or platform_machine != "aarch64"',
+  "duckdb-extension-azure>=1.5.0,<1.6.0",
   "azure-identity>=1.17.1,<1.18",
   "azure-storage-blob>=12.24,<12.30",
 ]


### PR DESCRIPTION
Aligns `duckdb-extension-azure` with the bundled `duckdb` 1.5.x line (matching `httpfs`/`aws`) and drops the now-unnecessary aarch64 platform marker. Supersedes #1326.