### PR TITLE
feat: include datacontractCliVersion in test run JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `datacontract test` JSON output now includes `datacontractCliVersion` (#1353)
+
 ### Fixed
 - `datacontract test` no longer fails the type check for SQL Server `uniqueidentifier` (UUID) columns with "the column type could not be determined" (#1354)
 - `datacontract test` against BigQuery no longer fails SQL quality checks with `'RowIterator' object has no attribute 'fetchone'`

--- a/datacontract/model/run.py
+++ b/datacontract/model/run.py
@@ -1,10 +1,18 @@
 import logging
 from datetime import datetime, timezone
 from enum import Enum
+from importlib import metadata
 from typing import List
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel
+
+
+def _cli_version() -> str:
+    try:
+        return metadata.version("datacontract-cli")
+    except metadata.PackageNotFoundError:
+        return "unknown"
 
 
 class ResultEnum(str, Enum):
@@ -47,6 +55,7 @@ class Log(BaseModel):
 
 class Run(BaseModel):
     runId: UUID
+    datacontractCliVersion: str = _cli_version()
     dataContractId: str | None = None
     dataContractVersion: str | None = None
     dataProductId: str | None = None

--- a/tests/test_ci_output.py
+++ b/tests/test_ci_output.py
@@ -325,6 +325,7 @@ def test_json_output_single(capsys):
     write_json_results([("datacontract.yaml", run)])
     captured = capsys.readouterr()
     data = json.loads(captured.out)
+    assert "datacontractCliVersion" in data
     assert data["result"] == "passed"
     assert data["location"] == "datacontract.yaml"
     assert len(data["checks"]) == 1
@@ -338,6 +339,8 @@ def test_json_output_multi(capsys):
     data = json.loads(captured.out)
     assert isinstance(data, list)
     assert len(data) == 2
+    assert "datacontractCliVersion" in data[0]
+    assert "datacontractCliVersion" in data[1]
     assert data[0]["result"] == "passed"
     assert data[0]["location"] == "orders.yaml"
     assert data[1]["result"] == "failed"
@@ -354,3 +357,4 @@ def test_ci_json_flag():
     assert "result" in data
     assert "location" in data
     assert "checks" in data
+    assert "datacontractCliVersion" in data

--- a/tests/test_test_output_json.py
+++ b/tests/test_test_output_json.py
@@ -25,4 +25,5 @@ def test_output_json_test_result(tmp_path):
     assert "runId" in data
     assert "checks" in data
     assert "result" in data
+    assert "datacontractCliVersion" in data
     assert data["result"] in ("passed", "warning", "failed", "error")


### PR DESCRIPTION
Fixes #1353 

This PR only adds the datacontract cli version to the test output.
It does not add a dedicated JSON output schema/version field. If that would be useful as well, I can try to add it.

- [x] Tests pass (`uv run pytest`)
- [x] Code formatted (`uv run ruff check --fix && uv run ruff format`)
- [ ] README.md updated (if relevant)
- [x] CHANGELOG.md entry added
