### PR TITLE
fix: Honor the `pattern` argument in `invalidValues` quality checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `datacontract test` against Kafka no longer reports every field as null for plain (non-Confluent Schema Registry) Avro messages (#1344)
+- Honor the `pattern` argument in `invalidValues` quality checks
 
 ## [1.0.8] - 2026-06-25
 

--- a/datacontract/engines/checks/create_checks.py
+++ b/datacontract/engines/checks/create_checks.py
@@ -548,7 +548,14 @@ def _quality_metric_check(model, field, quality: DataQuality, threshold: Thresho
         if field is None:
             logger.warning("Quality check invalidValues is only supported at field level")
             return []
-        valid_values = quality.arguments.get("validValues") if quality.arguments else None
+        args = quality.arguments or {}
+        valid_values = args.get("validValues")
+        pattern = args.get("pattern")
+        if valid_values is None and pattern is None:
+            logger.warning(
+                f"Quality check invalidValues on field {field} has no validValues or pattern argument; skipping"
+            )
+            return []
         return [
             _invalid_count_check(
                 model,
@@ -558,6 +565,7 @@ def _quality_metric_check(model, field, quality: DataQuality, threshold: Thresho
                 threshold=threshold,
                 category="quality",
                 valid_values=valid_values,
+                valid_regex=pattern,
                 threshold_is_percent=is_percent,
                 severity=severity,
             )

--- a/tests/test_test_quality_percent_severity.py
+++ b/tests/test_test_quality_percent_severity.py
@@ -190,3 +190,36 @@ def test_severity_warning_on_absolute_count_check():
     check = _quality_check(run, "field_invalid_values")
     assert check.result == ResultEnum.warning
     assert run.result == ResultEnum.warning
+
+
+def test_invalid_values_pattern_argument_runs_regex():
+    # 1 of 5 emails ("no-at-sign") lacks an @ => 20% invalid, threshold < 10% => fail.
+    contract = _odcs(
+        email_quality="""        quality:
+          - type: library
+            metric: invalidValues
+            unit: percent
+            mustBeLessThan: 10
+            arguments:
+              pattern: '@'
+"""
+    )
+    run = DataContract(data_contract_str=contract).test()
+    check = _quality_check(run, "field_invalid_values")
+    assert check.result == ResultEnum.failed
+    assert check.diagnostics["percent"] == 20.0
+    assert "20.0% (1 of 5 rows)" in check.reason
+
+
+def test_invalid_values_without_arguments_is_skipped(caplog):
+    # An invalidValues check with neither validValues nor pattern can never fail, therefore it should be dropped
+    contract = _odcs(
+        email_quality="""        quality:
+          - type: library
+            metric: invalidValues
+            mustBe: 0
+"""
+    )
+    checks = _checks(contract)
+    assert not any(c.type == "field_invalid_values" for c in checks)
+    assert "no validValues or pattern argument" in caplog.text


### PR DESCRIPTION
The `invalidValues` quality metric only read the `validValues` argument; a `pattern` argument was silently dropped, so the check ran with no validity constraint and passed vacuously (`invalid_count = 0 (no validity constraints configured)`).

- Wire `pattern` through to the regex check so it actually runs.
- Drop (with a warning) an `invalidValues` check that has neither `validValues` nor `pattern`, so a misconfigured check can no longer masquerade as passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)