### PR TITLE
Fix datacontract test on Databricks with a Spark session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Failed business definition IRI lookups now suggest the `ENTROPY_DATA_HOST` value to set when the IRI host does not match the configured entropy-data host.
+- `datacontract test` no longer fails with `CANNOT_CONVERT_COLUMN_INTO_BOOL` on Databricks when a Spark session is used
 
 ## [1.0.10] - 2026-07-08
 

--- a/datacontract/engines/ibis/native_type.py
+++ b/datacontract/engines/ibis/native_type.py
@@ -124,6 +124,10 @@ def _rows(con, query: str):
     try:
         if hasattr(cursor, "fetchall"):
             return list(cursor.fetchall())
+        # The pyspark backend (also used for databricks with a Spark session)
+        # returns a DataFrame; iterating it would yield Column objects.
+        if hasattr(cursor, "collect"):
+            return list(cursor.collect())
         # Some backends (e.g. BigQuery) return an iterable result set
         # (RowIterator) instead of a DBAPI cursor.
         return list(cursor)

--- a/tests/test_physical_type_match.py
+++ b/tests/test_physical_type_match.py
@@ -1,5 +1,6 @@
 from datacontract.engines.checks.physical_type_match import physical_type_matches
 from datacontract.engines.ibis.native_type import (
+    _rows,
     reconstruct_native_type,
     supports_native_type_introspection,
 )
@@ -123,3 +124,24 @@ def test_reconstruct_integer_ignores_numeric_precision():
 
 def test_reconstruct_none():
     assert reconstruct_native_type(None) is None
+
+
+# --- _rows -----------------------------------------------------------------
+class _SparkLikeDataFrame:
+    """Iterating a Spark DataFrame yields Column objects, not rows; only
+    ``collect()`` returns the rows."""
+
+    def __iter__(self):
+        raise AssertionError("must not iterate a Spark DataFrame")
+
+    def collect(self):
+        return [("postal_code", "string", None, None, None)]
+
+
+class _SparkLikeConnection:
+    def raw_sql(self, query):
+        return _SparkLikeDataFrame()
+
+
+def test_rows_collects_spark_dataframe():
+    assert _rows(_SparkLikeConnection(), "select 1") == [("postal_code", "string", None, None, None)]


### PR DESCRIPTION
`datacontract test` failed with `CANNOT_CONVERT_COLUMN_INTO_BOOL` on Databricks when connected via a Spark session (regression in 1.0.10). The pyspark backend's `raw_sql` returns a DataFrame, and iterating it yields `Column` objects instead of rows. Use `collect()` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)