### PR TITLE
Add --system-truststore option for OS trust store TLS verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.7] - 2026-06-25
+
+### Added
+- New global option `--system-truststore` (env `DATACONTRACT_SYSTEM_TRUSTSTORE`) to verify TLS using the operating system's certificate trust store, for use behind corporate proxies or with internal CAs.
+
 ## [1.0.6] - 2026-06-24
 
 ### Fixed

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -111,6 +111,19 @@ def version_callback(value: bool):
         raise typer.Exit()
 
 
+def inject_system_truststore() -> None:
+    """Verify TLS using the operating system's certificate trust store instead of the
+    bundled CA certificates. This lets the CLI work behind corporate proxies or with
+    internal CAs whose root certificates are installed in the OS trust store but not in
+    the certifi bundle that requests uses by default."""
+    try:
+        import truststore
+    except ImportError:
+        console.print("[red]--system-truststore requires the 'truststore' package, which is not installed.[/red]")
+        raise typer.Exit(code=1)
+    truststore.inject_into_ssl()
+
+
 @app.callback()
 def common(
     ctx: typer.Context,
@@ -120,6 +133,13 @@ def common(
         help="Prints the current version.",
         callback=version_callback,
         is_eager=True,
+    ),
+    system_truststore: bool = typer.Option(
+        False,
+        "--system-truststore",
+        help="Verify TLS using the operating system's certificate trust store "
+        "instead of the bundled CA certificates (e.g. behind a corporate proxy or internal CA).",
+        envvar="DATACONTRACT_SYSTEM_TRUSTSTORE",
     ),
 ):
     """
@@ -133,6 +153,9 @@ def common(
     # current working directory, walking up parent directories until one is found.
     # Already-set environment variables take precedence.
     load_dotenv(dotenv_path=find_dotenv(usecwd=True), override=False)
+
+    if system_truststore:
+        inject_system_truststore()
 
 
 def enable_debug_logging(debug: bool, otherwise_disable_stderr: bool = False):

--- a/docs/docs/entropy-data.md
+++ b/docs/docs/entropy-data.md
@@ -31,3 +31,21 @@ Use the [`publish`](./commands/publish.md) command to push a data contract itsel
 ```bash
 datacontract publish datacontract.yaml
 ```
+
+## TLS behind a corporate proxy or internal CA
+
+By default the CLI verifies TLS certificates against the bundled CA certificates (`certifi`). In a corporate network with a TLS-inspecting proxy or an internal certificate authority, this can fail with `CERTIFICATE_VERIFY_FAILED: unable to get local issuer certificate`, because the root CA is installed in the operating system's trust store but not in the bundled list.
+
+Use the global `--system-truststore` option to verify against the operating system's trust store (macOS Keychain, Windows certificate store, or the system CA certificates on Linux) instead:
+
+```bash
+datacontract --system-truststore publish datacontract.yaml
+```
+
+You can also enable it for every invocation with an environment variable:
+
+```bash
+export DATACONTRACT_SYSTEM_TRUSTSTORE=1
+```
+
+This keeps certificate verification on while trusting the corporate root CA. It works for all commands that make HTTPS requests, not only the Entropy Data integration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datacontract-cli"
-version = "1.0.6"
+version = "1.0.7"
 description = "The datacontract CLI is an open source command-line tool for working with Data Contracts. It uses data contract YAML files to lint the data contract, connect to data sources and execute schema and quality tests, detect breaking changes, and export to different formats. The tool is written in Python. It can be used as a standalone CLI tool, in a CI/CD pipeline, or directly as a Python library."
 license = "MIT"
 readme = "README.md"
@@ -20,6 +20,7 @@ dependencies = [
   "pydantic>=2.8.2,<2.14.0",
   "pyyaml~=6.0.1",
   "requests>=2.31,<2.35",
+  "truststore>=0.10,<1.0",
   "fastjsonschema>=2.19.1,<2.22.0",
   "jsonschema>=4.23.0,<5.0.0",
   "pytz>=2024.1",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,6 +73,39 @@ def test_env_file_does_not_override_existing_environment_variables(tmp_path, mon
     assert os.environ.get("DATACONTRACT_TEST_DOTENV_VAR") == "from-environment"
 
 
+def test_system_truststore_option_in_help():
+    result = runner.invoke(app, ["--help"], env={"COLUMNS": "200"})
+    assert result.exit_code == 0
+    plain_output = re.sub(r"\x1b\[[0-9;]*m", "", result.stdout)
+    assert "--system-truststore" in plain_output
+
+
+def test_system_truststore_flag_injects(monkeypatch):
+    calls = []
+    monkeypatch.setattr("datacontract.cli.inject_system_truststore", lambda: calls.append(True))
+    result = runner.invoke(app, ["--system-truststore", "lint", "unknown.yaml"])
+    assert result.exit_code == 1  # file does not exist, but the app callback has run
+    assert calls == [True]
+
+
+def test_system_truststore_env_var_injects(monkeypatch):
+    calls = []
+    monkeypatch.setattr("datacontract.cli.inject_system_truststore", lambda: calls.append(True))
+    monkeypatch.setenv("DATACONTRACT_SYSTEM_TRUSTSTORE", "1")
+    result = runner.invoke(app, ["lint", "unknown.yaml"])
+    assert result.exit_code == 1
+    assert calls == [True]
+
+
+def test_system_truststore_not_injected_by_default(monkeypatch):
+    calls = []
+    monkeypatch.setattr("datacontract.cli.inject_system_truststore", lambda: calls.append(True))
+    monkeypatch.delenv("DATACONTRACT_SYSTEM_TRUSTSTORE", raising=False)
+    result = runner.invoke(app, ["lint", "unknown.yaml"])
+    assert result.exit_code == 1
+    assert calls == []
+
+
 def test_changelog_help():
     result = runner.invoke(app, ["changelog", "--help"])
     assert result.exit_code == 0


### PR DESCRIPTION
## Summary

Adds a global `--system-truststore` option (and `DATACONTRACT_SYSTEM_TRUSTSTORE` env var) that verifies TLS using the operating system's certificate trust store instead of the bundled certifi CA list.

This fixes `CERTIFICATE_VERIFY_FAILED: unable to get local issuer certificate` errors that occur behind corporate TLS-inspecting proxies or with internal CAs, where the root CA is installed in the OS trust store (macOS Keychain, Windows cert store, Linux ca-certificates) but not in certifi. Certificate verification stays on.

```bash
datacontract --system-truststore publish datacontract.yaml
# or
export DATACONTRACT_SYSTEM_TRUSTSTORE=1
```

Implemented via the `truststore` package's `inject_into_ssl()`, which patches `ssl.SSLContext` globally, so it applies to all HTTPS requests the CLI makes (publish, lint URL/schema resolution, init templates, etc.), not just the Entropy Data integration.

## Changes
- `pyproject.toml` — add `truststore>=0.10,<1.0` dependency
- `datacontract/cli.py` — `inject_system_truststore()` helper + global flag wired into the app callback
- `tests/test_cli.py` — tests for help text, flag injection, env-var injection, and default-off
- `docs/docs/entropy-data.md` — new "TLS behind a corporate proxy or internal CA" section
- `CHANGELOG.md` — 1.0.7 entry

## Test plan
- `pytest tests/test_cli.py` (13 passed)
- `ruff check .` clean
- Verified `requests` over HTTPS succeeds after `truststore.inject_into_ssl()`