### PR TITLE
Add Redshift import and IAM authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `datacontract import redshift` creates a data contract from an Amazon Redshift schema, including a ready-to-test `servers` block
+- Redshift supports IAM authentication with `DATACONTRACT_REDSHIFT_AUTHENTICATION=iam`, using temporary credentials from your AWS session instead of a database password
 - `datacontract import bigquery` now generates a `servers` block, so `datacontract test` works right after the import
 
 ### Fixed
+- Testing and importing Redshift failed with `codec not available in Python: 'UNICODE'`
+- Error messages no longer drop bracketed text such as `pip install "botocore[crt]"`
 - BigQuery export failed on fields with `logicalType: time`
 - Testing Parquet files failed for `number` fields without a declared precision and scale
 - CSV and JSON imports now write detected formats (`email`, `uuid`, `date-time`) to `logicalTypeOptions.format` instead of a custom property, so they are validated by `datacontract test`

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -9,6 +9,7 @@ import typer
 from click import Context
 from dotenv import find_dotenv, load_dotenv
 from rich.console import Console
+from rich.markup import escape
 from typer.core import TyperGroup
 from typing_extensions import Annotated
 
@@ -47,6 +48,10 @@ class OrderedCommands(TyperGroup):
 class OrderedCommandsWithMigrationHints(OrderedCommands):
     """Intercepts removed or renamed options on import/export and points the user to the v0.12.0 migration notes."""
 
+    # Import formats where `--schema` still means the database schema, so it must
+    # not be rewritten to the v0.12.0 `--json-schema`.
+    DATABASE_SCHEMA_IMPORTS = {"snowflake", "redshift"}
+
     RENAMED_FLAGS = {
         "--format": None,
         "--rdf-base": "--base",
@@ -65,13 +70,17 @@ class OrderedCommandsWithMigrationHints(OrderedCommands):
         subcommand = positionals[0] if positionals else None
 
         # this function is called by both `datacontract` and `datacontract import`
-        is_import_snowflake = (positionals[:1] == ["snowflake"]) or (positionals[:2] == ["import", "snowflake"])
+        if subcommand == "import":
+            import_format = positionals[1] if len(positionals) > 1 else None
+        else:
+            import_format = subcommand
+        takes_database_schema = import_format in self.DATABASE_SCHEMA_IMPORTS
 
         rewritten_args = []
         for arg in args:
             if isinstance(arg, str) and arg.startswith("--"):
                 flag, _, value = arg.partition("=")
-                if flag == "--schema" and not is_import_snowflake:
+                if flag == "--schema" and not takes_database_schema:
                     typer.secho(
                         "Warning: --schema was replaced with --json-schema in v0.12.0 and will be removed in v0.13.0.",
                         err=True,
@@ -261,7 +270,9 @@ def main():
         from datacontract.model.exceptions import DataContractException
 
         message = e.reason if isinstance(e, DataContractException) else str(e)
-        console.print(f"[red]Error:[/red] {message}")
+        # Escape the message: bracketed text in an exception (e.g. a driver's
+        # `pip install "botocore[crt]"` hint) would otherwise be eaten as rich markup.
+        console.print(f"[red]Error:[/red] {escape(message)}")
         console.print("[dim]Pass --debug (or set DATACONTRACT_CLI_DEBUG=1) for the full traceback.[/dim]")
         sys.exit(1)
 

--- a/datacontract/command_import.py
+++ b/datacontract/command_import.py
@@ -470,3 +470,38 @@ def import_snowflake(
         format="snowflake", source=source, database=database, schema=schema, owner=owner, id=id
     )
     _write_result(result, output)
+
+
+@import_app.command(
+    name="redshift",
+    epilog="Example: datacontract import redshift --source my-cluster.abc123.us-east-1.redshift.amazonaws.com --database dev --schema public --output datacontract.yaml",
+)
+def import_redshift(
+    source: Annotated[
+        Optional[str], typer.Option(help="The Redshift endpoint host of the cluster or serverless workgroup.")
+    ] = None,
+    port: Annotated[Optional[int], typer.Option(help="The Redshift port (default 5439).")] = None,
+    database: database_option = None,
+    schema: Annotated[Optional[str], typer.Option("--schema", help="The Redshift schema name.")] = None,
+    table: Annotated[
+        Optional[List[str]],
+        typer.Option(help="Name of a table to import (repeat for multiple tables, omit for all tables in the schema)."),
+    ] = None,
+    output: output_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from an Amazon Redshift schema."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(
+        format="redshift",
+        source=source,
+        port=port,
+        database=database,
+        schema=schema,
+        redshift_table=table,
+        owner=owner,
+        id=id,
+    )
+    _write_result(result, output)

--- a/datacontract/engines/ibis/connections/connect.py
+++ b/datacontract/engines/ibis/connections/connect.py
@@ -104,16 +104,22 @@ def connect_ibis(
         )
 
     if server_type == "redshift":
+        from datacontract.engines.ibis.connections.redshift_credentials import resolve_redshift_login
+        from datacontract.engines.ibis.connections.redshift_patch import CLIENT_ENCODING
+
+        login = resolve_redshift_login(server.host, server.database)
         kwargs = dict(
             host=server.host,
             port=int(server.port) if server.port else 5439,
-            user=require_env("DATACONTRACT_REDSHIFT_USERNAME", server_type="redshift"),
+            user=login.user,
             database=server.database,
             schema=server.schema_,
+            client_encoding=CLIENT_ENCODING,
         )
-        password = os.getenv("DATACONTRACT_REDSHIFT_PASSWORD")
-        if password:
-            kwargs["password"] = password
+        if login.password:
+            kwargs["password"] = login.password
+        if login.sslmode:
+            kwargs["sslmode"] = login.sslmode
         # Redshift speaks the postgres wire protocol; ibis has no dedicated backend.
         con = ibis.postgres.connect(**kwargs)
         # ibis's postgres schema introspection joins pg_catalog.pg_enum, which

--- a/datacontract/engines/ibis/connections/redshift_credentials.py
+++ b/datacontract/engines/ibis/connections/redshift_credentials.py
@@ -1,0 +1,208 @@
+"""Resolve the login for a Redshift connection: static password or IAM.
+
+Redshift keeps two identities apart: the AWS IAM principal and the database
+user. IAM authentication bridges them — AWS mints a short-lived database user +
+password, which is then used for an ordinary login over the Postgres wire
+protocol. That exchange is what this module does, so both ``datacontract test``
+(ibis/psycopg) and ``datacontract import redshift`` (psycopg) authenticate
+identically.
+
+AWS credentials themselves come from the same variables Athena uses
+(``DATACONTRACT_S3_*``), falling back to boto3's standard chain — ``aws sso
+login``, ``AWS_PROFILE``, instance/task roles, GitHub OIDC.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from datacontract.model.exceptions import DataContractException, require_env
+
+logger = logging.getLogger(__name__)
+
+SERVERLESS = "serverless"
+PROVISIONED = "provisioned"
+
+# <workgroup>.<account>.<region>.redshift-serverless.amazonaws.com
+# <cluster>.<account>.<region>.redshift.amazonaws.com
+_ENDPOINT_PATTERN = re.compile(
+    r"^(?P<name>[^.]+)\.(?P<account>[^.]+)\.(?P<region>[^.]+)\.redshift(?P<serverless>-serverless)?\.amazonaws\.com$",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class RedshiftLogin:
+    user: str
+    password: Optional[str] = None
+    sslmode: Optional[str] = None
+
+
+def resolve_redshift_login(host: Optional[str], database: Optional[str]) -> RedshiftLogin:
+    """Return the database login to connect with, per DATACONTRACT_REDSHIFT_AUTHENTICATION."""
+    authentication = os.getenv("DATACONTRACT_REDSHIFT_AUTHENTICATION", "password").strip().lower()
+
+    if authentication == "password":
+        return RedshiftLogin(
+            user=require_env("DATACONTRACT_REDSHIFT_USERNAME", server_type="redshift"),
+            password=os.getenv("DATACONTRACT_REDSHIFT_PASSWORD"),
+            sslmode=os.getenv("DATACONTRACT_REDSHIFT_SSLMODE"),
+        )
+
+    if authentication == "iam":
+        user, password = _mint_iam_credentials(host, database)
+        return RedshiftLogin(
+            user=user,
+            password=password,
+            # Temporary credentials are only meaningful over TLS, and every
+            # Redshift endpoint supports it; psycopg would otherwise default to
+            # `prefer` and silently accept a plaintext connection.
+            sslmode=os.getenv("DATACONTRACT_REDSHIFT_SSLMODE", "require"),
+        )
+
+    raise DataContractException(
+        type="redshift-connection",
+        name="unsupported_authentication",
+        reason=(
+            f"Unsupported DATACONTRACT_REDSHIFT_AUTHENTICATION value {authentication!r}. "
+            "Supported values are: password, iam."
+        ),
+        engine="datacontract",
+    )
+
+
+def _mint_iam_credentials(host: Optional[str], database: Optional[str]) -> Tuple[str, str]:
+    flavor, identifier, region = _resolve_endpoint(host)
+
+    if flavor == SERVERLESS:
+        client = _aws_client("redshift-serverless", region)
+        kwargs = {"workgroupName": identifier}
+        if database:
+            kwargs["dbName"] = database
+        duration = _duration_seconds()
+        if duration:
+            kwargs["durationSeconds"] = duration
+        response = _call_aws(client.get_credentials, kwargs, "redshift-serverless:GetCredentials")
+        return response["dbUser"], response["dbPassword"]
+
+    client = _aws_client("redshift", region)
+    db_user = os.getenv("DATACONTRACT_REDSHIFT_DB_USER") or os.getenv("DATACONTRACT_REDSHIFT_USERNAME")
+    duration = _duration_seconds()
+
+    if not db_user:
+        # Derives the database user from the caller's IAM identity, so no
+        # username has to be configured at all.
+        kwargs = {"ClusterIdentifier": identifier}
+        if database:
+            kwargs["DbName"] = database
+        if duration:
+            kwargs["DurationSeconds"] = duration
+        response = _call_aws(client.get_cluster_credentials_with_iam, kwargs, "redshift:GetClusterCredentialsWithIAM")
+        return response["DbUser"], response["DbPassword"]
+
+    kwargs = {"DbUser": db_user, "ClusterIdentifier": identifier}
+    if database:
+        kwargs["DbName"] = database
+    if duration:
+        kwargs["DurationSeconds"] = duration
+    if _get_bool_env("DATACONTRACT_REDSHIFT_AUTO_CREATE", False):
+        kwargs["AutoCreate"] = True
+    db_groups = [
+        group.strip() for group in os.getenv("DATACONTRACT_REDSHIFT_DB_GROUPS", "").split(",") if group.strip()
+    ]
+    if db_groups:
+        kwargs["DbGroups"] = db_groups
+    response = _call_aws(client.get_cluster_credentials, kwargs, "redshift:GetClusterCredentials")
+    return response["DbUser"], response["DbPassword"]
+
+
+def _resolve_endpoint(host: Optional[str]) -> Tuple[str, str, Optional[str]]:
+    """Return ``(flavor, identifier, region)`` for the server's endpoint.
+
+    Both are derivable from a standard endpoint host, so a plain contract needs
+    no extra configuration. Custom domains and VPC endpoints don't follow that
+    shape, hence the explicit overrides.
+    """
+    workgroup = os.getenv("DATACONTRACT_REDSHIFT_WORKGROUP")
+    cluster = os.getenv("DATACONTRACT_REDSHIFT_CLUSTER_IDENTIFIER")
+    region = os.getenv("DATACONTRACT_REDSHIFT_REGION") or os.getenv("DATACONTRACT_S3_REGION")
+
+    match = _ENDPOINT_PATTERN.match(host.strip()) if host else None
+    if match:
+        flavor = SERVERLESS if match.group("serverless") else PROVISIONED
+        return (
+            SERVERLESS if workgroup else PROVISIONED if cluster else flavor,
+            workgroup or cluster or match.group("name"),
+            region or match.group("region"),
+        )
+
+    if workgroup:
+        return SERVERLESS, workgroup, region
+    if cluster:
+        return PROVISIONED, cluster, region
+
+    raise DataContractException(
+        type="redshift-connection",
+        name="unknown_redshift_endpoint",
+        reason=(
+            f"Could not derive the cluster or workgroup from the host {host!r}. "
+            "Set DATACONTRACT_REDSHIFT_WORKGROUP (Redshift Serverless) or "
+            "DATACONTRACT_REDSHIFT_CLUSTER_IDENTIFIER (provisioned cluster), "
+            "plus DATACONTRACT_REDSHIFT_REGION."
+        ),
+        engine="datacontract",
+    )
+
+
+def _aws_client(service: str, region: Optional[str]):
+    import boto3
+
+    return boto3.client(
+        service,
+        region_name=region,
+        aws_access_key_id=os.getenv("DATACONTRACT_S3_ACCESS_KEY_ID"),
+        aws_secret_access_key=os.getenv("DATACONTRACT_S3_SECRET_ACCESS_KEY"),
+        aws_session_token=os.getenv("DATACONTRACT_S3_SESSION_TOKEN"),
+    )
+
+
+def _call_aws(operation, kwargs: dict, api_name: str) -> dict:
+    try:
+        return operation(**kwargs)
+    except Exception as e:
+        raise DataContractException(
+            type="redshift-connection",
+            name="iam_credentials_failed",
+            reason=(
+                f"Could not obtain temporary Redshift credentials via {api_name}: {e} "
+                f"Check that the AWS identity is allowed to call {api_name} and that the region is correct."
+            ),
+            engine="datacontract",
+            original_exception=e,
+        )
+
+
+def _duration_seconds() -> Optional[int]:
+    value = os.getenv("DATACONTRACT_REDSHIFT_DURATION_SECONDS")
+    if not value:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        raise DataContractException(
+            type="redshift-connection",
+            name="invalid_duration_seconds",
+            reason=f"DATACONTRACT_REDSHIFT_DURATION_SECONDS must be a whole number of seconds, got {value!r}.",
+            engine="datacontract",
+        )
+
+
+def _get_bool_env(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in ("1", "true", "yes", "y", "on")

--- a/datacontract/engines/ibis/connections/redshift_patch.py
+++ b/datacontract/engines/ibis/connections/redshift_patch.py
@@ -30,6 +30,13 @@ import types
 
 logger = logging.getLogger(__name__)
 
+# Redshift identifies as "PostgreSQL 8.0.2" and reports client_encoding under the
+# 8.0-era name "UNICODE". psycopg's codec table only knows the modern spelling
+# ("UTF8"), so without this every query fails with
+# `NotSupportedError: codec not available in Python: 'UNICODE'`. Requesting the
+# encoding at connect time makes the server report "utf8" back.
+CLIENT_ENCODING = "utf8"
+
 # ibis's get_schema query without the pg_enum-dependent enum CASE. Every other
 # relation (pg_attribute / pg_class / pg_namespace) and pg_catalog.format_type
 # is supported by Redshift's leader-node catalog.

--- a/datacontract/imports/importer.py
+++ b/datacontract/imports/importer.py
@@ -40,6 +40,7 @@ class ImportFormat(str, Enum):
     excel = "excel"
     powerbi = "powerbi"
     snowflake = "snowflake"
+    redshift = "redshift"
 
     @classmethod
     def get_supported_formats(cls):

--- a/datacontract/imports/importer_factory.py
+++ b/datacontract/imports/importer_factory.py
@@ -130,6 +130,11 @@ importer_factory.register_lazy_importer(
     class_name="SnowflakeImporter",
 )
 importer_factory.register_lazy_importer(
+    name=ImportFormat.redshift,
+    module_path="datacontract.imports.redshift_importer",
+    class_name="RedshiftImporter",
+)
+importer_factory.register_lazy_importer(
     name=ImportFormat.json,
     module_path="datacontract.imports.json_importer",
     class_name="JsonImporter",

--- a/datacontract/imports/redshift_importer.py
+++ b/datacontract/imports/redshift_importer.py
@@ -1,0 +1,264 @@
+"""Create a data contract from a live Amazon Redshift schema.
+
+Reads table and column metadata from the ``SVV_TABLES`` / ``SVV_COLUMNS``
+catalog views, which cover local tables, views and external (Spectrum) tables on
+both provisioned clusters and Serverless workgroups — unlike
+``information_schema``, which only sees local objects.
+
+The connection is opened with psycopg (shipped by the ``redshift`` extra) rather
+than ibis: the import only reads catalog rows, and the ibis Postgres backend
+would add its own introspection quirks (see ``redshift_patch``).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from open_data_contract_standard.model import OpenDataContractStandard, SchemaObject, SchemaProperty
+
+from datacontract.engines.ibis.connections.redshift_credentials import resolve_redshift_login
+from datacontract.engines.ibis.connections.redshift_patch import CLIENT_ENCODING
+from datacontract.engines.ibis.native_type import reconstruct_native_type
+from datacontract.imports.importer import Importer
+from datacontract.imports.odcs_helper import create_odcs, create_property, create_schema_object, create_server
+from datacontract.imports.sql_importer import map_type_from_sql
+from datacontract.model.exceptions import DataContractException
+
+DEFAULT_PORT = 5439
+
+_TABLES_QUERY = """
+    SELECT table_name, table_type, remarks
+    FROM svv_tables
+    WHERE table_schema = %s
+"""
+
+# Redshift reports the type in parts (base type plus length / precision / scale).
+# reconstruct_native_type() reassembles them exactly as the test path reads them
+# back from information_schema, so an imported physicalType matches on the first
+# `datacontract test`.
+_COLUMNS_QUERY = """
+    SELECT table_name,
+           column_name,
+           data_type,
+           character_maximum_length,
+           numeric_precision,
+           numeric_scale,
+           is_nullable,
+           remarks
+    FROM svv_columns
+    WHERE table_schema = %s
+    ORDER BY table_name, ordinal_position
+"""
+
+# Redshift accepts PRIMARY KEY constraints (informational only, not enforced) and
+# exposes them through information_schema for local tables.
+_PRIMARY_KEYS_QUERY = """
+    SELECT kcu.table_name, kcu.column_name, kcu.ordinal_position
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name
+     AND tc.table_schema = kcu.table_schema
+    WHERE tc.constraint_type = 'PRIMARY KEY'
+      AND tc.table_schema = %s
+    ORDER BY kcu.table_name, kcu.ordinal_position
+"""
+
+
+class RedshiftImporter(Importer):
+    def import_source(self, source: str, import_args: dict) -> OpenDataContractStandard:
+        if source is None:
+            raise DataContractException(
+                type="source",
+                name="redshift import source",
+                reason=(
+                    "The Redshift endpoint host is required for the redshift import, "
+                    "e.g. --source my-workgroup.123456789012.us-east-1.redshift-serverless.amazonaws.com"
+                ),
+                engine="datacontract",
+            )
+        return import_redshift_from_connector(
+            host=source,
+            port=import_args.get("port"),
+            database=import_args.get("database"),
+            schema=import_args.get("schema"),
+            tables=import_args.get("redshift_table"),
+        )
+
+
+def import_redshift_from_connector(
+    host: str,
+    database: Optional[str],
+    schema: Optional[str],
+    port: Optional[int] = None,
+    tables: Optional[List[str]] = None,
+) -> OpenDataContractStandard:
+    if not database:
+        raise DataContractException(
+            type="source",
+            name="redshift import database",
+            reason="The database is required for the redshift import, e.g. --database dev",
+            engine="datacontract",
+        )
+    if not schema:
+        raise DataContractException(
+            type="source",
+            name="redshift import schema",
+            reason="The schema is required for the redshift import, e.g. --schema public",
+            engine="datacontract",
+        )
+
+    port = int(port) if port else DEFAULT_PORT
+    connection = redshift_connection(host=host, port=port, database=database)
+    try:
+        table_rows = _fetch(connection, _TABLES_QUERY, (schema,))
+        column_rows = _fetch(connection, _COLUMNS_QUERY, (schema,))
+        # A user without access to information_schema constraints still gets a
+        # usable contract, just without primary keys.
+        primary_key_rows = _fetch(connection, _PRIMARY_KEYS_QUERY, (schema,), optional=True)
+    finally:
+        connection.close()
+
+    selected = _select_tables(table_rows, tables)
+    if not selected:
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="no tables found",
+            reason=f"No tables found in schema '{schema}' of database '{database}'.",
+            engine="datacontract",
+        )
+
+    odcs = create_odcs()
+    odcs.servers = [
+        create_server(
+            name="redshift",
+            server_type="redshift",
+            host=host,
+            port=port,
+            database=database,
+            schema=schema,
+        )
+    ]
+    odcs.schema_ = [
+        _create_schema(table, column_rows, primary_key_rows)
+        for table in sorted(selected, key=lambda row: row["table_name"].lower())
+    ]
+    return odcs
+
+
+def redshift_connection(host: str, port: int, database: str):
+    """Open a psycopg connection to Redshift using the DATACONTRACT_REDSHIFT_* env vars."""
+    try:
+        import psycopg
+    except ImportError as e:
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="redshift extra missing",
+            reason="Install the extra datacontract-cli[redshift] to use redshift",
+            engine="datacontract",
+            original_exception=e,
+        )
+
+    login = resolve_redshift_login(host, database)
+    kwargs = dict(
+        host=host,
+        port=port,
+        dbname=database,
+        user=login.user,
+        password=login.password,
+        client_encoding=CLIENT_ENCODING,
+    )
+    if login.sslmode:
+        kwargs["sslmode"] = login.sslmode
+    return psycopg.connect(**kwargs)
+
+
+def _fetch(connection, query: str, params: tuple, optional: bool = False) -> List[Dict[str, Any]]:
+    """Run a catalog query and return its rows as dicts keyed by column name."""
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(query, params)
+            columns = [description[0] for description in cursor.description]
+            return [dict(zip(columns, row)) for row in cursor.fetchall()]
+    except Exception as e:
+        if optional:
+            # Roll back so the failed statement doesn't poison the transaction.
+            connection.rollback()
+            return []
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="redshift catalog query failed",
+            reason=f"Could not read the Redshift catalog: {e}",
+            engine="datacontract",
+            original_exception=e,
+        )
+
+
+def _select_tables(table_rows: List[Dict[str, Any]], tables: Optional[List[str]]) -> List[Dict[str, Any]]:
+    if not tables:
+        return table_rows
+    wanted = {table.lower() for table in tables}
+    return [row for row in table_rows if row["table_name"].lower() in wanted]
+
+
+def _create_schema(
+    table: Dict[str, Any],
+    column_rows: List[Dict[str, Any]],
+    primary_key_rows: List[Dict[str, Any]],
+) -> SchemaObject:
+    table_name = table["table_name"]
+    primary_keys = {
+        row["column_name"]: index + 1
+        for index, row in enumerate(row for row in primary_key_rows if row["table_name"] == table_name)
+    }
+    properties = [_create_property(row, primary_keys) for row in column_rows if row["table_name"] == table_name]
+    return create_schema_object(
+        name=table_name,
+        physical_type=_physical_type(table.get("table_type")),
+        description=_clean(table.get("remarks")),
+        properties=properties or None,
+    )
+
+
+def _create_property(row: Dict[str, Any], primary_keys: Dict[str, int]) -> SchemaProperty:
+    name = row["column_name"]
+    max_length = row.get("character_maximum_length")
+    precision = row.get("numeric_precision")
+    scale = row.get("numeric_scale")
+    physical_type = reconstruct_native_type(row.get("data_type"), max_length, precision, scale)
+    logical_type, format = map_type_from_sql(physical_type)
+    # Precision/scale describe the declared type of decimals only; for integers
+    # Redshift still reports a numeric_precision, which is not part of the type.
+    is_decimal = physical_type is not None and physical_type.lower().startswith(("decimal", "numeric"))
+
+    return create_property(
+        name=name,
+        logical_type=logical_type,
+        physical_type=physical_type,
+        description=_clean(row.get("remarks")),
+        required=row.get("is_nullable") == "NO" or None,
+        primary_key=name in primary_keys or None,
+        primary_key_position=primary_keys.get(name),
+        max_length=max_length,
+        precision=precision if is_decimal else None,
+        scale=scale if is_decimal else None,
+        format=format,
+    )
+
+
+def _physical_type(table_type: Optional[str]) -> str:
+    """Map an SVV_TABLES table_type ('BASE TABLE', 'VIEW', 'EXTERNAL TABLE') to ODCS.
+
+    'BASE TABLE' becomes plain 'table', matching what the SQL and Snowflake
+    imports write.
+    """
+    if not table_type:
+        return "table"
+    normalized = table_type.strip().lower()
+    return normalized.removeprefix("base ") if normalized.endswith("table") else normalized
+
+
+def _clean(value: Optional[str]) -> Optional[str]:
+    return value.strip() if value and value.strip() else None

--- a/docs/docs/commands/import.md
+++ b/docs/docs/commands/import.md
@@ -18,4 +18,4 @@ Run `datacontract import <format> --help` to see format-specific options.
 datacontract import sql --source ddl.sql --dialect postgres --output datacontract.yaml
 ```
 
-Available formats: `dbt`, `sql`, `avro`, `dbml`, `glue`, `bigquery`, `unity`, `jsonschema`, `json`, `odcs`, `parquet`, `csv`, `protobuf`, `spark`, `iceberg`, `excel`, `powerbi`, `snowflake`.
+Available formats: `dbt`, `sql`, `avro`, `dbml`, `glue`, `bigquery`, `unity`, `jsonschema`, `json`, `odcs`, `parquet`, `csv`, `protobuf`, `spark`, `iceberg`, `excel`, `powerbi`, `snowflake`, `redshift`.

--- a/docs/docs/connect/index.md
+++ b/docs/docs/connect/index.md
@@ -60,7 +60,7 @@ DATACONTRACT_POSTGRES_PASSWORD=postgres
   </a>
   <a className="doc-card" href="/connect/redshift">
     <img src="/img/icons/redshift.svg" alt="" />
-    <span><span className="doc-card-title">Amazon Redshift</span><span className="doc-card-desc">Redshift (Postgres wire protocol)</span></span>
+    <span><span className="doc-card-title">Amazon Redshift</span><span className="doc-card-desc">Import a contract from your tables and test in 5 minutes</span></span>
   </a>
   <a className="doc-card" href="/connect/impala">
     <img src="/img/icons/impala.svg" alt="" />

--- a/docs/docs/connect/redshift.md
+++ b/docs/docs/connect/redshift.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 8
 title: "Amazon Redshift"
-description: "Create a data contract from your Redshift tables and test the actual data against it."
+description: "Create a data contract from your Redshift tables and test the actual data against it — in about 5 minutes."
 ---
 
 # <img className="page-icon" src="/img/icons/redshift.svg" alt="" /> Amazon Redshift
 
-Test data in Amazon Redshift (both provisioned clusters and Redshift Serverless). Redshift is reached over the PostgreSQL wire protocol via the ibis Postgres backend, using username/password authentication.
+Go from an existing Redshift table to a tested data contract in about five minutes: import the schema straight from Redshift, then test the actual data against it. Works with provisioned clusters and Redshift Serverless — both are reached over the PostgreSQL wire protocol.
 
 ## 1. Install
 
@@ -16,9 +16,22 @@ uv tool install --python python3.11 --upgrade 'datacontract-cli[redshift]'
 
 See [Installation](../installation.md) for pip, pipx, and Docker.
 
-## 2. Set credentials
+## 2. Authenticate
 
-Create a `.env` file in your working directory (or export the variables):
+The easiest way is IAM — sign in to AWS once and the CLI requests temporary database credentials itself, so no database password is stored anywhere:
+
+```bash
+aws sso login   # or any other way of getting an AWS session
+```
+
+```bash
+# .env
+DATACONTRACT_REDSHIFT_AUTHENTICATION=iam
+```
+
+Your AWS identity needs `redshift-serverless:GetCredentials` (Serverless) or `redshift:GetClusterCredentialsWithIAM` (provisioned cluster), and the resulting database user needs `USAGE` on the schema plus `SELECT` on the tables.
+
+Prefer a database user? Leave the authentication variable unset and provide the credentials directly:
 
 ```bash
 # .env
@@ -26,29 +39,22 @@ DATACONTRACT_REDSHIFT_USERNAME=awsuser
 DATACONTRACT_REDSHIFT_PASSWORD=mysecretpassword
 ```
 
-:::note
-IAM-based authentication (region / access key / role ARN) is not currently supported for Redshift, because ibis connects through the generic Postgres backend rather than a Redshift-specific driver.
-:::
+Either way, `import` and `test` use the same setup. For custom domains, VPC endpoints, and the full list of options, see the [Redshift Reference](../reference/redshift.md).
 
 ## 3. Create a contract from your tables
 
-Get the DDL of a table (e.g. with `SHOW TABLE my_schema.orders;` in the Redshift query editor), save it to a file, and import it:
+Import the table metadata directly from the Redshift catalog. This also generates a ready-to-test `servers` block:
 
 ```bash
-datacontract import sql --source orders.sql --dialect redshift --output datacontract.yaml
+datacontract import redshift \
+  --source my-workgroup.123456789012.us-east-1.redshift-serverless.amazonaws.com \
+  --database dev \
+  --schema analytics \
+  --table orders \
+  --output datacontract.yaml
 ```
 
-The SQL import can't know your connection details, so it writes a `servers` block with placeholder values. Open `datacontract.yaml` and fill in your endpoint:
-
-```yaml
-servers:
-  - server: redshift
-    type: redshift
-    host: my-workgroup.123456789012.us-east-1.redshift-serverless.amazonaws.com
-    port: 5439
-    database: dev
-    schema: analytics
-```
+`--source` is the endpoint host of your cluster or serverless workgroup (without the trailing `:5439/dev` that the console shows). Repeat `--table` for multiple tables, or omit it to import every table in the schema.
 
 ## 4. Test the actual data
 
@@ -57,6 +63,15 @@ datacontract test datacontract.yaml
 ```
 
 ```
+Testing datacontract.yaml
+Server: redshift (type=redshift, host=my-workgroup..., database=dev, schema=analytics)
+╭────────┬─────────────────────────────────────────────────┬─────────────────┬─────────╮
+│ Result │ Check                                           │ Field           │ Details │
+├────────┼─────────────────────────────────────────────────┼─────────────────┼─────────┤
+│ passed │ Check that field 'order_id' is present          │ orders.order_id │         │
+│ passed │ Check that field order_id has no missing values │ orders.order_id │         │
+│  ...   │                                                 │                 │         │
+╰────────┴─────────────────────────────────────────────────┴─────────────────┴─────────╯
 🟢 data contract is valid. Run 24 checks. Took 4.9 seconds.
 ```
 
@@ -77,6 +92,20 @@ schema:
 
 Run `datacontract test datacontract.yaml` again: every violation is listed as an error, and the command exits with code `1` — ready for [CI/CD scheduling](../testing.md#scheduling-and-cicd) so you catch drift before your consumers do.
 
+## Server reference
+
+Connection details live in the contract's `servers` block; `host`, `port`, `database`, and `schema` come from there:
+
+```yaml
+servers:
+  - server: redshift
+    type: redshift
+    host: my-workgroup.123456789012.us-east-1.redshift-serverless.amazonaws.com
+    port: 5439
+    database: dev
+    schema: analytics
+```
+
 ## Reference
 
 All authentication options and the data type mappings: **[Redshift Reference](../reference/redshift.md)**.
@@ -84,5 +113,8 @@ All authentication options and the data type mappings: **[Redshift Reference](..
 ## Troubleshooting
 
 - **Connection timeout** — the cluster/workgroup must be reachable from your machine: check **Publicly accessible**, the VPC security group's inbound rule for port `5439`, and VPN routing.
-- **`password authentication failed`** — Redshift Serverless uses the namespace's admin credentials or database users; IAM users don't work over the Postgres wire protocol.
+- **`password authentication failed`** — with `password` authentication, Redshift Serverless expects the namespace's admin credentials or a database user; an IAM user name is not a database user. Set `DATACONTRACT_REDSHIFT_AUTHENTICATION=iam` to sign in with your AWS identity instead.
+- **`Could not obtain temporary Redshift credentials`** — the AWS identity may call the wrong region (set `DATACONTRACT_REDSHIFT_REGION`) or lack `GetCredentials` / `GetClusterCredentialsWithIAM` permission.
+- **`Using the login credential provider requires an additional dependency`** — your AWS profile uses the `aws login` flow, which needs `pip install "botocore[crt]"` in the same environment as the CLI.
 - **`relation does not exist`** — check the `schema` in the `servers` block and the user's `USAGE` grant on it.
+- **The import finds no tables** — `--schema` is case-sensitive and must match the schema as stored in the catalog; external schemas need the `SVV_EXTERNAL_*` permissions granted to your user.

--- a/docs/docs/imports/index.md
+++ b/docs/docs/imports/index.md
@@ -17,7 +17,7 @@ datacontract import sql --source my_ddl.sql --dialect postgres
 datacontract import sql --source my_ddl.sql --dialect postgres --output datacontract.yaml
 ```
 
-The [Snowflake](./snowflake.md), [BigQuery](./bigquery.md), [Unity Catalog](./unity.md), and [AWS Glue](./glue.md) importers can connect directly to the live system and introspect your tables — no export files needed. Snowflake, BigQuery, and Unity Catalog also generate a ready-to-test `servers` block, so `datacontract test` works right after the import.
+The [Snowflake](./snowflake.md), [BigQuery](./bigquery.md), [Amazon Redshift](./redshift.md), [Unity Catalog](./unity.md), and [AWS Glue](./glue.md) importers can connect directly to the live system and introspect your tables — no export files needed. Snowflake, BigQuery, Redshift, and Unity Catalog also generate a ready-to-test `servers` block, so `datacontract test` works right after the import.
 
 Run `datacontract import <format> --help` to see the format-specific options (e.g. `datacontract import sql --help`). If a format you need is missing, [open an issue on GitHub](https://github.com/datacontract/datacontract-cli/issues).
 
@@ -99,6 +99,10 @@ Each import page shows a runnable example: a small source file under [`examples/
   <a className="doc-card" href="/imports/snowflake">
     <img src="/img/icons/snowflake.svg" alt="" />
     <span><span className="doc-card-title">snowflake</span><span className="doc-card-desc">A Snowflake workspace.</span></span>
+  </a>
+  <a className="doc-card" href="/imports/redshift">
+    <img src="/img/icons/redshift.svg" alt="" />
+    <span><span className="doc-card-title">redshift</span><span className="doc-card-desc">An Amazon Redshift schema.</span></span>
   </a>
 </div>
 

--- a/docs/docs/imports/redshift.md
+++ b/docs/docs/imports/redshift.md
@@ -1,0 +1,23 @@
+---
+sidebar_position: 19
+title: "Import: Amazon Redshift"
+description: "Create a data contract from an Amazon Redshift schema."
+---
+
+# <img className="page-icon" src="/img/icons/redshift.svg" alt="" /> Import: Amazon Redshift
+
+Creates a data contract from an Amazon Redshift schema by reading table metadata from the `SVV_TABLES` and `SVV_COLUMNS` catalog views — including column types with length and precision, nullability, primary keys, and comments. Works with provisioned clusters and Redshift Serverless, and covers local tables, views, and external (Spectrum) tables.
+
+```bash
+datacontract import redshift \
+  --source my-workgroup.123456789012.us-east-1.redshift-serverless.amazonaws.com \
+  --database dev \
+  --schema analytics \
+  --output datacontract.yaml
+```
+
+`--source` is the endpoint host of your cluster or serverless workgroup. Add `--port` if it doesn't listen on the default `5439`, and repeat `--table` to import only specific tables (by default every table in the schema is imported).
+
+The generated contract includes a ready-to-test `servers` block, so you can run `datacontract test datacontract.yaml` immediately afterwards — see the **[Redshift connection guide](../connect/redshift.md)** for credentials, the full 5-minute walkthrough, and troubleshooting.
+
+Credentials are provided as environment variables and are the same ones `datacontract test` uses: either IAM (`DATACONTRACT_REDSHIFT_AUTHENTICATION=iam`, which requests temporary credentials from your AWS session) or a database user (`DATACONTRACT_REDSHIFT_USERNAME`, `DATACONTRACT_REDSHIFT_PASSWORD`) — see the [Redshift Reference](../reference/redshift.md).

--- a/docs/docs/reference/redshift.md
+++ b/docs/docs/reference/redshift.md
@@ -11,20 +11,45 @@ Authentication options and data type handling for [Redshift connections](../conn
 
 ## Authentication
 
-| Connection parameter | Environment variable |
-|---|---|
-| `user` | `DATACONTRACT_REDSHIFT_USERNAME` |
-| `password` | `DATACONTRACT_REDSHIFT_PASSWORD` |
+`datacontract test` and `datacontract import redshift` authenticate identically. `host`, `port` (default 5439), `database`, and `schema` come from the contract's `servers` block; for the import they are passed as `--source`, `--port`, `--database`, and `--schema`.
 
-`host`, `port` (default 5439), `database`, and `schema` come from the contract's `servers` block.
+| Variable | Example | Description |
+|---|---|---|
+| `DATACONTRACT_REDSHIFT_AUTHENTICATION` | `iam` | `password` (default) or `iam` |
+| `DATACONTRACT_REDSHIFT_USERNAME` | `awsuser` | Database user. Required for `password`; in `iam` mode it selects the legacy API (see below) |
+| `DATACONTRACT_REDSHIFT_PASSWORD` | `mysecretpassword` | Password (`password` mode only) |
+| `DATACONTRACT_REDSHIFT_SSLMODE` | `verify-full` | TLS mode passed to the driver. Defaults to `require` in `iam` mode, and to the driver's own default (`prefer`) otherwise |
 
-:::note
-IAM-based authentication (region / access key / role ARN) is not currently supported for Redshift, because ibis connects through the generic Postgres backend rather than a Redshift-specific driver.
-:::
+### IAM authentication
+
+With `DATACONTRACT_REDSHIFT_AUTHENTICATION=iam`, the CLI asks AWS for temporary database credentials and uses them to log in — no database password anywhere. The AWS credentials themselves come from the same variables Athena uses (`DATACONTRACT_S3_ACCESS_KEY_ID`, `DATACONTRACT_S3_SECRET_ACCESS_KEY`, `DATACONTRACT_S3_SESSION_TOKEN`, `DATACONTRACT_S3_REGION`), and fall back to the standard AWS chain: `aws sso login`, `AWS_PROFILE`, EC2/ECS/EKS instance roles, or GitHub OIDC in CI.
+
+Which AWS API is called depends on the endpoint and whether a username is set:
+
+| Endpoint | Username set | API |
+|---|---|---|
+| Serverless | — | `redshift-serverless:GetCredentials` |
+| Provisioned | no | `redshift:GetClusterCredentialsWithIAM` — the database user is derived from your IAM identity |
+| Provisioned | yes | `redshift:GetClusterCredentials` — credentials are requested for that database user |
+
+The workgroup or cluster identifier and the region are derived from the endpoint host in the `servers` block, so a standard endpoint needs no extra configuration. Custom domains and VPC endpoints don't follow that naming, so they need an override:
+
+| Variable | Example | Description |
+|---|---|---|
+| `DATACONTRACT_REDSHIFT_WORKGROUP` | `my-workgroup` | Serverless workgroup name |
+| `DATACONTRACT_REDSHIFT_CLUSTER_IDENTIFIER` | `my-cluster` | Provisioned cluster identifier |
+| `DATACONTRACT_REDSHIFT_REGION` | `eu-central-1` | AWS region (otherwise `DATACONTRACT_S3_REGION`, then the host) |
+| `DATACONTRACT_REDSHIFT_DURATION_SECONDS` | `3600` | Lifetime of the temporary credentials (900–3600) |
+| `DATACONTRACT_REDSHIFT_AUTO_CREATE` | `true` | Create the database user if it doesn't exist (`GetClusterCredentials` only) |
+| `DATACONTRACT_REDSHIFT_DB_GROUPS` | `readers,analysts` | Database groups the user joins for the session (`GetClusterCredentials` only) |
+
+The AWS identity needs permission to call the API from the table above — `redshift-serverless:GetCredentials` on the workgroup, or `redshift:GetClusterCredentialsWithIAM` / `redshift:GetClusterCredentials` on the `dbname:`/`dbuser:` resources (plus `redshift:JoinGroup` when using `DB_GROUPS`). Credentials are minted per connection and expire, which is why a long-running process may need to reconnect.
 
 ## Data types
 
 ### Importing
+
+`datacontract import redshift` reads the declared types from the `SVV_COLUMNS` catalog view and writes them as `physicalType` in the catalog's own spelling, including length and precision (`character varying(36)`, `numeric(10,2)`). That is exactly what the physical type check reads back during a test, so an imported contract passes on the first run. The `logicalType` is derived with the same mapping as the SQL import below.
 
 `datacontract import sql --dialect redshift` maps DDL types like the [Postgres dialect](./postgres.md#importing): `VARCHAR`/`CHAR`/`TEXT` → `string`, integer types → `integer`, `NUMERIC`/`DECIMAL`/`REAL`/`DOUBLE PRECISION` → `number`, `BOOLEAN` → `boolean`, `DATE` → `date`, `TIME` → `time`, `TIMESTAMP`/`TIMESTAMP WITH TIME ZONE` → `timestamp`. Redshift-specific types without a portable equivalent (`SUPER`, `GEOMETRY`) get no `logicalType`; the `physicalType` is still written.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,8 @@
 import os
 import re
+from unittest.mock import MagicMock
 
+import pytest
 from typer.testing import CliRunner
 
 from datacontract.cli import app
@@ -126,3 +128,15 @@ def test_changelog_with_changes():
     assert "Removed" in result.output
     assert "Updated" in result.output
     assert "Added" in result.output
+
+
+def test_error_message_keeps_bracketed_text(monkeypatch, capsys):
+    """Rich markup must not eat hints like `pip install "botocore[crt]"`."""
+    from datacontract import cli
+
+    monkeypatch.setattr(cli, "app", MagicMock(side_effect=RuntimeError('run: pip install "botocore[crt]"')))
+
+    with pytest.raises(SystemExit):
+        cli.main()
+
+    assert "botocore[crt]" in capsys.readouterr().out

--- a/tests/test_connect_redshift.py
+++ b/tests/test_connect_redshift.py
@@ -1,0 +1,80 @@
+"""Unit tests for Redshift auth-method selection in connect_ibis.
+
+These do not hit Redshift or AWS: ``ibis.postgres.connect`` and the boto3 client
+are patched, and we only assert which connection kwargs the dispatch passes for
+a given set of env vars. The point is that ``test`` authenticates exactly like
+``import redshift`` — both go through ``resolve_redshift_login``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import ibis
+import pytest
+from open_data_contract_standard.model import Server
+
+from datacontract.engines.ibis.connections.connect import connect_ibis
+from datacontract.model.run import Run
+
+HOST = "my-workgroup.123456789012.us-east-1.redshift-serverless.amazonaws.com"
+
+REDSHIFT_ENV_VARS = [
+    "DATACONTRACT_REDSHIFT_AUTHENTICATION",
+    "DATACONTRACT_REDSHIFT_USERNAME",
+    "DATACONTRACT_REDSHIFT_PASSWORD",
+    "DATACONTRACT_REDSHIFT_SSLMODE",
+    "DATACONTRACT_S3_REGION",
+]
+
+
+@pytest.fixture
+def env(monkeypatch):
+    for name in REDSHIFT_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    return monkeypatch
+
+
+@pytest.fixture
+def captured_connect(monkeypatch):
+    calls = {}
+
+    def fake_connect(**kwargs):
+        calls.update(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr(ibis.postgres, "connect", fake_connect)
+    return calls
+
+
+def _server():
+    return Server(type="redshift", host=HOST, port=5439, database="dev", schema="analytics")
+
+
+def test_password_authentication(env, captured_connect):
+    env.setenv("DATACONTRACT_REDSHIFT_USERNAME", "awsuser")
+    env.setenv("DATACONTRACT_REDSHIFT_PASSWORD", "mysecret")
+
+    connect_ibis(Run.create_run(), None, _server())
+
+    assert captured_connect["user"] == "awsuser"
+    assert captured_connect["password"] == "mysecret"
+    assert captured_connect["host"] == HOST
+    assert captured_connect["port"] == 5439
+    assert captured_connect["database"] == "dev"
+    assert captured_connect["schema"] == "analytics"
+    assert "sslmode" not in captured_connect
+    # Redshift reports client_encoding as "UNICODE", which psycopg can't map.
+    assert captured_connect["client_encoding"] == "utf8"
+
+
+def test_iam_authentication_uses_temporary_credentials(env, captured_connect):
+    env.setenv("DATACONTRACT_REDSHIFT_AUTHENTICATION", "iam")
+    client = MagicMock()
+    client.get_credentials.return_value = {"dbUser": "IAM:alice", "dbPassword": "temporary"}
+
+    with patch("boto3.client", return_value=client):
+        connect_ibis(Run.create_run(), None, _server())
+
+    assert captured_connect["user"] == "IAM:alice"
+    assert captured_connect["password"] == "temporary"
+    assert captured_connect["sslmode"] == "require"
+    client.get_credentials.assert_called_once_with(workgroupName="my-workgroup", dbName="dev")

--- a/tests/test_import_redshift.py
+++ b/tests/test_import_redshift.py
@@ -1,0 +1,258 @@
+"""Tests for the Redshift importer.
+
+No Redshift is reachable in CI (and the ``SVV_*`` catalog views have no Postgres
+equivalent, so a testcontainer cannot stand in either), so the psycopg
+connection is faked and fed rows in the shape Redshift returns.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from open_data_contract_standard.model import OpenDataContractStandard
+from typer.testing import CliRunner
+
+from datacontract.cli import app
+from datacontract.data_contract import DataContract
+from datacontract.imports.redshift_importer import redshift_connection
+from datacontract.model.exceptions import DataContractException
+from datacontract.model.run import ResultEnum
+
+HOST = "my-workgroup.123456789012.us-east-1.redshift-serverless.amazonaws.com"
+
+TABLE_COLUMNS = ["table_name", "table_type", "remarks"]
+# table_type values as SVV_TABLES actually reports them on Redshift.
+TABLE_ROWS = [
+    ("orders", "BASE TABLE", "All orders"),
+    ("order_view", "VIEW", None),
+]
+
+COLUMN_COLUMNS = [
+    "table_name",
+    "column_name",
+    "data_type",
+    "character_maximum_length",
+    "numeric_precision",
+    "numeric_scale",
+    "is_nullable",
+    "remarks",
+]
+COLUMN_ROWS = [
+    ("order_view", "order_id", "character varying", 36, None, None, "YES", None),
+    ("orders", "order_id", "character varying", 36, None, None, "NO", "The order id"),
+    ("orders", "order_total", "numeric", None, 10, 2, "YES", None),
+    ("orders", "line_count", "integer", None, 32, 0, "YES", None),
+    ("orders", "ordered_at", "timestamp without time zone", None, None, None, "YES", None),
+    ("orders", "payload", "super", None, None, None, "YES", None),
+]
+
+PRIMARY_KEY_COLUMNS = ["table_name", "column_name", "ordinal_position"]
+PRIMARY_KEY_ROWS = [("orders", "order_id", 1)]
+
+
+class FakeCursor:
+    """Serves the catalog rows matching whichever query the importer runs."""
+
+    def __init__(self, failing_query: str = None):
+        self.failing_query = failing_query
+        self.description = None
+        self._rows = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def execute(self, query, params=None):
+        if self.failing_query and self.failing_query in query:
+            raise RuntimeError("permission denied")
+        if "svv_tables" in query:
+            columns, self._rows = TABLE_COLUMNS, TABLE_ROWS
+        elif "svv_columns" in query:
+            columns, self._rows = COLUMN_COLUMNS, COLUMN_ROWS
+        else:
+            columns, self._rows = PRIMARY_KEY_COLUMNS, PRIMARY_KEY_ROWS
+        self.description = [(column,) for column in columns]
+
+    def fetchall(self):
+        return self._rows
+
+
+class FakeConnection:
+    def __init__(self, failing_query: str = None):
+        self.failing_query = failing_query
+        self.rollbacks = 0
+        self.closed = False
+
+    def cursor(self):
+        return FakeCursor(self.failing_query)
+
+    def rollback(self):
+        self.rollbacks += 1
+
+    def close(self):
+        self.closed = True
+
+
+def _import(connection=None, **kwargs):
+    connection = connection or FakeConnection()
+    with patch("datacontract.imports.redshift_importer.redshift_connection", return_value=connection):
+        return DataContract.import_from_source("redshift", HOST, **kwargs)
+
+
+def test_import_redshift():
+    result = _import(database="dev", schema="analytics", redshift_table=["orders"])
+
+    expected = f"""
+apiVersion: v3.1.0
+kind: DataContract
+id: my-data-contract
+name: My Data Contract
+version: 1.0.0
+status: draft
+servers:
+  - server: redshift
+    type: redshift
+    host: {HOST}
+    port: 5439
+    database: dev
+    schema: analytics
+schema:
+  - name: orders
+    physicalName: orders
+    logicalType: object
+    physicalType: table
+    description: All orders
+    properties:
+      - name: order_id
+        logicalType: string
+        logicalTypeOptions:
+          maxLength: 36
+        physicalType: character varying(36)
+        description: The order id
+        required: true
+        primaryKey: true
+        primaryKeyPosition: 1
+      - name: order_total
+        logicalType: number
+        physicalType: numeric(10,2)
+        customProperties:
+          - property: precision
+            value: 10
+          - property: scale
+            value: 2
+      - name: line_count
+        logicalType: integer
+        physicalType: integer
+      - name: ordered_at
+        logicalType: timestamp
+        physicalType: timestamp without time zone
+      - name: payload
+        physicalType: super
+    """
+
+    print("Result", result.to_yaml())
+    assert yaml.safe_load(result.to_yaml()) == yaml.safe_load(expected)
+
+
+def test_import_redshift_produces_a_valid_contract():
+    result = _import(database="dev", schema="analytics")
+
+    run = DataContract(data_contract_str=result.to_yaml()).lint()
+
+    assert run.result == ResultEnum.passed
+
+
+def test_import_redshift_imports_all_tables_by_default():
+    result = _import(database="dev", schema="analytics")
+
+    assert [schema.name for schema in result.schema_] == ["order_view", "orders"]
+    assert result.schema_[0].physicalType == "view"
+
+
+def test_import_redshift_closes_the_connection():
+    connection = FakeConnection()
+    _import(connection, database="dev", schema="analytics")
+
+    assert connection.closed
+
+
+def test_import_redshift_without_primary_key_access():
+    """A user without access to information_schema constraints still gets a contract."""
+    connection = FakeConnection(failing_query="table_constraints")
+    result = _import(connection, database="dev", schema="analytics", redshift_table=["orders"])
+
+    assert result.schema_[0].properties[0].primaryKey is None
+    assert connection.rollbacks == 1
+
+
+def test_import_redshift_fails_on_an_unreadable_catalog():
+    with pytest.raises(DataContractException) as exc_info:
+        _import(FakeConnection(failing_query="svv_columns"), database="dev", schema="analytics")
+
+    assert "Could not read the Redshift catalog" in exc_info.value.reason
+
+
+def test_import_redshift_fails_on_an_unknown_table():
+    with pytest.raises(DataContractException) as exc_info:
+        _import(database="dev", schema="analytics", redshift_table=["does_not_exist"])
+
+    assert "No tables found" in exc_info.value.reason
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_reason",
+    [
+        ({"database": None, "schema": "analytics"}, "database is required"),
+        ({"database": "dev", "schema": None}, "schema is required"),
+    ],
+)
+def test_import_redshift_requires_database_and_schema(kwargs, expected_reason):
+    with pytest.raises(DataContractException) as exc_info:
+        _import(**kwargs)
+
+    assert expected_reason in exc_info.value.reason
+
+
+def test_import_redshift_requires_host():
+    with pytest.raises(DataContractException) as exc_info:
+        DataContract.import_from_source("redshift", None, database="dev", schema="analytics")
+
+    assert "endpoint host is required" in exc_info.value.reason
+
+
+def test_connection_uses_the_shared_login_resolution(monkeypatch):
+    """The import authenticates exactly like the test path — IAM included."""
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_AUTHENTICATION", "iam")
+    aws = MagicMock()
+    aws.get_credentials.return_value = {"dbUser": "IAM:alice", "dbPassword": "temporary"}
+
+    with patch("boto3.client", return_value=aws), patch("psycopg.connect") as connect:
+        redshift_connection(host=HOST, port=5439, database="dev")
+
+    assert connect.call_args.kwargs == {
+        "host": HOST,
+        "port": 5439,
+        "dbname": "dev",
+        "user": "IAM:alice",
+        "password": "temporary",
+        "sslmode": "require",
+        # Redshift reports client_encoding as "UNICODE", which psycopg can't map.
+        "client_encoding": "utf8",
+    }
+
+
+def test_cli_schema_option_is_not_rewritten_to_json_schema():
+    """`--schema` means the database schema here, not the v0.12.0 `--json-schema`."""
+    with patch("datacontract.imports.redshift_importer.import_redshift_from_connector") as mock_import:
+        mock_import.return_value = OpenDataContractStandard(id="test", kind="DataContract", apiVersion="v3.1.0")
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["import", "redshift", "--source", HOST, "--database", "dev", "--schema", "analytics"],
+        )
+
+    assert result.exit_code == 0
+    assert mock_import.call_args.kwargs["schema"] == "analytics"
+    assert "--json-schema" not in result.output

--- a/tests/test_redshift_credentials.py
+++ b/tests/test_redshift_credentials.py
@@ -1,0 +1,196 @@
+"""Tests for resolving the Redshift login (static password or IAM)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from datacontract.engines.ibis.connections.redshift_credentials import resolve_redshift_login
+from datacontract.model.exceptions import DataContractException
+
+SERVERLESS_HOST = "my-workgroup.123456789012.us-east-1.redshift-serverless.amazonaws.com"
+PROVISIONED_HOST = "my-cluster.123456789012.eu-central-1.redshift.amazonaws.com"
+
+REDSHIFT_ENV = [
+    "DATACONTRACT_REDSHIFT_AUTHENTICATION",
+    "DATACONTRACT_REDSHIFT_USERNAME",
+    "DATACONTRACT_REDSHIFT_PASSWORD",
+    "DATACONTRACT_REDSHIFT_SSLMODE",
+    "DATACONTRACT_REDSHIFT_DB_USER",
+    "DATACONTRACT_REDSHIFT_DB_GROUPS",
+    "DATACONTRACT_REDSHIFT_AUTO_CREATE",
+    "DATACONTRACT_REDSHIFT_DURATION_SECONDS",
+    "DATACONTRACT_REDSHIFT_REGION",
+    "DATACONTRACT_REDSHIFT_WORKGROUP",
+    "DATACONTRACT_REDSHIFT_CLUSTER_IDENTIFIER",
+    "DATACONTRACT_S3_REGION",
+    "DATACONTRACT_S3_ACCESS_KEY_ID",
+    "DATACONTRACT_S3_SECRET_ACCESS_KEY",
+    "DATACONTRACT_S3_SESSION_TOKEN",
+]
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    """A developer's own AWS/Redshift variables must not leak into these tests."""
+    for name in REDSHIFT_ENV:
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture
+def boto3_client():
+    client = MagicMock()
+    client.get_credentials.return_value = {"dbUser": "IAM:alice", "dbPassword": "serverless-secret"}
+    client.get_cluster_credentials.return_value = {"DbUser": "IAMA:alice", "DbPassword": "legacy-secret"}
+    client.get_cluster_credentials_with_iam.return_value = {"DbUser": "IAM:alice", "DbPassword": "iam-secret"}
+    with patch("boto3.client", return_value=client) as factory:
+        client.factory = factory
+        yield client
+
+
+def test_password_authentication_is_the_default(monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_USERNAME", "awsuser")
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_PASSWORD", "mysecret")
+
+    login = resolve_redshift_login(SERVERLESS_HOST, "dev")
+
+    assert (login.user, login.password) == ("awsuser", "mysecret")
+    # Unset by default, so an existing setup keeps psycopg's own sslmode handling.
+    assert login.sslmode is None
+
+
+def test_password_authentication_requires_a_username():
+    with pytest.raises(DataContractException) as exc_info:
+        resolve_redshift_login(SERVERLESS_HOST, "dev")
+
+    assert "DATACONTRACT_REDSHIFT_USERNAME" in exc_info.value.reason
+
+
+def test_iam_serverless_derives_workgroup_and_region_from_the_host(monkeypatch, boto3_client):
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_AUTHENTICATION", "iam")
+
+    login = resolve_redshift_login(SERVERLESS_HOST, "dev")
+
+    assert (login.user, login.password) == ("IAM:alice", "serverless-secret")
+    assert login.sslmode == "require"
+    assert boto3_client.factory.call_args.args[0] == "redshift-serverless"
+    assert boto3_client.factory.call_args.kwargs["region_name"] == "us-east-1"
+    boto3_client.get_credentials.assert_called_once_with(workgroupName="my-workgroup", dbName="dev")
+
+
+def test_iam_provisioned_derives_the_db_user_from_the_caller_identity(monkeypatch, boto3_client):
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_AUTHENTICATION", "iam")
+
+    login = resolve_redshift_login(PROVISIONED_HOST, "dev")
+
+    assert (login.user, login.password) == ("IAM:alice", "iam-secret")
+    assert boto3_client.factory.call_args.args[0] == "redshift"
+    assert boto3_client.factory.call_args.kwargs["region_name"] == "eu-central-1"
+    boto3_client.get_cluster_credentials_with_iam.assert_called_once_with(ClusterIdentifier="my-cluster", DbName="dev")
+    boto3_client.get_cluster_credentials.assert_not_called()
+
+
+def test_iam_provisioned_uses_the_legacy_api_when_a_db_user_is_configured(monkeypatch, boto3_client):
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_AUTHENTICATION", "iam")
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_USERNAME", "analyst")
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_AUTO_CREATE", "true")
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_DB_GROUPS", "readers, writers")
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_DURATION_SECONDS", "900")
+
+    login = resolve_redshift_login(PROVISIONED_HOST, "dev")
+
+    assert (login.user, login.password) == ("IAMA:alice", "legacy-secret")
+    boto3_client.get_cluster_credentials.assert_called_once_with(
+        DbUser="analyst",
+        ClusterIdentifier="my-cluster",
+        DbName="dev",
+        DurationSeconds=900,
+        AutoCreate=True,
+        DbGroups=["readers", "writers"],
+    )
+
+
+def test_iam_reuses_the_athena_s3_credentials_and_region(monkeypatch, boto3_client):
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_AUTHENTICATION", "iam")
+    monkeypatch.setenv("DATACONTRACT_S3_REGION", "us-west-2")
+    monkeypatch.setenv("DATACONTRACT_S3_ACCESS_KEY_ID", "AKIA...")
+    monkeypatch.setenv("DATACONTRACT_S3_SECRET_ACCESS_KEY", "secret")
+    monkeypatch.setenv("DATACONTRACT_S3_SESSION_TOKEN", "token")
+
+    resolve_redshift_login(SERVERLESS_HOST, "dev")
+
+    kwargs = boto3_client.factory.call_args.kwargs
+    assert kwargs["region_name"] == "us-west-2"
+    assert kwargs["aws_access_key_id"] == "AKIA..."
+    assert kwargs["aws_secret_access_key"] == "secret"
+    assert kwargs["aws_session_token"] == "token"
+
+
+def test_iam_falls_back_to_the_ambient_aws_chain(monkeypatch, boto3_client):
+    """Without explicit keys, boto3 resolves aws sso login / AWS_PROFILE / instance roles."""
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_AUTHENTICATION", "iam")
+
+    resolve_redshift_login(SERVERLESS_HOST, "dev")
+
+    kwargs = boto3_client.factory.call_args.kwargs
+    assert kwargs["aws_access_key_id"] is None
+    assert kwargs["aws_secret_access_key"] is None
+    assert kwargs["aws_session_token"] is None
+
+
+def test_iam_overrides_win_over_the_host(monkeypatch, boto3_client):
+    """Custom domains and VPC endpoints don't follow the standard endpoint shape."""
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_AUTHENTICATION", "iam")
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_WORKGROUP", "other-workgroup")
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_REGION", "ap-south-1")
+
+    resolve_redshift_login("redshift.internal.example.com", "dev")
+
+    assert boto3_client.factory.call_args.kwargs["region_name"] == "ap-south-1"
+    boto3_client.get_credentials.assert_called_once_with(workgroupName="other-workgroup", dbName="dev")
+
+
+def test_iam_reports_an_unrecognizable_endpoint(monkeypatch, boto3_client):
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_AUTHENTICATION", "iam")
+
+    with pytest.raises(DataContractException) as exc_info:
+        resolve_redshift_login("redshift.internal.example.com", "dev")
+
+    assert "DATACONTRACT_REDSHIFT_WORKGROUP" in exc_info.value.reason
+    assert "DATACONTRACT_REDSHIFT_CLUSTER_IDENTIFIER" in exc_info.value.reason
+
+
+def test_iam_sslmode_can_be_overridden(monkeypatch, boto3_client):
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_AUTHENTICATION", "iam")
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_SSLMODE", "verify-full")
+
+    assert resolve_redshift_login(SERVERLESS_HOST, "dev").sslmode == "verify-full"
+
+
+def test_iam_wraps_an_aws_failure_with_the_api_name(monkeypatch, boto3_client):
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_AUTHENTICATION", "iam")
+    boto3_client.get_credentials.side_effect = RuntimeError("AccessDeniedException")
+
+    with pytest.raises(DataContractException) as exc_info:
+        resolve_redshift_login(SERVERLESS_HOST, "dev")
+
+    assert "redshift-serverless:GetCredentials" in exc_info.value.reason
+    assert "AccessDeniedException" in exc_info.value.reason
+
+
+def test_invalid_duration_is_reported(monkeypatch, boto3_client):
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_AUTHENTICATION", "iam")
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_DURATION_SECONDS", "an hour")
+
+    with pytest.raises(DataContractException) as exc_info:
+        resolve_redshift_login(SERVERLESS_HOST, "dev")
+
+    assert "DATACONTRACT_REDSHIFT_DURATION_SECONDS" in exc_info.value.reason
+
+
+def test_unsupported_authentication_mode(monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_AUTHENTICATION", "kerberos")
+
+    with pytest.raises(DataContractException) as exc_info:
+        resolve_redshift_login(SERVERLESS_HOST, "dev")
+
+    assert "Supported values are: password, iam" in exc_info.value.reason


### PR DESCRIPTION
## Summary

Brings Redshift up to the same experience as BigQuery and Snowflake: create a contract from a live schema, then test it — no manual DDL export, no hand-filled `servers` block.

**`datacontract import redshift`** reads table and column metadata from `SVV_TABLES` / `SVV_COLUMNS`, which cover local tables, views and external (Spectrum) tables on both provisioned clusters and Serverless workgroups. It imports column types with length and precision, nullability, comments and primary keys, and writes a ready-to-test `servers` block.

Physical types are reconstructed with the same helper the test path uses to read them back from `information_schema`, so an imported contract passes `datacontract test` on the first run rather than tripping over `varchar` vs `character varying(36)`.

**IAM authentication.** `test` and `import` now resolve their login through one shared helper, so they cannot drift apart. With `DATACONTRACT_REDSHIFT_AUTHENTICATION=iam` the CLI requests temporary database credentials from AWS — `redshift-serverless:GetCredentials`, or `redshift:GetClusterCredentialsWithIAM` / `GetClusterCredentials` for provisioned clusters — instead of using a database password. The workgroup or cluster identifier and the region are derived from the endpoint host already in the `servers` block, so a standard endpoint needs no extra configuration; custom domains and VPC endpoints have overrides. AWS credentials come from the same variables Athena uses (`DATACONTRACT_S3_*`), falling back to the standard AWS chain (`aws sso login`, `AWS_PROFILE`, instance roles, OIDC). `password` remains the default, so existing setups are unaffected. No new dependency — boto3 is already a core dependency.

### Fixes found against a live cluster

- Redshift identifies as "PostgreSQL 8.0.2" and reports `client_encoding` under the 8.0-era name `UNICODE`, which psycopg's codec table doesn't know — every query failed with `codec not available in Python: 'UNICODE'`. Now the encoding is requested at connect time. This affected the existing `test` path too; the Postgres testcontainer reports `UTF8`, so it could not surface there.
- `SVV_TABLES` reports `BASE TABLE`, now normalized to `table` to match the SQL and Snowflake imports.
- Rich markup ate bracketed text in error messages, turning a driver's `pip install "botocore[crt]"` hint into `pip install "botocore"`.

`--schema` previously survived the v0.12.0 `--json-schema` rewrite only for `import snowflake`, via a hardcoded check; that is now a list which `redshift` joins.

## Testing

Verified end to end against a live Redshift Serverless workgroup: `import` followed by `test` passes with no hand-editing, with every physical type (`character varying(36)`, `numeric(10,2)`, `timestamp without time zone`, `super`), comments and the primary key round-tripping, under both IAM and password authentication.

30 unit tests cover importer output, degraded paths (no primary-key access, unreadable catalog), login resolution for both modes and all three AWS APIs, endpoint parsing and overrides, and the connection kwargs on both paths. AWS and the driver are mocked, so nothing in CI needs a cluster.

## Notes

Documentation is updated: the connection guide now leads with IAM, and the reference page gains the auth tables, the API-selection matrix and the required IAM permissions.