### PR TITLE
UI/UX: Hardcoded API Endpoint Without Environment Configuration

### DIFF
--- a/datacontract/editor_assets/index.html
+++ b/datacontract/editor_assets/index.html
@@ -16,6 +16,8 @@
     <script type="module">
       import { init } from './datacontract-editor.es.js';
 
+      const apiUrl = window.DATACONTRACT_API_URL || 'https://api.datacontract.com';
+
       init({
         container: '#root',
         mode: 'SERVER',
@@ -23,7 +25,7 @@
         initialView: 'form',
         tests: {
           enabled: true,
-          dataContractCliApiServerUrl: 'https://api.datacontract.com'
+          dataContractCliApiServerUrl: apiUrl
         },
       });
     </script>


### PR DESCRIPTION
## Summary

UI/UX: Hardcoded API Endpoint Without Environment Configuration

## Problem

**Severity**: `Medium` | **File**: `datacontract/editor_assets/index.html:L17`

The editor configuration hardcodes `dataContractCliApiServerUrl: 'https://api.datacontract.com'` directly in the HTML. This prevents environment-specific deployments, makes local development difficult, and creates a single point of failure. No fallback or override mechanism is visible for different deployment contexts.

## Solution

Move the API URL to an environment variable or configuration file. Use a relative URL or placeholder that gets replaced at build time. Add a fallback mechanism and document the configuration options.

## Changes

- `datacontract/editor_assets/index.html` (modified)