### PR TITLE
Fix SQL Server schema not qualified during table introspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract dbt sync` resolves `{object}`/`{property}` placeholders in custom `sql` quality checks to the dbt `ref()` and column name (#1397)
 - SyntaxWarning during installation: `datacontract/lint/resolve.py:72: SyntaxWarning: 'return' in a 'finally' block return except_message` is handled properly (#1384 @Cupprum)
 - `datacontract test` no longer reports "backend is not installed" for Athena and other ibis SQL backends when `packaging` is missing from the environment
+- `datacontract test` against SQL Server no longer fails every check with "Could not read model" when `server.schema` differs from the login's default schema
 
 ## [1.0.13] - 2026-07-14
 

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -1053,6 +1053,9 @@ def _table_database(con, server: Optional[Server]) -> Optional[str]:
     - **Oracle** logs in as one user but the tables may be owned by a different
       schema (``server.schema``). ibis defaults the owner to the login user, so
       an unqualified lookup raises ``TableNotFound``.
+    - **SQL Server** (``mssql`` backend) has no ``schema`` kwarg on
+      ``do_connect()`` either, so it has the same limitation as Oracle: an
+      unqualified lookup falls back to the login's default schema.
     - **Redshift** has no dedicated ibis backend and goes through the Postgres
       backend (``con.name == "postgres"``). When no schema is passed, ibis's
       Postgres introspection resolves the active schema with ``SELECT
@@ -1065,7 +1068,7 @@ def _table_database(con, server: Optional[Server]) -> Optional[str]:
     """
     if server is None or not server.schema_:
         return None
-    if getattr(con, "name", None) == "oracle":
+    if getattr(con, "name", None) in ("oracle", "mssql"):
         return server.schema_
     # Redshift rides the Postgres backend, so detect it by the contract's server
     # type rather than con.name.

--- a/tests/test_ibis_mssql_schema.py
+++ b/tests/test_ibis_mssql_schema.py
@@ -1,0 +1,44 @@
+"""Unit tests for SQL Server table resolution across schemas.
+
+The mssql ibis backend has no ``schema`` kwarg on ``do_connect()``, so tables
+living outside the login's default schema (e.g. not ``dbo``) raise
+``TableNotFound`` on an unqualified lookup — the same limitation Oracle has.
+The engine must qualify the table with the configured schema. See issue:
+cross-schema SQL Server test fails with "Could not read model '<table>': <table>".
+"""
+
+from open_data_contract_standard.model import Server
+
+from datacontract.engines.ibis.ibis_check_execute import _table_database
+
+
+class _FakeBackend:
+    """Minimal stand-in for an ibis backend that records how it is queried."""
+
+    def __init__(self, name, tables):
+        self.name = name
+        # tables: {database_or_None: {table_name: object}}
+        self._tables = tables
+        self.table_calls = []
+
+    def table(self, name, database=None):
+        self.table_calls.append((name, database))
+        try:
+            return self._tables[database][name]
+        except KeyError:
+            raise Exception(name)
+
+    def list_tables(self, database=None):
+        return list(self._tables.get(database, {}))
+
+
+def test_table_database_uses_server_schema_for_sqlserver():
+    server = Server(type="sqlserver", schema="myschema")
+    con = _FakeBackend("mssql", {})
+    assert _table_database(con, server) == "myschema"
+
+
+def test_table_database_none_for_sqlserver_without_schema():
+    server = Server(type="sqlserver")
+    con = _FakeBackend("mssql", {})
+    assert _table_database(con, server) is None


### PR DESCRIPTION
## Summary
- The mssql ibis backend has no `schema` kwarg at connect time, so an unqualified table lookup fell back to the login's default schema instead of the one configured in `server.schema`
- This made `datacontract test` fail every check with "Could not read model" whenever a SQL Server contract's tables lived outside the login's default schema
- Extends `_table_database()` to pass the schema explicitly at read time for the `mssql` backend, mirroring the existing Oracle workaround


- [x] Tests pass (`uv run pytest`)
- [x] Code formatted (`uv run ruff check --fix && uv run ruff format`)
- [ ] ~~Docs updated (if relevant)~~
- [x] CHANGELOG.md entry added
