### PR TITLE
feat: verify physicalType against the real native type (#1354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `datacontract test` now verifies a field's `physicalType` against the column's real native type from the platform catalog (length and precision included), taking precedence over `logicalType` (#1354)
+
 ### Fixed
 - `datacontract test` no longer fails the type check for SQL Server `uniqueidentifier` (UUID) columns with "the column type could not be determined" (#1354)
 - `datacontract test` against BigQuery no longer fails SQL quality checks with `'RowIterator' object has no attribute 'fetchone'`

--- a/datacontract/engines/checks/check_spec.py
+++ b/datacontract/engines/checks/check_spec.py
@@ -29,6 +29,7 @@ class MetricType(str, Enum):
     INVALID_COUNT = "invalid_count"
     FIELD_PRESENT = "field_present"
     FIELD_TYPE = "field_type"
+    FIELD_PHYSICAL_TYPE = "field_physical_type"
     FRESHNESS = "freshness"
     RETENTION = "retention"
     CUSTOM_SQL = "custom_sql"
@@ -122,6 +123,7 @@ class CheckSpec:
     expected_category: Optional[str] = None  # FIELD_TYPE: human-readable label (display only)
     expected_type_label: Optional[str] = None  # FIELD_TYPE: human-readable expected type
     expected_schema_property: Optional["SchemaProperty"] = None  # FIELD_TYPE: structural comparison
+    expected_physical_type: Optional[str] = None  # FIELD_PHYSICAL_TYPE: contract physicalType
 
     columns: Optional[List[str]] = None  # DUPLICATE_COUNT across multiple columns
 

--- a/datacontract/engines/checks/create_checks.py
+++ b/datacontract/engines/checks/create_checks.py
@@ -22,6 +22,7 @@ from open_data_contract_standard.model import (
 )
 
 from datacontract.engines.checks.check_spec import CheckSpec, MetricType, Op, Threshold
+from datacontract.engines.ibis.native_type import supports_native_type_introspection
 
 logger = logging.getLogger(__name__)
 
@@ -171,7 +172,29 @@ def _to_schema_checks(schema_object: SchemaObject, server: Optional[Server]) -> 
             )
         )
 
-        if check_types and prop.logicalType is not None:
+        # A declared physicalType is checked against the column's real native
+        # type in the platform catalog and takes precedence over logicalType,
+        # but only on backends that expose a meaningful native type. Elsewhere
+        # (file sources, etc.) fall through to the logicalType category check.
+        if check_types and prop.physicalType is not None and supports_native_type_introspection(server_type):
+            checks.append(
+                CheckSpec(
+                    key=f"{model}__{field}__field_physical_type",
+                    category="schema",
+                    type="field_physical_type",
+                    name=f"Check that field {field} has physical type {prop.physicalType}",
+                    model=model,
+                    field=field,
+                    metric=MetricType.FIELD_PHYSICAL_TYPE,
+                    expected_category=prop.physicalType,
+                    expected_type_label=prop.physicalType,
+                    expected_physical_type=prop.physicalType,
+                    # Carried for the logicalType fallback when the native type
+                    # cannot be read or the physicalType is cross-dialect.
+                    expected_schema_property=prop if prop.logicalType is not None else None,
+                )
+            )
+        elif check_types and prop.logicalType is not None:
             schema_prop, label = prop, prop.logicalType or ""
             checks.append(
                 CheckSpec(

--- a/datacontract/engines/checks/physical_type_match.py
+++ b/datacontract/engines/checks/physical_type_match.py
@@ -1,0 +1,133 @@
+"""Compare a contract ``physicalType`` against a column's real native type.
+
+Both sides are parsed with sqlglot in the server's dialect, so dialect aliases
+(``int`` ≡ ``integer``, ``decimal`` ≡ ``numeric``) and case are handled, while
+genuinely distinct native types (``varchar`` vs ``nvarchar``) stay distinct.
+
+Length/precision is only enforced when the contract declares it: a bare
+``varchar`` in the contract matches ``varchar(255)`` in the database, but
+``varchar(255)`` does not match ``varchar(100)``.
+
+``physical_type_matches`` returns a tri-state:
+
+- ``True``  — the native type satisfies the declared ``physicalType``
+- ``False`` — it does not (with a human-readable reason)
+- ``None``  — the declared type cannot be interpreted in the server's dialect
+  (e.g. a SQL Server ``uniqueidentifier`` declared while testing Snowflake), so
+  the caller should skip the check with a warning rather than fail it.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional, Tuple
+
+import sqlglot
+from sqlglot import exp
+
+# Tokens that mean "sqlglot parsed something, but not a type it understands".
+_UNRESOLVED = {exp.DataType.Type.UNKNOWN, exp.DataType.Type.USERDEFINED, exp.DataType.Type.NULL}
+
+
+def _timestamp_family() -> set:
+    """Timestamp tokens that differ only by timezone handling.
+
+    A declared ``timestamp`` is treated as compatible with a ``timestamp with
+    time zone`` column: they are the same base type and the distinction is not
+    modelled at the logical level many contracts are written at (in particular,
+    DCS contracts store the logical ``timestamp`` keyword as the physicalType).
+    """
+    names = ("TIMESTAMP", "TIMESTAMPTZ", "TIMESTAMPLTZ", "TIMESTAMPNTZ", "TIMESTAMP_S", "TIMESTAMP_MS", "TIMESTAMP_NS")
+    return {getattr(exp.DataType.Type, n) for n in names if hasattr(exp.DataType.Type, n)}
+
+
+_TIMESTAMP_FAMILY = _timestamp_family()
+
+
+def _parse(type_str: str, dialect) -> Optional[exp.DataType]:
+    """Parse a type string into an ``exp.DataType`` for ``dialect``, or ``None``."""
+    if not type_str or not type_str.strip():
+        return None
+    try:
+        parsed = sqlglot.parse_one(type_str.strip(), into=exp.DataType, dialect=dialect)
+    except Exception:
+        return None
+    if not isinstance(parsed, exp.DataType) or parsed.this in _UNRESOLVED:
+        return None
+    return parsed
+
+
+def _params(dtype: exp.DataType) -> list[str]:
+    """Rendered type parameters (length / precision / scale), normalized for comparison."""
+    return [e.sql().strip().lower() for e in dtype.expressions]
+
+
+def _normalize_raw(type_str: str) -> str:
+    return re.sub(r"\s+", " ", type_str.strip().lower())
+
+
+def _split_base(type_str: str):
+    """Split ``varchar(255)`` into ``('varchar', '(255)')``."""
+    i = type_str.find("(")
+    if i == -1:
+        return type_str.strip(), ""
+    return type_str[:i].strip(), type_str[i:].strip()
+
+
+def _raw_match(expected: str, actual: str) -> Optional[bool]:
+    """String-level comparison for types sqlglot cannot parse (Oracle ROWID,
+    RAW, INTERVAL …). Returns True/False, matching on the base type name and
+    enforcing parameters only when the contract declares them; the length-only
+    difference (``raw`` vs ``raw(2000)``) is treated as a match.
+    """
+    e, a = _normalize_raw(expected), _normalize_raw(actual)
+    if e == a:
+        return True
+    e_base, e_params = _split_base(e)
+    a_base, _ = _split_base(a)
+    if e_base != a_base:
+        return False
+    return True if not e_params else e == a
+
+
+def physical_type_matches(
+    expected: Optional[str],
+    actual: Optional[str],
+    dialect,
+) -> Tuple[Optional[bool], str]:
+    """Compare a declared ``physicalType`` against an actual native type.
+
+    ``dialect`` is a sqlglot dialect (name or Dialect) for the server under test.
+    Returns ``(result, reason)`` where ``result`` is ``True`` / ``False`` /
+    ``None`` (skip) as described in the module docstring.
+    """
+    if not expected or not expected.strip() or not actual or not actual.strip():
+        return None, "no physical type to compare; skipping the physical type check"
+
+    exp_dt = _parse(expected, dialect)
+    act_dt = _parse(actual, dialect)
+
+    # When both sides are types sqlglot cannot model (e.g. Oracle ROWID / RAW /
+    # INTERVAL), fall back to a string-level comparison so an identical column
+    # still matches. When only the declared type is unparseable while the column
+    # is an ordinary type, the physicalType is foreign to this server's dialect
+    # (e.g. a SQL Server 'uniqueidentifier' declared against Snowflake): skip.
+    if exp_dt is None and act_dt is None:
+        if _raw_match(expected, actual):
+            return True, ""
+        return False, f"expected physical type '{expected}' but the column is '{actual}'"
+    if exp_dt is None or act_dt is None:
+        return None, (
+            f"physicalType '{expected}' could not be interpreted in the '{dialect}' dialect of the "
+            f"server under test; skipping the physical type check"
+        )
+
+    same_base = exp_dt.this == act_dt.this or {exp_dt.this, act_dt.this} <= _TIMESTAMP_FAMILY
+    if not same_base:
+        return False, f"expected physical type '{expected}' but the column is '{actual}'"
+
+    expected_params = _params(exp_dt)
+    if expected_params and expected_params != _params(act_dt):
+        return False, f"expected physical type '{expected}' but the column is '{actual}'"
+
+    return True, ""

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -17,9 +17,11 @@ from typing import List, Optional
 from open_data_contract_standard.model import OpenDataContractStandard, Server
 
 from datacontract.engines.checks.check_spec import CheckSpec, MetricType
+from datacontract.engines.checks.physical_type_match import physical_type_matches
 from datacontract.engines.checks.type_normalize import schema_property_matches, schema_property_mismatch_reason
 from datacontract.engines.ibis.connections.connect import connect_ibis
 from datacontract.engines.ibis.dtype_category import ibis_dtype_to_schema_property
+from datacontract.engines.ibis.native_type import fetch_native_types, sqlglot_dialect
 from datacontract.model.exceptions import DataContractException
 from datacontract.model.run import Check, ResultEnum, Run
 from datacontract.model.server import get_server_type
@@ -58,6 +60,8 @@ def _describe(spec: CheckSpec) -> str:
         return spec.query or ""
     if spec.metric == MetricType.FIELD_TYPE:
         return f"type({spec.field}) == {spec.expected_type_label}"
+    if spec.metric == MetricType.FIELD_PHYSICAL_TYPE:
+        return f"physical_type({spec.field}) == {spec.expected_physical_type}"
     if spec.metric == MetricType.FIELD_PRESENT:
         return f"present({spec.field})"
     if spec.threshold is not None:
@@ -186,6 +190,12 @@ def _run_model(
     columns = {c.lower(): c for c in t.columns}
     schema = t.schema()
 
+    # Physical type checks read the real declared native types from the catalog;
+    # fetch once per model, and only when such a check exists.
+    native_types = None
+    if any(spec.metric == MetricType.FIELD_PHYSICAL_TYPE for spec in specs):
+        native_types = fetch_native_types(con, server, model)
+
     agg_exprs = []  # list[(spec, named_expr)]
     for spec in specs:
         try:
@@ -210,6 +220,8 @@ def _run_model(
                 _run_present(run, con, model, columns, spec)
             elif spec.metric == MetricType.FIELD_TYPE:
                 _run_type(run, schema, columns, spec)
+            elif spec.metric == MetricType.FIELD_PHYSICAL_TYPE:
+                _run_physical_type(run, con, server, schema, columns, native_types, spec)
             elif spec.metric in (MetricType.FRESHNESS, MetricType.RETENTION):
                 _run_freshness(run, t, columns, spec)
             elif spec.metric == MetricType.CUSTOM_SQL:
@@ -632,6 +644,73 @@ def _run_type(run: Run, schema, columns, spec: CheckSpec):
             ResultEnum.failed,
             reason or f"Expected type '{spec.expected_type_label}' but column is '{dtype}'",
         )
+
+
+def _run_physical_type(run: Run, con, server, schema, columns, native_types, spec: CheckSpec):
+    """Compare a column's real native type against the contract's physicalType.
+
+    When the native type cannot be read for this backend, or the declared
+    physicalType cannot be interpreted in the server's dialect, fall back to the
+    coarse logicalType category check if the property declares one, and only warn
+    (skip) when there is nothing left to compare against.
+    """
+    _set_impl(
+        run,
+        spec.key,
+        f"physical type of '{spec.field}' is '{spec.expected_physical_type}'",
+        "introspection",
+    )
+    actual_col = columns.get(spec.field.lower())
+    if actual_col is None:
+        _set_diagnostics(
+            run, spec.key, _diag(metric="field_physical_type", field=spec.field, expected=spec.expected_physical_type)
+        )
+        _set_result(run, spec.key, ResultEnum.failed, f"Column '{spec.field}' is missing")
+        return
+
+    actual_native = native_types.get(spec.field.lower()) if native_types else None
+    _set_diagnostics(
+        run,
+        spec.key,
+        _diag(
+            metric="field_physical_type",
+            field=spec.field,
+            expected=spec.expected_physical_type,
+            actual=actual_native,
+        ),
+    )
+
+    result, reason = (None, "")
+    if actual_native is not None:
+        result, reason = physical_type_matches(spec.expected_physical_type, actual_native, sqlglot_dialect(con))
+    else:
+        reason = f"Could not read the native type of '{spec.field}' from the {get_server_type(server)} catalog"
+
+    if result is True:
+        _set_result(run, spec.key, ResultEnum.passed, None)
+        return
+    if result is False:
+        _set_result(run, spec.key, ResultEnum.failed, reason)
+        return
+
+    # result is None: the physical type could not be evaluated. Fall back to the
+    # logicalType category check when the property declares one.
+    fallback = spec.expected_schema_property
+    if fallback is not None and fallback.logicalType is not None:
+        actual_prop = ibis_dtype_to_schema_property(schema[actual_col])
+        if schema_property_matches(fallback, actual_prop):
+            _set_result(run, spec.key, ResultEnum.passed, None)
+        else:
+            mismatch = schema_property_mismatch_reason(fallback, actual_prop)
+            _set_result(
+                run,
+                spec.key,
+                ResultEnum.failed,
+                mismatch or f"Expected type '{fallback.logicalType}' but column is '{schema[actual_col]}'",
+            )
+        return
+
+    _set_result(run, spec.key, ResultEnum.warning, f"{reason}; skipping the physical type check")
 
 
 def _run_freshness(run: Run, t, columns, spec: CheckSpec):

--- a/datacontract/engines/ibis/native_type.py
+++ b/datacontract/engines/ibis/native_type.py
@@ -1,0 +1,237 @@
+"""Read the real, declared native column types from a platform's catalog.
+
+The ibis dtype reported by ``table.schema()`` has already collapsed native types
+into ibis's own type system (SQL Server ``uniqueidentifier`` becomes ibis
+``UUID``, ``nvarchar(255)`` becomes ``String``), so it cannot answer "does the
+column exactly match the declared ``physicalType``". This module queries the
+platform's own catalog to recover the true declared type, including length and
+precision.
+
+``_CATALOG_STRATEGY`` (below) is the single source of truth for which server
+types are supported and which catalog-reading strategy each uses. Two catalog
+shapes exist:
+
+- engines that expose the type as separate parts (``data_type`` plus length /
+  precision / scale), reconstructed by ``reconstruct_native_type``; and
+- engines whose ``data_type`` is already a complete type string (Athena,
+  BigQuery), used verbatim.
+
+Everything here is best-effort: any failure (unsupported backend, missing
+catalog, permission error) returns ``None`` so the caller skips the physical
+type check with a warning rather than failing the run.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from open_data_contract_standard.model import Server
+
+from datacontract.model.server import get_server_type
+
+logger = logging.getLogger(__name__)
+
+# Which server types support native physical type checks, and which catalog
+# strategy each uses. Server types not listed here (file sources, the DuckDB
+# MySQL scanner, impala, kafka/dataframe) have no usable native declared type,
+# so physicalType falls back to the logicalType check. The strategies are
+# implemented by the ``_read_*`` readers further down and wired in ``_READERS``.
+_CATALOG_STRATEGY = {
+    "sqlserver": "information_schema",
+    "postgres": "information_schema",
+    "redshift": "information_schema",
+    "snowflake": "information_schema",
+    "databricks": "information_schema",
+    "trino": "information_schema",
+    "oracle": "oracle",
+    "athena": "athena",
+    "bigquery": "bigquery",
+}
+
+
+def supports_native_type_introspection(server_type: Optional[str]) -> bool:
+    """True when this backend exposes a real declared native type to check against."""
+    return server_type in _CATALOG_STRATEGY
+
+
+# Numeric types whose precision/scale form part of the declared type. Integer
+# types also report a numeric_precision, but ``int(10)`` is not a real declared
+# type, so precision is only appended for these.
+_DECIMAL_TYPES = {"decimal", "numeric", "number", "dec"}
+
+# Oracle reports DATA_LENGTH (in bytes) for every column, but the length is only
+# part of the declared type for character and raw types. Appending it elsewhere
+# would corrupt types such as ROWID or DATE (``rowid(10)``).
+_ORACLE_LENGTH_TYPES = {"char", "nchar", "varchar", "varchar2", "nvarchar2", "raw"}
+
+
+def reconstruct_native_type(
+    data_type: Optional[str],
+    char_len=None,
+    num_precision=None,
+    num_scale=None,
+) -> Optional[str]:
+    """Rebuild a parameterized native type string from catalog columns.
+
+    ``varchar`` + char_len 255 -> ``varchar(255)`` (``-1`` means SQL Server MAX
+    -> ``varchar(max)``); ``decimal`` + precision 10 + scale 2 ->
+    ``decimal(10,2)``. Precision is only attached to genuine decimal types.
+    """
+    if not data_type:
+        return None
+    base = data_type.strip()
+    if not base:
+        return None
+
+    if char_len is not None:
+        try:
+            length = int(char_len)
+        except (TypeError, ValueError):
+            return base
+        return f"{base}(max)" if length < 0 else f"{base}({length})"
+
+    if base.lower() in _DECIMAL_TYPES and num_precision is not None:
+        if num_scale:
+            return f"{base}({int(num_precision)},{int(num_scale)})"
+        return f"{base}({int(num_precision)})"
+
+    return base
+
+
+def sqlglot_dialect(con):
+    """Return the sqlglot dialect for an ibis connection, or ``None``."""
+    try:
+        return con.compiler.dialect
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# low-level catalog query helpers
+# ---------------------------------------------------------------------------
+def _quote(value: str) -> str:
+    return value.replace("'", "''")
+
+
+def _rows(con, query: str):
+    """Execute a raw catalog query and return a list of row tuples, or ``None``."""
+    try:
+        cursor = con.raw_sql(query)
+    except Exception as e:
+        logger.debug("native type catalog query failed: %s", e)
+        return None
+    try:
+        if hasattr(cursor, "fetchall"):
+            return list(cursor.fetchall())
+        # Some backends (e.g. BigQuery) return an iterable result set
+        # (RowIterator) instead of a DBAPI cursor.
+        return list(cursor)
+    except Exception as e:
+        logger.debug("could not read native type catalog rows: %s", e)
+        return None
+    finally:
+        # On DuckDB, raw_sql returns the shared connection itself; closing it
+        # would tear down the connection and break subsequent checks.
+        if cursor is not getattr(con, "con", None):
+            try:
+                cursor.close()
+            except Exception:
+                pass
+
+
+def _map_reconstructed(con, query: str, oracle_length: bool = False) -> Optional[dict[str, str]]:
+    """Read ``(column_name, data_type, length, precision, scale)`` rows and
+    reconstruct each parameterized native type string."""
+    rows = _rows(con, query)
+    if not rows:
+        return None
+    result: dict[str, str] = {}
+    for row in rows:
+        column_name, data_type = row[0], row[1]
+        char_len = row[2]
+        if oracle_length:
+            # Oracle reports DATA_LENGTH for every column; keep it only for the
+            # types where it is really part of the declared type.
+            char_len = char_len if (data_type or "").strip().lower() in _ORACLE_LENGTH_TYPES else None
+        native = reconstruct_native_type(data_type, char_len, row[3], row[4])
+        if column_name and native:
+            result[str(column_name).lower()] = native
+    return result or None
+
+
+def _map_full_type(con, query: str) -> Optional[dict[str, str]]:
+    """Read ``(column_name, data_type)`` rows where ``data_type`` is already a
+    complete native type string."""
+    rows = _rows(con, query)
+    if not rows:
+        return None
+    result: dict[str, str] = {}
+    for row in rows:
+        column_name, data_type = row[0], row[1]
+        if column_name and data_type:
+            result[str(column_name).lower()] = str(data_type).strip()
+    return result or None
+
+
+# ---------------------------------------------------------------------------
+# per-backend catalog readers (one per strategy in _CATALOG_STRATEGY)
+# ---------------------------------------------------------------------------
+def _read_information_schema(con, server: Server, model: str) -> Optional[dict[str, str]]:
+    """Standard ``INFORMATION_SCHEMA.COLUMNS`` with separate length/precision."""
+    query = (
+        "SELECT column_name, data_type, character_maximum_length, "
+        "numeric_precision, numeric_scale "
+        f"FROM information_schema.columns WHERE upper(table_name) = upper('{_quote(model)}')"
+    )
+    return _map_reconstructed(con, query)
+
+
+def _read_oracle(con, server: Server, model: str) -> Optional[dict[str, str]]:
+    """Oracle exposes columns via ``ALL_TAB_COLUMNS`` instead of information_schema."""
+    query = (
+        "SELECT column_name, data_type, data_length, data_precision, data_scale "
+        f"FROM all_tab_columns WHERE upper(table_name) = upper('{_quote(model)}')"
+    )
+    return _map_reconstructed(con, query, oracle_length=True)
+
+
+def _read_athena(con, server: Server, model: str) -> Optional[dict[str, str]]:
+    """Athena's information_schema.data_type is already a full type string."""
+    schema_filter = f" AND table_schema = '{_quote(server.schema_)}'" if server.schema_ else ""
+    query = (
+        "SELECT column_name, data_type FROM information_schema.columns "
+        f"WHERE lower(table_name) = lower('{_quote(model)}'){schema_filter}"
+    )
+    return _map_full_type(con, query)
+
+
+def _read_bigquery(con, server: Server, model: str) -> Optional[dict[str, str]]:
+    """BigQuery's INFORMATION_SCHEMA must be dataset-qualified; table names are
+    case-sensitive and data_type is already a full type string."""
+    if not server.project or not server.dataset:
+        return None
+    query = (
+        "SELECT column_name, data_type "
+        f"FROM `{server.project}.{server.dataset}`.INFORMATION_SCHEMA.COLUMNS "
+        f"WHERE table_name = '{_quote(model)}'"
+    )
+    return _map_full_type(con, query)
+
+
+_READERS = {
+    "information_schema": _read_information_schema,
+    "oracle": _read_oracle,
+    "athena": _read_athena,
+    "bigquery": _read_bigquery,
+}
+
+
+def fetch_native_types(con, server: Server, model: str) -> Optional[dict[str, str]]:
+    """Return ``{column_name_lower: native_type_string}`` for ``model``.
+
+    Returns ``None`` when the native declared type is unavailable for this
+    backend, so the caller skips physical type checks rather than failing them.
+    """
+    strategy = _CATALOG_STRATEGY.get(get_server_type(server))
+    return _READERS[strategy](con, server, model) if strategy else None

--- a/tests/fixtures/sqlserver/data/data.sql
+++ b/tests/fixtures/sqlserver/data/data.sql
@@ -2,7 +2,8 @@
 CREATE TABLE [dbo].[my_table] (
     field_one VARCHAR(10) PRIMARY KEY,
     field_two INT NOT NULL,
-    field_three DATETIME2
+    field_three DATETIME2,
+    field_uuid UNIQUEIDENTIFIER
 );
 
 -- Insert the data

--- a/tests/fixtures/sqlserver/datacontract.yaml
+++ b/tests/fixtures/sqlserver/datacontract.yaml
@@ -28,3 +28,10 @@ models:
         type: timestamp
         config:
           sqlserverType: DATETIME2
+      # Regression for #1354: a UUID column has logicalType string but
+      # physicalType uniqueidentifier; the physical type must be verified
+      # against the real native type rather than failing the string check.
+      field_uuid:
+        type: string
+        config:
+          sqlserverType: uniqueidentifier

--- a/tests/test_create_checks_physical_type.py
+++ b/tests/test_create_checks_physical_type.py
@@ -1,0 +1,46 @@
+from open_data_contract_standard.model import (
+    OpenDataContractStandard,
+    SchemaObject,
+    SchemaProperty,
+    Server,
+)
+
+from datacontract.engines.checks.check_spec import MetricType
+from datacontract.engines.checks.create_checks import create_checks
+
+
+def _contract(prop: SchemaProperty, server_type: str, fmt: str | None = None):
+    schema = SchemaObject(name="USERS", physicalType="table", properties=[prop])
+    dc = OpenDataContractStandard(version="1", kind="DataContract", apiVersion="v3.1.0", id="x", schema=[schema])
+    server = Server(server="s", type=server_type, format=fmt)
+    return create_checks(dc, server)
+
+
+def _type_check(checks):
+    return next(
+        (c for c in checks if c.metric in (MetricType.FIELD_TYPE, MetricType.FIELD_PHYSICAL_TYPE)),
+        None,
+    )
+
+
+def test_physicaltype_preferred_on_database_backend():
+    prop = SchemaProperty(name="user_id", physicalType="uniqueidentifier", logicalType="string")
+    check = _type_check(_contract(prop, "sqlserver"))
+    assert check.metric == MetricType.FIELD_PHYSICAL_TYPE
+    assert check.expected_physical_type == "uniqueidentifier"
+    # logicalType is carried for the fallback path.
+    assert check.expected_schema_property is not None
+
+
+def test_logicaltype_used_when_no_physicaltype():
+    prop = SchemaProperty(name="user_name", logicalType="string")
+    check = _type_check(_contract(prop, "sqlserver"))
+    assert check.metric == MetricType.FIELD_TYPE
+
+
+def test_physicaltype_not_checked_on_file_backend():
+    # File sources have no meaningful native platform type, so a declared
+    # physicalType falls through to the logicalType category check.
+    prop = SchemaProperty(name="user_id", physicalType="uniqueidentifier", logicalType="string")
+    check = _type_check(_contract(prop, "local", fmt="parquet"))
+    assert check.metric == MetricType.FIELD_TYPE

--- a/tests/test_physical_type_match.py
+++ b/tests/test_physical_type_match.py
@@ -1,0 +1,125 @@
+from datacontract.engines.checks.physical_type_match import physical_type_matches
+from datacontract.engines.ibis.native_type import (
+    reconstruct_native_type,
+    supports_native_type_introspection,
+)
+
+
+# --- physical_type_matches -------------------------------------------------
+def test_uniqueidentifier_matches_on_sqlserver():
+    ok, reason = physical_type_matches("uniqueidentifier", "uniqueidentifier", "tsql")
+    assert ok is True
+    assert reason == ""
+
+
+def test_case_insensitive():
+    ok, _ = physical_type_matches("UNIQUEIDENTIFIER", "uniqueidentifier", "tsql")
+    assert ok is True
+
+
+def test_dialect_aliases_match():
+    # int ≡ integer, decimal ≡ numeric
+    assert physical_type_matches("int", "integer", "postgres")[0] is True
+    assert physical_type_matches("decimal(10,2)", "numeric(10,2)", "postgres")[0] is True
+
+
+def test_length_enforced_only_when_declared():
+    # Contract declares a length -> must match.
+    ok, reason = physical_type_matches("varchar(255)", "varchar(100)", "tsql")
+    assert ok is False
+    assert "varchar(255)" in reason and "varchar(100)" in reason
+    # Contract omits the length -> any length matches.
+    assert physical_type_matches("varchar", "varchar(255)", "tsql")[0] is True
+
+
+def test_timestamp_matches_timestamptz():
+    # A declared timestamp is compatible with a timestamptz column (timezone
+    # variance is not distinguished at the level most contracts are written at).
+    assert physical_type_matches("timestamp", "timestamp with time zone", "postgres")[0] is True
+    assert physical_type_matches("timestamp", "timestamptz", "postgres")[0] is True
+
+
+def test_distinct_native_types_do_not_match():
+    # varchar and nvarchar are genuinely different native types.
+    ok, _ = physical_type_matches("varchar(255)", "nvarchar(255)", "tsql")
+    assert ok is False
+
+
+def test_wrong_base_type_fails():
+    ok, reason = physical_type_matches("uniqueidentifier", "int", "tsql")
+    assert ok is False
+    assert "uniqueidentifier" in reason
+
+
+def test_cross_dialect_physicaltype_is_skipped():
+    # uniqueidentifier is not a Snowflake type -> cannot resolve -> skip (None).
+    result, reason = physical_type_matches("uniqueidentifier", "varchar", "snowflake")
+    assert result is None
+    assert "snowflake" in reason.lower() or "not a valid type" in reason.lower()
+
+
+def test_exotic_oracle_types_match_via_string_fallback():
+    # sqlglot cannot parse these Oracle types; identical columns still match.
+    assert physical_type_matches("ROWID", "ROWID", "oracle")[0] is True
+    assert physical_type_matches("RAW", "RAW(2000)", "oracle")[0] is True
+    assert physical_type_matches("INTERVAL DAY(2) TO SECOND(6)", "INTERVAL DAY(2) TO SECOND(6)", "oracle")[0] is True
+
+
+def test_exotic_oracle_types_mismatch_when_different():
+    # Both unparseable but genuinely different base types -> fail, not skip.
+    assert physical_type_matches("ROWID", "UROWID", "oracle")[0] is False
+
+
+def test_empty_expected_is_skipped():
+    assert physical_type_matches("", "varchar", "tsql")[0] is None
+    assert physical_type_matches(None, "varchar", "tsql")[0] is None
+
+
+def test_bigquery_types_match():
+    assert physical_type_matches("STRING", "STRING", "bigquery")[0] is True
+    assert physical_type_matches("NUMERIC", "NUMERIC(10, 2)", "bigquery")[0] is True
+    assert physical_type_matches("STRING", "INT64", "bigquery")[0] is False
+
+
+def test_athena_types_match():
+    assert physical_type_matches("varchar", "varchar(255)", "athena")[0] is True
+    assert physical_type_matches("varchar(255)", "varchar(100)", "athena")[0] is False
+
+
+# --- supports_native_type_introspection ------------------------------------
+def test_supported_backends():
+    for s in ["sqlserver", "postgres", "redshift", "snowflake", "databricks", "trino", "oracle", "athena", "bigquery"]:
+        assert supports_native_type_introspection(s) is True
+
+
+def test_unsupported_backends():
+    for s in ["local", "s3", "mysql", "impala", "kafka", "dataframe", None]:
+        assert supports_native_type_introspection(s) is False
+
+
+# --- reconstruct_native_type ----------------------------------------------
+def test_reconstruct_plain_type():
+    assert reconstruct_native_type("uniqueidentifier") == "uniqueidentifier"
+
+
+def test_reconstruct_with_char_length():
+    assert reconstruct_native_type("varchar", char_len=255) == "varchar(255)"
+
+
+def test_reconstruct_sqlserver_max_length():
+    # SQL Server reports CHARACTER_MAXIMUM_LENGTH = -1 for varchar(max).
+    assert reconstruct_native_type("varchar", char_len=-1) == "varchar(max)"
+
+
+def test_reconstruct_decimal_precision_scale():
+    assert reconstruct_native_type("decimal", num_precision=10, num_scale=2) == "decimal(10,2)"
+    assert reconstruct_native_type("decimal", num_precision=10, num_scale=0) == "decimal(10)"
+
+
+def test_reconstruct_integer_ignores_numeric_precision():
+    # int reports numeric_precision 10, but int(10) is not a real declared type.
+    assert reconstruct_native_type("int", num_precision=10, num_scale=0) == "int"
+
+
+def test_reconstruct_none():
+    assert reconstruct_native_type(None) is None


### PR DESCRIPTION
## Summary

When a field declares a `physicalType`, `datacontract test` now verifies it against the column's **real declared native type** read from the platform catalog (length and precision included), taking precedence over `logicalType`. When `physicalType` is absent, or cannot be read/interpreted for the backend, the check falls back to the existing `logicalType` category check. Follow-up to #1354.

## Behaviour

- `physicalType` set → compare the declared type against the actual native type using sqlglot in the server's dialect. Dialect aliases (`int`≡`integer`, `decimal`≡`numeric`) and case are handled; length/precision is enforced only when the contract declares it; `varchar` vs `nvarchar` stay distinct; timestamp vs timestamptz is treated as compatible; a string fallback covers types sqlglot cannot model (Oracle `ROWID`/`RAW`/`INTERVAL`).
- Native type unavailable for the backend, or `physicalType` foreign to the server's dialect → fall back to the `logicalType` category check; warn (skip) only when there is nothing left to compare.

## Supported backends

Native types are read from the platform catalog:

- `INFORMATION_SCHEMA.COLUMNS` — SQL Server, Postgres, Redshift, Snowflake, Databricks, Trino
- `ALL_TAB_COLUMNS` — Oracle
- dataset-qualified `INFORMATION_SCHEMA.COLUMNS` — Athena, BigQuery

`_CATALOG_STRATEGY` in `native_type.py` is the single source of truth for which server types are supported and how each catalog is read. File sources, the DuckDB MySQL scanner, impala and kafka/dataframe have no usable native type and fall back to the logicalType check.

## Tests

- Unit: `test_physical_type_match.py` (matching, length/alias/timezone rules, cross-dialect skip, exotic Oracle types, BigQuery/Athena dialects, supported-backends table), `test_create_checks_physical_type.py` (precedence + backend gating).
- Integration: verified end-to-end against live Postgres and Oracle (testcontainers); extended the CI-gated SQL Server fixture with a `uniqueidentifier` column (the #1354 scenario).
- Full suite: 957 passed, 18 skipped (with Java 21 for the PySpark tests).

## Note

The live catalog round-trip for Athena and BigQuery is validated by design rather than execution (no local credentials): the fetch mechanics mirror the Postgres/Oracle paths that are verified against testcontainers, and the BigQuery `RowIterator` handling mirrors the existing `RowIterator` fix. Real validation happens in CI with credentials.