### PR TITLE
fix: Kafka Avro nulls all fields for plain (non-Confluent) messages (#1344)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `datacontract test` against Kafka no longer reports every field as null for plain (non-Confluent Schema Registry) Avro messages (#1344)
+
 ## [1.0.8] - 2026-06-25
 
 ### Fixed

--- a/datacontract/engines/ibis/connections/kafka.py
+++ b/datacontract/engines/ibis/connections/kafka.py
@@ -148,7 +148,15 @@ def process_avro_format(df, model_name: str, schema_obj: SchemaObject):
         )
 
     avro_schema = to_avro_schema_json(model_name, schema_obj)
-    df2 = df.withColumn("fixedValue", expr("substring(value, 6, length(value)-5)"))
+    # Messages serialized through the Confluent Schema Registry are framed with a
+    # 5-byte prefix (magic byte 0x00 + 4-byte schema id) that must be stripped
+    # before Avro decoding. Plain Avro messages carry no such prefix, so strip it
+    # only when the magic byte is present; otherwise stripping 5 bytes would
+    # corrupt every record and from_avro (PERMISSIVE) would silently null them out.
+    df2 = df.withColumn(
+        "fixedValue",
+        expr("CASE WHEN substring(value, 1, 1) = X'00' THEN substring(value, 6, length(value)-5) ELSE value END"),
+    )
     options = {"mode": "PERMISSIVE"}
     df2.select(from_avro(col("fixedValue"), avro_schema, options).alias("avro")).select(
         col("avro.*")

--- a/tests/fixtures/kafka/datacontract_avro.yaml
+++ b/tests/fixtures/kafka/datacontract_avro.yaml
@@ -1,0 +1,32 @@
+apiVersion: v3.1.0
+kind: DataContract
+id: inventory-events
+name: Inventory Events
+version: 0.0.1
+status: active
+servers:
+  - server: production
+    type: kafka
+    host: __KAFKA_HOST__
+    format: avro
+schema:
+  - name: inventory
+    physicalName: inventory-events-avro
+    physicalType: topic
+    logicalType: object
+    properties:
+      - name: updated_at
+        logicalType: string
+        required: true
+      - name: available
+        logicalType: integer
+        required: true
+      - name: location
+        logicalType: string
+      - name: sku
+        logicalType: string
+        required: true
+    quality:
+      - type: library
+        metric: rowCount
+        mustBeGreaterOrEqualTo: 10

--- a/tests/test_test_kafka.py
+++ b/tests/test_test_kafka.py
@@ -1,3 +1,5 @@
+import io
+import json
 import os
 import sys
 import time
@@ -11,11 +13,14 @@ if sys.version_info >= (3, 12, 1):
 
 
 from kafka import KafkaProducer
+from open_data_contract_standard.model import OpenDataContractStandard
 from testcontainers.kafka import KafkaContainer
 
 from datacontract.data_contract import DataContract
+from datacontract.export.avro_exporter import to_avro_schema_json
 
 datacontract = "fixtures/kafka/datacontract.yaml"
+datacontract_avro = "fixtures/kafka/datacontract_avro.yaml"
 
 # Skip when running under pytest-xdist workers - Spark's Java Kafka client
 # experiences timeouts when running in xdist subprocess environment
@@ -34,6 +39,56 @@ def test_test_kafka(monkeypatch):
 
     print(run.pretty())
     assert run.result == "passed"
+
+
+@pytest.mark.skipif(is_xdist_worker, reason="Spark Kafka tests fail under pytest-xdist workers")
+def test_test_kafka_avro_plain(monkeypatch):
+    """Plain Avro messages (no Confluent Schema Registry framing) must decode without
+    being corrupted by the 5-byte magic-byte/schema-id strip. Regression for #1344,
+    where every field was reported as null (missing_count == row count)."""
+    monkeypatch.delenv("DATACONTRACT_KAFKA_SASL_USERNAME", raising=False)
+
+    with KafkaContainer("confluentinc/cp-kafka:7.7.0").with_kraft() as kafka:
+        send_avro_messages_to_topic(kafka, "fixtures/kafka/data/messages.json", "inventory-events-avro")
+        data_contract_str = _setup_datacontract(kafka, datacontract_avro)
+        data_contract = DataContract(data_contract_str=data_contract_str)
+        run = data_contract.test()
+
+    print(run.pretty())
+    assert run.result == "passed"
+
+
+def send_avro_messages_to_topic(kafka: KafkaContainer, messages_file_path: str, topic_name: str):
+    """Serialize the JSON sample records as plain Avro (no Confluent prefix) and publish them."""
+    from avro.io import BinaryEncoder, DatumWriter
+    from avro.schema import parse as parse_avro_schema
+
+    print(f"Sending Avro messages from {messages_file_path} to Kafka topic {topic_name}")
+
+    bootstrap_server = kafka.get_bootstrap_server().replace("localhost", "127.0.0.1")
+    _ensure_topic_exists(bootstrap_server, topic_name)
+
+    with open(datacontract_avro) as data_contract_file:
+        odcs = OpenDataContractStandard.from_string(data_contract_file.read())
+    schema_obj = odcs.schema_[0]
+    avro_schema = parse_avro_schema(to_avro_schema_json(schema_obj.name, schema_obj))
+    writer = DatumWriter(avro_schema)
+
+    def encode(record: dict) -> bytes:
+        buffer = io.BytesIO()
+        writer.write(record, BinaryEncoder(buffer))
+        return buffer.getvalue()
+
+    producer = KafkaProducer(bootstrap_servers=bootstrap_server, value_serializer=encode)
+    messages_sent = 0
+    with open(messages_file_path) as messages_file:
+        for line in messages_file:
+            producer.send(topic=topic_name, value=json.loads(line))
+            messages_sent += 1
+
+    producer.flush()
+    producer.close()
+    print(f"Sent {messages_sent} Avro messages from {messages_file_path} to Kafka topic {topic_name}")
 
 
 def send_messages_to_topic(kafka: KafkaContainer, messages_file_path: str, topic_name: str):
@@ -88,8 +143,8 @@ def _ensure_topic_exists(bootstrap_server: str, topic_name: str, timeout_seconds
     raise TimeoutError(f"Topic {topic_name} not available after {timeout_seconds}s")
 
 
-def _setup_datacontract(kafka: KafkaContainer):
-    with open(datacontract) as data_contract_file:
+def _setup_datacontract(kafka: KafkaContainer, contract_path: str = datacontract):
+    with open(contract_path) as data_contract_file:
         data_contract_str = data_contract_file.read()
     host = kafka.get_bootstrap_server()
     # Replace localhost with 127.0.0.1 to avoid IPv4/IPv6 resolution issues


### PR DESCRIPTION
Fixes #1344

## Problem

`datacontract test` against a Kafka topic with `format: avro` reported every field as null (`missing_count` equal to the row count), even when records clearly contained values.

## Cause

`process_avro_format` unconditionally stripped a 5-byte prefix from every message:

```python
df2 = df.withColumn("fixedValue", expr("substring(value, 6, length(value)-5)"))
```

Those 5 bytes are the Confluent Schema Registry framing (magic byte `0x00` + 4-byte schema id). Plain Avro messages (produced without the registry serializer) carry no such prefix, so the strip dropped 5 real payload bytes and corrupted every record. `from_avro` in `PERMISSIVE` mode then silently decoded each corrupt record to an all-null row, so the `missing_count = 0` checks failed for all fields.

## Fix

Strip the prefix only when the Confluent magic byte is present:

```python
expr("CASE WHEN substring(value, 1, 1) = X'00' THEN substring(value, 6, length(value)-5) ELSE value END")
```

Registry-framed messages are still handled; plain Avro payloads are passed through intact.

## Test

- New fixture `tests/fixtures/kafka/datacontract_avro.yaml` with `required` fields (which generate the `missing_count = 0` checks from the issue).
- New `test_test_kafka_avro_plain` publishes records serialized as plain Avro (no Confluent prefix) and asserts the contract test passes.
- Confirmed it's a real regression test: reverting the fix to the unconditional strip makes the new test fail.
- Full suite: 926 passed, 18 skipped.