### PR TITLE
Report nested types as a separate check in `datacontract test`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `datacontract test` reports the nested types of a property that declares `properties:` or `items:` as a separate check
+
 ## [1.0.12] - 2026-07-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract test` on Snowflake verifies the `physicalType` of nested properties against the real column type
 
 ### Fixed
-- `datacontract test` on Snowflake no longer reports a physical type mismatch for a `physicalType` of `VARCHAR` on a `VARCHAR` column, which the catalog reports as `TEXT`
+- `datacontract test` on Snowflake matches a `physicalType` against the alias the catalog reports, such as `BIGINT` on a `NUMBER(38,0)` column
+- `datacontract test` no longer reports a mismatch for a `physicalType` without precision, such as `NUMBER` on a `NUMBER(12,2)` column
 
 ## [1.0.12] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `datacontract test` reports the nested types of a property that declares `properties:` or `items:` as a separate check
+- `datacontract test` on Snowflake verifies the `physicalType` of nested properties against the real column type
 
 ## [1.0.12] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract test` reports the nested types of a property that declares `properties:` or `items:` as a separate check
 - `datacontract test` on Snowflake verifies the `physicalType` of nested properties against the real column type
 
+### Fixed
+- `datacontract test` on Snowflake no longer reports a physical type mismatch for a `physicalType` of `VARCHAR` on a `VARCHAR` column, which the catalog reports as `TEXT`
+
 ## [1.0.12] - 2026-07-10
 
 ### Fixed

--- a/datacontract/engines/checks/check_spec.py
+++ b/datacontract/engines/checks/check_spec.py
@@ -31,7 +31,6 @@ class MetricType(str, Enum):
     FIELD_TYPE = "field_type"
     FIELD_PHYSICAL_TYPE = "field_physical_type"
     FIELD_NESTED_TYPE = "field_nested_type"
-    FIELD_NESTED_PHYSICAL_TYPE = "field_nested_physical_type"
     FRESHNESS = "freshness"
     RETENTION = "retention"
     CUSTOM_SQL = "custom_sql"

--- a/datacontract/engines/checks/check_spec.py
+++ b/datacontract/engines/checks/check_spec.py
@@ -30,6 +30,8 @@ class MetricType(str, Enum):
     FIELD_PRESENT = "field_present"
     FIELD_TYPE = "field_type"
     FIELD_PHYSICAL_TYPE = "field_physical_type"
+    FIELD_NESTED_TYPE = "field_nested_type"
+    FIELD_NESTED_PHYSICAL_TYPE = "field_nested_physical_type"
     FRESHNESS = "freshness"
     RETENTION = "retention"
     CUSTOM_SQL = "custom_sql"

--- a/datacontract/engines/checks/create_checks.py
+++ b/datacontract/engines/checks/create_checks.py
@@ -55,10 +55,6 @@ def to_schema_name(schema_object: SchemaObject, server_type: Optional[str]) -> s
     return schema_object.name
 
 
-def _without_children(prop: SchemaProperty) -> SchemaProperty:
-    return SchemaProperty(name=prop.name, logicalType=prop.logicalType, physicalType=prop.physicalType)
-
-
 def _scalar_element_type(prop: SchemaProperty, physical: bool) -> Optional[str]:
     """The declared element type of an array of scalars, or None for anything else."""
     if normalize_type_name(prop.logicalType or prop.physicalType) != "array" or prop.items is None:
@@ -69,6 +65,18 @@ def _scalar_element_type(prop: SchemaProperty, physical: bool) -> Optional[str]:
     label = (items.physicalType or items.logicalType) if physical else (items.logicalType or items.physicalType)
     if normalize_type_name(label) in ("object", "array"):
         return None
+    return label
+
+
+def _declared_type_label(prop: SchemaProperty, physical: bool) -> Optional[str]:
+    """Render the declared type with its children, e.g. ``OBJECT(code VARCHAR(10), description VARCHAR)``."""
+    label = (prop.physicalType or prop.logicalType) if physical else (prop.logicalType or prop.physicalType)
+    base = normalize_type_name(label)
+    if base == "array" and prop.items is not None:
+        return f"{label}({_declared_type_label(prop.items, physical)})"
+    if base == "object" and prop.properties:
+        children = ", ".join(f"{child.name} {_declared_type_label(child, physical)}" for child in prop.properties)
+        return f"{label}({children})"
     return label
 
 
@@ -86,8 +94,8 @@ def _nested_type_check(model: str, field: str, prop: SchemaProperty, physical: b
         name=name,
         model=model,
         field=field,
-        metric=MetricType.FIELD_NESTED_PHYSICAL_TYPE if physical else MetricType.FIELD_NESTED_TYPE,
-        expected_type_label=element or (prop.physicalType if physical else prop.logicalType),
+        metric=MetricType.FIELD_NESTED_TYPE,
+        expected_type_label=_declared_type_label(prop, physical),
         expected_schema_property=prop,
     )
 
@@ -211,8 +219,18 @@ def _to_schema_checks(schema_object: SchemaObject, server: Optional[Server]) -> 
         )
 
         # The raw view cannot provide nested type checks
-        nested_checks_possible = check_types and not uses_raw_view and (bool(prop.properties) or prop.items is not None)
-        base_prop = _without_children(prop) if nested_checks_possible else prop
+        declared_base = normalize_type_name(prop.logicalType or prop.physicalType)
+        nested_checks_possible = (
+            check_types
+            and not uses_raw_view
+            and declared_base in ("object", "array")
+            and (bool(prop.properties) or prop.items is not None)
+        )
+        base_prop = (
+            SchemaProperty(name=prop.name, logicalType=prop.logicalType, physicalType=prop.physicalType)
+            if nested_checks_possible
+            else prop
+        )
 
         # A declared physicalType is checked against the column's real native
         # type in the platform catalog and takes precedence over logicalType,

--- a/datacontract/engines/checks/create_checks.py
+++ b/datacontract/engines/checks/create_checks.py
@@ -22,6 +22,7 @@ from open_data_contract_standard.model import (
 )
 
 from datacontract.engines.checks.check_spec import CheckSpec, MetricType, Op, Threshold
+from datacontract.engines.checks.type_normalize import normalize_type_name
 from datacontract.engines.ibis.native_type import supports_native_type_introspection
 
 logger = logging.getLogger(__name__)
@@ -52,6 +53,43 @@ def to_schema_name(schema_object: SchemaObject, server_type: Optional[str]) -> s
     if schema_object.physicalName:
         return schema_object.physicalName
     return schema_object.name
+
+
+def _without_children(prop: SchemaProperty) -> SchemaProperty:
+    return SchemaProperty(name=prop.name, logicalType=prop.logicalType, physicalType=prop.physicalType)
+
+
+def _scalar_element_type(prop: SchemaProperty, physical: bool) -> Optional[str]:
+    """The declared element type of an array of scalars, or None for anything else."""
+    if normalize_type_name(prop.logicalType or prop.physicalType) != "array" or prop.items is None:
+        return None
+    items = prop.items
+    if items.properties or items.items is not None:
+        return None
+    label = (items.physicalType or items.logicalType) if physical else (items.logicalType or items.physicalType)
+    if normalize_type_name(label) in ("object", "array"):
+        return None
+    return label
+
+
+def _nested_type_check(model: str, field: str, prop: SchemaProperty, physical: bool) -> CheckSpec:
+    check_type = "field_nested_physical_type" if physical else "field_nested_type"
+    element = _scalar_element_type(prop, physical)
+    if element is not None:
+        name = f"Check that items of array {field} have {'physical type' if physical else 'type'} {element}"
+    else:
+        name = f"Check that nested {'physical types' if physical else 'types'} of {field} are correct"
+    return CheckSpec(
+        key=f"{model}__{field}__{check_type}",
+        category="schema",
+        type=check_type,
+        name=name,
+        model=model,
+        field=field,
+        metric=MetricType.FIELD_NESTED_PHYSICAL_TYPE if physical else MetricType.FIELD_NESTED_TYPE,
+        expected_type_label=element or (prop.physicalType if physical else prop.logicalType),
+        expected_schema_property=prop,
+    )
 
 
 _PERCENT_UNITS = {"percent", "percentage", "%"}
@@ -172,6 +210,10 @@ def _to_schema_checks(schema_object: SchemaObject, server: Optional[Server]) -> 
             )
         )
 
+        # The raw view cannot provide nested type checks
+        nested_checks_possible = check_types and not uses_raw_view and (bool(prop.properties) or prop.items is not None)
+        base_prop = _without_children(prop) if nested_checks_possible else prop
+
         # A declared physicalType is checked against the column's real native
         # type in the platform catalog and takes precedence over logicalType,
         # but only on backends that expose a meaningful native type. Elsewhere
@@ -191,11 +233,13 @@ def _to_schema_checks(schema_object: SchemaObject, server: Optional[Server]) -> 
                     expected_physical_type=prop.physicalType,
                     # Carried for the logicalType fallback when the native type
                     # cannot be read or the physicalType is cross-dialect.
-                    expected_schema_property=prop if prop.logicalType is not None else None,
+                    expected_schema_property=base_prop if prop.logicalType is not None else None,
                 )
             )
+            if nested_checks_possible:
+                checks.append(_nested_type_check(model, field, prop, physical=True))
         elif check_types and prop.logicalType is not None:
-            schema_prop, label = prop, prop.logicalType or ""
+            label = prop.logicalType or ""
             checks.append(
                 CheckSpec(
                     key=f"{model}__{field}__field_type",
@@ -207,9 +251,11 @@ def _to_schema_checks(schema_object: SchemaObject, server: Optional[Server]) -> 
                     metric=MetricType.FIELD_TYPE,
                     expected_category=label,
                     expected_type_label=label,
-                    expected_schema_property=schema_prop,
+                    expected_schema_property=base_prop,
                 )
             )
+            if nested_checks_possible:
+                checks.append(_nested_type_check(model, field, prop, physical=False))
 
         if prop.required:
             checks.append(

--- a/datacontract/engines/checks/physical_type_match.py
+++ b/datacontract/engines/checks/physical_type_match.py
@@ -43,6 +43,21 @@ def _timestamp_family() -> set:
 
 _TIMESTAMP_FAMILY = _timestamp_family()
 
+# In Snowflake these are one type, and its INFORMATION_SCHEMA reports a VARCHAR
+# column as TEXT, so a contract declaring VARCHAR would never match its own
+# column. Dialect-specific because elsewhere (MySQL, SQL Server) TEXT and VARCHAR
+# are genuinely different types.
+_SNOWFLAKE_TEXT_FAMILY = {
+    exp.DataType.Type.VARCHAR,
+    exp.DataType.Type.TEXT,
+    exp.DataType.Type.NVARCHAR,
+}
+
+
+def _is_snowflake(dialect) -> bool:
+    name = getattr(dialect, "__name__", None) or type(dialect).__name__
+    return str(name).lower() == "snowflake" or str(dialect).lower() == "snowflake"
+
 
 def _parse(type_str: str, dialect) -> Optional[exp.DataType]:
     """Parse a type string into an ``exp.DataType`` for ``dialect``, or ``None``."""
@@ -132,6 +147,7 @@ def physical_type_matches(
         exp_dt.this == act_dt.this
         or {exp_dt.this, act_dt.this} <= _TIMESTAMP_FAMILY
         or (both_numeric and _base_sql(exp_dt, dialect) == _base_sql(act_dt, dialect))
+        or (_is_snowflake(dialect) and {exp_dt.this, act_dt.this} <= _SNOWFLAKE_TEXT_FAMILY)
     )
     if not same_base:
         return False, f"expected physical type '{expected}' but the column is '{actual}'"

--- a/datacontract/engines/checks/physical_type_match.py
+++ b/datacontract/engines/checks/physical_type_match.py
@@ -43,20 +43,30 @@ def _timestamp_family() -> set:
 
 _TIMESTAMP_FAMILY = _timestamp_family()
 
-# In Snowflake these are one type, and its INFORMATION_SCHEMA reports a VARCHAR
-# column as TEXT, so a contract declaring VARCHAR would never match its own
-# column. Dialect-specific because elsewhere (MySQL, SQL Server) TEXT and VARCHAR
-# are genuinely different types.
-_SNOWFLAKE_TEXT_FAMILY = {
-    exp.DataType.Type.VARCHAR,
-    exp.DataType.Type.TEXT,
-    exp.DataType.Type.NVARCHAR,
-}
+# Each group is a single Snowflake type under different names, which its catalog
+# reports as the one canonical name (TEXT, NUMBER, FLOAT), so a contract declaring
+# any of the aliases must match its own column. Dialect-specific because elsewhere
+# (MySQL, SQL Server) TEXT and VARCHAR, or INT and DECIMAL, are distinct types.
+_SNOWFLAKE_FAMILIES = (
+    {exp.DataType.Type.VARCHAR, exp.DataType.Type.TEXT, exp.DataType.Type.NVARCHAR},
+    # exact numerics: INT/INTEGER/BIGINT/SMALLINT/TINYINT/BYTEINT/NUMERIC are NUMBER(38,0)
+    {
+        exp.DataType.Type.DECIMAL,
+        exp.DataType.Type.INT,
+        exp.DataType.Type.BIGINT,
+        exp.DataType.Type.SMALLINT,
+        exp.DataType.Type.TINYINT,
+    },
+    # approximate numerics: FLOAT/FLOAT4/FLOAT8/DOUBLE/REAL are all 64-bit FLOAT
+    {exp.DataType.Type.DOUBLE, exp.DataType.Type.FLOAT},
+)
 
 
 def _is_snowflake(dialect) -> bool:
+    if isinstance(dialect, str):
+        return dialect.lower() == "snowflake"
     name = getattr(dialect, "__name__", None) or type(dialect).__name__
-    return str(name).lower() == "snowflake" or str(dialect).lower() == "snowflake"
+    return name.lower() == "snowflake"
 
 
 def _parse(type_str: str, dialect) -> Optional[exp.DataType]:
@@ -147,13 +157,14 @@ def physical_type_matches(
         exp_dt.this == act_dt.this
         or {exp_dt.this, act_dt.this} <= _TIMESTAMP_FAMILY
         or (both_numeric and _base_sql(exp_dt, dialect) == _base_sql(act_dt, dialect))
-        or (_is_snowflake(dialect) and {exp_dt.this, act_dt.this} <= _SNOWFLAKE_TEXT_FAMILY)
+        or (_is_snowflake(dialect) and any({exp_dt.this, act_dt.this} <= family for family in _SNOWFLAKE_FAMILIES))
     )
     if not same_base:
         return False, f"expected physical type '{expected}' but the column is '{actual}'"
 
-    expected_params = _params(exp_dt)
-    if expected_params and expected_params != _params(act_dt):
+    # sqlglot fills in a dialect's default precision (a bare NUMBER parses as
+    # DECIMAL(38,0)), so what the contract declares is read off the raw string.
+    if _split_base(_normalize_raw(expected))[1] and _params(exp_dt) != _params(act_dt):
         return False, f"expected physical type '{expected}' but the column is '{actual}'"
 
     return True, ""

--- a/datacontract/engines/checks/type_normalize.py
+++ b/datacontract/engines/checks/type_normalize.py
@@ -11,6 +11,7 @@ the actual type is structurally compatible with the expected one.
 from __future__ import annotations
 
 import re
+from typing import NamedTuple
 
 from open_data_contract_standard.model import SchemaProperty
 
@@ -176,29 +177,40 @@ def schema_property_matches(expected: SchemaProperty | None, actual: SchemaPrope
     return True
 
 
+class TypeMismatch(NamedTuple):
+    message: str
+    # False when the actual structure cannot be read (json / variant / untyped
+    # object): the declared type is neither confirmed nor refuted.
+    verifiable: bool
+
+
+def format_mismatch_reason(errors: list[TypeMismatch]) -> str:
+    """The first mismatch and a count of the other type errors, or '' if none."""
+    num_errors = len(errors)
+
+    if num_errors == 0:
+        return ""
+    elif num_errors == 1:
+        return errors[0].message
+    else:
+        return f"{errors[0].message} (and {num_errors - 1} other error{'s' if num_errors > 2 else ''})"
+
+
 def schema_property_mismatch_reason(
     expected: SchemaProperty | None,
     actual: SchemaProperty | None,
     path: str = "",
 ) -> str:
     """Return a human-readable description of the first structural mismatch and a count of other type errors, or '' if none."""
-    errors = schema_property_mismatch_reasons(expected, actual, path)
-    num_errors = len(errors)
-
-    if num_errors == 0:
-        return ""
-    elif num_errors == 1:
-        return errors[0]
-    else:
-        return f"{errors[0]} (and {num_errors - 1} other error{'s' if num_errors > 2 else ''})"
+    return format_mismatch_reason(schema_property_mismatch_reasons(expected, actual, path))
 
 
 def schema_property_mismatch_reasons(
     expected: SchemaProperty | None,
     actual: SchemaProperty | None,
     path: str = "",
-) -> list[str]:
-    errors: list[str] = []
+) -> list[TypeMismatch]:
+    errors: list[TypeMismatch] = []
 
     if expected is None:
         return errors
@@ -206,7 +218,12 @@ def schema_property_mismatch_reasons(
     field_label = f"field '{path}'" if path else "column"
     if actual is None:
         exp_str = expected.logicalType or expected.physicalType
-        errors.append(f"{field_label}: expected type '{exp_str}' but the column type could not be determined")
+        errors.append(
+            TypeMismatch(
+                f"{field_label}: expected type '{exp_str}' but the column type could not be determined",
+                verifiable=False,
+            )
+        )
         return errors
     expected_base = normalize_type_name(expected.logicalType or expected.physicalType)
     actual_base = normalize_type_name(actual.logicalType or actual.physicalType)
@@ -218,16 +235,19 @@ def schema_property_mismatch_reasons(
         exp_str = expected.logicalType or expected.physicalType
         act_str = actual.physicalType or "unknown"
         errors.append(
-            f"{field_label}: has type '{act_str}', but the contract specifies '{exp_str}'. "
-            f"A '{act_str}' value has no verifiable logical type. "
-            f"If this is intentional, specify `physicalType: {act_str}`."
+            TypeMismatch(
+                f"{field_label}: has type '{act_str}', but the contract specifies '{exp_str}'. "
+                f"A '{act_str}' value has no verifiable logical type. "
+                f"If this is intentional, specify `physicalType: {act_str}`.",
+                verifiable=False,
+            )
         )
         return errors
 
     if expected_base != actual_base and not (expected_base in _NUMERIC and actual_base in _NUMERIC):
         exp_str = expected.logicalType or expected.physicalType
         act_str = actual.logicalType or actual.physicalType
-        errors.append(f"{field_label}: expected type '{exp_str}' but got '{act_str}'")
+        errors.append(TypeMismatch(f"{field_label}: expected type '{exp_str}' but got '{act_str}'", verifiable=True))
         return errors
 
     if expected_base == "array":
@@ -240,8 +260,12 @@ def schema_property_mismatch_reasons(
             return errors
         if actual.properties is None:
             errors.append(
-                f"{field_label}: declared with nested fields but the column is an untyped object "
-                "(map/variant) whose structure can't be verified; use a structured type or specify physicalType"
+                TypeMismatch(
+                    f"{field_label}: nested properties are declared but the column is an untyped object "
+                    "whose structure can't be verified. Use a structured type for your data or specify "
+                    "physicalType.",
+                    verifiable=False,
+                )
             )
             return errors
 
@@ -254,7 +278,7 @@ def schema_property_mismatch_reasons(
             act_field = actual_by_name.get(exp_field.name.lower())
 
             if act_field is None:
-                errors.append(f"field '{child_path}' is missing")
+                errors.append(TypeMismatch(f"field '{child_path}' is missing", verifiable=True))
                 continue
 
             errors.extend(schema_property_mismatch_reasons(exp_field, act_field, child_path))

--- a/datacontract/engines/checks/type_normalize.py
+++ b/datacontract/engines/checks/type_normalize.py
@@ -125,10 +125,6 @@ def normalize_type_name(type_name: str | None) -> str | None:
 
 _NUMERIC = {"integer", "number"}
 
-# Contracts routinely carry the logical type keyword in physicalType (it is what
-# DCS did). Such a value names no native type, so it is compared as a category.
-_LOGICAL_KEYWORDS = {"string", "integer", "number", "boolean", "timestamp", "date", "time", "object", "array"}
-
 
 def schema_property_matches(expected: SchemaProperty | None, actual: SchemaProperty | None) -> bool:
     """Return True if ``actual`` is structurally compatible with ``expected``.
@@ -252,35 +248,18 @@ def schema_property_mismatch_reasons(
         )
         return errors
 
-    # A physicalType that is only a logical keyword names no native type, but it
-    # still states a category, which the logicalType must not silently overrule.
-    if expected.physicalType and expected.physicalType.strip().lower() in _LOGICAL_KEYWORDS:
-        keyword_base = normalize_type_name(expected.physicalType)
-        if keyword_base != actual_base and not (keyword_base in _NUMERIC and actual_base in _NUMERIC):
-            act_str = actual.logicalType or actual.physicalType
-            errors.append(
-                TypeMismatch(
-                    f"{field_label}: expected type '{expected.physicalType}' but got '{act_str}'", verifiable=True
-                )
-            )
-            return errors
-
-    # A leaf that declares a native physicalType is compared against the column's
-    # real native type, where the backend reports one. The declared type wins over
-    # the logicalType, as it does for the column itself.
-    if (
-        expected_base not in ("object", "array")
-        and expected.physicalType
-        and expected.physicalType.strip().lower() not in _LOGICAL_KEYWORDS
-        and actual.physicalType
-    ):
+    # A leaf that declares a physicalType is compared against the column's real
+    # native type, where the backend reports one. The declared type wins over the
+    # logicalType, as it does for the column itself.
+    if expected_base not in ("object", "array") and expected.physicalType and actual.physicalType:
         result, reason = physical_type_matches(expected.physicalType, actual.physicalType, dialect)
         if result is True:
             return errors
         if result is False:
             errors.append(TypeMismatch(f"{field_label}: {reason}", verifiable=True))
             return errors
-        # The declared type is foreign to this dialect: fall back to the category
+        # The declared type names nothing in this dialect (a logical keyword such
+        # as `string`, or a type from another platform): fall back to the category
         # comparison, and only give up when there is no logicalType to fall back on.
         if expected.logicalType is None:
             errors.append(TypeMismatch(f"{field_label}: {reason}", verifiable=False))

--- a/datacontract/engines/checks/type_normalize.py
+++ b/datacontract/engines/checks/type_normalize.py
@@ -15,6 +15,8 @@ from typing import NamedTuple
 
 from open_data_contract_standard.model import SchemaProperty
 
+from datacontract.engines.checks.physical_type_match import physical_type_matches
+
 # logicalType marker for a field whose type the backend cannot describe: a
 # dynamically-typed column (ibis json: Snowflake VARIANT, Postgres JSONB,
 # BigQuery JSON) or an unsupported one (binary, geography). No declared type can
@@ -123,6 +125,10 @@ def normalize_type_name(type_name: str | None) -> str | None:
 
 _NUMERIC = {"integer", "number"}
 
+# Contracts routinely carry the logical type keyword in physicalType (it is what
+# DCS did). Such a value names no native type, so it is compared as a category.
+_LOGICAL_KEYWORDS = {"string", "integer", "number", "boolean", "timestamp", "date", "time", "object", "array"}
+
 
 def schema_property_matches(expected: SchemaProperty | None, actual: SchemaProperty | None) -> bool:
     """Return True if ``actual`` is structurally compatible with ``expected``.
@@ -200,15 +206,17 @@ def schema_property_mismatch_reason(
     expected: SchemaProperty | None,
     actual: SchemaProperty | None,
     path: str = "",
+    dialect=None,
 ) -> str:
     """Return a human-readable description of the first structural mismatch and a count of other type errors, or '' if none."""
-    return format_mismatch_reason(schema_property_mismatch_reasons(expected, actual, path))
+    return format_mismatch_reason(schema_property_mismatch_reasons(expected, actual, path, dialect))
 
 
 def schema_property_mismatch_reasons(
     expected: SchemaProperty | None,
     actual: SchemaProperty | None,
     path: str = "",
+    dialect=None,
 ) -> list[TypeMismatch]:
     errors: list[TypeMismatch] = []
 
@@ -244,6 +252,40 @@ def schema_property_mismatch_reasons(
         )
         return errors
 
+    # A physicalType that is only a logical keyword names no native type, but it
+    # still states a category, which the logicalType must not silently overrule.
+    if expected.physicalType and expected.physicalType.strip().lower() in _LOGICAL_KEYWORDS:
+        keyword_base = normalize_type_name(expected.physicalType)
+        if keyword_base != actual_base and not (keyword_base in _NUMERIC and actual_base in _NUMERIC):
+            act_str = actual.logicalType or actual.physicalType
+            errors.append(
+                TypeMismatch(
+                    f"{field_label}: expected type '{expected.physicalType}' but got '{act_str}'", verifiable=True
+                )
+            )
+            return errors
+
+    # A leaf that declares a native physicalType is compared against the column's
+    # real native type, where the backend reports one. The declared type wins over
+    # the logicalType, as it does for the column itself.
+    if (
+        expected_base not in ("object", "array")
+        and expected.physicalType
+        and expected.physicalType.strip().lower() not in _LOGICAL_KEYWORDS
+        and actual.physicalType
+    ):
+        result, reason = physical_type_matches(expected.physicalType, actual.physicalType, dialect)
+        if result is True:
+            return errors
+        if result is False:
+            errors.append(TypeMismatch(f"{field_label}: {reason}", verifiable=True))
+            return errors
+        # The declared type is foreign to this dialect: fall back to the category
+        # comparison, and only give up when there is no logicalType to fall back on.
+        if expected.logicalType is None:
+            errors.append(TypeMismatch(f"{field_label}: {reason}", verifiable=False))
+            return errors
+
     if expected_base != actual_base and not (expected_base in _NUMERIC and actual_base in _NUMERIC):
         exp_str = expected.logicalType or expected.physicalType
         act_str = actual.logicalType or actual.physicalType
@@ -253,7 +295,7 @@ def schema_property_mismatch_reasons(
     if expected_base == "array":
         if expected.items is not None:
             child_path = f"{path}[]" if path else "[]"
-            errors.extend(schema_property_mismatch_reasons(expected.items, actual.items, child_path))
+            errors.extend(schema_property_mismatch_reasons(expected.items, actual.items, child_path, dialect))
 
     if expected_base == "object":
         if not expected.properties:
@@ -281,6 +323,6 @@ def schema_property_mismatch_reasons(
                 errors.append(TypeMismatch(f"field '{child_path}' is missing", verifiable=True))
                 continue
 
-            errors.extend(schema_property_mismatch_reasons(exp_field, act_field, child_path))
+            errors.extend(schema_property_mismatch_reasons(exp_field, act_field, child_path, dialect))
 
     return errors

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -18,7 +18,12 @@ from open_data_contract_standard.model import OpenDataContractStandard, SchemaPr
 
 from datacontract.engines.checks.check_spec import CheckSpec, MetricType
 from datacontract.engines.checks.physical_type_match import physical_type_matches
-from datacontract.engines.checks.type_normalize import schema_property_matches, schema_property_mismatch_reason
+from datacontract.engines.checks.type_normalize import (
+    normalize_type_name,
+    schema_property_matches,
+    schema_property_mismatch_reason,
+    schema_property_mismatch_reasons,
+)
 from datacontract.engines.ibis.connections.connect import connect_ibis
 from datacontract.engines.ibis.dtype_category import ibis_dtype_to_schema_property
 from datacontract.engines.ibis.native_type import fetch_native_types, sqlglot_dialect
@@ -63,6 +68,8 @@ def _describe(spec: CheckSpec) -> str:
         return f"type({spec.field}) == {spec.expected_type_label}"
     if spec.metric == MetricType.FIELD_PHYSICAL_TYPE:
         return f"physical_type({spec.field}) == {spec.expected_physical_type}"
+    if spec.metric in (MetricType.FIELD_NESTED_TYPE, MetricType.FIELD_NESTED_PHYSICAL_TYPE):
+        return f"nested_types({spec.field}) match the contract"
     if spec.metric == MetricType.FIELD_PRESENT:
         return f"present({spec.field})"
     if spec.threshold is not None:
@@ -201,7 +208,14 @@ def _run_model(
     # the real nested types from SHOW COLUMNS so field_type checks can recurse.
     structured_types = None
     if get_server_type(server) == "snowflake" and any(
-        spec.metric in (MetricType.FIELD_TYPE, MetricType.FIELD_PHYSICAL_TYPE) for spec in specs
+        spec.metric
+        in (
+            MetricType.FIELD_TYPE,
+            MetricType.FIELD_PHYSICAL_TYPE,
+            MetricType.FIELD_NESTED_TYPE,
+            MetricType.FIELD_NESTED_PHYSICAL_TYPE,
+        )
+        for spec in specs
     ):
         structured_types = fetch_structured_types(con, server, t.get_name())
 
@@ -231,6 +245,8 @@ def _run_model(
                 _run_type(run, schema, columns, spec, structured_types)
             elif spec.metric == MetricType.FIELD_PHYSICAL_TYPE:
                 _run_physical_type(run, con, server, schema, columns, native_types, spec, structured_types)
+            elif spec.metric in (MetricType.FIELD_NESTED_TYPE, MetricType.FIELD_NESTED_PHYSICAL_TYPE):
+                _run_nested_type(run, schema, columns, spec, structured_types)
             elif spec.metric in (MetricType.FRESHNESS, MetricType.RETENTION):
                 _run_freshness(run, t, columns, spec)
             elif spec.metric == MetricType.CUSTOM_SQL:
@@ -744,6 +760,63 @@ def _run_physical_type(
         return
 
     _set_result(run, spec.key, ResultEnum.warning, f"{reason}; skipping the physical type check")
+
+
+def _run_nested_type(
+    run: Run, schema, columns, spec: CheckSpec, structured_types: dict[str, SchemaProperty] | None = None
+):
+    """Compare the children a property declares (``properties:`` / ``items:``) against
+    the column's real nested structure. The column's own type is the base check's job.
+    """
+    metric = spec.metric.value
+    _set_impl(run, spec.key, f"nested types of '{spec.field}' match the contract", "introspection")
+    actual_col = columns.get(spec.field.lower())
+    if actual_col is None:
+        _set_diagnostics(run, spec.key, _diag(metric=metric, field=spec.field, expected=spec.expected_type_label))
+        _set_result(run, spec.key, ResultEnum.failed, f"Column '{spec.field}' is missing")
+        return
+
+    dtype = schema[actual_col]
+    structured_prop = structured_types.get(spec.field.lower()) if structured_types else None
+    actual_prop = structured_prop or ibis_dtype_to_schema_property(dtype)
+    actual_label = (structured_prop.physicalType if structured_prop else None) or str(dtype)
+    _set_diagnostics(
+        run,
+        spec.key,
+        _diag(metric=metric, field=spec.field, expected=spec.expected_type_label, actual=actual_label),
+    )
+
+    expected = spec.expected_schema_property
+    expected_base = normalize_type_name(expected.logicalType or expected.physicalType)
+    actual_base = normalize_type_name(actual_prop.logicalType or actual_prop.physicalType)
+    if actual_base is None:
+        # A dynamically-typed column (json / variant / jsonb) holds a different
+        # structure per row, so there is nothing to compare the children against.
+        _set_result(
+            run,
+            spec.key,
+            ResultEnum.warning,
+            f"The structure of the '{actual_label}' column '{spec.field}' cannot be read; "
+            f"skipping the nested type check",
+        )
+        return
+    if expected_base != actual_base:
+        # The base type check reports why; nested verification cannot run at all.
+        _set_result(
+            run,
+            spec.key,
+            ResultEnum.failed,
+            f"Cannot verify the nested types of '{spec.field}': the column is '{actual_label}', "
+            f"not a nested {expected_base}",
+        )
+        return
+
+    errors = schema_property_mismatch_reasons(expected, actual_prop, spec.field)
+    if not errors:
+        _set_result(run, spec.key, ResultEnum.passed, None)
+        return
+    _update_diagnostics(run, spec.key, {"errors": errors})
+    _set_result(run, spec.key, ResultEnum.failed, schema_property_mismatch_reason(expected, actual_prop, spec.field))
 
 
 def _run_freshness(run: Run, t, columns, spec: CheckSpec):

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -19,6 +19,7 @@ from open_data_contract_standard.model import OpenDataContractStandard, SchemaPr
 from datacontract.engines.checks.check_spec import CheckSpec, MetricType
 from datacontract.engines.checks.physical_type_match import physical_type_matches
 from datacontract.engines.checks.type_normalize import (
+    format_mismatch_reason,
     normalize_type_name,
     schema_property_matches,
     schema_property_mismatch_reason,
@@ -68,7 +69,7 @@ def _describe(spec: CheckSpec) -> str:
         return f"type({spec.field}) == {spec.expected_type_label}"
     if spec.metric == MetricType.FIELD_PHYSICAL_TYPE:
         return f"physical_type({spec.field}) == {spec.expected_physical_type}"
-    if spec.metric in (MetricType.FIELD_NESTED_TYPE, MetricType.FIELD_NESTED_PHYSICAL_TYPE):
+    if spec.metric == MetricType.FIELD_NESTED_TYPE:
         return f"nested_types({spec.field}) match the contract"
     if spec.metric == MetricType.FIELD_PRESENT:
         return f"present({spec.field})"
@@ -208,13 +209,7 @@ def _run_model(
     # the real nested types from SHOW COLUMNS so field_type checks can recurse.
     structured_types = None
     if get_server_type(server) == "snowflake" and any(
-        spec.metric
-        in (
-            MetricType.FIELD_TYPE,
-            MetricType.FIELD_PHYSICAL_TYPE,
-            MetricType.FIELD_NESTED_TYPE,
-            MetricType.FIELD_NESTED_PHYSICAL_TYPE,
-        )
+        spec.metric in (MetricType.FIELD_TYPE, MetricType.FIELD_PHYSICAL_TYPE, MetricType.FIELD_NESTED_TYPE)
         for spec in specs
     ):
         structured_types = fetch_structured_types(con, server, t.get_name())
@@ -245,7 +240,7 @@ def _run_model(
                 _run_type(run, schema, columns, spec, structured_types)
             elif spec.metric == MetricType.FIELD_PHYSICAL_TYPE:
                 _run_physical_type(run, con, server, schema, columns, native_types, spec, structured_types)
-            elif spec.metric in (MetricType.FIELD_NESTED_TYPE, MetricType.FIELD_NESTED_PHYSICAL_TYPE):
+            elif spec.metric == MetricType.FIELD_NESTED_TYPE:
                 _run_nested_type(run, schema, columns, spec, structured_types)
             elif spec.metric in (MetricType.FRESHNESS, MetricType.RETENTION):
                 _run_freshness(run, t, columns, spec)
@@ -768,7 +763,7 @@ def _run_nested_type(
     """Compare the children a property declares (``properties:`` / ``items:``) against
     the column's real nested structure. The column's own type is the base check's job.
     """
-    metric = spec.metric.value
+    metric = spec.type
     _set_impl(run, spec.key, f"nested types of '{spec.field}' match the contract", "introspection")
     actual_col = columns.get(spec.field.lower())
     if actual_col is None:
@@ -801,13 +796,13 @@ def _run_nested_type(
         )
         return
     if expected_base != actual_base:
-        # The base type check reports why; nested verification cannot run at all.
+        # The base type check names the actual type; repeating it here would print
+        # the column's whole rendered structure.
         _set_result(
             run,
             spec.key,
             ResultEnum.failed,
-            f"Cannot verify the nested types of '{spec.field}': the column is '{actual_label}', "
-            f"not a nested {expected_base}",
+            f"Cannot verify the nested types of '{spec.field}': the column is not an {expected_base}",
         )
         return
 
@@ -815,8 +810,14 @@ def _run_nested_type(
     if not errors:
         _set_result(run, spec.key, ResultEnum.passed, None)
         return
-    _update_diagnostics(run, spec.key, {"errors": errors})
-    _set_result(run, spec.key, ResultEnum.failed, schema_property_mismatch_reason(expected, actual_prop, spec.field))
+    _update_diagnostics(run, spec.key, {"errors": [error.message for error in errors]})
+    verified = any(error.verifiable for error in errors)
+    _set_result(
+        run,
+        spec.key,
+        ResultEnum.failed if verified else ResultEnum.warning,
+        format_mismatch_reason(errors),
+    )
 
 
 def _run_freshness(run: Run, t, columns, spec: CheckSpec):

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -241,7 +241,7 @@ def _run_model(
             elif spec.metric == MetricType.FIELD_PHYSICAL_TYPE:
                 _run_physical_type(run, con, server, schema, columns, native_types, spec, structured_types)
             elif spec.metric == MetricType.FIELD_NESTED_TYPE:
-                _run_nested_type(run, schema, columns, spec, structured_types)
+                _run_nested_type(run, schema, columns, spec, structured_types, sqlglot_dialect(con))
             elif spec.metric in (MetricType.FRESHNESS, MetricType.RETENTION):
                 _run_freshness(run, t, columns, spec)
             elif spec.metric == MetricType.CUSTOM_SQL:
@@ -758,7 +758,12 @@ def _run_physical_type(
 
 
 def _run_nested_type(
-    run: Run, schema, columns, spec: CheckSpec, structured_types: dict[str, SchemaProperty] | None = None
+    run: Run,
+    schema,
+    columns,
+    spec: CheckSpec,
+    structured_types: dict[str, SchemaProperty] | None = None,
+    dialect=None,
 ):
     """Compare the children a property declares (``properties:`` / ``items:``) against
     the column's real nested structure. The column's own type is the base check's job.
@@ -806,7 +811,7 @@ def _run_nested_type(
         )
         return
 
-    errors = schema_property_mismatch_reasons(expected, actual_prop, spec.field)
+    errors = schema_property_mismatch_reasons(expected, actual_prop, spec.field, dialect)
     if not errors:
         _set_result(run, spec.key, ResultEnum.passed, None)
         return

--- a/datacontract/engines/ibis/snowflake_structured_types.py
+++ b/datacontract/engines/ibis/snowflake_structured_types.py
@@ -26,13 +26,18 @@ _LEAF_TYPES = {
 
 
 def _to_property(node: dict) -> SchemaProperty:
-    """Convert one ``data_type`` JSON node to a ``SchemaProperty``."""
+    """Convert one ``data_type`` JSON node to a ``SchemaProperty``.
+
+    Every node also carries its rendered native type, so a declared physicalType
+    can be checked against the column's real one down the whole tree.
+    """
+    native = _render_native(node)
     node_type = node.get("type")
     if node_type == "OBJECT":
         fields = node.get("fields")
         if not fields:
             # untyped OBJECT: same shape as the collapsed ibis map
-            return SchemaProperty(logicalType="object", properties=None)
+            return SchemaProperty(logicalType="object", physicalType=native, properties=None)
         properties = []
         for field in fields:
             name = field.get("fieldName")
@@ -48,19 +53,21 @@ def _to_property(node: dict) -> SchemaProperty:
                     properties=child.properties,
                 )
             )
-        return SchemaProperty(logicalType="object", properties=properties or None)
+        return SchemaProperty(logicalType="object", physicalType=native, properties=properties or None)
     if node_type == "ARRAY":
         element = node.get("elementType")
         # untyped ARRAY: no element type to recurse into
-        return SchemaProperty(logicalType="array", items=_to_property(element) if element else None)
+        return SchemaProperty(
+            logicalType="array", physicalType=native, items=_to_property(element) if element else None
+        )
     if node_type == "MAP":
         # dynamic keys can't be matched to named contract properties
-        return SchemaProperty(logicalType="object", properties=None)
+        return SchemaProperty(logicalType="object", physicalType=native, properties=None)
     logical = _LEAF_TYPES.get(node_type)
     if logical:
-        return SchemaProperty(logicalType=logical)
+        return SchemaProperty(logicalType=logical, physicalType=native)
     # VARIANT, BINARY, GEOGRAPHY, …: keep the Snowflake token for the failure message
-    return SchemaProperty(logicalType=UNKNOWN_LOGICAL_TYPE, physicalType=node_type)
+    return SchemaProperty(logicalType=UNKNOWN_LOGICAL_TYPE, physicalType=native)
 
 
 def has_nesting(prop: SchemaProperty) -> bool:
@@ -122,10 +129,7 @@ def fetch_structured_types(con, server: Server, table_name: str) -> dict[str, Sc
         except (TypeError, ValueError):
             continue
         prop = _to_property(node)
-        if has_nesting(prop):
-            # the real native type, for diagnostics the collapsed ibis dtype can't give
-            prop.physicalType = _render_native(node)
-        elif prop.logicalType != UNKNOWN_LOGICAL_TYPE:
+        if not has_nesting(prop) and prop.logicalType != UNKNOWN_LOGICAL_TYPE:
             # scalars and untyped OBJECT/ARRAY: the collapsed ibis dtype says the same
             continue
         # an unverifiable leaf (VARIANT, GEOGRAPHY, …) keeps its Snowflake token, which

--- a/tests/test_create_checks_nested_type.py
+++ b/tests/test_create_checks_nested_type.py
@@ -25,10 +25,7 @@ def _checks(prop: SchemaProperty, server_type: str, fmt: str | None = None):
 
 
 def _nested(checks):
-    return next(
-        (c for c in checks if c.metric in (MetricType.FIELD_NESTED_TYPE, MetricType.FIELD_NESTED_PHYSICAL_TYPE)),
-        None,
-    )
+    return next((c for c in checks if c.metric == MetricType.FIELD_NESTED_TYPE), None)
 
 
 def _base(checks):
@@ -68,6 +65,14 @@ def test_object_with_properties_gets_a_nested_physical_type_check():
     assert nested.key == "USERS__primary_sic_code__field_nested_physical_type"
     assert nested.field == "primary_sic_code"
     assert nested.name == "Check that nested physical types of primary_sic_code are correct"
+
+
+def test_the_expected_label_renders_the_declared_children():
+    # The base check already reports the bare container type; the nested check's
+    # diagnostics are only useful if they show the declared structure.
+    nested = _nested(_checks(_SIC_CODE, "snowflake"))
+
+    assert nested.expected_type_label == "OBJECT(code VARCHAR(10), description VARCHAR)"
 
 
 def test_array_of_scalars_names_the_element_type():
@@ -140,6 +145,39 @@ def test_no_nested_check_on_parquet():
     assert _nested(_checks(_SIC_CODE, "local", fmt="parquet")) is None
 
 
+def test_no_nested_check_for_an_uninterpretable_container():
+    # A vendor type outside the 9 ODCS categories has no nested structure the
+    # CLI can name; the base check still compares it against the catalog.
+    prop = SchemaProperty(
+        name="attrs",
+        physicalType="MAP(VARCHAR, VARCHAR)",
+        properties=[SchemaProperty(name="a", physicalType="VARCHAR")],
+    )
+    checks = _checks(prop, "snowflake")
+
+    assert _nested(checks) is None
+    assert _base(checks).expected_physical_type == "MAP(VARCHAR, VARCHAR)"
+
+
+def test_no_nested_check_for_a_scalar_with_items():
+    prop = SchemaProperty(name="weird", logicalType="string", items=SchemaProperty(logicalType="string"))
+
+    assert _nested(_checks(prop, "local", fmt="delta")) is None
+
+
+def test_dynamically_typed_column_still_gets_a_nested_check():
+    # variant / json / jsonb are objects; the check is what reports that their
+    # structure cannot be read.
+    prop = SchemaProperty(
+        name="payload",
+        physicalType="VARIANT",
+        logicalType="object",
+        properties=[SchemaProperty(name="code", logicalType="string")],
+    )
+
+    assert _nested(_checks(prop, "snowflake")) is not None
+
+
 # ---------------------------------------------------------------------------
 # execution
 # ---------------------------------------------------------------------------
@@ -196,10 +234,51 @@ def test_nested_check_warns_for_a_dynamically_typed_column():
     assert "cannot be read" in check.reason
 
 
+def test_nested_check_warns_for_an_untyped_object():
+    # Snowflake's untyped OBJECT reads as a map: the keys differ per row, so the
+    # declared children are as unverifiable as those of a variant.
+    check = _run(_SIC_CODE, "map<string, json>")
+
+    assert check.result == ResultEnum.warning
+    assert "can't be verified" in check.reason
+
+
+def test_nested_check_warns_for_an_untyped_array():
+    check = _run(_SIC_CODES, "array<json>")
+
+    assert check.result == ResultEnum.warning
+    assert "no verifiable logical type" in check.reason
+
+
+def test_a_real_mismatch_outranks_an_unverifiable_child():
+    prop = SchemaProperty(
+        name="primary_sic_code",
+        logicalType="object",
+        properties=[
+            SchemaProperty(name="code", logicalType="integer"),
+            SchemaProperty(
+                name="description", logicalType="object", properties=[SchemaProperty(name="x", logicalType="string")]
+            ),
+        ],
+    )
+    check = _run(prop, "struct<code: string, description: json>")
+
+    assert check.result == ResultEnum.failed
+    assert "primary_sic_code.code" in check.reason
+
+
 def test_nested_check_fails_when_the_column_is_not_a_nested_type():
     check = _run(_SIC_CODE, "int64")
 
     assert check.result == ResultEnum.failed
-    assert check.reason == (
-        "Cannot verify the nested types of 'primary_sic_code': the column is 'int64', not a nested object"
-    )
+    assert check.reason == "Cannot verify the nested types of 'primary_sic_code': the column is not an object"
+
+
+def test_the_mismatch_reason_does_not_repeat_the_columns_own_structure():
+    # The base type check names the actual type; rendering a whole structured
+    # column here would run for lines.
+    check = _run(_SIC_CODE, "array<struct<sku: string, quantity: int64, price: decimal(12, 2)>>")
+
+    assert check.result == ResultEnum.failed
+    assert check.reason == "Cannot verify the nested types of 'primary_sic_code': the column is not an object"
+    assert check.diagnostics["actual"] == "array<struct<sku: string, quantity: int64, price: decimal(12, 2)>>"

--- a/tests/test_create_checks_nested_type.py
+++ b/tests/test_create_checks_nested_type.py
@@ -315,16 +315,16 @@ def test_an_unparameterized_nested_physical_type_matches_any_length():
     assert _run_snowflake(_sic_code(code="VARCHAR")).result == ResultEnum.passed
 
 
-def test_a_logical_keyword_in_the_physical_type_is_compared_as_a_category():
-    # Contracts routinely carry the logical keyword in physicalType; it names no
-    # native type, so it must not be compared against 'VARCHAR(10)' as one.
+def test_a_logical_keyword_in_the_physical_type_resolves_to_the_native_type():
+    # Contracts routinely carry the logical keyword in physicalType. The dialect
+    # decides what it names: 'string' is Snowflake's VARCHAR, 'boolean' is not.
     assert _run_snowflake(_sic_code(code="string")).result == ResultEnum.passed
     assert _run_snowflake(_sic_code(code="boolean")).result == ResultEnum.failed
 
 
 def test_a_logical_keyword_in_the_physical_type_is_not_overruled_by_the_logical_type():
-    # A property that contradicts itself is still wrong: the physicalType states a
-    # category too, so the logicalType must not silently win.
+    # A property that contradicts itself is still wrong: the physicalType names a
+    # type too, so the logicalType must not silently win.
     prop = SchemaProperty(
         name="primary_sic_code",
         physicalType="OBJECT",
@@ -333,7 +333,44 @@ def test_a_logical_keyword_in_the_physical_type_is_not_overruled_by_the_logical_
     check = _run_snowflake(prop)
 
     assert check.result == ResultEnum.failed
-    assert check.reason == "field 'primary_sic_code.code': expected type 'boolean' but got 'string'"
+    assert (
+        check.reason
+        == "field 'primary_sic_code.code': expected physical type 'boolean' but the column is 'VARCHAR(10)'"
+    )
+
+
+def test_a_nested_number_does_not_match_a_float_column():
+    # NUMBER is both a Snowflake type and an ODCS logical keyword; it must be
+    # checked as the type, so it cannot silently pass on an approximate column.
+    check = _run_snowflake(
+        SchemaProperty(
+            name="geo",
+            physicalType="OBJECT",
+            properties=[SchemaProperty(name="lat", logicalType="number", physicalType="NUMBER")],
+        ),
+        data_type={"type": "OBJECT", "fields": [{"fieldName": "lat", "fieldType": {"type": "REAL"}}]},
+    )
+
+    assert check.result == ResultEnum.failed
+    assert check.reason == "field 'geo.lat': expected physical type 'NUMBER' but the column is 'FLOAT'"
+
+
+def test_an_unparameterized_nested_number_matches_any_precision():
+    # A bare NUMBER declares no precision, so the column's own must not be compared
+    # against the default one sqlglot fills in.
+    check = _run_snowflake(
+        SchemaProperty(
+            name="order",
+            physicalType="OBJECT",
+            properties=[SchemaProperty(name="price", logicalType="number", physicalType="NUMBER")],
+        ),
+        data_type={
+            "type": "OBJECT",
+            "fields": [{"fieldName": "price", "fieldType": {"type": "FIXED", "precision": 12, "scale": 2}}],
+        },
+    )
+
+    assert check.result == ResultEnum.passed
 
 
 def test_a_too_wide_nested_physical_type_fails():

--- a/tests/test_create_checks_nested_type.py
+++ b/tests/test_create_checks_nested_type.py
@@ -1,0 +1,205 @@
+"""Nested type checks get their own check line.
+
+A property that declares children via ``properties:`` / ``items:`` gets a second
+check next to the base type check, which verifies the nested structure.
+"""
+
+import ibis
+from open_data_contract_standard.model import (
+    OpenDataContractStandard,
+    SchemaObject,
+    SchemaProperty,
+    Server,
+)
+
+from datacontract.engines.checks.check_spec import MetricType
+from datacontract.engines.checks.create_checks import create_checks
+from datacontract.engines.ibis.ibis_check_execute import _run_nested_type, build_check_stubs
+from datacontract.model.run import ResultEnum, Run
+
+
+def _checks(prop: SchemaProperty, server_type: str, fmt: str | None = None):
+    schema = SchemaObject(name="USERS", physicalType="table", properties=[prop])
+    dc = OpenDataContractStandard(version="1", kind="DataContract", apiVersion="v3.1.0", id="x", schema=[schema])
+    return create_checks(dc, Server(server="s", type=server_type, format=fmt))
+
+
+def _nested(checks):
+    return next(
+        (c for c in checks if c.metric in (MetricType.FIELD_NESTED_TYPE, MetricType.FIELD_NESTED_PHYSICAL_TYPE)),
+        None,
+    )
+
+
+def _base(checks):
+    return next(
+        (c for c in checks if c.metric in (MetricType.FIELD_TYPE, MetricType.FIELD_PHYSICAL_TYPE)),
+        None,
+    )
+
+
+_SIC_CODE = SchemaProperty(
+    name="primary_sic_code",
+    physicalType="OBJECT",
+    logicalType="object",
+    properties=[
+        SchemaProperty(name="code", physicalType="VARCHAR(10)", logicalType="string"),
+        SchemaProperty(name="description", physicalType="VARCHAR", logicalType="string"),
+    ],
+)
+
+_SIC_CODES = SchemaProperty(
+    name="sic_codes",
+    physicalType="ARRAY",
+    logicalType="array",
+    items=SchemaProperty(physicalType="STRING", logicalType="string"),
+)
+
+
+# ---------------------------------------------------------------------------
+# emission
+# ---------------------------------------------------------------------------
+def test_object_with_properties_gets_a_nested_physical_type_check():
+    checks = _checks(_SIC_CODE, "snowflake")
+
+    assert _base(checks).name == "Check that field primary_sic_code has physical type OBJECT"
+    nested = _nested(checks)
+    assert nested.type == "field_nested_physical_type"
+    assert nested.key == "USERS__primary_sic_code__field_nested_physical_type"
+    assert nested.field == "primary_sic_code"
+    assert nested.name == "Check that nested physical types of primary_sic_code are correct"
+
+
+def test_array_of_scalars_names_the_element_type():
+    nested = _nested(_checks(_SIC_CODES, "snowflake"))
+
+    assert nested.name == "Check that items of array sic_codes have physical type STRING"
+
+
+def test_array_of_objects_uses_the_generic_wording():
+    prop = SchemaProperty(
+        name="lines",
+        physicalType="ARRAY",
+        items=SchemaProperty(logicalType="object", properties=[SchemaProperty(name="qty", logicalType="integer")]),
+    )
+
+    assert _nested(_checks(prop, "snowflake")).name == "Check that nested physical types of lines are correct"
+
+
+def test_logical_path_gets_a_nested_type_check():
+    checks = _checks(_SIC_CODE, "local", fmt="delta")
+
+    assert _base(checks).metric == MetricType.FIELD_TYPE
+    nested = _nested(checks)
+    assert nested.type == "field_nested_type"
+    assert nested.name == "Check that nested types of primary_sic_code are correct"
+
+
+def test_logical_path_array_of_scalars_names_the_element_type():
+    nested = _nested(_checks(_SIC_CODES, "local", fmt="delta"))
+
+    assert nested.name == "Check that items of array sic_codes have type string"
+
+
+def test_base_check_no_longer_compares_the_children():
+    # The nested check owns the children, so the base check only compares the
+    # column's own type.
+    base = _base(_checks(_SIC_CODE, "local", fmt="delta"))
+
+    assert base.expected_schema_property.logicalType == "object"
+    assert not base.expected_schema_property.properties
+
+
+def test_children_declared_inline_only_stay_a_single_check():
+    prop = SchemaProperty(name="primary_sic_code", physicalType="OBJECT(code VARCHAR, description VARCHAR)")
+    checks = _checks(prop, "snowflake")
+
+    assert _nested(checks) is None
+    assert _base(checks).expected_physical_type == "OBJECT(code VARCHAR, description VARCHAR)"
+
+
+def test_both_declaration_forms_are_enforced_independently():
+    prop = SchemaProperty(
+        name="primary_sic_code",
+        physicalType="OBJECT(code VARCHAR)",
+        properties=[SchemaProperty(name="code", physicalType="VARCHAR", logicalType="string")],
+    )
+    checks = _checks(prop, "snowflake")
+
+    assert _base(checks).expected_physical_type == "OBJECT(code VARCHAR)"
+    assert _nested(checks) is not None
+
+
+def test_array_without_items_stays_a_single_check():
+    assert _nested(_checks(SchemaProperty(name="tags", logicalType="array"), "snowflake")) is None
+
+
+def test_no_nested_check_on_parquet():
+    # Parquet/CSV are read through a DuckDB view built from the contract's own
+    # types, so the reported nested types are the declared ones.
+    assert _nested(_checks(_SIC_CODE, "local", fmt="parquet")) is None
+
+
+# ---------------------------------------------------------------------------
+# execution
+# ---------------------------------------------------------------------------
+def _run(prop: SchemaProperty, dtype: str, server_type: str = "local", fmt: str | None = "delta"):
+    specs = _checks(prop, server_type, fmt)
+    run = Run.create_run()
+    run.checks = build_check_stubs(specs)
+    spec = _nested(specs)
+    field = prop.physicalName or prop.name
+    _run_nested_type(run, ibis.schema({field: dtype}), {field.lower(): field}, spec)
+    return next(c for c in run.checks if c.key == spec.key)
+
+
+def test_matching_nested_types_pass():
+    check = _run(_SIC_CODE, "struct<code: string, description: string>")
+
+    assert check.result == ResultEnum.passed
+
+
+def test_wrong_nested_type_fails_and_names_the_path():
+    check = _run(_SIC_CODE, "struct<code: int64, description: string>")
+
+    assert check.result == ResultEnum.failed
+    assert "primary_sic_code.code" in check.reason
+
+
+def test_missing_nested_field_fails():
+    check = _run(_SIC_CODE, "struct<code: string>")
+
+    assert check.result == ResultEnum.failed
+    assert "primary_sic_code.description" in check.reason
+
+
+def test_all_nested_errors_are_reported_in_the_diagnostics():
+    check = _run(_SIC_CODE, "struct<code: int64, description: int64>")
+
+    assert "and 1 other error" in check.reason
+    assert len(check.diagnostics["errors"]) == 2
+
+
+def test_wrong_array_element_type_fails():
+    check = _run(_SIC_CODES, "array<int64>")
+
+    assert check.result == ResultEnum.failed
+    assert "sic_codes[]" in check.reason
+
+
+def test_nested_check_warns_for_a_dynamically_typed_column():
+    # A json / variant / jsonb column holds a different structure per row, so the
+    # declared children can be neither confirmed nor refuted.
+    check = _run(_SIC_CODE, "json")
+
+    assert check.result == ResultEnum.warning
+    assert "cannot be read" in check.reason
+
+
+def test_nested_check_fails_when_the_column_is_not_a_nested_type():
+    check = _run(_SIC_CODE, "int64")
+
+    assert check.result == ResultEnum.failed
+    assert check.reason == (
+        "Cannot verify the nested types of 'primary_sic_code': the column is 'int64', not a nested object"
+    )

--- a/tests/test_create_checks_nested_type.py
+++ b/tests/test_create_checks_nested_type.py
@@ -15,6 +15,7 @@ from open_data_contract_standard.model import (
 from datacontract.engines.checks.check_spec import MetricType
 from datacontract.engines.checks.create_checks import create_checks
 from datacontract.engines.ibis.ibis_check_execute import _run_nested_type, build_check_stubs
+from datacontract.engines.ibis.snowflake_structured_types import _to_property
 from datacontract.model.run import ResultEnum, Run
 
 
@@ -272,6 +273,122 @@ def test_nested_check_fails_when_the_column_is_not_a_nested_type():
 
     assert check.result == ResultEnum.failed
     assert check.reason == "Cannot verify the nested types of 'primary_sic_code': the column is not an object"
+
+
+# ---------------------------------------------------------------------------
+# execution against Snowflake's structured types, where the nested native types
+# are recovered from SHOW COLUMNS
+# ---------------------------------------------------------------------------
+_SHOW_COLUMNS_SIC_CODE = {
+    "type": "OBJECT",
+    "fields": [
+        {"fieldName": "code", "fieldType": {"type": "TEXT", "length": 10}},
+        {"fieldName": "description", "fieldType": {"type": "TEXT", "length": 16777216}},
+    ],
+}
+
+
+def _run_snowflake(prop: SchemaProperty, data_type: dict = _SHOW_COLUMNS_SIC_CODE, dtype: str = "map<string, json>"):
+    specs = _checks(prop, "snowflake")
+    run = Run.create_run()
+    run.checks = build_check_stubs(specs)
+    spec = _nested(specs)
+    field = prop.physicalName or prop.name
+    structured_types = {field.lower(): _to_property(data_type)}
+    _run_nested_type(run, ibis.schema({field: dtype}), {field.lower(): field}, spec, structured_types, "snowflake")
+    return next(c for c in run.checks if c.key == spec.key)
+
+
+def _sic_code(**children: str) -> SchemaProperty:
+    return SchemaProperty(
+        name="primary_sic_code",
+        physicalType="OBJECT",
+        properties=[SchemaProperty(name=name, physicalType=t) for name, t in children.items()],
+    )
+
+
+def test_a_declared_nested_physical_type_is_checked_against_the_real_one():
+    assert _run_snowflake(_sic_code(code="VARCHAR(10)")).result == ResultEnum.passed
+
+
+def test_an_unparameterized_nested_physical_type_matches_any_length():
+    assert _run_snowflake(_sic_code(code="VARCHAR")).result == ResultEnum.passed
+
+
+def test_a_logical_keyword_in_the_physical_type_is_compared_as_a_category():
+    # Contracts routinely carry the logical keyword in physicalType; it names no
+    # native type, so it must not be compared against 'VARCHAR(10)' as one.
+    assert _run_snowflake(_sic_code(code="string")).result == ResultEnum.passed
+    assert _run_snowflake(_sic_code(code="boolean")).result == ResultEnum.failed
+
+
+def test_a_logical_keyword_in_the_physical_type_is_not_overruled_by_the_logical_type():
+    # A property that contradicts itself is still wrong: the physicalType states a
+    # category too, so the logicalType must not silently win.
+    prop = SchemaProperty(
+        name="primary_sic_code",
+        physicalType="OBJECT",
+        properties=[SchemaProperty(name="code", logicalType="string", physicalType="boolean")],
+    )
+    check = _run_snowflake(prop)
+
+    assert check.result == ResultEnum.failed
+    assert check.reason == "field 'primary_sic_code.code': expected type 'boolean' but got 'string'"
+
+
+def test_a_too_wide_nested_physical_type_fails():
+    check = _run_snowflake(_sic_code(code="VARCHAR(64)"))
+
+    assert check.result == ResultEnum.failed
+    assert (
+        check.reason
+        == "field 'primary_sic_code.code': expected physical type 'VARCHAR(64)' but the column is 'VARCHAR(10)'"
+    )
+
+
+def test_the_nested_physical_type_wins_over_the_logical_one():
+    # Only some children declare a physicalType; the others stay on the coarse
+    # category check.
+    prop = SchemaProperty(
+        name="primary_sic_code",
+        physicalType="OBJECT",
+        properties=[
+            SchemaProperty(name="code", logicalType="string"),
+            SchemaProperty(name="description", logicalType="string", physicalType="VARCHAR(5)"),
+        ],
+    )
+    check = _run_snowflake(prop)
+
+    assert check.result == ResultEnum.failed
+    assert "primary_sic_code.description" in check.reason
+
+
+def test_the_declared_element_physical_type_of_an_array_is_checked():
+    prop = SchemaProperty(name="sic_codes", physicalType="ARRAY", items=SchemaProperty(physicalType="VARCHAR(64)"))
+    check = _run_snowflake(prop, {"type": "ARRAY", "elementType": {"type": "TEXT", "length": 10}}, dtype="array<json>")
+
+    assert check.result == ResultEnum.failed
+    assert "sic_codes[]" in check.reason
+
+
+def test_a_nested_physical_type_foreign_to_the_dialect_warns():
+    # An Oracle NCLOB declared against Snowflake can be neither confirmed nor refuted.
+    check = _run_snowflake(_sic_code(code="NCLOB"))
+
+    assert check.result == ResultEnum.warning
+    assert "could not be interpreted" in check.reason
+
+
+def test_a_foreign_nested_physical_type_falls_back_to_the_logical_type():
+    # Same as the column itself: an uninterpretable physicalType degrades to the
+    # category check when the property declares a logicalType.
+    prop = SchemaProperty(
+        name="primary_sic_code",
+        physicalType="OBJECT",
+        properties=[SchemaProperty(name="code", physicalType="NCLOB", logicalType="string")],
+    )
+
+    assert _run_snowflake(prop).result == ResultEnum.passed
 
 
 def test_the_mismatch_reason_does_not_repeat_the_columns_own_structure():

--- a/tests/test_physical_type_match.py
+++ b/tests/test_physical_type_match.py
@@ -46,6 +46,17 @@ def test_distinct_native_types_do_not_match():
     assert ok is False
 
 
+def test_snowflake_text_and_varchar_are_the_same_type():
+    # Snowflake's INFORMATION_SCHEMA reports a VARCHAR column as TEXT; there they
+    # are synonyms, so a contract declaring VARCHAR must match its own column.
+    assert physical_type_matches("VARCHAR", "TEXT(16777216)", "snowflake")[0] is True
+    assert physical_type_matches("TEXT", "TEXT(16777216)", "snowflake")[0] is True
+    # the declared length is still enforced
+    assert physical_type_matches("VARCHAR(10)", "TEXT(16777216)", "snowflake")[0] is False
+    # and the alias is Snowflake's alone
+    assert physical_type_matches("VARCHAR(255)", "TEXT", "tsql")[0] is False
+
+
 def test_bigquery_legacy_type_names_match_googlesql_names():
     # `datacontract import bigquery` writes the names the BigQuery API returns
     # (INTEGER, FLOAT, BOOLEAN, RECORD); INFORMATION_SCHEMA reports the GoogleSQL

--- a/tests/test_physical_type_match.py
+++ b/tests/test_physical_type_match.py
@@ -57,6 +57,29 @@ def test_snowflake_text_and_varchar_are_the_same_type():
     assert physical_type_matches("VARCHAR(255)", "TEXT", "tsql")[0] is False
 
 
+def test_snowflake_numeric_aliases_are_the_same_type():
+    # Snowflake stores INT/INTEGER/BIGINT/SMALLINT/TINYINT/BYTEINT/NUMBER as
+    # NUMBER(38,0), and FLOAT/REAL/DOUBLE as FLOAT, and reports only the canonical
+    # name, so a contract declaring any alias must match its own column.
+    assert physical_type_matches("BIGINT", "NUMBER(38,0)", "snowflake")[0] is True
+    assert physical_type_matches("INTEGER", "NUMBER(38,0)", "snowflake")[0] is True
+    assert physical_type_matches("REAL", "FLOAT", "snowflake")[0] is True
+    assert physical_type_matches("DOUBLE", "FLOAT", "snowflake")[0] is True
+    # exact and approximate numerics stay distinct
+    assert physical_type_matches("NUMBER", "FLOAT", "snowflake")[0] is False
+    assert physical_type_matches("FLOAT", "NUMBER(12,2)", "snowflake")[0] is False
+
+
+def test_precision_is_only_enforced_when_the_contract_declares_it():
+    # sqlglot fills in the dialect's default precision, so a bare NUMBER parses as
+    # DECIMAL(38,0); that default must not be compared against the real column.
+    assert physical_type_matches("NUMBER", "NUMBER(12,2)", "snowflake")[0] is True
+    assert physical_type_matches("DECIMAL", "NUMBER(12,2)", "snowflake")[0] is True
+    assert physical_type_matches("NUMERIC", "NUMBER(12,2)", "postgres")[0] is True
+    # a declared precision is still enforced
+    assert physical_type_matches("NUMBER(5,0)", "NUMBER(12,2)", "snowflake")[0] is False
+
+
 def test_bigquery_legacy_type_names_match_googlesql_names():
     # `datacontract import bigquery` writes the names the BigQuery API returns
     # (INTEGER, FLOAT, BOOLEAN, RECORD); INFORMATION_SCHEMA reports the GoogleSQL
@@ -71,9 +94,8 @@ def test_bigquery_legacy_type_names_match_googlesql_names():
 
 def test_integer_widths_stay_distinct_outside_bigquery():
     # Aliasing is the dialect's call, not ours: INTEGER is a narrower type than
-    # BIGINT in Postgres and Snowflake, so declaring one against the other fails.
+    # BIGINT in Postgres, so declaring one against the other fails.
     assert physical_type_matches("INTEGER", "BIGINT", "postgres")[0] is False
-    assert physical_type_matches("INTEGER", "BIGINT", "snowflake")[0] is False
 
 
 def test_non_numeric_types_never_alias():

--- a/tests/test_snowflake_structured_types.py
+++ b/tests/test_snowflake_structured_types.py
@@ -58,6 +58,21 @@ def test_nested_object_recurses():
     assert inner["tag"].logicalType == "string"
 
 
+def test_every_node_carries_its_native_type():
+    # A declared physicalType is checked against the column's real native type all
+    # the way down the tree, so every recovered node keeps its rendered type.
+    prop = _prop(
+        '{"type":"OBJECT","fields":['
+        '{"fieldName":"code","fieldType":{"type":"TEXT","length":10}},'
+        '{"fieldName":"lines","fieldType":{"type":"ARRAY","elementType":{"type":"FIXED","precision":12,"scale":2}}}]}'
+    )
+    assert prop.physicalType == "OBJECT(code VARCHAR(10), lines ARRAY(NUMBER(12,2)))"
+    children = {p.name: p for p in prop.properties}
+    assert children["code"].physicalType == "VARCHAR(10)"
+    assert children["lines"].physicalType == "ARRAY(NUMBER(12,2))"
+    assert children["lines"].items.physicalType == "NUMBER(12,2)"
+
+
 def test_leaf_token_mapping():
     assert _prop('{"type":"TIMESTAMP_NTZ"}').logicalType == "timestamp"
     assert _prop('{"type":"TIMESTAMP_LTZ"}').logicalType == "timestamp"


### PR DESCRIPTION
A property that declares children via `properties:` / `items:` now gets its own check line next to the base type check:

```
Check that field my_field has physical type OBJECT
Check that nested physical types of my_field are correct
```

The base check compares only the column's own type; the nested check walks the declared tree and names the full path on failure. Dynamically typed columns (json/variant/jsonb) warn instead of failing, since their structure cannot be read.

On Snowflake, a `physicalType` declared on a nested property is checked against the column's real native type, read from `SHOW COLUMNS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)