### PR TITLE
Match physical types by dialect-rendered base type (#1371)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Failed business definition IRI lookups now suggest the `ENTROPY_DATA_HOST` value to set when the IRI host does not match the configured entropy-data host.
+- `datacontract test` no longer reports a physical type mismatch for BigQuery type aliases, such as a `physicalType` of `INTEGER` on an `INT64` column (#1371)
 
 ## [1.0.10] - 2026-07-08
 

--- a/datacontract/engines/checks/physical_type_match.py
+++ b/datacontract/engines/checks/physical_type_match.py
@@ -4,11 +4,6 @@ Both sides are parsed with sqlglot in the server's dialect, so dialect aliases
 (``int`` ≡ ``integer``, ``decimal`` ≡ ``numeric``) and case are handled, while
 genuinely distinct native types (``varchar`` vs ``nvarchar``) stay distinct.
 
-Which names alias each other is decided by the dialect, not by a table here: the
-base type is rendered back out through sqlglot's generator for the server's
-dialect, so BigQuery's ``INTEGER`` ≡ ``INT64`` ≡ ``SMALLINT`` while Postgres
-keeps ``integer`` and ``bigint`` apart.
-
 Length/precision is only enforced when the contract declares it: a bare
 ``varchar`` in the contract matches ``varchar(255)`` in the database, but
 ``varchar(255)`` does not match ``varchar(100)``.
@@ -96,13 +91,7 @@ def _raw_match(expected: str, actual: str) -> Optional[bool]:
 
 
 def _base_sql(dtype: exp.DataType, dialect) -> str:
-    """Render the bare base type in ``dialect``, collapsing that dialect's aliases.
-
-    BigQuery renders ``INTEGER`` and ``INT64`` both as ``INT64``, while Postgres
-    keeps ``INT`` and ``BIGINT`` apart. Parameters are dropped because generators
-    inject dialect defaults (Snowflake renders a bare ``NUMERIC`` as
-    ``DECIMAL(38, 0)``).
-    """
+    """Render the bare base type in ``dialect``, collapsing that dialect's aliases."""
     return exp.DataType(this=dtype.this).sql(dialect=dialect).lower()
 
 
@@ -138,10 +127,11 @@ def physical_type_matches(
             f"server under test; skipping the physical type check"
         )
 
+    both_numeric = {exp_dt.this, act_dt.this} <= exp.DataType.NUMERIC_TYPES
     same_base = (
         exp_dt.this == act_dt.this
         or {exp_dt.this, act_dt.this} <= _TIMESTAMP_FAMILY
-        or _base_sql(exp_dt, dialect) == _base_sql(act_dt, dialect)
+        or (both_numeric and _base_sql(exp_dt, dialect) == _base_sql(act_dt, dialect))
     )
     if not same_base:
         return False, f"expected physical type '{expected}' but the column is '{actual}'"

--- a/datacontract/engines/checks/physical_type_match.py
+++ b/datacontract/engines/checks/physical_type_match.py
@@ -4,6 +4,11 @@ Both sides are parsed with sqlglot in the server's dialect, so dialect aliases
 (``int`` ≡ ``integer``, ``decimal`` ≡ ``numeric``) and case are handled, while
 genuinely distinct native types (``varchar`` vs ``nvarchar``) stay distinct.
 
+Which names alias each other is decided by the dialect, not by a table here: the
+base type is rendered back out through sqlglot's generator for the server's
+dialect, so BigQuery's ``INTEGER`` ≡ ``INT64`` ≡ ``SMALLINT`` while Postgres
+keeps ``integer`` and ``bigint`` apart.
+
 Length/precision is only enforced when the contract declares it: a bare
 ``varchar`` in the contract matches ``varchar(255)`` in the database, but
 ``varchar(255)`` does not match ``varchar(100)``.
@@ -90,6 +95,17 @@ def _raw_match(expected: str, actual: str) -> Optional[bool]:
     return True if not e_params else e == a
 
 
+def _base_sql(dtype: exp.DataType, dialect) -> str:
+    """Render the bare base type in ``dialect``, collapsing that dialect's aliases.
+
+    BigQuery renders ``INTEGER`` and ``INT64`` both as ``INT64``, while Postgres
+    keeps ``INT`` and ``BIGINT`` apart. Parameters are dropped because generators
+    inject dialect defaults (Snowflake renders a bare ``NUMERIC`` as
+    ``DECIMAL(38, 0)``).
+    """
+    return exp.DataType(this=dtype.this).sql(dialect=dialect).lower()
+
+
 def physical_type_matches(
     expected: Optional[str],
     actual: Optional[str],
@@ -122,7 +138,11 @@ def physical_type_matches(
             f"server under test; skipping the physical type check"
         )
 
-    same_base = exp_dt.this == act_dt.this or {exp_dt.this, act_dt.this} <= _TIMESTAMP_FAMILY
+    same_base = (
+        exp_dt.this == act_dt.this
+        or {exp_dt.this, act_dt.this} <= _TIMESTAMP_FAMILY
+        or _base_sql(exp_dt, dialect) == _base_sql(act_dt, dialect)
+    )
     if not same_base:
         return False, f"expected physical type '{expected}' but the column is '{actual}'"
 

--- a/tests/test_physical_type_match.py
+++ b/tests/test_physical_type_match.py
@@ -64,6 +64,16 @@ def test_integer_widths_stay_distinct_outside_bigquery():
     assert physical_type_matches("INTEGER", "BIGINT", "snowflake")[0] is False
 
 
+def test_non_numeric_types_never_alias():
+    # sqlglot renders a type a dialect does not model onto the nearest one it has
+    # (Databricks TIME onto TIMESTAMP, MySQL VARCHAR onto TEXT). Only numeric
+    # widths alias, so those stay distinct.
+    assert physical_type_matches("TIME", "TIMESTAMP", "databricks")[0] is False
+    assert physical_type_matches("TIMESTAMP", "TIME", "databricks")[0] is False
+    assert physical_type_matches("TEXT", "VARCHAR(255)", "mysql")[0] is False
+    assert physical_type_matches("STRING", "VARCHAR(10)", "databricks")[0] is False
+
+
 def test_wrong_base_type_fails():
     ok, reason = physical_type_matches("uniqueidentifier", "int", "tsql")
     assert ok is False

--- a/tests/test_physical_type_match.py
+++ b/tests/test_physical_type_match.py
@@ -45,6 +45,25 @@ def test_distinct_native_types_do_not_match():
     assert ok is False
 
 
+def test_bigquery_legacy_type_names_match_googlesql_names():
+    # `datacontract import bigquery` writes the names the BigQuery API returns
+    # (INTEGER, FLOAT, BOOLEAN, RECORD); INFORMATION_SCHEMA reports the GoogleSQL
+    # names. BigQuery resolves both to the same type.
+    assert physical_type_matches("INTEGER", "INT64", "bigquery")[0] is True
+    assert physical_type_matches("FLOAT", "FLOAT64", "bigquery")[0] is True
+    assert physical_type_matches("BOOLEAN", "BOOL", "bigquery")[0] is True
+    assert physical_type_matches("RECORD", "STRUCT<field1 INT64>", "bigquery")[0] is True
+    assert physical_type_matches("SMALLINT", "INT64", "bigquery")[0] is True
+    assert physical_type_matches("BYTEINT", "INT64", "bigquery")[0] is True
+
+
+def test_integer_widths_stay_distinct_outside_bigquery():
+    # Aliasing is the dialect's call, not ours: INTEGER is a narrower type than
+    # BIGINT in Postgres and Snowflake, so declaring one against the other fails.
+    assert physical_type_matches("INTEGER", "BIGINT", "postgres")[0] is False
+    assert physical_type_matches("INTEGER", "BIGINT", "snowflake")[0] is False
+
+
 def test_wrong_base_type_fails():
     ok, reason = physical_type_matches("uniqueidentifier", "int", "tsql")
     assert ok is False


### PR DESCRIPTION
Fixes #1371.

BigQuery's `INTEGER` and `INT64` are the same type, but sqlglot tokenizes them as `INT` and `BIGINT`, so `datacontract test` reported a mismatch against any contract produced by `datacontract import bigquery`. Same for `FLOAT` vs `FLOAT64`.

The physicalType check now compares the base type as the server's dialect renders it, letting each dialect's own alias table decide which names are equivalent — BigQuery folds `INT`/`SMALLINT`/`TINYINT`/`BIGINT` into `INT64`, while Postgres keeps `INT` and `BIGINT` apart. Parameters keep their existing semantics.

Verified against a live BigQuery table: `import` then `test` now passes.

Note: `import` still writes the BigQuery API's legacy names (`INTEGER`, `FLOAT`). Normalizing those to GoogleSQL names is cosmetic and left for a follow-up — this fix repairs contracts that already exist, without a re-import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)