### PR TITLE
added Optional for message type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `datacontract export protobuf` supports a customizable package name via the `protoPackageName` custom property (#1381)
+- `datacontract export protobuf` emits `optional` for non-required message/object fields (#1390)
 
 ### Fixed
 - SyntaxWarning during installation: `datacontract/lint/resolve.py:72: SyntaxWarning: 'return' in a 'finally' block return except_message` is handled properly

--- a/datacontract/export/protobuf_exporter.py
+++ b/datacontract/export/protobuf_exporter.py
@@ -374,9 +374,8 @@ def _get_field_declaration(prop: SchemaProperty) -> str:
 
     logical_type = (prop.logicalType or "").lower()
     is_array = logical_type == "array"
-    is_message_type = logical_type in OBJECT_TYPES
 
-    # Add 'optional' only for non-required, non-array, non-message fields (scalars/enums)
-    if hasattr(prop, "required") and prop.required is False and not is_array and not is_message_type:
+    # Add 'optional' only for non-required, non-array
+    if hasattr(prop, "required") and prop.required is False and not is_array:
         return f"optional {field_type}"
     return field_type

--- a/tests/test_export_protobuf.py
+++ b/tests/test_export_protobuf.py
@@ -148,7 +148,6 @@ message Review {
 
     """.strip()
     result = to_protobuf(data_contract).strip()
-    print(result)
 
     assert result == expected_protobuf
 

--- a/tests/test_export_protobuf.py
+++ b/tests/test_export_protobuf.py
@@ -21,9 +21,6 @@ def test_to_protobuf():
 kind: DataContract
 apiVersion: v3.1.0
 id: test_protobuf
-customProperties:
-  - property: protoPackageName
-    value: com.example.mydata
 schema:
   - name: Product
     description: Details of Product.
@@ -96,7 +93,7 @@ schema:
     expected_protobuf = """
 syntax = "proto3";
 
-package com.example.mydata;
+package example;
 
 // Enum for Category
 enum Category {

--- a/tests/test_export_protobuf.py
+++ b/tests/test_export_protobuf.py
@@ -21,6 +21,9 @@ def test_to_protobuf():
 kind: DataContract
 apiVersion: v3.1.0
 id: test_protobuf
+customProperties:
+  - property: protoPackageName
+    value: com.example.mydata
 schema:
   - name: Product
     description: Details of Product.
@@ -79,13 +82,21 @@ schema:
       - name: user
         logicalType: string
         description: Field user
+      - name: sub_review
+        description: Details of sub review.
+        required: False
+        logicalType: object
+        properties:
+          - name: comment
+            logicalType: string
+            description: Field comment
 """
     data_contract = OpenDataContractStandard(**yaml.safe_load(odcs_yaml))
 
     expected_protobuf = """
 syntax = "proto3";
 
-package example;
+package com.example.mydata;
 
 // Enum for Category
 enum Category {
@@ -119,17 +130,25 @@ message Product {
 
 // Details of Review.
 message Review {
+  // Details of sub review.
+  message SubReview {
+    // Field comment
+    string comment = 1;
+  }
+
   // Field comment
   string comment = 1;
   // Field rating
   int32 rating = 2;
   // Field user
   string user = 3;
+  // Details of sub review.
+  optional SubReview sub_review = 4;
 }
-
 
     """.strip()
     result = to_protobuf(data_contract).strip()
+    print(result)
 
     assert result == expected_protobuf
 


### PR DESCRIPTION
I think we briefly discussed whether the message type field should be optional before, but I want to discuss it again. Plus, I've added some tests to the previous fix.



- [ ] Tests pass (`uv run pytest`)
- [ ] Code formatted (`uv run ruff check --fix && uv run ruff format`)
- [ ] Docs updated (if relevant)
- [ ] CHANGELOG.md entry added
