### PR TITLE
Stop promising a release that never happened

### DIFF
--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -82,7 +82,7 @@ class OrderedCommandsWithMigrationHints(OrderedCommands):
                 flag, _, value = arg.partition("=")
                 if flag == "--schema" and not takes_database_schema:
                     typer.secho(
-                        "Warning: --schema was replaced with --json-schema in v0.12.0 and will be removed in v0.13.0.",
+                        "Warning: --schema was replaced with --json-schema in v0.12.0 and will be removed in a future release.",
                         err=True,
                         fg=typer.colors.YELLOW,
                     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -140,3 +140,11 @@ def test_error_message_keeps_bracketed_text(monkeypatch, capsys):
         cli.main()
 
     assert "botocore[crt]" in capsys.readouterr().out
+
+
+def test_schema_alias_warning_does_not_cite_an_unreleased_version():
+    """The alias predates the switch to 1.x, so it must not promise removal in v0.13.0."""
+    result = runner.invoke(app, ["lint", "--schema", "some-schema.json", "unknown.yaml"])
+
+    assert "--json-schema" in result.output
+    assert "v0.13.0" not in result.output


### PR DESCRIPTION
## Summary

Passing `--schema` to `lint`, `test`, `ci`, `publish`, or `catalog` warns:

> Warning: --schema was replaced with --json-schema in v0.12.0 and will be removed in v0.13.0.

The project moved to 1.x after v0.12.1 and is now at **1.0.14**, so v0.13.0 never shipped and the deadline the message names cannot arrive. The alias now says "in a future release" instead, which is both true and doesn't commit to a version number that will drift again.

Whether to actually drop the alias is a separate decision — this only stops the message from being wrong.

## Testing

Regression test asserting the warning still points at `--json-schema` and no longer cites v0.13.0. Full suite: 1127 passed, 19 skipped (the 6 PySpark errors are the pre-existing `JAVA_HOME` requirement).

## Notes / out of scope

While checking the second half of this — that `import redshift` and `import snowflake` are the only import formats without `--json-schema` — it turned out the flag does nothing on **any** import subcommand. It is declared, passed into `import_args`, and never read: the only consumers of that argument are the Snowflake and Redshift importers, which use it as the *database* schema. Verified directly:

```
datacontract import csv --source examples/imports/csv/orders.csv --json-schema /nonexistent/does-not-exist.json
# succeeds and prints the contract
```

So adding it to the two live-connection importers would only spread a no-op. The real options are to remove `--json-schema` from the import subcommands, or to wire it up so the generated contract is validated against the given schema. Both change public CLI behavior, so neither is included here.