### PR TITLE
Verify logicalType for semi-structured columns in `datacontract test`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ db.duckdb
 .vscode/
 .duckdb/
 uv.lock
+/docs/yarn.lock
 
 ### JetBrains template
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- `datacontract test` now verifies `logicalType` for Snowflake `OBJECT`/`ARRAY` columns
+- `datacontract test` now recursively verifies nested `logicalType` for Snowflake structured `OBJECT`/`ARRAY` columns
+- `datacontract test` now fails (instead of silently passing) when a contract declares nested fields on a column whose type is dynamically typed and cannot be verified
 
 ## [1.0.10] - 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `datacontract test` now verifies `logicalType` for Snowflake `OBJECT`/`ARRAY` columns
+
 ## [1.0.10] - 2026-07-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `datacontract test` now recursively verifies nested `logicalType` for Snowflake structured `OBJECT`/`ARRAY` columns
-- `datacontract test` now fails (instead of silently passing) when a contract declares nested fields on a column whose type is dynamically typed and cannot be verified
+- `datacontract test` now fails for complex types when the nested type definition cannot be verified (e.g. if array<integer> is required, array<json> will no longer be accepted)
 
 ## [1.0.10] - 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `datacontract test` now recursively verifies nested `logicalType` for Snowflake structured `OBJECT`/`ARRAY` columns
 - `datacontract test` now fails for complex types when the nested type definition cannot be verified (e.g. if array<integer> is required, array<json> will no longer be accepted)
+- `datacontract test` now checks `physicalType` against the full native type of a Snowflake structured `OBJECT`/`ARRAY` column, instead of failing against the bare `OBJECT`/`ARRAY` the catalog reports
+- `datacontract test` now names the Snowflake type (e.g. `VARIANT`) in the type-check failure message instead of the ibis type `json`
 
 ## [1.0.10] - 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `datacontract test` now recursively verifies nested `logicalType` for Snowflake structured `OBJECT`/`ARRAY` columns
 - `datacontract test` now fails for complex types when the nested type definition cannot be verified (e.g. if array<integer> is required, array<json> will no longer be accepted)
-- `datacontract test` now checks `physicalType` against the full native type of a Snowflake structured `OBJECT`/`ARRAY` column, instead of failing against the bare `OBJECT`/`ARRAY` the catalog reports
-- `datacontract test` now names the Snowflake type (e.g. `VARIANT`) in the type-check failure message instead of the ibis type `json`
 
 ## [1.0.11] - 2026-07-09
 

--- a/datacontract/engines/checks/type_normalize.py
+++ b/datacontract/engines/checks/type_normalize.py
@@ -159,7 +159,7 @@ def schema_property_matches(expected: SchemaProperty | None, actual: SchemaPrope
     if expected_base == "object":
         if not expected.properties:
             return True
-        # actual.properties is None for an opaque object (ibis map/variant): the
+        # actual.properties is None for an untyped object (ibis map/variant): the
         # empty lookup below fails every declared field, which is what we want.
         actual_by_name = {p.name.lower(): p for p in (actual.properties or []) if p.name}
         for exp_field in expected.properties:
@@ -215,7 +215,7 @@ def schema_property_mismatch_reasons(
 
     if actual_base is None:
         # actual is unsupported or dynamically typed (json element/variant): the
-        # declared type can't be verified against an opaque column.
+        # declared type can't be verified against an untyped column.
         exp_str = expected.logicalType or expected.physicalType
         errors.append(
             f"{field_label}: declared as '{exp_str}' but the column is dynamically typed (json/variant) and can't be verified"
@@ -238,7 +238,7 @@ def schema_property_mismatch_reasons(
             return errors
         if actual.properties is None:
             errors.append(
-                f"{field_label}: declared with nested fields but the column is an opaque object "
+                f"{field_label}: declared with nested fields but the column is an untyped object "
                 "(map/variant) whose structure can't be verified; use a structured type or specify physicalType"
             )
             return errors

--- a/datacontract/engines/checks/type_normalize.py
+++ b/datacontract/engines/checks/type_normalize.py
@@ -220,7 +220,7 @@ def schema_property_mismatch_reasons(
         errors.append(
             f"{field_label}: has type '{act_str}', but the contract specifies '{exp_str}'. "
             f"A '{act_str}' value has no verifiable logical type. "
-            "If this is intentional, specify the native type as physicalType."
+            f"If this is intentional, specify `physicalType: {act_str}`."
         )
         return errors
 

--- a/datacontract/engines/checks/type_normalize.py
+++ b/datacontract/engines/checks/type_normalize.py
@@ -14,10 +14,11 @@ import re
 
 from open_data_contract_standard.model import SchemaProperty
 
-# logicalType marker for a dynamically-typed column the backend cannot describe
-# (ibis json: Snowflake VARIANT, Postgres JSONB, BigQuery JSON). Its storage
-# constrains nothing, so no declared type can be confirmed against it. As a
-# nested element it is skipped here; a top-level occurrence is failed in _run_type.
+# logicalType marker for a field whose type the backend cannot describe: a
+# dynamically-typed column (ibis json: Snowflake VARIANT, Postgres JSONB,
+# BigQuery JSON) or an unsupported one (binary, geography). No declared type can
+# be confirmed against it, so any expected type fails rather than silently passing.
+# Distinct from a missing field, which is what dropping it would look like.
 UNKNOWN_LOGICAL_TYPE = "__unknown__"
 
 
@@ -214,11 +215,12 @@ def schema_property_mismatch_reasons(
         return errors
 
     if actual_base is None:
-        # actual is unsupported or dynamically typed (json element/variant): the
-        # declared type can't be verified against an untyped column.
         exp_str = expected.logicalType or expected.physicalType
+        act_str = actual.physicalType or "unknown"
         errors.append(
-            f"{field_label}: declared as '{exp_str}' but the column is dynamically typed (json/variant) and can't be verified"
+            f"{field_label}: has type '{act_str}', but the contract specifies '{exp_str}'. "
+            f"A '{act_str}' value has no verifiable logical type. "
+            "If this is intentional, specify the native type as physicalType."
         )
         return errors
 

--- a/datacontract/engines/checks/type_normalize.py
+++ b/datacontract/engines/checks/type_normalize.py
@@ -14,6 +14,12 @@ import re
 
 from open_data_contract_standard.model import SchemaProperty
 
+# logicalType marker for a dynamically-typed column the backend cannot describe
+# (ibis json: Snowflake VARIANT, Postgres JSONB, BigQuery JSON). Its storage
+# constrains nothing, so no declared type can be confirmed against it. As a
+# nested element it is skipped here; a top-level occurrence is failed in _run_type.
+UNKNOWN_LOGICAL_TYPE = "__unknown__"
+
 
 def normalize_type_name(type_name: str | None) -> str | None:
     """Map a contract type name (logical or physical) to one of the 9 ODCS categories.
@@ -132,6 +138,9 @@ def schema_property_matches(expected: SchemaProperty | None, actual: SchemaPrope
         return True
     if actual is None:
         return False
+    if actual.logicalType == UNKNOWN_LOGICAL_TYPE:
+        # unknown inner type (json element/value): unconfirmable, so skip
+        return True
 
     expected_base = normalize_type_name(expected.logicalType or expected.physicalType)
     actual_base = normalize_type_name(actual.logicalType or actual.physicalType)
@@ -150,6 +159,9 @@ def schema_property_matches(expected: SchemaProperty | None, actual: SchemaPrope
 
     if expected_base == "object":
         if not expected.properties:
+            return True
+        if actual.properties is None:
+            # opaque object (ibis map): inner structure unknowable, skip descent
             return True
         actual_by_name = {p.name.lower(): p for p in (actual.properties or []) if p.name}
         for exp_field in expected.properties:
@@ -197,6 +209,9 @@ def schema_property_mismatch_reasons(
         exp_str = expected.logicalType or expected.physicalType
         errors.append(f"{field_label}: expected type '{exp_str}' but the column type could not be determined")
         return errors
+    if actual.logicalType == UNKNOWN_LOGICAL_TYPE:
+        # unknown inner type (json element/value): unconfirmable, so skip
+        return errors
 
     expected_base = normalize_type_name(expected.logicalType or expected.physicalType)
     actual_base = normalize_type_name(actual.logicalType or actual.physicalType)
@@ -217,6 +232,9 @@ def schema_property_mismatch_reasons(
 
     if expected_base == "object":
         if not expected.properties:
+            return errors
+        if actual.properties is None:
+            # opaque object (ibis map): inner structure unknowable, skip descent
             return errors
 
         actual_by_name = {p.name.lower(): p for p in (actual.properties or []) if p.name}

--- a/datacontract/engines/checks/type_normalize.py
+++ b/datacontract/engines/checks/type_normalize.py
@@ -138,9 +138,6 @@ def schema_property_matches(expected: SchemaProperty | None, actual: SchemaPrope
         return True
     if actual is None:
         return False
-    if actual.logicalType == UNKNOWN_LOGICAL_TYPE:
-        # unknown inner type (json element/value): unconfirmable, so skip
-        return True
 
     expected_base = normalize_type_name(expected.logicalType or expected.physicalType)
     actual_base = normalize_type_name(actual.logicalType or actual.physicalType)
@@ -148,6 +145,8 @@ def schema_property_matches(expected: SchemaProperty | None, actual: SchemaPrope
     if expected_base is None:
         return True
     if actual_base is None:
+        # actual is unsupported or dynamically typed (json element/variant): a
+        # declared concrete type can't be confirmed against it, so it fails.
         return False
     if expected_base != actual_base and not (expected_base in _NUMERIC and actual_base in _NUMERIC):
         return False
@@ -160,9 +159,8 @@ def schema_property_matches(expected: SchemaProperty | None, actual: SchemaPrope
     if expected_base == "object":
         if not expected.properties:
             return True
-        if actual.properties is None:
-            # opaque object (ibis map): inner structure unknowable, skip descent
-            return True
+        # actual.properties is None for an opaque object (ibis map/variant): the
+        # empty lookup below fails every declared field, which is what we want.
         actual_by_name = {p.name.lower(): p for p in (actual.properties or []) if p.name}
         for exp_field in expected.properties:
             if not exp_field.name:
@@ -209,14 +207,19 @@ def schema_property_mismatch_reasons(
         exp_str = expected.logicalType or expected.physicalType
         errors.append(f"{field_label}: expected type '{exp_str}' but the column type could not be determined")
         return errors
-    if actual.logicalType == UNKNOWN_LOGICAL_TYPE:
-        # unknown inner type (json element/value): unconfirmable, so skip
-        return errors
-
     expected_base = normalize_type_name(expected.logicalType or expected.physicalType)
     actual_base = normalize_type_name(actual.logicalType or actual.physicalType)
 
     if expected_base is None:
+        return errors
+
+    if actual_base is None:
+        # actual is unsupported or dynamically typed (json element/variant): the
+        # declared type can't be verified against an opaque column.
+        exp_str = expected.logicalType or expected.physicalType
+        errors.append(
+            f"{field_label}: declared as '{exp_str}' but the column is dynamically typed (json/variant) and can't be verified"
+        )
         return errors
 
     if expected_base != actual_base and not (expected_base in _NUMERIC and actual_base in _NUMERIC):
@@ -234,7 +237,10 @@ def schema_property_mismatch_reasons(
         if not expected.properties:
             return errors
         if actual.properties is None:
-            # opaque object (ibis map): inner structure unknowable, skip descent
+            errors.append(
+                f"{field_label}: declared with nested fields but the column is an opaque object "
+                "(map/variant) whose structure can't be verified; use a structured type or specify physicalType"
+            )
             return errors
 
         actual_by_name = {p.name.lower(): p for p in (actual.properties or []) if p.name}

--- a/datacontract/engines/ibis/dtype_category.py
+++ b/datacontract/engines/ibis/dtype_category.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 
 from open_data_contract_standard.model import SchemaProperty
 
+from datacontract.engines.checks.type_normalize import UNKNOWN_LOGICAL_TYPE
+
 if TYPE_CHECKING:
     from ibis.expr.datatypes import DataType
 
@@ -53,7 +55,7 @@ def ibis_dtype_to_schema_property(dtype: DataType) -> SchemaProperty | None:
 
     Returns a ``SchemaProperty`` with ``logicalType`` set to one of the 9 ODCS
     categories, recursively populating ``properties`` for structs and ``items``
-    for arrays. Returns ``None`` for unsupported types (binary, map, null, etc.)
+    for arrays. Returns ``None`` for unsupported types (binary, null, etc.)
     so the caller can skip comparison rather than raising a false failure.
     """
     try:
@@ -88,6 +90,12 @@ def ibis_dtype_to_schema_property(dtype: DataType) -> SchemaProperty | None:
         if dtype.is_array():
             element = ibis_dtype_to_schema_property(dtype.value_type)
             return SchemaProperty(logicalType="array", items=element)
+        if dtype.is_map():
+            # base is confirmable, inner values are not (yet)
+            return SchemaProperty(logicalType="object", properties=None)
+        if dtype.is_json():
+            # json is the fallback type which could be everything
+            return SchemaProperty(logicalType=UNKNOWN_LOGICAL_TYPE)
     except AttributeError:
         return None
     return None

--- a/datacontract/engines/ibis/dtype_category.py
+++ b/datacontract/engines/ibis/dtype_category.py
@@ -86,7 +86,7 @@ def ibis_dtype_to_schema_property(dtype: DataType) -> SchemaProperty | None:
                             properties=child.properties,
                         )
                     )
-            return SchemaProperty(logicalType="object", properties=properties if properties else None)
+            return SchemaProperty(logicalType="object", properties=properties)
         if dtype.is_array():
             element = ibis_dtype_to_schema_property(dtype.value_type)
             return SchemaProperty(logicalType="array", items=element)

--- a/datacontract/engines/ibis/dtype_category.py
+++ b/datacontract/engines/ibis/dtype_category.py
@@ -50,13 +50,14 @@ def ibis_dtype_category(dtype) -> str:
     return "other"
 
 
-def ibis_dtype_to_schema_property(dtype: DataType) -> SchemaProperty | None:
+def ibis_dtype_to_schema_property(dtype: DataType) -> SchemaProperty:
     """Map an ibis DataType to a SchemaProperty for structural type comparison.
 
     Returns a ``SchemaProperty`` with ``logicalType`` set to one of the 9 ODCS
     categories, recursively populating ``properties`` for structs and ``items``
-    for arrays. Returns ``None`` for unsupported types (binary, null, etc.)
-    so the caller can skip comparison rather than raising a false failure.
+    for arrays. A type that carries no verifiable logical type (json, binary,
+    null, …) becomes ``UNKNOWN_LOGICAL_TYPE`` with the actual type kept in
+    ``physicalType``, so the failure message can name it.
     """
     try:
         if dtype.is_boolean():
@@ -76,16 +77,17 @@ def ibis_dtype_to_schema_property(dtype: DataType) -> SchemaProperty | None:
         if dtype.is_struct():
             properties = []
             for field_name, ftype in dtype.fields.items():
+                # an unverifiable field type is still a field: keep it, so it is not reported missing
                 child = ibis_dtype_to_schema_property(ftype)
-                if child is not None:
-                    properties.append(
-                        SchemaProperty(
-                            name=field_name,
-                            logicalType=child.logicalType,
-                            items=child.items,
-                            properties=child.properties,
-                        )
+                properties.append(
+                    SchemaProperty(
+                        name=field_name,
+                        logicalType=child.logicalType,
+                        physicalType=child.physicalType,
+                        items=child.items,
+                        properties=child.properties,
                     )
+                )
             return SchemaProperty(logicalType="object", properties=properties)
         if dtype.is_array():
             element = ibis_dtype_to_schema_property(dtype.value_type)
@@ -93,9 +95,7 @@ def ibis_dtype_to_schema_property(dtype: DataType) -> SchemaProperty | None:
         if dtype.is_map():
             # base is confirmable, inner values are not (yet)
             return SchemaProperty(logicalType="object", properties=None)
-        if dtype.is_json():
-            # json is the fallback type which could be everything
-            return SchemaProperty(logicalType=UNKNOWN_LOGICAL_TYPE)
     except AttributeError:
-        return None
-    return None
+        return SchemaProperty(logicalType=UNKNOWN_LOGICAL_TYPE)
+    # json holds a different type per row; binary and null have no ODCS category
+    return SchemaProperty(logicalType=UNKNOWN_LOGICAL_TYPE, physicalType=str(dtype))

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -635,17 +635,12 @@ def _run_type(run: Run, schema, columns, spec: CheckSpec):
         _diag(metric="field_type", field=spec.field, expected=spec.expected_type_label, actual=str(dtype)),
     )
     if dtype.is_json() or dtype.is_unknown():
-        hint = (
-            f"specify {dtype} as physicalType"
-            if dtype.is_json()
-            else "specify the column's native type as physicalType"
-        )
         _set_result(
             run,
             spec.key,
             ResultEnum.failed,
             f"Column '{spec.field}' has type '{dtype}', but the contract specifies '{spec.expected_type_label}'. "
-            f"If this is intentional, {hint}.",
+            "If this is intentional, specify the column's native type as physicalType.",
         )
         return
     if schema_property_matches(spec.expected_schema_property, actual_prop):

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -22,7 +22,7 @@ from datacontract.engines.checks.type_normalize import schema_property_matches, 
 from datacontract.engines.ibis.connections.connect import connect_ibis
 from datacontract.engines.ibis.dtype_category import ibis_dtype_to_schema_property
 from datacontract.engines.ibis.native_type import fetch_native_types, sqlglot_dialect
-from datacontract.engines.ibis.snowflake_structured_types import fetch_structured_types
+from datacontract.engines.ibis.snowflake_structured_types import fetch_structured_types, has_nesting
 from datacontract.model.exceptions import DataContractException
 from datacontract.model.run import Check, ResultEnum, Run
 from datacontract.model.server import get_server_type
@@ -694,7 +694,13 @@ def _run_physical_type(
         _set_result(run, spec.key, ResultEnum.failed, f"Column '{spec.field}' is missing")
         return
 
-    actual_native = native_types.get(spec.field.lower()) if native_types else None
+    # The catalog reports a structured OBJECT/ARRAY as its bare token, dropping the
+    # nested types; the tree recovered from SHOW COLUMNS renders the real native type.
+    structured_prop = structured_types.get(spec.field.lower()) if structured_types else None
+    if structured_prop is not None and has_nesting(structured_prop):
+        actual_native = structured_prop.physicalType
+    else:
+        actual_native = native_types.get(spec.field.lower()) if native_types else None
     _set_diagnostics(
         run,
         spec.key,
@@ -723,13 +729,12 @@ def _run_physical_type(
     # logicalType category check when the property declares one.
     fallback = spec.expected_schema_property
     if fallback is not None and fallback.logicalType is not None:
-        structured_prop = structured_types.get(spec.field.lower()) if structured_types else None
         actual_prop = structured_prop or ibis_dtype_to_schema_property(schema[actual_col])
         if schema_property_matches(fallback, actual_prop):
             _set_result(run, spec.key, ResultEnum.passed, None)
         else:
             mismatch = schema_property_mismatch_reason(fallback, actual_prop)
-            actual_label = structured_prop.physicalType if structured_prop else schema[actual_col]
+            actual_label = actual_native or schema[actual_col]
             _set_result(
                 run,
                 spec.key,

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -201,7 +201,7 @@ def _run_model(
     # the real nested types from SHOW COLUMNS so field_type checks can recurse.
     structured_types = None
     if get_server_type(server) == "snowflake" and any(spec.metric == MetricType.FIELD_TYPE for spec in specs):
-        structured_types = fetch_structured_types(con, server, model)
+        structured_types = fetch_structured_types(con, server, t.get_name())
 
     agg_exprs = []  # list[(spec, named_expr)]
     for spec in specs:

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -22,6 +22,7 @@ from datacontract.engines.checks.type_normalize import schema_property_matches, 
 from datacontract.engines.ibis.connections.connect import connect_ibis
 from datacontract.engines.ibis.dtype_category import ibis_dtype_to_schema_property
 from datacontract.engines.ibis.native_type import fetch_native_types, sqlglot_dialect
+from datacontract.engines.ibis.snowflake_structured_types import fetch_structured_types
 from datacontract.model.exceptions import DataContractException
 from datacontract.model.run import Check, ResultEnum, Run
 from datacontract.model.server import get_server_type
@@ -196,6 +197,12 @@ def _run_model(
     if any(spec.metric == MetricType.FIELD_PHYSICAL_TYPE for spec in specs):
         native_types = fetch_native_types(con, server, model)
 
+    # Snowflake collapses structured OBJECT/ARRAY nesting in the ibis dtype; read
+    # the real nested types from SHOW COLUMNS so field_type checks can recurse.
+    structured_types = None
+    if get_server_type(server) == "snowflake" and any(spec.metric == MetricType.FIELD_TYPE for spec in specs):
+        structured_types = fetch_structured_types(con, server, model)
+
     agg_exprs = []  # list[(spec, named_expr)]
     for spec in specs:
         try:
@@ -219,7 +226,7 @@ def _run_model(
             elif spec.metric == MetricType.FIELD_PRESENT:
                 _run_present(run, con, model, columns, spec)
             elif spec.metric == MetricType.FIELD_TYPE:
-                _run_type(run, schema, columns, spec)
+                _run_type(run, schema, columns, spec, structured_types)
             elif spec.metric == MetricType.FIELD_PHYSICAL_TYPE:
                 _run_physical_type(run, con, server, schema, columns, native_types, spec)
             elif spec.metric in (MetricType.FRESHNESS, MetricType.RETENTION):
@@ -615,7 +622,7 @@ def _run_present(run: Run, con, model: str, columns, spec: CheckSpec):
     )
 
 
-def _run_type(run: Run, schema, columns, spec: CheckSpec):
+def _run_type(run: Run, schema, columns, spec: CheckSpec, structured_types=None):
     _set_impl(
         run,
         spec.key,
@@ -628,13 +635,16 @@ def _run_type(run: Run, schema, columns, spec: CheckSpec):
         _set_result(run, spec.key, ResultEnum.failed, f"Column '{spec.field}' is missing")
         return
     dtype = schema[actual_col]
-    actual_prop = ibis_dtype_to_schema_property(dtype)
+    # Snowflake structured types come back collapsed from ibis; prefer the nested
+    # tree recovered from SHOW COLUMNS when available.
+    structured_prop = structured_types.get(spec.field.lower()) if structured_types else None
+    actual_prop = structured_prop or ibis_dtype_to_schema_property(dtype)
     _set_diagnostics(
         run,
         spec.key,
         _diag(metric="field_type", field=spec.field, expected=spec.expected_type_label, actual=str(dtype)),
     )
-    if dtype.is_json() or dtype.is_unknown():
+    if structured_prop is None and (dtype.is_json() or dtype.is_unknown()):
         _set_result(
             run,
             spec.key,

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -634,6 +634,20 @@ def _run_type(run: Run, schema, columns, spec: CheckSpec):
         spec.key,
         _diag(metric="field_type", field=spec.field, expected=spec.expected_type_label, actual=str(dtype)),
     )
+    if dtype.is_json() or dtype.is_unknown():
+        hint = (
+            f"specify {dtype} as physicalType"
+            if dtype.is_json()
+            else "specify the column's native type as physicalType"
+        )
+        _set_result(
+            run,
+            spec.key,
+            ResultEnum.failed,
+            f"Column '{spec.field}' has type '{dtype}', but the contract specifies '{spec.expected_type_label}'. "
+            f"If this is intentional, {hint}.",
+        )
+        return
     if schema_property_matches(spec.expected_schema_property, actual_prop):
         _set_result(run, spec.key, ResultEnum.passed, None)
     else:

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -14,7 +14,7 @@ import uuid
 from collections import defaultdict
 from typing import List, Optional
 
-from open_data_contract_standard.model import OpenDataContractStandard, Server
+from open_data_contract_standard.model import OpenDataContractStandard, SchemaProperty, Server
 
 from datacontract.engines.checks.check_spec import CheckSpec, MetricType
 from datacontract.engines.checks.physical_type_match import physical_type_matches
@@ -200,7 +200,9 @@ def _run_model(
     # Snowflake collapses structured OBJECT/ARRAY nesting in the ibis dtype; read
     # the real nested types from SHOW COLUMNS so field_type checks can recurse.
     structured_types = None
-    if get_server_type(server) == "snowflake" and any(spec.metric == MetricType.FIELD_TYPE for spec in specs):
+    if get_server_type(server) == "snowflake" and any(
+        spec.metric in (MetricType.FIELD_TYPE, MetricType.FIELD_PHYSICAL_TYPE) for spec in specs
+    ):
         structured_types = fetch_structured_types(con, server, t.get_name())
 
     agg_exprs = []  # list[(spec, named_expr)]
@@ -228,7 +230,7 @@ def _run_model(
             elif spec.metric == MetricType.FIELD_TYPE:
                 _run_type(run, schema, columns, spec, structured_types)
             elif spec.metric == MetricType.FIELD_PHYSICAL_TYPE:
-                _run_physical_type(run, con, server, schema, columns, native_types, spec)
+                _run_physical_type(run, con, server, schema, columns, native_types, spec, structured_types)
             elif spec.metric in (MetricType.FRESHNESS, MetricType.RETENTION):
                 _run_freshness(run, t, columns, spec)
             elif spec.metric == MetricType.CUSTOM_SQL:
@@ -622,7 +624,7 @@ def _run_present(run: Run, con, model: str, columns, spec: CheckSpec):
     )
 
 
-def _run_type(run: Run, schema, columns, spec: CheckSpec, structured_types=None):
+def _run_type(run: Run, schema, columns, spec: CheckSpec, structured_types: dict[str, SchemaProperty] | None = None):
     _set_impl(
         run,
         spec.key,
@@ -642,7 +644,12 @@ def _run_type(run: Run, schema, columns, spec: CheckSpec, structured_types=None)
     _set_diagnostics(
         run,
         spec.key,
-        _diag(metric="field_type", field=spec.field, expected=spec.expected_type_label, actual=str(dtype)),
+        _diag(
+            metric="field_type",
+            field=spec.field,
+            expected=spec.expected_type_label,
+            actual=structured_prop.physicalType if structured_prop else str(dtype),
+        ),
     )
     if schema_property_matches(spec.expected_schema_property, actual_prop):
         _set_result(run, spec.key, ResultEnum.passed, None)
@@ -656,7 +663,16 @@ def _run_type(run: Run, schema, columns, spec: CheckSpec, structured_types=None)
         )
 
 
-def _run_physical_type(run: Run, con, server, schema, columns, native_types, spec: CheckSpec):
+def _run_physical_type(
+    run: Run,
+    con,
+    server,
+    schema,
+    columns,
+    native_types,
+    spec: CheckSpec,
+    structured_types: dict[str, SchemaProperty] | None = None,
+):
     """Compare a column's real native type against the contract's physicalType.
 
     When the native type cannot be read for this backend, or the declared
@@ -707,16 +723,18 @@ def _run_physical_type(run: Run, con, server, schema, columns, native_types, spe
     # logicalType category check when the property declares one.
     fallback = spec.expected_schema_property
     if fallback is not None and fallback.logicalType is not None:
-        actual_prop = ibis_dtype_to_schema_property(schema[actual_col])
+        structured_prop = structured_types.get(spec.field.lower()) if structured_types else None
+        actual_prop = structured_prop or ibis_dtype_to_schema_property(schema[actual_col])
         if schema_property_matches(fallback, actual_prop):
             _set_result(run, spec.key, ResultEnum.passed, None)
         else:
             mismatch = schema_property_mismatch_reason(fallback, actual_prop)
+            actual_label = structured_prop.physicalType if structured_prop else schema[actual_col]
             _set_result(
                 run,
                 spec.key,
                 ResultEnum.failed,
-                mismatch or f"Expected type '{fallback.logicalType}' but column is '{schema[actual_col]}'",
+                mismatch or f"Expected type '{fallback.logicalType}' but column is '{actual_label}'",
             )
         return
 

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -644,15 +644,6 @@ def _run_type(run: Run, schema, columns, spec: CheckSpec, structured_types=None)
         spec.key,
         _diag(metric="field_type", field=spec.field, expected=spec.expected_type_label, actual=str(dtype)),
     )
-    if structured_prop is None and (dtype.is_json() or dtype.is_unknown()):
-        _set_result(
-            run,
-            spec.key,
-            ResultEnum.failed,
-            f"Column '{spec.field}' has type '{dtype}', but the contract specifies '{spec.expected_type_label}'. "
-            "If this is intentional, specify the column's native type as physicalType.",
-        )
-        return
     if schema_property_matches(spec.expected_schema_property, actual_prop):
         _set_result(run, spec.key, ResultEnum.passed, None)
     else:

--- a/datacontract/engines/ibis/snowflake_structured_types.py
+++ b/datacontract/engines/ibis/snowflake_structured_types.py
@@ -1,27 +1,13 @@
-"""Recover Snowflake structured-type nesting that ibis collapses.
-
-ibis reflects a Snowflake structured ``OBJECT(a INT, b TEXT)`` as
-``map<string, json>`` (indistinguishable from an untyped ``OBJECT``) and
-``ARRAY(NUMBER)`` as ``array<json>``, discarding the nested field and element
-types. Snowflake still exposes them through ``SHOW COLUMNS``, whose ``data_type``
-column is a recursive JSON tree. This module reads that tree and rebuilds a
-``SchemaProperty`` so the ``field_type`` check can verify nested types.
-
-Best-effort: any failure returns ``None`` so the caller falls back to the
-collapsed ibis dtype.
-"""
+"""Rebuild Snowflake structured OBJECT/ARRAY nesting, which ibis collapses, from SHOW COLUMNS."""
 
 from __future__ import annotations
 
 import json
-import logging
-from typing import Optional
 
 from open_data_contract_standard.model import SchemaProperty, Server
 
 from datacontract.engines.checks.type_normalize import UNKNOWN_LOGICAL_TYPE
-
-logger = logging.getLogger(__name__)
+from datacontract.engines.ibis.native_type import _quote, _rows
 
 # SHOW COLUMNS leaf ``type`` tokens -> ODCS logical type. FIXED and REAL both map
 # to "number" (the comparator treats integer/number as compatible). Tokens not
@@ -82,31 +68,49 @@ def _has_nesting(prop: SchemaProperty) -> bool:
     return bool(prop.properties) or prop.items is not None
 
 
-def fetch_structured_types(con, server: Server, table_name: str) -> Optional[dict[str, SchemaProperty]]:
-    """Return ``{column_name_lower: SchemaProperty}`` for the Snowflake columns of
-    ``table_name`` whose declared structured type carries nested detail.
+def _render_native(node: dict) -> str:
+    """Render one ``data_type`` JSON node back to its Snowflake type string."""
+    node_type = node.get("type")
+    if node_type == "OBJECT":
+        fields = node.get("fields")
+        if not fields:
+            return "OBJECT"
+        rendered = [
+            f"{field['fieldName']} {_render_native(field.get('fieldType') or {})}"
+            for field in fields
+            if field.get("fieldName")
+        ]
+        return "OBJECT({})".format(", ".join(rendered)) if rendered else "OBJECT"
+    if node_type == "ARRAY":
+        element = node.get("elementType")
+        return "ARRAY({})".format(_render_native(element)) if element else "ARRAY"
+    if node_type == "MAP":
+        key, value = node.get("keyType"), node.get("valueType")
+        if key and value:
+            return "MAP({}, {})".format(_render_native(key), _render_native(value))
+        return "MAP"
+    if node_type == "FIXED":
+        return "NUMBER({},{})".format(node.get("precision", 38), node.get("scale", 0))
+    if node_type == "REAL":
+        return "FLOAT"
+    if node_type == "TEXT":
+        length = node.get("length")
+        return f"VARCHAR({length})" if length is not None else "VARCHAR"
+    return str(node_type)
 
-    Columns without recoverable nesting (scalars, plain VARIANT/OBJECT/ARRAY,
-    MAP) are omitted, so the caller keeps the collapsed ibis dtype for them.
+
+def fetch_structured_types(con, server: Server, table_name: str) -> dict[str, SchemaProperty] | None:
+    """Return ``{column_name_lower: SchemaProperty}`` for the columns with nested detail.
+
+    Columns without recoverable nesting are omitted; the caller keeps the collapsed ibis dtype.
+    Best-effort: any failure returns ``None``.
     """
     quoted_table = '"{}"'.format(table_name.replace('"', '""'))
     path = ".".join(part for part in (server.database, server.schema_, quoted_table) if part)
-    identifier = "IDENTIFIER('{}')".format(path.replace("'", "''"))
-    try:
-        cursor = con.raw_sql(f"SHOW COLUMNS IN TABLE {identifier}")
-    except Exception as e:
-        logger.debug("SHOW COLUMNS failed for %s: %s", identifier, e)
+    identifier = "IDENTIFIER('{}')".format(_quote(path))
+    rows = _rows(con, f"SHOW COLUMNS IN TABLE {identifier}")
+    if not rows:
         return None
-    try:
-        rows = list(cursor.fetchall())
-    except Exception as e:
-        logger.debug("could not read SHOW COLUMNS rows for %s: %s", identifier, e)
-        return None
-    finally:
-        try:
-            cursor.close()
-        except Exception:
-            pass
 
     # SHOW COLUMNS columns: table_name, schema_name, column_name, data_type, ...
     result: dict[str, SchemaProperty] = {}
@@ -120,5 +124,7 @@ def fetch_structured_types(con, server: Server, table_name: str) -> Optional[dic
             continue
         prop = _to_property(node)
         if _has_nesting(prop):
+            # the real native type, for diagnostics the collapsed ibis dtype can't give
+            prop.physicalType = _render_native(node)
             result[str(column_name).lower()] = prop
     return result or None

--- a/datacontract/engines/ibis/snowflake_structured_types.py
+++ b/datacontract/engines/ibis/snowflake_structured_types.py
@@ -1,0 +1,119 @@
+"""Recover Snowflake structured-type nesting that ibis collapses.
+
+ibis reflects a Snowflake structured ``OBJECT(a INT, b TEXT)`` as
+``map<string, json>`` (indistinguishable from an untyped ``OBJECT``) and
+``ARRAY(NUMBER)`` as ``array<json>``, discarding the nested field and element
+types. Snowflake still exposes them through ``SHOW COLUMNS``, whose ``data_type``
+column is a recursive JSON tree. This module reads that tree and rebuilds a
+``SchemaProperty`` so the ``field_type`` check can verify nested types.
+
+Best-effort: any failure returns ``None`` so the caller falls back to the
+collapsed ibis dtype.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Optional
+
+from open_data_contract_standard.model import SchemaProperty, Server
+
+logger = logging.getLogger(__name__)
+
+# SHOW COLUMNS leaf ``type`` tokens -> ODCS logical type. FIXED and REAL both map
+# to "number" (the comparator treats integer/number as compatible). Tokens not
+# listed (BINARY, GEOGRAPHY, VARIANT, …) carry no verifiable logical type.
+_LEAF_TYPES = {
+    "FIXED": "number",
+    "REAL": "number",
+    "TEXT": "string",
+    "BOOLEAN": "boolean",
+    "DATE": "date",
+    "TIME": "time",
+    "TIMESTAMP_NTZ": "timestamp",
+    "TIMESTAMP_LTZ": "timestamp",
+    "TIMESTAMP_TZ": "timestamp",
+}
+
+
+def _to_property(node: dict) -> Optional[SchemaProperty]:
+    """Convert one ``data_type`` JSON node to a ``SchemaProperty``.
+
+    Returns ``None`` when the node carries no structure the contract can be
+    verified against: an untyped/empty ``OBJECT`` or ``ARRAY``, a ``MAP`` (dynamic
+    keys), a ``VARIANT``, or an unmapped leaf token.
+    """
+    node_type = node.get("type")
+    if node_type == "OBJECT":
+        fields = node.get("fields")
+        if not fields:
+            return None  # untyped/semi-structured OBJECT: opaque
+        properties = []
+        for field in fields:
+            child = _to_property(field.get("fieldType") or {})
+            name = field.get("fieldName")
+            if name and child is not None:
+                properties.append(
+                    SchemaProperty(
+                        name=name,
+                        logicalType=child.logicalType,
+                        items=child.items,
+                        properties=child.properties,
+                    )
+                )
+        return SchemaProperty(logicalType="object", properties=properties or None)
+    if node_type == "ARRAY":
+        element = node.get("elementType")
+        if not element:
+            return None  # untyped/semi-structured ARRAY: opaque
+        return SchemaProperty(logicalType="array", items=_to_property(element))
+    if node_type == "MAP":
+        return None  # dynamic keys can't be matched to named contract properties
+    logical = _LEAF_TYPES.get(node_type)
+    return SchemaProperty(logicalType=logical) if logical else None
+
+
+def _has_nesting(prop: Optional[SchemaProperty]) -> bool:
+    """True only when the property is a structured OBJECT/ARRAY worth substituting."""
+    return prop is not None and (bool(prop.properties) or prop.items is not None)
+
+
+def fetch_structured_types(con, server: Server, model: str) -> Optional[dict[str, SchemaProperty]]:
+    """Return ``{column_name_lower: SchemaProperty}`` for the Snowflake columns of
+    ``model`` whose declared structured type carries nested detail.
+
+    Columns without recoverable nesting (scalars, plain VARIANT/OBJECT/ARRAY,
+    MAP) are omitted, so the caller keeps the collapsed ibis dtype for them.
+    """
+    identifier = ".".join(part for part in (server.database, server.schema_, model) if part)
+    try:
+        cursor = con.raw_sql(f"SHOW COLUMNS IN TABLE {identifier}")
+    except Exception as e:
+        logger.debug("SHOW COLUMNS failed for %s: %s", identifier, e)
+        return None
+    try:
+        rows = list(cursor.fetchall())
+    except Exception as e:
+        logger.debug("could not read SHOW COLUMNS rows for %s: %s", identifier, e)
+        return None
+    finally:
+        try:
+            cursor.close()
+        except Exception:
+            pass
+
+    # SHOW COLUMNS columns: table_name, schema_name, column_name, data_type, ...
+    result: dict[str, SchemaProperty] = {}
+    for row in rows:
+        column_name, data_type = row[2], row[3]
+        if not column_name or not data_type:
+            continue
+        try:
+            node = json.loads(data_type)
+        except (TypeError, ValueError):
+            continue
+        prop = _to_property(node)
+        if _has_nesting(prop):
+            result[str(column_name).lower()] = prop
+    return result or None

--- a/datacontract/engines/ibis/snowflake_structured_types.py
+++ b/datacontract/engines/ibis/snowflake_structured_types.py
@@ -63,7 +63,7 @@ def _to_property(node: dict) -> SchemaProperty:
     return SchemaProperty(logicalType=UNKNOWN_LOGICAL_TYPE, physicalType=node_type)
 
 
-def _has_nesting(prop: SchemaProperty) -> bool:
+def has_nesting(prop: SchemaProperty) -> bool:
     """True only when the property is a structured OBJECT/ARRAY worth substituting."""
     return bool(prop.properties) or prop.items is not None
 
@@ -100,10 +100,9 @@ def _render_native(node: dict) -> str:
 
 
 def fetch_structured_types(con, server: Server, table_name: str) -> dict[str, SchemaProperty] | None:
-    """Return ``{column_name_lower: SchemaProperty}`` for the columns with nested detail.
-
-    Columns without recoverable nesting are omitted; the caller keeps the collapsed ibis dtype.
-    Best-effort: any failure returns ``None``.
+    """Return ``{column_name_lower: SchemaProperty}`` for the columns whose real type
+    the collapsed ibis dtype does not convey: structured OBJECT/ARRAY, and leaves with
+    no verifiable logical type. Other columns are omitted. Any failure returns ``None``.
     """
     quoted_table = '"{}"'.format(table_name.replace('"', '""'))
     path = ".".join(part for part in (server.database, server.schema_, quoted_table) if part)
@@ -123,8 +122,13 @@ def fetch_structured_types(con, server: Server, table_name: str) -> dict[str, Sc
         except (TypeError, ValueError):
             continue
         prop = _to_property(node)
-        if _has_nesting(prop):
+        if has_nesting(prop):
             # the real native type, for diagnostics the collapsed ibis dtype can't give
             prop.physicalType = _render_native(node)
-            result[str(column_name).lower()] = prop
+        elif prop.logicalType != UNKNOWN_LOGICAL_TYPE:
+            # scalars and untyped OBJECT/ARRAY: the collapsed ibis dtype says the same
+            continue
+        # an unverifiable leaf (VARIANT, GEOGRAPHY, …) keeps its Snowflake token, which
+        # the ibis dtype renders as the useless 'json'
+        result[str(column_name).lower()] = prop
     return result or None

--- a/datacontract/engines/ibis/snowflake_structured_types.py
+++ b/datacontract/engines/ibis/snowflake_structured_types.py
@@ -79,14 +79,16 @@ def _has_nesting(prop: Optional[SchemaProperty]) -> bool:
     return prop is not None and (bool(prop.properties) or prop.items is not None)
 
 
-def fetch_structured_types(con, server: Server, model: str) -> Optional[dict[str, SchemaProperty]]:
+def fetch_structured_types(con, server: Server, table_name: str) -> Optional[dict[str, SchemaProperty]]:
     """Return ``{column_name_lower: SchemaProperty}`` for the Snowflake columns of
-    ``model`` whose declared structured type carries nested detail.
+    ``table_name`` whose declared structured type carries nested detail.
 
     Columns without recoverable nesting (scalars, plain VARIANT/OBJECT/ARRAY,
     MAP) are omitted, so the caller keeps the collapsed ibis dtype for them.
     """
-    identifier = ".".join(part for part in (server.database, server.schema_, model) if part)
+    quoted_table = '"{}"'.format(table_name.replace('"', '""'))
+    path = ".".join(part for part in (server.database, server.schema_, quoted_table) if part)
+    identifier = "IDENTIFIER('{}')".format(path.replace("'", "''"))
     try:
         cursor = con.raw_sql(f"SHOW COLUMNS IN TABLE {identifier}")
     except Exception as e:

--- a/datacontract/engines/ibis/snowflake_structured_types.py
+++ b/datacontract/engines/ibis/snowflake_structured_types.py
@@ -19,6 +19,8 @@ from typing import Optional
 
 from open_data_contract_standard.model import SchemaProperty, Server
 
+from datacontract.engines.checks.type_normalize import UNKNOWN_LOGICAL_TYPE
+
 logger = logging.getLogger(__name__)
 
 # SHOW COLUMNS leaf ``type`` tokens -> ODCS logical type. FIXED and REAL both map
@@ -37,46 +39,47 @@ _LEAF_TYPES = {
 }
 
 
-def _to_property(node: dict) -> Optional[SchemaProperty]:
-    """Convert one ``data_type`` JSON node to a ``SchemaProperty``.
-
-    Returns ``None`` when the node carries no structure the contract can be
-    verified against: an untyped/empty ``OBJECT`` or ``ARRAY``, a ``MAP`` (dynamic
-    keys), a ``VARIANT``, or an unmapped leaf token.
-    """
+def _to_property(node: dict) -> SchemaProperty:
+    """Convert one ``data_type`` JSON node to a ``SchemaProperty``."""
     node_type = node.get("type")
     if node_type == "OBJECT":
         fields = node.get("fields")
         if not fields:
-            return None  # untyped/semi-structured OBJECT
+            # untyped OBJECT: same shape as the collapsed ibis map
+            return SchemaProperty(logicalType="object", properties=None)
         properties = []
         for field in fields:
-            child = _to_property(field.get("fieldType") or {})
             name = field.get("fieldName")
-            if name and child is not None:
-                properties.append(
-                    SchemaProperty(
-                        name=name,
-                        logicalType=child.logicalType,
-                        items=child.items,
-                        properties=child.properties,
-                    )
+            if not name:
+                continue
+            child = _to_property(field.get("fieldType") or {})
+            properties.append(
+                SchemaProperty(
+                    name=name,
+                    logicalType=child.logicalType,
+                    physicalType=child.physicalType,
+                    items=child.items,
+                    properties=child.properties,
                 )
+            )
         return SchemaProperty(logicalType="object", properties=properties or None)
     if node_type == "ARRAY":
         element = node.get("elementType")
-        if not element:
-            return None  # untyped/semi-structured ARRAY
-        return SchemaProperty(logicalType="array", items=_to_property(element))
+        # untyped ARRAY: no element type to recurse into
+        return SchemaProperty(logicalType="array", items=_to_property(element) if element else None)
     if node_type == "MAP":
-        return None  # dynamic keys can't be matched to named contract properties
+        # dynamic keys can't be matched to named contract properties
+        return SchemaProperty(logicalType="object", properties=None)
     logical = _LEAF_TYPES.get(node_type)
-    return SchemaProperty(logicalType=logical) if logical else None
+    if logical:
+        return SchemaProperty(logicalType=logical)
+    # VARIANT, BINARY, GEOGRAPHY, …: keep the Snowflake token for the failure message
+    return SchemaProperty(logicalType=UNKNOWN_LOGICAL_TYPE, physicalType=node_type)
 
 
-def _has_nesting(prop: Optional[SchemaProperty]) -> bool:
+def _has_nesting(prop: SchemaProperty) -> bool:
     """True only when the property is a structured OBJECT/ARRAY worth substituting."""
-    return prop is not None and (bool(prop.properties) or prop.items is not None)
+    return bool(prop.properties) or prop.items is not None
 
 
 def fetch_structured_types(con, server: Server, table_name: str) -> Optional[dict[str, SchemaProperty]]:

--- a/datacontract/engines/ibis/snowflake_structured_types.py
+++ b/datacontract/engines/ibis/snowflake_structured_types.py
@@ -48,7 +48,7 @@ def _to_property(node: dict) -> Optional[SchemaProperty]:
     if node_type == "OBJECT":
         fields = node.get("fields")
         if not fields:
-            return None  # untyped/semi-structured OBJECT: opaque
+            return None  # untyped/semi-structured OBJECT
         properties = []
         for field in fields:
             child = _to_property(field.get("fieldType") or {})
@@ -66,7 +66,7 @@ def _to_property(node: dict) -> Optional[SchemaProperty]:
     if node_type == "ARRAY":
         element = node.get("elementType")
         if not element:
-            return None  # untyped/semi-structured ARRAY: opaque
+            return None  # untyped/semi-structured ARRAY
         return SchemaProperty(logicalType="array", items=_to_property(element))
     if node_type == "MAP":
         return None  # dynamic keys can't be matched to named contract properties

--- a/tests/test_dtype_category.py
+++ b/tests/test_dtype_category.py
@@ -35,24 +35,43 @@ def test_uuid_column_matches_string_contract_property():
 def test_json_maps_to_unknown_marker():
     # Snowflake VARIANT / Postgres JSONB / BigQuery JSON reflect as ibis json.
     prop = ibis_dtype_to_schema_property(dt.JSON())
-    assert prop is not None
     assert prop.logicalType == UNKNOWN_LOGICAL_TYPE
+    assert prop.physicalType == "json"
+
+
+def test_unsupported_types_are_unknown_and_name_themselves():
+    # binary/null have no ODCS category; the type is kept for the failure message
+    for dtype, name in ((dt.binary, "binary"), (dt.null, "null")):
+        prop = ibis_dtype_to_schema_property(dtype)
+        assert prop.logicalType == UNKNOWN_LOGICAL_TYPE
+        assert prop.physicalType == name
 
 
 def test_map_maps_to_untyped_object():
     # Snowflake OBJECT reflects as ibis map<string, json>: base confirmable,
     # inner structure unknowable (properties=None).
     prop = ibis_dtype_to_schema_property(dt.Map(dt.string, dt.JSON()))
-    assert prop is not None
     assert prop.logicalType == "object"
     assert prop.properties is None
 
 
-def test_struct_without_representable_fields_is_not_untyped():
-    # properties=None means untyped map; a struct keeps its (possibly empty) field list
+def test_struct_keeps_unsupported_field_as_unknown():
+    # a binary field is present but unverifiable: keep it, so it is not reported missing
+    actual = ibis_dtype_to_schema_property(dt.Struct({"blob": dt.binary}))
+    assert [(p.name, p.logicalType, p.physicalType) for p in actual.properties] == [
+        ("blob", UNKNOWN_LOGICAL_TYPE, "binary")
+    ]
+
+    expected = SchemaProperty(logicalType="object", properties=[SchemaProperty(name="blob", logicalType="string")])
+    assert not schema_property_matches(expected, actual)
+    reason = schema_property_mismatch_reason(expected, actual)
+    assert "missing" not in reason
+    assert "field 'blob': has type 'binary'" in reason
+
+
+def test_struct_still_reports_a_genuinely_absent_field_as_missing():
     actual = ibis_dtype_to_schema_property(dt.Struct({"blob": dt.binary}))
     expected = SchemaProperty(logicalType="object", properties=[SchemaProperty(name="city", logicalType="string")])
-    assert actual.properties == []
     assert not schema_property_matches(expected, actual)
     assert schema_property_mismatch_reason(expected, actual) == "field 'city' is missing"
 
@@ -61,7 +80,5 @@ def test_array_of_json_items_are_unknown():
     # Snowflake ARRAY reflects as ibis array<json>: array base with an
     # unknown-typed element.
     prop = ibis_dtype_to_schema_property(dt.Array(dt.JSON()))
-    assert prop is not None
     assert prop.logicalType == "array"
-    assert prop.items is not None
     assert prop.items.logicalType == UNKNOWN_LOGICAL_TYPE

--- a/tests/test_dtype_category.py
+++ b/tests/test_dtype_category.py
@@ -39,7 +39,7 @@ def test_json_maps_to_unknown_marker():
     assert prop.logicalType == UNKNOWN_LOGICAL_TYPE
 
 
-def test_map_maps_to_opaque_object():
+def test_map_maps_to_untyped_object():
     # Snowflake OBJECT reflects as ibis map<string, json>: base confirmable,
     # inner structure unknowable (properties=None).
     prop = ibis_dtype_to_schema_property(dt.Map(dt.string, dt.JSON()))

--- a/tests/test_dtype_category.py
+++ b/tests/test_dtype_category.py
@@ -1,7 +1,11 @@
 import ibis.expr.datatypes as dt
 from open_data_contract_standard.model import SchemaProperty
 
-from datacontract.engines.checks.type_normalize import UNKNOWN_LOGICAL_TYPE, schema_property_matches
+from datacontract.engines.checks.type_normalize import (
+    UNKNOWN_LOGICAL_TYPE,
+    schema_property_matches,
+    schema_property_mismatch_reason,
+)
 from datacontract.engines.ibis.dtype_category import (
     ibis_dtype_category,
     ibis_dtype_to_schema_property,
@@ -42,6 +46,15 @@ def test_map_maps_to_opaque_object():
     assert prop is not None
     assert prop.logicalType == "object"
     assert prop.properties is None
+
+
+def test_struct_without_representable_fields_is_not_untyped():
+    # properties=None means untyped map; a struct keeps its (possibly empty) field list
+    actual = ibis_dtype_to_schema_property(dt.Struct({"blob": dt.binary}))
+    expected = SchemaProperty(logicalType="object", properties=[SchemaProperty(name="city", logicalType="string")])
+    assert actual.properties == []
+    assert not schema_property_matches(expected, actual)
+    assert schema_property_mismatch_reason(expected, actual) == "field 'city' is missing"
 
 
 def test_array_of_json_items_are_unknown():

--- a/tests/test_dtype_category.py
+++ b/tests/test_dtype_category.py
@@ -1,7 +1,7 @@
 import ibis.expr.datatypes as dt
 from open_data_contract_standard.model import SchemaProperty
 
-from datacontract.engines.checks.type_normalize import schema_property_matches
+from datacontract.engines.checks.type_normalize import UNKNOWN_LOGICAL_TYPE, schema_property_matches
 from datacontract.engines.ibis.dtype_category import (
     ibis_dtype_category,
     ibis_dtype_to_schema_property,
@@ -26,3 +26,29 @@ def test_uuid_column_matches_string_contract_property():
     expected = SchemaProperty(logicalType="string", physicalType="uniqueidentifier")
     actual = ibis_dtype_to_schema_property(dt.UUID())
     assert schema_property_matches(expected, actual)
+
+
+def test_json_maps_to_unknown_marker():
+    # Snowflake VARIANT / Postgres JSONB / BigQuery JSON reflect as ibis json.
+    prop = ibis_dtype_to_schema_property(dt.JSON())
+    assert prop is not None
+    assert prop.logicalType == UNKNOWN_LOGICAL_TYPE
+
+
+def test_map_maps_to_opaque_object():
+    # Snowflake OBJECT reflects as ibis map<string, json>: base confirmable,
+    # inner structure unknowable (properties=None).
+    prop = ibis_dtype_to_schema_property(dt.Map(dt.string, dt.JSON()))
+    assert prop is not None
+    assert prop.logicalType == "object"
+    assert prop.properties is None
+
+
+def test_array_of_json_items_are_unknown():
+    # Snowflake ARRAY reflects as ibis array<json>: array base with an
+    # unknown-typed element.
+    prop = ibis_dtype_to_schema_property(dt.Array(dt.JSON()))
+    assert prop is not None
+    assert prop.logicalType == "array"
+    assert prop.items is not None
+    assert prop.items.logicalType == UNKNOWN_LOGICAL_TYPE

--- a/tests/test_snowflake_structured_types.py
+++ b/tests/test_snowflake_structured_types.py
@@ -9,12 +9,15 @@ import json
 
 from open_data_contract_standard.model import SchemaProperty
 
+from datacontract.engines.checks.check_spec import CheckSpec, MetricType
 from datacontract.engines.checks.type_normalize import (
     UNKNOWN_LOGICAL_TYPE,
     schema_property_matches,
     schema_property_mismatch_reason,
 )
-from datacontract.engines.ibis.snowflake_structured_types import _has_nesting, _to_property
+from datacontract.engines.ibis.ibis_check_execute import _run_physical_type
+from datacontract.engines.ibis.snowflake_structured_types import _has_nesting, _render_native, _to_property
+from datacontract.model.run import Check, ResultEnum, Run
 
 
 def _prop(data_type: str):
@@ -105,6 +108,85 @@ def test_unverifiable_field_is_kept_not_dropped():
         "If this is intentional, specify the native type as physicalType."
     )
     assert "missing" not in reason
+
+
+def test_render_native_rebuilds_the_snowflake_type_string():
+    node = json.loads(
+        '{"type":"OBJECT","fields":['
+        '{"fieldName":"a","fieldType":{"type":"FIXED","precision":38,"scale":0}},'
+        '{"fieldName":"b","fieldType":{"type":"TEXT","length":16777216}},'
+        '{"fieldName":"c","fieldType":{"type":"ARRAY","elementType":{"type":"BOOLEAN"}}}]}'
+    )
+    # matches Snowflake's own DESCRIBE TABLE rendering
+    assert _render_native(node) == "OBJECT(a NUMBER(38,0), b VARCHAR(16777216), c ARRAY(BOOLEAN))"
+
+
+def test_render_native_untyped_and_leaf_forms():
+    assert _render_native({"type": "OBJECT"}) == "OBJECT"
+    assert _render_native({"type": "ARRAY"}) == "ARRAY"
+    assert _render_native({"type": "VARIANT"}) == "VARIANT"
+    assert _render_native({"type": "REAL"}) == "FLOAT"
+    assert _render_native({"type": "TEXT"}) == "VARCHAR"
+    assert (
+        _render_native({"type": "MAP", "keyType": {"type": "TEXT"}, "valueType": {"type": "FIXED"}})
+        == "MAP(VARCHAR, NUMBER(38,0))"
+    )
+
+
+def _physical_type_check(expected: SchemaProperty, structured_types):
+    """Run the physicalType check on the branch where the native type is unavailable."""
+    spec = CheckSpec(
+        key="k",
+        category="schema",
+        type="field_physical_type",
+        name="check",
+        model="m",
+        field="s_obj",
+        metric=MetricType.FIELD_PHYSICAL_TYPE,
+        expected_category=expected.physicalType,
+        expected_type_label=expected.physicalType,
+        expected_physical_type=expected.physicalType,
+        expected_schema_property=expected,
+    )
+    run = Run.create_run()
+    run.checks = [Check(id="k", key="k", category="schema", type=spec.type, name=spec.name, model="m", field="s_obj")]
+    _run_physical_type(
+        run, None, None, {"S_OBJ": "map<string, json>"}, {"s_obj": "S_OBJ"}, None, spec, structured_types
+    )
+    return run.checks[0]
+
+
+def test_physical_type_fallback_uses_the_recovered_structured_tree():
+    tree = _prop(
+        '{"type":"OBJECT","fields":['
+        '{"fieldName":"a","fieldType":{"type":"FIXED","precision":38,"scale":0}},'
+        '{"fieldName":"b","fieldType":{"type":"TEXT","length":16777216}}]}'
+    )
+    expected = SchemaProperty(
+        name="s_obj",
+        logicalType="object",
+        # foreign to the Snowflake dialect, so the physical comparison yields "skip"
+        physicalType="uniqueidentifier",
+        properties=[SchemaProperty(name="a", logicalType="integer"), SchemaProperty(name="b", logicalType="string")],
+    )
+    assert _physical_type_check(expected, {"s_obj": tree}).result == ResultEnum.passed
+
+    # without the tree, the collapsed ibis dtype makes a structured column look untyped
+    check = _physical_type_check(expected, None)
+    assert check.result == ResultEnum.failed
+
+
+def test_physical_type_fallback_names_the_mismatched_nested_field():
+    tree = _prop('{"type":"OBJECT","fields":[{"fieldName":"a","fieldType":{"type":"FIXED","precision":38,"scale":0}}]}')
+    expected = SchemaProperty(
+        name="s_obj",
+        logicalType="object",
+        physicalType="uniqueidentifier",
+        properties=[SchemaProperty(name="a", logicalType="string")],
+    )
+    check = _physical_type_check(expected, {"s_obj": tree})
+    assert check.result == ResultEnum.failed
+    assert check.reason == "field 'a': expected type 'string' but got 'number'"
 
 
 def test_has_nesting_only_for_structured():

--- a/tests/test_snowflake_structured_types.py
+++ b/tests/test_snowflake_structured_types.py
@@ -7,7 +7,7 @@ from structured-type nesting to the tree the field_type check recurses over.
 
 import json
 
-from open_data_contract_standard.model import SchemaProperty
+from open_data_contract_standard.model import SchemaProperty, Server
 
 from datacontract.engines.checks.check_spec import CheckSpec, MetricType
 from datacontract.engines.checks.type_normalize import (
@@ -15,8 +15,9 @@ from datacontract.engines.checks.type_normalize import (
     schema_property_matches,
     schema_property_mismatch_reason,
 )
+from datacontract.engines.ibis import snowflake_structured_types
 from datacontract.engines.ibis.ibis_check_execute import _run_physical_type
-from datacontract.engines.ibis.snowflake_structured_types import _has_nesting, _render_native, _to_property
+from datacontract.engines.ibis.snowflake_structured_types import _render_native, _to_property, has_nesting
 from datacontract.model.run import Check, ResultEnum, Run
 
 
@@ -105,7 +106,7 @@ def test_unverifiable_field_is_kept_not_dropped():
     assert reason == (
         "field 'extra': has type 'VARIANT', but the contract specifies 'object'. "
         "A 'VARIANT' value has no verifiable logical type. "
-        "If this is intentional, specify the native type as physicalType."
+        "If this is intentional, specify `physicalType: VARIANT`."
     )
     assert "missing" not in reason
 
@@ -134,7 +135,7 @@ def test_render_native_untyped_and_leaf_forms():
 
 
 def _physical_type_check(expected: SchemaProperty, structured_types):
-    """Run the physicalType check on the branch where the native type is unavailable."""
+    """Run the physicalType check with no native type from the catalog."""
     spec = CheckSpec(
         key="k",
         category="schema",
@@ -189,9 +190,47 @@ def test_physical_type_fallback_names_the_mismatched_nested_field():
     assert check.reason == "field 'a': expected type 'string' but got 'number'"
 
 
+def test_physical_type_compares_against_the_recovered_native_type():
+    # the catalog only reports 'OBJECT'; the recovered tree carries the real native type
+    tree = _prop(
+        '{"type":"OBJECT","fields":['
+        '{"fieldName":"a","fieldType":{"type":"FIXED","precision":38,"scale":0}},'
+        '{"fieldName":"b","fieldType":{"type":"TEXT","length":16777216}}]}'
+    )
+    tree.physicalType = "OBJECT(a NUMBER(38,0), b VARCHAR(16777216))"
+
+    declared = SchemaProperty(name="s_obj", logicalType="object", physicalType=tree.physicalType)
+    check = _physical_type_check(declared, {"s_obj": tree})
+    assert check.result == ResultEnum.passed
+    assert check.diagnostics["actual"] == "OBJECT(a NUMBER(38,0), b VARCHAR(16777216))"
+
+    wrong = SchemaProperty(name="s_obj", logicalType="object", physicalType="OBJECT(a NUMBER(38,0))")
+    check = _physical_type_check(wrong, {"s_obj": tree})
+    assert check.result == ResultEnum.failed
+    assert "but the column is 'OBJECT(a NUMBER(38,0), b VARCHAR(16777216))'" in check.reason
+
+
+def test_fetch_keeps_unverifiable_leaves_and_drops_scalars(monkeypatch):
+    rows = [
+        ("t", "s", "V", '{"type":"VARIANT"}'),
+        ("t", "s", "N", '{"type":"FIXED","precision":38,"scale":0}'),
+        ("t", "s", "U_OBJ", '{"type":"OBJECT"}'),
+        ("t", "s", "S_ARR", '{"type":"ARRAY","elementType":{"type":"TEXT"}}'),
+    ]
+    monkeypatch.setattr(snowflake_structured_types, "_rows", lambda con, query: rows)
+    result = snowflake_structured_types.fetch_structured_types(None, Server(database="d", schema="s"), "t")
+
+    # a VARIANT is unverifiable but must name itself; a scalar and an untyped OBJECT
+    # add nothing the collapsed ibis dtype does not already say
+    assert sorted(result) == ["s_arr", "v"]
+    assert result["v"].logicalType == UNKNOWN_LOGICAL_TYPE
+    assert result["v"].physicalType == "VARIANT"
+    assert result["s_arr"].physicalType == "ARRAY(VARCHAR)"
+
+
 def test_has_nesting_only_for_structured():
-    assert _has_nesting(_prop('{"type":"OBJECT","fields":[{"fieldName":"a","fieldType":{"type":"TEXT"}}]}'))
-    assert _has_nesting(_prop('{"type":"ARRAY","elementType":{"type":"TEXT"}}'))
-    assert not _has_nesting(_to_property({"type": "OBJECT"}))
-    assert not _has_nesting(_to_property({"type": "ARRAY"}))
-    assert not _has_nesting(_to_property({"type": "VARIANT"}))
+    assert has_nesting(_prop('{"type":"OBJECT","fields":[{"fieldName":"a","fieldType":{"type":"TEXT"}}]}'))
+    assert has_nesting(_prop('{"type":"ARRAY","elementType":{"type":"TEXT"}}'))
+    assert not has_nesting(_to_property({"type": "OBJECT"}))
+    assert not has_nesting(_to_property({"type": "ARRAY"}))
+    assert not has_nesting(_to_property({"type": "VARIANT"}))

--- a/tests/test_snowflake_structured_types.py
+++ b/tests/test_snowflake_structured_types.py
@@ -7,6 +7,13 @@ from structured-type nesting to the tree the field_type check recurses over.
 
 import json
 
+from open_data_contract_standard.model import SchemaProperty
+
+from datacontract.engines.checks.type_normalize import (
+    UNKNOWN_LOGICAL_TYPE,
+    schema_property_matches,
+    schema_property_mismatch_reason,
+)
 from datacontract.engines.ibis.snowflake_structured_types import _has_nesting, _to_property
 
 
@@ -55,17 +62,54 @@ def test_leaf_token_mapping():
     assert _prop('{"type":"REAL"}').logicalType == "number"
 
 
-def test_untyped_types_yield_no_tree():
-    # plain VARIANT, untyped OBJECT/ARRAY, and MAP carry nothing to recurse into.
-    assert _to_property({"type": "VARIANT"}) is None
-    assert _to_property({"type": "OBJECT"}) is None
-    assert _to_property({"type": "ARRAY"}) is None
-    assert _to_property({"type": "MAP", "keyType": {"type": "TEXT"}, "valueType": {"type": "FIXED"}}) is None
-    assert _to_property({"type": "BINARY"}) is None
+def test_untyped_object_array_and_map_keep_their_base_type():
+    # untyped OBJECT/ARRAY and MAP confirm their base type but carry no nesting.
+    assert _to_property({"type": "OBJECT"}).properties is None
+    assert _to_property({"type": "ARRAY"}).items is None
+    assert _to_property({"type": "MAP", "keyType": {"type": "TEXT"}, "valueType": {"type": "FIXED"}}).properties is None
+    assert _to_property({"type": "MAP"}).logicalType == "object"
+
+
+def test_variant_and_unmapped_leaves_are_unknown_and_keep_their_token():
+    for token in ("VARIANT", "BINARY", "GEOGRAPHY"):
+        prop = _to_property({"type": token})
+        assert prop.logicalType == UNKNOWN_LOGICAL_TYPE
+        # the token names the type in the failure message
+        assert prop.physicalType == token
+
+
+def test_unverifiable_field_is_kept_not_dropped():
+    # A VARIANT inside a structured OBJECT is a real, present field: it must not
+    # vanish from properties, or the comparator reports it as missing.
+    prop = _prop(
+        '{"type":"OBJECT","fields":['
+        '{"fieldName":"id","fieldType":{"type":"TEXT"}},'
+        '{"fieldName":"extra","fieldType":{"type":"VARIANT"}}]}'
+    )
+    assert [(p.name, p.logicalType) for p in prop.properties] == [
+        ("id", "string"),
+        ("extra", UNKNOWN_LOGICAL_TYPE),
+    ]
+    expected = SchemaProperty(
+        logicalType="object",
+        properties=[
+            SchemaProperty(name="id", logicalType="string"),
+            SchemaProperty(name="extra", logicalType="object"),
+        ],
+    )
+    assert not schema_property_matches(expected, prop)
+    reason = schema_property_mismatch_reason(expected, prop)
+    assert reason == (
+        "field 'extra': has type 'VARIANT', but the contract specifies 'object'. "
+        "A 'VARIANT' value has no verifiable logical type. "
+        "If this is intentional, specify the native type as physicalType."
+    )
+    assert "missing" not in reason
 
 
 def test_has_nesting_only_for_structured():
     assert _has_nesting(_prop('{"type":"OBJECT","fields":[{"fieldName":"a","fieldType":{"type":"TEXT"}}]}'))
     assert _has_nesting(_prop('{"type":"ARRAY","elementType":{"type":"TEXT"}}'))
     assert not _has_nesting(_to_property({"type": "OBJECT"}))
-    assert not _has_nesting(None)
+    assert not _has_nesting(_to_property({"type": "ARRAY"}))
+    assert not _has_nesting(_to_property({"type": "VARIANT"}))

--- a/tests/test_snowflake_structured_types.py
+++ b/tests/test_snowflake_structured_types.py
@@ -1,0 +1,71 @@
+"""Offline guards for the Snowflake SHOW COLUMNS -> SchemaProperty parser.
+
+The JSON payloads here are the real ``data_type`` blobs Snowflake returns from
+``SHOW COLUMNS`` (captured from a live account), so these lock in the mapping
+from structured-type nesting to the tree the field_type check recurses over.
+"""
+
+import json
+
+from datacontract.engines.ibis.snowflake_structured_types import _has_nesting, _to_property
+
+
+def _prop(data_type: str):
+    return _to_property(json.loads(data_type))
+
+
+def test_structured_object_becomes_named_properties():
+    prop = _prop(
+        '{"type":"OBJECT","fields":['
+        '{"fieldName":"a","fieldType":{"type":"FIXED","precision":10,"scale":0}},'
+        '{"fieldName":"b","fieldType":{"type":"TEXT","length":16777216}},'
+        '{"fieldName":"c","fieldType":{"type":"BOOLEAN"}}]}'
+    )
+    assert prop.logicalType == "object"
+    assert [(p.name, p.logicalType) for p in prop.properties] == [
+        ("a", "number"),
+        ("b", "string"),
+        ("c", "boolean"),
+    ]
+
+
+def test_structured_array_becomes_typed_items():
+    prop = _prop('{"type":"ARRAY","elementType":{"type":"FIXED","precision":10,"scale":0}}')
+    assert prop.logicalType == "array"
+    assert prop.items.logicalType == "number"
+
+
+def test_nested_object_recurses():
+    prop = _prop(
+        '{"type":"OBJECT","fields":['
+        '{"fieldName":"inner","fieldType":{"type":"ARRAY","elementType":{"type":"FIXED"}}},'
+        '{"fieldName":"tag","fieldType":{"type":"TEXT"}}]}'
+    )
+    inner = {p.name: p for p in prop.properties}
+    assert inner["inner"].logicalType == "array"
+    assert inner["inner"].items.logicalType == "number"
+    assert inner["tag"].logicalType == "string"
+
+
+def test_leaf_token_mapping():
+    assert _prop('{"type":"TIMESTAMP_NTZ"}').logicalType == "timestamp"
+    assert _prop('{"type":"TIMESTAMP_LTZ"}').logicalType == "timestamp"
+    assert _prop('{"type":"DATE"}').logicalType == "date"
+    assert _prop('{"type":"TIME"}').logicalType == "time"
+    assert _prop('{"type":"REAL"}').logicalType == "number"
+
+
+def test_opaque_types_yield_no_tree():
+    # plain VARIANT, untyped OBJECT/ARRAY, and MAP carry nothing to recurse into.
+    assert _to_property({"type": "VARIANT"}) is None
+    assert _to_property({"type": "OBJECT"}) is None
+    assert _to_property({"type": "ARRAY"}) is None
+    assert _to_property({"type": "MAP", "keyType": {"type": "TEXT"}, "valueType": {"type": "FIXED"}}) is None
+    assert _to_property({"type": "BINARY"}) is None
+
+
+def test_has_nesting_only_for_structured():
+    assert _has_nesting(_prop('{"type":"OBJECT","fields":[{"fieldName":"a","fieldType":{"type":"TEXT"}}]}'))
+    assert _has_nesting(_prop('{"type":"ARRAY","elementType":{"type":"TEXT"}}'))
+    assert not _has_nesting(_to_property({"type": "OBJECT"}))
+    assert not _has_nesting(None)

--- a/tests/test_snowflake_structured_types.py
+++ b/tests/test_snowflake_structured_types.py
@@ -55,7 +55,7 @@ def test_leaf_token_mapping():
     assert _prop('{"type":"REAL"}').logicalType == "number"
 
 
-def test_opaque_types_yield_no_tree():
+def test_untyped_types_yield_no_tree():
     # plain VARIANT, untyped OBJECT/ARRAY, and MAP carry nothing to recurse into.
     assert _to_property({"type": "VARIANT"}) is None
     assert _to_property({"type": "OBJECT"}) is None

--- a/tests/test_test_dataframe.py
+++ b/tests/test_test_dataframe.py
@@ -194,7 +194,7 @@ def test_pyspark_unconvertible_column_as_unknown(spark: SparkSession):
     t = _resolve_table(con, "unconvertible_model")
 
     assert set(t.columns) == {"id", "payload", "amount"}  # kept
-    assert isinstance(t.schema()["payload"], dt.Unknown)  # typed opaque
+    assert isinstance(t.schema()["payload"], dt.Unknown)  # untyped column
     assert t.count().execute() == 1  # table is queryable
     assert t.amount.isnull().sum().execute() == 0  # checks on other columns run
-    assert t.payload.isnull().sum().execute() == 0  # not-null still works on the opaque column
+    assert t.payload.isnull().sum().execute() == 0  # not-null still works on the untyped column

--- a/tests/test_type_normalize.py
+++ b/tests/test_type_normalize.py
@@ -32,9 +32,17 @@ def _unknown():
     return SchemaProperty(logicalType=UNKNOWN_LOGICAL_TYPE)
 
 
-def test_opaque_object_matches_declared_object_with_properties():
-    # OBJECT column declared with nested properties: base enforced, inner skipped.
+def test_opaque_object_fails_declared_object_with_properties():
+    # OBJECT column declared with nested properties, but the actual column is an
+    # opaque object (untyped OBJECT / MAP): the nested types can't be verified.
     expected = SchemaProperty(logicalType="object", properties=[SchemaProperty(name="city", logicalType="string")])
+    assert not schema_property_matches(expected, _opaque_object())
+    assert "can't be verified" in schema_property_mismatch_reason(expected, _opaque_object())
+
+
+def test_bare_object_matches_opaque_object():
+    # No nested properties declared: the base 'object' is confirmable, so it passes.
+    expected = SchemaProperty(logicalType="object")
     assert schema_property_matches(expected, _opaque_object())
     assert schema_property_mismatch_reason(expected, _opaque_object()) == ""
 
@@ -44,10 +52,18 @@ def test_opaque_object_fails_against_wrong_base():
     assert not schema_property_matches(expected, _opaque_object())
 
 
-def test_array_with_typed_items_matches_unknown_element():
-    # ARRAY reflects as array<json>; a declared items type must not fail on the
-    # unknown element (inner types are skipped, never asserted).
+def test_array_with_typed_items_fails_unknown_element():
+    # ARRAY reflects as array<json>; a declared items type can't be verified
+    # against the dynamically-typed element, so it fails.
     expected = SchemaProperty(logicalType="array", items=SchemaProperty(logicalType="number"))
+    actual = SchemaProperty(logicalType="array", items=_unknown())
+    assert not schema_property_matches(expected, actual)
+    assert "can't be verified" in schema_property_mismatch_reason(expected, actual)
+
+
+def test_bare_array_matches_unknown_element():
+    # No items declared: the base 'array' is confirmable, so it passes.
+    expected = SchemaProperty(logicalType="array")
     actual = SchemaProperty(logicalType="array", items=_unknown())
     assert schema_property_matches(expected, actual)
     assert schema_property_mismatch_reason(expected, actual) == ""

--- a/tests/test_type_normalize.py
+++ b/tests/test_type_normalize.py
@@ -61,7 +61,7 @@ def test_array_with_typed_items_fails_unknown_element():
     assert schema_property_mismatch_reason(expected, actual) == (
         "field '[]': has type 'json', but the contract specifies 'number'. "
         "A 'json' value has no verifiable logical type. "
-        "If this is intentional, specify the native type as physicalType."
+        "If this is intentional, specify `physicalType: json`."
     )
 
 
@@ -73,7 +73,7 @@ def test_unverifiable_type_reports_the_same_message_at_any_depth():
         SchemaProperty(logicalType="array", items=_unknown()),
     )
     assert top == nested.replace("field '[]'", "column")
-    assert "specify the native type as physicalType" in top
+    assert "specify `physicalType: json`" in top
 
 
 def test_bare_array_matches_unknown_element():

--- a/tests/test_type_normalize.py
+++ b/tests/test_type_normalize.py
@@ -29,7 +29,7 @@ def _untyped_object():
 
 def _unknown():
     # what it produces for a Snowflake VARIANT (json)
-    return SchemaProperty(logicalType=UNKNOWN_LOGICAL_TYPE)
+    return SchemaProperty(logicalType=UNKNOWN_LOGICAL_TYPE, physicalType="json")
 
 
 def test_untyped_object_fails_declared_object_with_properties():
@@ -58,7 +58,22 @@ def test_array_with_typed_items_fails_unknown_element():
     expected = SchemaProperty(logicalType="array", items=SchemaProperty(logicalType="number"))
     actual = SchemaProperty(logicalType="array", items=_unknown())
     assert not schema_property_matches(expected, actual)
-    assert "can't be verified" in schema_property_mismatch_reason(expected, actual)
+    assert schema_property_mismatch_reason(expected, actual) == (
+        "field '[]': has type 'json', but the contract specifies 'number'. "
+        "A 'json' value has no verifiable logical type. "
+        "If this is intentional, specify the native type as physicalType."
+    )
+
+
+def test_unverifiable_type_reports_the_same_message_at_any_depth():
+    # The top-level and nested paths must not diverge: one condition, one message.
+    top = schema_property_mismatch_reason(SchemaProperty(logicalType="number"), _unknown())
+    nested = schema_property_mismatch_reason(
+        SchemaProperty(logicalType="array", items=SchemaProperty(logicalType="number")),
+        SchemaProperty(logicalType="array", items=_unknown()),
+    )
+    assert top == nested.replace("field '[]'", "column")
+    assert "specify the native type as physicalType" in top
 
 
 def test_bare_array_matches_unknown_element():

--- a/tests/test_type_normalize.py
+++ b/tests/test_type_normalize.py
@@ -22,7 +22,7 @@ def test_normalize_oracle_string_types():
     assert normalize_type_name("nvarchar2(100)") == "string"
 
 
-def _opaque_object():
+def _untyped_object():
     # what ibis_dtype_to_schema_property produces for a Snowflake OBJECT (map)
     return SchemaProperty(logicalType="object", properties=None)
 
@@ -32,24 +32,24 @@ def _unknown():
     return SchemaProperty(logicalType=UNKNOWN_LOGICAL_TYPE)
 
 
-def test_opaque_object_fails_declared_object_with_properties():
+def test_untyped_object_fails_declared_object_with_properties():
     # OBJECT column declared with nested properties, but the actual column is an
-    # opaque object (untyped OBJECT / MAP): the nested types can't be verified.
+    # untyped object (untyped OBJECT / MAP): the nested types can't be verified.
     expected = SchemaProperty(logicalType="object", properties=[SchemaProperty(name="city", logicalType="string")])
-    assert not schema_property_matches(expected, _opaque_object())
-    assert "can't be verified" in schema_property_mismatch_reason(expected, _opaque_object())
+    assert not schema_property_matches(expected, _untyped_object())
+    assert "can't be verified" in schema_property_mismatch_reason(expected, _untyped_object())
 
 
-def test_bare_object_matches_opaque_object():
+def test_bare_object_matches_untyped_object():
     # No nested properties declared: the base 'object' is confirmable, so it passes.
     expected = SchemaProperty(logicalType="object")
-    assert schema_property_matches(expected, _opaque_object())
-    assert schema_property_mismatch_reason(expected, _opaque_object()) == ""
+    assert schema_property_matches(expected, _untyped_object())
+    assert schema_property_mismatch_reason(expected, _untyped_object()) == ""
 
 
-def test_opaque_object_fails_against_wrong_base():
+def test_untyped_object_fails_against_wrong_base():
     expected = SchemaProperty(logicalType="array")
-    assert not schema_property_matches(expected, _opaque_object())
+    assert not schema_property_matches(expected, _untyped_object())
 
 
 def test_array_with_typed_items_fails_unknown_element():
@@ -70,7 +70,7 @@ def test_bare_array_matches_unknown_element():
 
 
 def test_real_struct_still_descends_and_fails_on_wrong_nested_type():
-    # Guard: a genuinely-typed nested structure (not opaque) is still validated.
+    # Guard: a genuinely-typed nested structure (not untyped) is still validated.
     expected = SchemaProperty(logicalType="object", properties=[SchemaProperty(name="a", logicalType="string")])
     actual = SchemaProperty(logicalType="object", properties=[SchemaProperty(name="a", logicalType="integer")])
     assert not schema_property_matches(expected, actual)

--- a/tests/test_type_normalize.py
+++ b/tests/test_type_normalize.py
@@ -1,4 +1,11 @@
-from datacontract.engines.checks.type_normalize import normalize_type_name
+from open_data_contract_standard.model import SchemaProperty
+
+from datacontract.engines.checks.type_normalize import (
+    UNKNOWN_LOGICAL_TYPE,
+    normalize_type_name,
+    schema_property_matches,
+    schema_property_mismatch_reason,
+)
 
 
 def test_normalize_strips_length_parameters():
@@ -13,3 +20,42 @@ def test_normalize_oracle_string_types():
     assert normalize_type_name("VARCHAR2") == "string"
     assert normalize_type_name("NVARCHAR2") == "string"
     assert normalize_type_name("nvarchar2(100)") == "string"
+
+
+def _opaque_object():
+    # what ibis_dtype_to_schema_property produces for a Snowflake OBJECT (map)
+    return SchemaProperty(logicalType="object", properties=None)
+
+
+def _unknown():
+    # what it produces for a Snowflake VARIANT (json)
+    return SchemaProperty(logicalType=UNKNOWN_LOGICAL_TYPE)
+
+
+def test_opaque_object_matches_declared_object_with_properties():
+    # OBJECT column declared with nested properties: base enforced, inner skipped.
+    expected = SchemaProperty(logicalType="object", properties=[SchemaProperty(name="city", logicalType="string")])
+    assert schema_property_matches(expected, _opaque_object())
+    assert schema_property_mismatch_reason(expected, _opaque_object()) == ""
+
+
+def test_opaque_object_fails_against_wrong_base():
+    expected = SchemaProperty(logicalType="array")
+    assert not schema_property_matches(expected, _opaque_object())
+
+
+def test_array_with_typed_items_matches_unknown_element():
+    # ARRAY reflects as array<json>; a declared items type must not fail on the
+    # unknown element (inner types are skipped, never asserted).
+    expected = SchemaProperty(logicalType="array", items=SchemaProperty(logicalType="number"))
+    actual = SchemaProperty(logicalType="array", items=_unknown())
+    assert schema_property_matches(expected, actual)
+    assert schema_property_mismatch_reason(expected, actual) == ""
+
+
+def test_real_struct_still_descends_and_fails_on_wrong_nested_type():
+    # Guard: a genuinely-typed nested structure (not opaque) is still validated.
+    expected = SchemaProperty(logicalType="object", properties=[SchemaProperty(name="a", logicalType="string")])
+    actual = SchemaProperty(logicalType="object", properties=[SchemaProperty(name="a", logicalType="integer")])
+    assert not schema_property_matches(expected, actual)
+    assert "expected type 'string'" in schema_property_mismatch_reason(expected, actual)


### PR DESCRIPTION
Makes the `datacontract test` field_type (logicalType) check work for semi-structured columns:

- Snowflake `OBJECT`/`ARRAY` (and equivalent map/array types on other backends) now pass instead of failing with "column type could not be determined".
- Dynamically-typed columns (`VARIANT`/`JSON`, Databricks `Variant`) fail with an actionable message directing to `physicalType`.

Fix lives at the backend-agnostic ibis-dtype layer. Verified live against Snowflake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)