### PR TITLE
fix: SQL Server uniqueidentifier columns fail type check (#1354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `datacontract test` no longer fails the type check for SQL Server `uniqueidentifier` (UUID) columns with "the column type could not be determined" (#1354)
 - `datacontract test` against BigQuery no longer fails SQL quality checks with `'RowIterator' object has no attribute 'fetchone'`
 
 ## [1.0.9] - 2026-06-26

--- a/datacontract/engines/ibis/dtype_category.py
+++ b/datacontract/engines/ibis/dtype_category.py
@@ -25,7 +25,7 @@ def ibis_dtype_category(dtype) -> str:
             return "decimal"
         if dtype.is_floating():
             return "float"
-        if dtype.is_string():
+        if dtype.is_string() or dtype.is_uuid():
             return "string"
         if dtype.is_timestamp():
             return "timestamp"
@@ -63,7 +63,7 @@ def ibis_dtype_to_schema_property(dtype: DataType) -> SchemaProperty | None:
             return SchemaProperty(logicalType="integer")
         if dtype.is_decimal() or dtype.is_floating():
             return SchemaProperty(logicalType="number")
-        if dtype.is_string():
+        if dtype.is_string() or dtype.is_uuid():
             return SchemaProperty(logicalType="string")
         if dtype.is_timestamp():
             return SchemaProperty(logicalType="timestamp")

--- a/tests/test_dtype_category.py
+++ b/tests/test_dtype_category.py
@@ -1,0 +1,28 @@
+import ibis.expr.datatypes as dt
+from open_data_contract_standard.model import SchemaProperty
+
+from datacontract.engines.checks.type_normalize import schema_property_matches
+from datacontract.engines.ibis.dtype_category import (
+    ibis_dtype_category,
+    ibis_dtype_to_schema_property,
+)
+
+
+def test_uuid_maps_to_string_category():
+    # SQL Server `uniqueidentifier` columns surface as ibis UUID; they must be
+    # treated as strings, not "other" (regression for #1354).
+    assert ibis_dtype_category(dt.UUID()) == "string"
+
+
+def test_uuid_dtype_to_schema_property_is_string():
+    prop = ibis_dtype_to_schema_property(dt.UUID())
+    assert prop is not None
+    assert prop.logicalType == "string"
+
+
+def test_uuid_column_matches_string_contract_property():
+    # A property declared as logicalType string (physicalType uniqueidentifier)
+    # must match a column ibis reports as UUID.
+    expected = SchemaProperty(logicalType="string", physicalType="uniqueidentifier")
+    actual = ibis_dtype_to_schema_property(dt.UUID())
+    assert schema_property_matches(expected, actual)


### PR DESCRIPTION
## Problem

Since 1.0.5, `datacontract test` fails the type check for SQL Server `uniqueidentifier` columns with:

```
expected type 'string' but the column type could not be determined
```

Fixes #1354.

## Root cause

The 1.0.5 rewrite moved type checking to ibis introspection + coarse logical categories. SQL Server `uniqueidentifier` columns come back as ibis's `UUID` dtype, which had no case in `dtype_category.py` — both `ibis_dtype_category()` and `ibis_dtype_to_schema_property()` fell through to `"other"` / `None`, so the actual column type could not be determined. The contract side already normalizes `uuid` → `string`; only the actual side was missing the mapping.

## Fix

Map ibis `UUID` to the `string` category in both functions.

## Tests

Added `tests/test_dtype_category.py` covering the category mapping, the schema-property mapping, and an end-to-end match of a `logicalType: string` / `physicalType: uniqueidentifier` property against a UUID column. Full suite: 927 passed (PySpark tests error out only due to the missing Java runtime in this environment, unrelated to this change).