### PR TITLE
fix(test): compare structured physicalType fields by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - BigQuery export failed on fields with `logicalType: time`
 - Testing Parquet files failed for `number` fields without a declared precision and scale
+- `datacontract test` no longer fails the `physicalType` check for structured types such as Snowflake `OBJECT(a INT, b TEXT)`, whose fields are now compared by name with the same alias-aware rule as top-level types (#1377)
 
 ## [1.0.14] - 2026-07-23
 

--- a/datacontract/engines/checks/physical_type_match.py
+++ b/datacontract/engines/checks/physical_type_match.py
@@ -87,6 +87,17 @@ def _params(dtype: exp.DataType) -> list[str]:
     return [e.sql().strip().lower() for e in dtype.expressions]
 
 
+def _fields(dtype: exp.DataType) -> Optional[list[Tuple[str, exp.DataType]]]:
+    """Named fields of a structured type (``OBJECT(a INT, b TEXT)``), or ``None``.
+
+    Returns ``None`` for ordinary parameterized types, whose ``expressions`` are
+    length/precision literals rather than field definitions.
+    """
+    if not dtype.expressions or not all(isinstance(e, exp.ColumnDef) for e in dtype.expressions):
+        return None
+    return [(e.name.lower(), e.args["kind"]) for e in dtype.expressions]
+
+
 def _normalize_raw(type_str: str) -> str:
     return re.sub(r"\s+", " ", type_str.strip().lower())
 
@@ -118,6 +129,41 @@ def _raw_match(expected: str, actual: str) -> Optional[bool]:
 def _base_sql(dtype: exp.DataType, dialect) -> str:
     """Render the bare base type in ``dialect``, collapsing that dialect's aliases."""
     return exp.DataType(this=dtype.this).sql(dialect=dialect).lower()
+
+
+def _same_base(exp_dt: exp.DataType, act_dt: exp.DataType, dialect) -> bool:
+    """Whether two types are the same base type, ignoring parameters."""
+    both_numeric = {exp_dt.this, act_dt.this} <= exp.DataType.NUMERIC_TYPES
+    return (
+        exp_dt.this == act_dt.this
+        or {exp_dt.this, act_dt.this} <= _TIMESTAMP_FAMILY
+        or (both_numeric and _base_sql(exp_dt, dialect) == _base_sql(act_dt, dialect))
+        or (_is_snowflake(dialect) and any({exp_dt.this, act_dt.this} <= family for family in _SNOWFLAKE_FAMILIES))
+    )
+
+
+def _fields_match(expected_fields, actual_fields, dialect) -> bool:
+    """Compare the fields of two structured types, ignoring field order.
+
+    Each field is compared with the same alias-aware rule used for top-level
+    types, so ``a INT`` matches Snowflake's ``a NUMBER(38,0)``, and a field
+    parameter is only enforced when the contract declares one.
+    """
+    actual_by_name = dict(actual_fields)
+    if set(actual_by_name) != {name for name, _ in expected_fields}:
+        return False
+    for name, exp_kind in expected_fields:
+        act_kind = actual_by_name[name]
+        if not _same_base(exp_kind, act_kind, dialect):
+            return False
+        nested_expected = _fields(exp_kind)
+        if nested_expected is not None:
+            nested_actual = _fields(act_kind)
+            if nested_actual is None or not _fields_match(nested_expected, nested_actual, dialect):
+                return False
+        elif exp_kind.expressions and _params(exp_kind) != _params(act_kind):
+            return False
+    return True
 
 
 def physical_type_matches(
@@ -152,15 +198,22 @@ def physical_type_matches(
             f"server under test; skipping the physical type check"
         )
 
-    both_numeric = {exp_dt.this, act_dt.this} <= exp.DataType.NUMERIC_TYPES
-    same_base = (
-        exp_dt.this == act_dt.this
-        or {exp_dt.this, act_dt.this} <= _TIMESTAMP_FAMILY
-        or (both_numeric and _base_sql(exp_dt, dialect) == _base_sql(act_dt, dialect))
-        or (_is_snowflake(dialect) and any({exp_dt.this, act_dt.this} <= family for family in _SNOWFLAKE_FAMILIES))
-    )
-    if not same_base:
+    if not _same_base(exp_dt, act_dt, dialect):
         return False, f"expected physical type '{expected}' but the column is '{actual}'"
+
+    # Structured types (Snowflake OBJECT(a INT, b TEXT)) carry named fields
+    # rather than length/precision literals, so compare them field by field and
+    # order-independently. The catalog reports the bare base type when it cannot
+    # supply the field list, in which case the base match is all that can be
+    # checked.
+    expected_fields = _fields(exp_dt)
+    if expected_fields is not None:
+        actual_fields = _fields(act_dt)
+        if actual_fields is None:
+            return True, ""
+        if not _fields_match(expected_fields, actual_fields, dialect):
+            return False, f"expected physical type '{expected}' but the column is '{actual}'"
+        return True, ""
 
     # sqlglot fills in a dialect's default precision (a bare NUMBER parses as
     # DECIMAL(38,0)), so what the contract declares is read off the raw string.

--- a/tests/test_physical_type_match.py
+++ b/tests/test_physical_type_match.py
@@ -80,6 +80,25 @@ def test_precision_is_only_enforced_when_the_contract_declares_it():
     assert physical_type_matches("NUMBER(5,0)", "NUMBER(12,2)", "snowflake")[0] is False
 
 
+def test_structured_object_fields_are_compared_by_name():
+    # OBJECT(a INT, b TEXT) must match its own column, whose catalog type spells
+    # the field types with Snowflake's canonical names, in any field order.
+    assert (
+        physical_type_matches("OBJECT(a INT, b TEXT)", "OBJECT(a NUMBER(38,0), b VARCHAR(16777216))", "snowflake")[0]
+        is True
+    )
+    assert physical_type_matches("OBJECT(b TEXT, a INT)", "OBJECT(a INT, b TEXT)", "snowflake")[0] is True
+    # INFORMATION_SCHEMA reports structured types as a bare OBJECT, so only the
+    # base type can be checked.
+    assert physical_type_matches("OBJECT(a INT, b TEXT)", "OBJECT", "snowflake")[0] is True
+    # genuine differences still fail
+    assert physical_type_matches("OBJECT(a INT, b TEXT)", "OBJECT(a INT, c TEXT)", "snowflake")[0] is False
+    assert physical_type_matches("OBJECT(a INT)", "OBJECT(a TEXT)", "snowflake")[0] is False
+    # a declared field length is enforced, a bare field type is not
+    assert physical_type_matches("OBJECT(a VARCHAR(10))", "OBJECT(a VARCHAR(20))", "snowflake")[0] is False
+    assert physical_type_matches("OBJECT(a VARCHAR)", "OBJECT(a VARCHAR(20))", "snowflake")[0] is True
+
+
 def test_bigquery_legacy_type_names_match_googlesql_names():
     # `datacontract import bigquery` writes the names the BigQuery API returns
     # (INTEGER, FLOAT, BOOLEAN, RECORD); INFORMATION_SCHEMA reports the GoogleSQL


### PR DESCRIPTION
Closes #1377

The `physicalType` check compared a structured type's rendered parameter list, so a Snowflake `OBJECT` column never matched its own contract: `OBJECT(a INT, b TEXT)` was compared string-wise against the catalog's `OBJECT(a NUMBER(38,0), b VARCHAR(16777216))`, field order mattered, and a bare `OBJECT` (what `INFORMATION_SCHEMA` reports when the field list is unavailable) failed too. Structured types are now split into named fields and compared field by field, order-independently, reusing the same alias-aware base-type rule already used for top-level types. Genuine differences still fail.

The three scalar cases in the issue (`INT`/`NUMBER`/`VARCHAR` vs the reconstructed Snowflake types) already pass on `main`, so this PR addresses the remaining structured-type half.

- [x] Tests pass (`uv run pytest`)
- [x] Code formatted (`uv run ruff check --fix && uv run ruff format`)
- [ ] Docs updated (if relevant)
- [x] CHANGELOG.md entry added
