### PR TITLE
fix: support BigQuery RowIterator in SQL quality check fallback (DMM-457)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `datacontract test` against BigQuery no longer fails SQL quality checks with `'RowIterator' object has no attribute 'fetchone'`
+
 ## [1.0.9] - 2026-06-26
 
 ### Fixed

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -692,7 +692,12 @@ def _run_scalar(con, query: str, dialect: Optional[str]):
         logger.debug("con.sql failed (%s); falling back to raw_sql", primary_error)
         cursor = con.raw_sql(query)
         try:
-            row = cursor.fetchone()
+            if hasattr(cursor, "fetchone"):
+                row = cursor.fetchone()
+            else:
+                # Some backends (e.g. BigQuery) return an iterable result set
+                # (RowIterator) instead of a DBAPI cursor.
+                row = next(iter(cursor), None)
         finally:
             # On DuckDB, raw_sql returns the shared connection itself; closing it
             # would tear down the connection and break every subsequent check.

--- a/tests/test_test_quality_local_fallback.py
+++ b/tests/test_test_quality_local_fallback.py
@@ -1,4 +1,41 @@
 from datacontract.data_contract import DataContract
+from datacontract.engines.ibis.ibis_check_execute import _run_scalar
+
+
+class _FakeRow:
+    """A result row that supports integer indexing, like a BigQuery Row."""
+
+    def __init__(self, values):
+        self._values = values
+
+    def __getitem__(self, idx):
+        return self._values[idx]
+
+
+class _RowIterator:
+    """Mimics BigQuery's RowIterator: iterable, but no DBAPI fetchone()."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+class _FakeBigQueryConnection:
+    def sql(self, query, dialect=None):
+        # Force the raw_sql fallback, as happens on BigQuery for queries
+        # ibis cannot round-trip.
+        raise NotImplementedError("ibis cannot round-trip this query")
+
+    def raw_sql(self, query):
+        return _RowIterator([_FakeRow([42])])
+
+
+def test_run_scalar_fallback_handles_iterable_result_without_fetchone():
+    """The raw_sql fallback must support backends like BigQuery whose result is an
+    iterable RowIterator rather than a DBAPI cursor with fetchone() (DMM-457)."""
+    assert _run_scalar(_FakeBigQueryConnection(), "SELECT count(*) FROM t", None) == 42
 
 
 def test_sql_quality_fallback_does_not_close_connection():


### PR DESCRIPTION
## Problem

`datacontract test` against BigQuery fails SQL-type quality checks with `'RowIterator' object has no attribute 'fetchone'` (DMM-457). The check is reported as `failed` even though nothing is wrong with the data.

## Root cause

`_run_scalar`'s `raw_sql` fallback in `datacontract/engines/ibis/ibis_check_execute.py` assumed every backend returns a DBAPI cursor and called `cursor.fetchone()`. BigQuery's ibis backend returns a `google.cloud.bigquery.table.RowIterator`, which is iterable but has no `fetchone()`, so the fallback itself crashed.

## Fix

Iterate the result set when `fetchone` is absent. BigQuery `Row` objects support integer indexing, so `row[0]` continues to work downstream.

## Test

Added `test_run_scalar_fallback_handles_iterable_result_without_fetchone`, which drives `_run_scalar` with a `fetchone`-less iterable mirroring BigQuery's `RowIterator`. Verified it reproduces the exact `AttributeError` against the old code and passes with the fix.