### PR TITLE
Fix SQL server schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract import bigquery` now generates a `servers` block, so `datacontract test` works right after the import
 
 ### Fixed
+- `datacontract test` now respects the schema provided when running against SQL server. (Previously only used `dbo`)
 - BigQuery export failed on fields with `logicalType: time`
 - Testing Parquet files failed for `number` fields without a declared precision and scale
 - CSV and JSON imports now write detected formats (`email`, `uuid`, `date-time`) to `logicalTypeOptions.format` instead of a custom property, so they are validated by `datacontract test`

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -1060,6 +1060,10 @@ def _table_database(con, server: Optional[Server]) -> Optional[str]:
       Redshift with ``column "current_schema" does not exist``, since Redshift
       only supports the parenthesized ``current_schema()``. Passing the schema
       explicitly skips that query.
+    - **SQL Server** cannot pin the schema at connect time. ``ibis.mssql.connect()``
+      has no ``schema`` parameter. Its ``database`` kwarf is forwarded to pyodbc as
+      the ODBC ``Database =`` attribute. This functions as expected when the sql schema
+      is ``dbo`` as there is a default, but cannot handle other schemas.
 
     Other backends pin the schema at connect time and need no qualifier.
     """
@@ -1069,7 +1073,7 @@ def _table_database(con, server: Optional[Server]) -> Optional[str]:
         return server.schema_
     # Redshift rides the Postgres backend, so detect it by the contract's server
     # type rather than con.name.
-    if get_server_type(server) == "redshift":
+    if get_server_type(server) in ("redshift", "sqlserver"):
         return server.schema_
     return None
 

--- a/tests/test_ibis_oracle_schema.py
+++ b/tests/test_ibis_oracle_schema.py
@@ -66,6 +66,7 @@ def test_table_database_none_for_redshift_without_schema():
     con = _FakeBackend("postgres", {})
     assert _table_database(con, server) is None
 
+
 def test_table_database_uses_server_schema_for_sqlserver():
     server = Server(type="sqlserver", schema="DEBUG")
     con = _FakeBackend("sqlserver", {})

--- a/tests/test_ibis_oracle_schema.py
+++ b/tests/test_ibis_oracle_schema.py
@@ -66,6 +66,17 @@ def test_table_database_none_for_redshift_without_schema():
     con = _FakeBackend("postgres", {})
     assert _table_database(con, server) is None
 
+def test_table_database_uses_server_schema_for_sqlserver():
+    server = Server(type="sqlserver", schema="DEBUG")
+    con = _FakeBackend("sqlserver", {})
+    assert _table_database(con, server) == "DEBUG"
+
+
+def test_table_database_none_for_sqlserver_without_schema():
+    server = Server(type="sqlserver")
+    con = _FakeBackend("sqlserver", {})
+    assert _table_database(con, server) is None
+
 
 def test_table_database_none_without_server():
     con = _FakeBackend("oracle", {})


### PR DESCRIPTION
Fix:
Update ibis connection method to include the specified database schema when using SQL Server.


- [x] Tests pass (`uv run pytest`)
- [x] Code formatted (`uv run ruff check --fix && uv run ruff format`)
- [x] Docs updated (if relevant)
- [x] CHANGELOG.md entry added
