### PR TITLE
Route users to the Redshift guide

### DIFF
--- a/docs/docs/connect/athena.md
+++ b/docs/docs/connect/athena.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 title: "Amazon Athena"
 description: "Create a data contract from your Athena tables and test the actual data against it."
 ---

--- a/docs/docs/connect/index.md
+++ b/docs/docs/connect/index.md
@@ -42,6 +42,10 @@ DATACONTRACT_POSTGRES_PASSWORD=postgres
     <img src="/img/icons/databricks.svg" alt="" />
     <span><span className="doc-card-title">Databricks</span><span className="doc-card-desc">Import a contract from Unity Catalog and test in 5 minutes</span></span>
   </a>
+  <a className="doc-card" href="/connect/redshift">
+    <img src="/img/icons/redshift.svg" alt="" />
+    <span><span className="doc-card-title">Amazon Redshift</span><span className="doc-card-desc">Import a contract from your tables and test in 5 minutes</span></span>
+  </a>
   <a className="doc-card" href="/connect/postgres">
     <img src="/img/icons/postgres.svg" alt="" />
     <span><span className="doc-card-title">Postgres</span><span className="doc-card-desc">Postgres and Postgres-compatible (e.g. RisingWave)</span></span>
@@ -57,10 +61,6 @@ DATACONTRACT_POSTGRES_PASSWORD=postgres
   <a className="doc-card" href="/connect/athena">
     <img src="/img/icons/athena.svg" alt="" />
     <span><span className="doc-card-title">Amazon Athena</span><span className="doc-card-desc">Athena over data in S3</span></span>
-  </a>
-  <a className="doc-card" href="/connect/redshift">
-    <img src="/img/icons/redshift.svg" alt="" />
-    <span><span className="doc-card-title">Amazon Redshift</span><span className="doc-card-desc">Import a contract from your tables and test in 5 minutes</span></span>
   </a>
   <a className="doc-card" href="/connect/impala">
     <img src="/img/icons/impala.svg" alt="" />

--- a/docs/docs/connect/local.md
+++ b/docs/docs/connect/local.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 title: "Local files"
 description: "Test local files in Parquet, JSON, CSV, or Delta format — the fastest way to try the CLI, no credentials needed."
 ---

--- a/docs/docs/connect/postgres.md
+++ b/docs/docs/connect/postgres.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 title: "Postgres"
 description: "Create a data contract from your Postgres tables and test the actual data against it — in about 5 minutes."
 ---

--- a/docs/docs/connect/redshift.md
+++ b/docs/docs/connect/redshift.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 4
 title: "Amazon Redshift"
 description: "Create a data contract from your Redshift tables and test the actual data against it — in about 5 minutes."
 ---

--- a/docs/docs/connect/s3.md
+++ b/docs/docs/connect/s3.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 title: "Amazon S3"
 description: "Create a data contract from files in S3 and test them against it — in about 5 minutes."
 ---

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -53,7 +53,7 @@ When you run `datacontract test`, the CLI connects to a data source and runs sch
 ## Next steps
 
 - New here? Start with the **[Quickstart](./quickstart.md)**.
-- Test your own warehouse in 5 minutes: **[Snowflake](./connect/snowflake.md)**, **[BigQuery](./connect/bigquery.md)**, **[Databricks](./connect/databricks.md)**, or **[any other source](./connect/index.md)**.
+- Test your own warehouse in 5 minutes: **[Snowflake](./connect/snowflake.md)**, **[BigQuery](./connect/bigquery.md)**, **[Databricks](./connect/databricks.md)**, **[Amazon Redshift](./connect/redshift.md)**, or **[any other source](./connect/index.md)**.
 - Learn the underlying format in **[Open Data Contract Standard](./open-data-contract-standard.md)**.
 - Author contracts visually with the **[Data Contract Editor](./editor.md)**.
 - Run checks against real data with **[Testing](./testing.md)**, then keep them running with **[Scheduling and CI/CD](./ci-cd.md)**.

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -69,6 +69,7 @@ Follow the copy-paste guide for your data source, including credentials setup an
 - **[Snowflake](./connect/snowflake.md)** — import from your tables, test in 5 minutes
 - **[Google BigQuery](./connect/bigquery.md)** — import from your tables, test in 5 minutes
 - **[Databricks](./connect/databricks.md)** — import from Unity Catalog, test in 5 minutes
+- **[Amazon Redshift](./connect/redshift.md)** — import from your tables, test in 5 minutes
 - **[Postgres](./connect/postgres.md)**, **[Amazon S3](./connect/s3.md)**, and [15+ other sources](./connect/index.md)
 - **[Local files](./connect/local.md)** — no warehouse or credentials needed, works offline
 


### PR DESCRIPTION
## Summary

Redshift gained a live-table import and a full connection guide in #1412, putting it in the same class as Snowflake, BigQuery, and Databricks. The pages that route people to those guides were never updated, so someone arriving with a Redshift warehouse was funnelled into the generic "15+ other sources" list instead of the guide that now does exactly what they want.

- **Quickstart** — Redshift joins the "import from your tables, test in 5 minutes" list.
- **Intro** — added to "Test your own warehouse in 5 minutes".
- **Connect index** — its card said "Import a contract from your tables and test in 5 minutes" (identical to the first three cards) but sat in position 7, behind Local files and Athena. Moved next to the other import-capable warehouses, with the sidebar order following the same grouping.

The connection, reference, and import pages themselves were already aligned with the BigQuery set; this is only about discovery.

## Testing

`npm run build` passes with no broken links or anchors.