### PR TITLE
fix(dbt sync): resolve {object}/{property} placeholders in custom sql quality checks (#1397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract export protobuf` emits `optional` for non-required message/object fields (#1390)
 
 ### Fixed
+- `datacontract dbt sync` resolves `{object}`/`{property}` placeholders in custom `sql` quality checks to the dbt `ref()` and column name (#1397)
 - SyntaxWarning during installation: `datacontract/lint/resolve.py:72: SyntaxWarning: 'return' in a 'finally' block return except_message` is handled properly
 - `datacontract test` no longer reports "backend is not installed" for Athena and other ibis SQL backends when `packaging` is missing from the environment
 

--- a/datacontract/integration/dbt_sync.py
+++ b/datacontract/integration/dbt_sync.py
@@ -482,9 +482,11 @@ def _singular_tests_for_qualities(
     *,
     label_prefix: str = "",
     field: Optional[str] = None,
+    model_version: Optional[str] = None,
 ) -> list[SingularTest]:
     """Generate singular tests for ODCS quality entries that have an associated `query` and bound."""
     out: list[SingularTest] = []
+    model_ref = _model_ref(model, model_version)
     for idx, quality in enumerate(qualities or [], start=1):
         if not quality.query:
             continue
@@ -495,13 +497,17 @@ def _singular_tests_for_qualities(
                 f"Skipping singular SQL test `{test_label}` on `{model}`: quality has a `query` but no `mustBe*` bound."
             )
             continue
+        # Resolve the ODCS placeholders to dbt constructs (same tokens as the test engine).
+        query = re.sub(r'["\']?\$?\{(model|table|object)}["\']?', model_ref, quality.query)
+        if field is not None:
+            query = re.sub(r'["\']?\$?\{(field|column|property)}["\']?', field, query)
         severity = _normalize_severity(quality.severity)
         filename = f"{_slugify(contract_id)}__{_slugify(contract_version)}__{_slugify(model)}__{_slugify(test_label)}"
         out.append(
             SingularTest(
                 filename=f"{filename}.sql",
                 sql=_build_singular_sql(
-                    quality.query,
+                    query,
                     predicate,
                     severity,
                     contract_id,
@@ -982,9 +988,14 @@ def generate_dbt_tests_for_schema(
                 run,
                 label_prefix=f"{prop.name}__",
                 field=prop.name,
+                model_version=model_version,
             )
         )
-    singulars.extend(_singular_tests_for_qualities(schema_obj.quality, contract_id, contract_version, model_name, run))
+    singulars.extend(
+        _singular_tests_for_qualities(
+            schema_obj.quality, contract_id, contract_version, model_name, run, model_version=model_version
+        )
+    )
     _disambiguate_singular_filenames(singulars)
 
     return model_dict, singulars

--- a/datacontract/integration/dbt_sync.py
+++ b/datacontract/integration/dbt_sync.py
@@ -497,7 +497,8 @@ def _singular_tests_for_qualities(
                 f"Skipping singular SQL test `{test_label}` on `{model}`: quality has a `query` but no `mustBe*` bound."
             )
             continue
-        # Resolve the ODCS placeholders to dbt constructs (same tokens as the test engine).
+        # Resolve the ODCS model/field placeholders to dbt constructs. `{schema}` (which the test
+        # engine also resolves) has no clean dbt equivalent and is intentionally left untouched.
         query = re.sub(r'["\']?\$?\{(model|table|object)}["\']?', model_ref, quality.query)
         if field is not None:
             query = re.sub(r'["\']?\$?\{(field|column|property)}["\']?', field, query)

--- a/tests/test_dbt_sync.py
+++ b/tests/test_dbt_sync.py
@@ -684,6 +684,32 @@ def test_singular_tests_skipped_when_query_has_no_bound():
     assert any("no `mustBe*` bound" in log.message for log in run.logs)
 
 
+def test_singular_query_resolves_object_and_property_placeholders():
+    """ODCS `{object}`/`{property}` placeholders in a custom `quality.query` resolve to the dbt
+    `ref()` and column name so the generated singular test compiles (issue #1397)."""
+    run = Run.create_run()
+    qualities = [
+        DataQuality(
+            query="SELECT COUNT(*) FROM {object} WHERE {property} < 0",
+            mustBe=0,
+            name="positive",
+        )
+    ]
+    out = _singular_tests_for_qualities(qualities, "c", "1.0.0", "MY_TABLE", run, field="my_column")
+    assert len(out) == 1
+    assert "SELECT COUNT(*) FROM {{ ref('MY_TABLE') }} WHERE my_column < 0" in out[0].sql
+    assert "{object}" not in out[0].sql
+    assert "{property}" not in out[0].sql
+
+
+def test_singular_query_placeholder_resolves_versioned_ref():
+    """On a versioned model, `{object}` resolves to a version-pinned `ref()`."""
+    run = Run.create_run()
+    qualities = [DataQuality(query="SELECT COUNT(*) FROM {model}", mustBe=0, name="rc")]
+    out = _singular_tests_for_qualities(qualities, "c", "1.0.0", "MY_TABLE", run, model_version="2")
+    assert "{{ ref('MY_TABLE', version=2) }}" in out[0].sql
+
+
 def test_generate_outputs_warns_on_unsupported_model_qualities():
     """Model-level qualities that can't map to a test are skipped with a warning — not dropped
     silently or crashed on: a `rowCount` with no bound, and a non-`rowCount` metric with no query."""


### PR DESCRIPTION
`datacontract dbt sync` left `{object}`/`{property}` placeholders raw in the singular test generated for custom `type: "sql"` quality checks, so dbt failed to compile it. They now resolve to the version-aware dbt `ref()` and column name, matching the test engine's token conventions.

Fixes #1397

🤖 Generated with [Claude Code](https://claude.com/claude-code)