### PR TITLE
Fix SyntaxError during installation of datacontract-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- SyntaxWarning during installation: `datacontract/lint/resolve.py:72: SyntaxWarning: 'return' in a 'finally' block return except_message` is handled properly
+
 ## [1.0.13] - 2026-07-14
 
 ### Added

--- a/datacontract/lint/resolve.py
+++ b/datacontract/lint/resolve.py
@@ -44,11 +44,12 @@ _SafeLoaderNoTimestamp.yaml_implicit_resolvers = {
 
 
 def _resolve_jsonschema_compliance_error_message_path(yaml_str, message):
+    except_message = message
+
     try:
         matches = re.findall(r"\[(\d+)\]", message)
         schema_index = matches[0] if len(matches) > 0 else None
         property_index = matches[1] if len(matches) > 1 else None
-        except_message = message
         if schema_index is not None and "schema" in yaml_str and int(schema_index) < len(yaml_str["schema"]):
             except_message = except_message.replace(
                 f"schema[{schema_index}]", f"schema.{yaml_str['schema'][int(schema_index)]['name']}"
@@ -68,8 +69,8 @@ def _resolve_jsonschema_compliance_error_message_path(yaml_str, message):
     except Exception:
         logging.warning("YAML doesn't conform to JSON schema. Could not resolve indexed schema or property names.")
         except_message = message
-    finally:
-        return except_message
+
+    return except_message
 
 
 def resolve_data_contract_dict(


### PR DESCRIPTION
fixes the/path/to/datacontract/lint/resolve.py:72: SyntaxWarning: 'return' in a 'finally' block

- [x] Tests pass (`uv run pytest`) -> I am running in a corporate environemnt in devcontainer, so the tests about docker fail of course, but the rest works fine
- [x] Code formatted (`uv run ruff check --fix && uv run ruff format`)
- [x] Docs updated (if relevant) -> we are fixing syntax error, i dont think we need to update docs
- [x] CHANGELOG.md entry added
