### PR TITLE
Add Postgres import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `datacontract import postgres` creates a data contract from a live Postgres schema, including a ready-to-test `servers` block
 - `datacontract import redshift` creates a data contract from an Amazon Redshift schema, including a ready-to-test `servers` block
 - Redshift supports IAM authentication with `DATACONTRACT_REDSHIFT_AUTHENTICATION=iam`, using temporary credentials from your AWS session instead of a database password
 - `datacontract import bigquery` now generates a `servers` block, so `datacontract test` works right after the import

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -50,7 +50,7 @@ class OrderedCommandsWithMigrationHints(OrderedCommands):
 
     # Import formats where `--schema` still means the database schema, so it must
     # not be rewritten to the v0.12.0 `--json-schema`.
-    DATABASE_SCHEMA_IMPORTS = {"snowflake", "redshift"}
+    DATABASE_SCHEMA_IMPORTS = {"snowflake", "redshift", "postgres"}
 
     RENAMED_FLAGS = {
         "--format": None,

--- a/datacontract/command_import.py
+++ b/datacontract/command_import.py
@@ -505,3 +505,38 @@ def import_redshift(
         id=id,
     )
     _write_result(result, output)
+
+
+@import_app.command(
+    name="postgres",
+    epilog="Example: datacontract import postgres --source localhost --database postgres --schema public --output datacontract.yaml",
+)
+def import_postgres(
+    source: Annotated[Optional[str], typer.Option(help="The host of the Postgres server.")] = None,
+    port: Annotated[Optional[int], typer.Option(help="The Postgres port (default 5432).")] = None,
+    database: database_option = None,
+    schema: Annotated[
+        Optional[str], typer.Option("--schema", help="The Postgres schema name (default public).")
+    ] = None,
+    table: Annotated[
+        Optional[List[str]],
+        typer.Option(help="Name of a table to import (repeat for multiple tables, omit for all tables in the schema)."),
+    ] = None,
+    output: output_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from a Postgres schema."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(
+        format="postgres",
+        source=source,
+        port=port,
+        database=database,
+        schema=schema,
+        postgres_table=table,
+        owner=owner,
+        id=id,
+    )
+    _write_result(result, output)

--- a/datacontract/imports/importer.py
+++ b/datacontract/imports/importer.py
@@ -41,6 +41,7 @@ class ImportFormat(str, Enum):
     powerbi = "powerbi"
     snowflake = "snowflake"
     redshift = "redshift"
+    postgres = "postgres"
 
     @classmethod
     def get_supported_formats(cls):

--- a/datacontract/imports/importer_factory.py
+++ b/datacontract/imports/importer_factory.py
@@ -135,6 +135,11 @@ importer_factory.register_lazy_importer(
     class_name="RedshiftImporter",
 )
 importer_factory.register_lazy_importer(
+    name=ImportFormat.postgres,
+    module_path="datacontract.imports.postgres_importer",
+    class_name="PostgresImporter",
+)
+importer_factory.register_lazy_importer(
     name=ImportFormat.json,
     module_path="datacontract.imports.json_importer",
     class_name="JsonImporter",

--- a/datacontract/imports/postgres_importer.py
+++ b/datacontract/imports/postgres_importer.py
@@ -1,0 +1,245 @@
+"""Create a data contract from a live PostgreSQL schema.
+
+Reads table and column metadata from ``information_schema``, the same catalog
+``datacontract test`` reads back to verify physical types, so an imported
+contract passes on the first run without hand-editing. Comments come from
+``pg_description`` via ``obj_description`` / ``col_description``, which
+``information_schema`` does not expose.
+
+The connection is opened with psycopg (shipped by the ``postgres`` extra)
+rather than ibis: the import only reads catalog rows, so a full ibis backend
+with its own introspection quirks would buy nothing.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from open_data_contract_standard.model import OpenDataContractStandard, SchemaObject, SchemaProperty
+
+from datacontract.engines.ibis.native_type import reconstruct_native_type
+from datacontract.imports.importer import Importer
+from datacontract.imports.odcs_helper import create_odcs, create_property, create_schema_object, create_server
+from datacontract.imports.sql_importer import map_type_from_sql
+from datacontract.model.exceptions import DataContractException, require_env
+
+DEFAULT_PORT = 5432
+DEFAULT_SCHEMA = "public"
+
+# to_regclass() yields NULL instead of raising for objects the user cannot see,
+# so a missing comment never fails the whole import.
+_TABLES_QUERY = """
+    SELECT table_name,
+           lower(replace(table_type, 'BASE ', '')) AS table_type,
+           obj_description(
+               to_regclass(quote_ident(table_schema) || '.' || quote_ident(table_name))
+           ) AS remarks
+    FROM information_schema.tables
+    WHERE table_schema = %s
+"""
+
+# Postgres reports the type in parts (base type plus length / precision / scale).
+# reconstruct_native_type() reassembles them exactly as the test path reads them
+# back from information_schema, so an imported physicalType matches on the first
+# `datacontract test`.
+_COLUMNS_QUERY = """
+    SELECT table_name,
+           column_name,
+           data_type,
+           character_maximum_length,
+           numeric_precision,
+           numeric_scale,
+           is_nullable,
+           col_description(
+               to_regclass(quote_ident(table_schema) || '.' || quote_ident(table_name)),
+               ordinal_position
+           ) AS remarks
+    FROM information_schema.columns
+    WHERE table_schema = %s
+    ORDER BY table_name, ordinal_position
+"""
+
+_PRIMARY_KEYS_QUERY = """
+    SELECT kcu.table_name, kcu.column_name, kcu.ordinal_position
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name
+     AND tc.table_schema = kcu.table_schema
+    WHERE tc.constraint_type = 'PRIMARY KEY'
+      AND tc.table_schema = %s
+    ORDER BY kcu.table_name, kcu.ordinal_position
+"""
+
+
+class PostgresImporter(Importer):
+    def import_source(self, source: str, import_args: dict) -> OpenDataContractStandard:
+        if source is None:
+            raise DataContractException(
+                type="source",
+                name="postgres import source",
+                reason="The host is required for the postgres import, e.g. --source localhost",
+                engine="datacontract",
+            )
+        return import_postgres_from_connector(
+            host=source,
+            port=import_args.get("port"),
+            database=import_args.get("database"),
+            schema=import_args.get("schema"),
+            tables=import_args.get("postgres_table"),
+        )
+
+
+def import_postgres_from_connector(
+    host: str,
+    database: Optional[str],
+    schema: Optional[str] = None,
+    port: Optional[int] = None,
+    tables: Optional[List[str]] = None,
+) -> OpenDataContractStandard:
+    if not database:
+        raise DataContractException(
+            type="source",
+            name="postgres import database",
+            reason="The database is required for the postgres import, e.g. --database postgres",
+            engine="datacontract",
+        )
+
+    port = int(port) if port else DEFAULT_PORT
+    schema = schema or DEFAULT_SCHEMA
+    connection = postgres_connection(host=host, port=port, database=database)
+    try:
+        table_rows = _fetch(connection, _TABLES_QUERY, (schema,))
+        column_rows = _fetch(connection, _COLUMNS_QUERY, (schema,))
+        # A user without access to information_schema constraints still gets a
+        # usable contract, just without primary keys.
+        primary_key_rows = _fetch(connection, _PRIMARY_KEYS_QUERY, (schema,), optional=True)
+    finally:
+        connection.close()
+
+    selected = _select_tables(table_rows, tables)
+    if not selected:
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="no tables found",
+            reason=f"No tables found in schema '{schema}' of database '{database}'.",
+            engine="datacontract",
+        )
+
+    odcs = create_odcs()
+    odcs.servers = [
+        create_server(
+            name="postgres",
+            server_type="postgres",
+            host=host,
+            port=port,
+            database=database,
+            schema=schema,
+        )
+    ]
+    odcs.schema_ = [
+        _create_schema(table, column_rows, primary_key_rows)
+        for table in sorted(selected, key=lambda row: row["table_name"].lower())
+    ]
+    return odcs
+
+
+def postgres_connection(host: str, port: int, database: str):
+    """Open a psycopg connection using the same DATACONTRACT_POSTGRES_* env vars as `datacontract test`."""
+    try:
+        import psycopg
+    except ImportError as e:
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="postgres extra missing",
+            reason="Install the extra datacontract-cli[postgres] to use postgres",
+            engine="datacontract",
+            original_exception=e,
+        )
+
+    return psycopg.connect(
+        host=host,
+        port=port,
+        dbname=database,
+        user=require_env("DATACONTRACT_POSTGRES_USERNAME", server_type="postgres"),
+        password=require_env("DATACONTRACT_POSTGRES_PASSWORD", server_type="postgres"),
+    )
+
+
+def _fetch(connection, query: str, params: tuple, optional: bool = False) -> List[Dict[str, Any]]:
+    """Run a catalog query and return its rows as dicts keyed by column name."""
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(query, params)
+            columns = [description[0] for description in cursor.description]
+            return [dict(zip(columns, row)) for row in cursor.fetchall()]
+    except Exception as e:
+        if optional:
+            # Roll back so the failed statement doesn't poison the transaction.
+            connection.rollback()
+            return []
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="postgres catalog query failed",
+            reason=f"Could not read the Postgres catalog: {e}",
+            engine="datacontract",
+            original_exception=e,
+        )
+
+
+def _select_tables(table_rows: List[Dict[str, Any]], tables: Optional[List[str]]) -> List[Dict[str, Any]]:
+    if not tables:
+        return table_rows
+    wanted = {table.lower() for table in tables}
+    return [row for row in table_rows if row["table_name"].lower() in wanted]
+
+
+def _create_schema(
+    table: Dict[str, Any],
+    column_rows: List[Dict[str, Any]],
+    primary_key_rows: List[Dict[str, Any]],
+) -> SchemaObject:
+    table_name = table["table_name"]
+    primary_keys = {
+        row["column_name"]: index + 1
+        for index, row in enumerate(row for row in primary_key_rows if row["table_name"] == table_name)
+    }
+    properties = [_create_property(row, primary_keys) for row in column_rows if row["table_name"] == table_name]
+    return create_schema_object(
+        name=table_name,
+        physical_type=table.get("table_type") or "table",
+        description=_clean(table.get("remarks")),
+        properties=properties or None,
+    )
+
+
+def _create_property(row: Dict[str, Any], primary_keys: Dict[str, int]) -> SchemaProperty:
+    name = row["column_name"]
+    max_length = row.get("character_maximum_length")
+    precision = row.get("numeric_precision")
+    scale = row.get("numeric_scale")
+    physical_type = reconstruct_native_type(row.get("data_type"), max_length, precision, scale)
+    logical_type, format = map_type_from_sql(physical_type)
+    # Precision/scale describe the declared type of decimals only; for integers
+    # Postgres still reports a numeric_precision, which is not part of the type.
+    is_decimal = physical_type is not None and physical_type.lower().startswith(("decimal", "numeric"))
+
+    return create_property(
+        name=name,
+        logical_type=logical_type,
+        physical_type=physical_type,
+        description=_clean(row.get("remarks")),
+        required=row.get("is_nullable") == "NO" or None,
+        primary_key=name in primary_keys or None,
+        primary_key_position=primary_keys.get(name),
+        max_length=max_length,
+        precision=precision if is_decimal else None,
+        scale=scale if is_decimal else None,
+        format=format,
+    )
+
+
+def _clean(value: Optional[str]) -> Optional[str]:
+    return value.strip() if value and value.strip() else None

--- a/docs/docs/commands/import.md
+++ b/docs/docs/commands/import.md
@@ -18,4 +18,4 @@ Run `datacontract import <format> --help` to see format-specific options.
 datacontract import sql --source ddl.sql --dialect postgres --output datacontract.yaml
 ```
 
-Available formats: `dbt`, `sql`, `avro`, `dbml`, `glue`, `bigquery`, `unity`, `jsonschema`, `json`, `odcs`, `parquet`, `csv`, `protobuf`, `spark`, `iceberg`, `excel`, `powerbi`, `snowflake`, `redshift`.
+Available formats: `dbt`, `sql`, `avro`, `dbml`, `glue`, `bigquery`, `unity`, `jsonschema`, `json`, `odcs`, `parquet`, `csv`, `protobuf`, `spark`, `iceberg`, `excel`, `powerbi`, `snowflake`, `redshift`, `postgres`.

--- a/docs/docs/imports/avro.md
+++ b/docs/docs/imports/avro.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 1
 title: "Import: Avro"
 description: "Create a data contract from an Avro schema file."
 ---

--- a/docs/docs/imports/bigquery.md
+++ b/docs/docs/imports/bigquery.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 2
 title: "Import: BigQuery"
 description: "Create a data contract from BigQuery, via an exported JSON file or the BigQuery API."
 ---

--- a/docs/docs/imports/csv.md
+++ b/docs/docs/imports/csv.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 3
 title: "Import: CSV"
 description: "Create a data contract by inferring a schema from a CSV file."
 ---

--- a/docs/docs/imports/dbt.md
+++ b/docs/docs/imports/dbt.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 5
 title: "Import: dbt"
 description: "Create a data contract from a dbt manifest file."
 ---

--- a/docs/docs/imports/excel.md
+++ b/docs/docs/imports/excel.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 6
 title: "Import: Excel"
 description: "Create a data contract from an ODCS Excel template."
 ---

--- a/docs/docs/imports/glue.md
+++ b/docs/docs/imports/glue.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 7
 title: "Import: AWS Glue"
 description: "Create a data contract from the AWS Glue Data Catalog."
 ---

--- a/docs/docs/imports/iceberg.md
+++ b/docs/docs/imports/iceberg.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 8
 title: "Import: Iceberg"
 description: "Create a data contract from an Apache Iceberg schema."
 ---

--- a/docs/docs/imports/index.md
+++ b/docs/docs/imports/index.md
@@ -28,41 +28,45 @@ Each import page shows a runnable example: a small source file under [`examples/
 ## Available importers
 
 <div className="card-grid">
-  <a className="doc-card" href="/imports/sql">
-    <img src="/img/icons/database.svg" alt="" />
-    <span><span className="doc-card-title">sql</span><span className="doc-card-desc">A SQL DDL file.</span></span>
-  </a>
-  <a className="doc-card" href="/imports/dbt">
-    <img src="/img/icons/dbt.svg" alt="" />
-    <span><span className="doc-card-title">dbt</span><span className="doc-card-desc">A dbt manifest file.</span></span>
-  </a>
   <a className="doc-card" href="/imports/avro">
     <img src="/img/icons/avro.svg" alt="" />
     <span><span className="doc-card-title">avro</span><span className="doc-card-desc">An Avro schema file.</span></span>
-  </a>
-  <a className="doc-card" href="/imports/dbml">
-    <img src="/img/icons/dbml.svg" alt="" />
-    <span><span className="doc-card-title">dbml</span><span className="doc-card-desc">A DBML file.</span></span>
-  </a>
-  <a className="doc-card" href="/imports/glue">
-    <img src="/img/icons/glue.svg" alt="" />
-    <span><span className="doc-card-title">glue</span><span className="doc-card-desc">AWS Glue Data Catalog.</span></span>
   </a>
   <a className="doc-card" href="/imports/bigquery">
     <img src="/img/icons/bigquery.svg" alt="" />
     <span><span className="doc-card-title">bigquery</span><span className="doc-card-desc">Google BigQuery (file or API).</span></span>
   </a>
-  <a className="doc-card" href="/imports/unity">
-    <img src="/img/icons/databricks.svg" alt="" />
-    <span><span className="doc-card-title">unity</span><span className="doc-card-desc">Databricks Unity Catalog.</span></span>
+  <a className="doc-card" href="/imports/csv">
+    <img src="/img/icons/custom.svg" alt="" />
+    <span><span className="doc-card-title">csv</span><span className="doc-card-desc">A CSV file.</span></span>
   </a>
-  <a className="doc-card" href="/imports/jsonschema">
-    <img src="/img/icons/jsonschema.svg" alt="" />
-    <span><span className="doc-card-title">jsonschema</span><span className="doc-card-desc">A JSON Schema file.</span></span>
+  <a className="doc-card" href="/imports/dbml">
+    <img src="/img/icons/dbml.svg" alt="" />
+    <span><span className="doc-card-title">dbml</span><span className="doc-card-desc">A DBML file.</span></span>
+  </a>
+  <a className="doc-card" href="/imports/dbt">
+    <img src="/img/icons/dbt.svg" alt="" />
+    <span><span className="doc-card-title">dbt</span><span className="doc-card-desc">A dbt manifest file.</span></span>
+  </a>
+  <a className="doc-card" href="/imports/excel">
+    <img src="/img/icons/excel.svg" alt="" />
+    <span><span className="doc-card-title">excel</span><span className="doc-card-desc">An ODCS Excel template.</span></span>
+  </a>
+  <a className="doc-card" href="/imports/glue">
+    <img src="/img/icons/glue.svg" alt="" />
+    <span><span className="doc-card-title">glue</span><span className="doc-card-desc">AWS Glue Data Catalog.</span></span>
+  </a>
+  <a className="doc-card" href="/imports/iceberg">
+    <img src="/img/icons/iceberg.svg" alt="" />
+    <span><span className="doc-card-title">iceberg</span><span className="doc-card-desc">An Iceberg schema.</span></span>
   </a>
   <a className="doc-card" href="/imports/json">
     <img src="/img/icons/json.svg" alt="" />
     <span><span className="doc-card-title">json</span><span className="doc-card-desc">A JSON data file.</span></span>
+  </a>
+  <a className="doc-card" href="/imports/jsonschema">
+    <img src="/img/icons/jsonschema.svg" alt="" />
+    <span><span className="doc-card-title">jsonschema</span><span className="doc-card-desc">A JSON Schema file.</span></span>
   </a>
   <a className="doc-card" href="/imports/odcs">
     <img src="/img/icons/odcs.svg" alt="" />
@@ -72,41 +76,37 @@ Each import page shows a runnable example: a small source file under [`examples/
     <img src="/img/icons/parquet.svg" alt="" />
     <span><span className="doc-card-title">parquet</span><span className="doc-card-desc">A Parquet file.</span></span>
   </a>
-  <a className="doc-card" href="/imports/csv">
-    <img src="/img/icons/custom.svg" alt="" />
-    <span><span className="doc-card-title">csv</span><span className="doc-card-desc">A CSV file.</span></span>
-  </a>
-  <a className="doc-card" href="/imports/protobuf">
-    <img src="/img/icons/custom.svg" alt="" />
-    <span><span className="doc-card-title">protobuf</span><span className="doc-card-desc">A Protobuf schema file.</span></span>
-  </a>
-  <a className="doc-card" href="/imports/spark">
-    <img src="/img/icons/spark.svg" alt="" />
-    <span><span className="doc-card-title">spark</span><span className="doc-card-desc">A Spark schema / DataFrame.</span></span>
-  </a>
-  <a className="doc-card" href="/imports/iceberg">
-    <img src="/img/icons/iceberg.svg" alt="" />
-    <span><span className="doc-card-title">iceberg</span><span className="doc-card-desc">An Iceberg schema.</span></span>
-  </a>
-  <a className="doc-card" href="/imports/excel">
-    <img src="/img/icons/excel.svg" alt="" />
-    <span><span className="doc-card-title">excel</span><span className="doc-card-desc">An ODCS Excel template.</span></span>
+  <a className="doc-card" href="/imports/postgres">
+    <img src="/img/icons/postgres.svg" alt="" />
+    <span><span className="doc-card-title">postgres</span><span className="doc-card-desc">A Postgres schema.</span></span>
   </a>
   <a className="doc-card" href="/imports/powerbi">
     <img src="/img/icons/powerbi.svg" alt="" />
     <span><span className="doc-card-title">powerbi</span><span className="doc-card-desc">A Power BI semantic model (.pbit, .bim, or .json).</span></span>
   </a>
-  <a className="doc-card" href="/imports/snowflake">
-    <img src="/img/icons/snowflake.svg" alt="" />
-    <span><span className="doc-card-title">snowflake</span><span className="doc-card-desc">A Snowflake workspace.</span></span>
-  </a>
-  <a className="doc-card" href="/imports/postgres">
-    <img src="/img/icons/postgres.svg" alt="" />
-    <span><span className="doc-card-title">postgres</span><span className="doc-card-desc">A Postgres schema.</span></span>
+  <a className="doc-card" href="/imports/protobuf">
+    <img src="/img/icons/custom.svg" alt="" />
+    <span><span className="doc-card-title">protobuf</span><span className="doc-card-desc">A Protobuf schema file.</span></span>
   </a>
   <a className="doc-card" href="/imports/redshift">
     <img src="/img/icons/redshift.svg" alt="" />
     <span><span className="doc-card-title">redshift</span><span className="doc-card-desc">An Amazon Redshift schema.</span></span>
+  </a>
+  <a className="doc-card" href="/imports/snowflake">
+    <img src="/img/icons/snowflake.svg" alt="" />
+    <span><span className="doc-card-title">snowflake</span><span className="doc-card-desc">A Snowflake workspace.</span></span>
+  </a>
+  <a className="doc-card" href="/imports/spark">
+    <img src="/img/icons/spark.svg" alt="" />
+    <span><span className="doc-card-title">spark</span><span className="doc-card-desc">A Spark schema / DataFrame.</span></span>
+  </a>
+  <a className="doc-card" href="/imports/sql">
+    <img src="/img/icons/database.svg" alt="" />
+    <span><span className="doc-card-title">sql</span><span className="doc-card-desc">A SQL DDL file.</span></span>
+  </a>
+  <a className="doc-card" href="/imports/unity">
+    <img src="/img/icons/databricks.svg" alt="" />
+    <span><span className="doc-card-title">unity</span><span className="doc-card-desc">Databricks Unity Catalog.</span></span>
   </a>
 </div>
 

--- a/docs/docs/imports/index.md
+++ b/docs/docs/imports/index.md
@@ -17,7 +17,7 @@ datacontract import sql --source my_ddl.sql --dialect postgres
 datacontract import sql --source my_ddl.sql --dialect postgres --output datacontract.yaml
 ```
 
-The [Snowflake](./snowflake.md), [BigQuery](./bigquery.md), [Amazon Redshift](./redshift.md), [Unity Catalog](./unity.md), and [AWS Glue](./glue.md) importers can connect directly to the live system and introspect your tables — no export files needed. Snowflake, BigQuery, Redshift, and Unity Catalog also generate a ready-to-test `servers` block, so `datacontract test` works right after the import.
+The [Snowflake](./snowflake.md), [BigQuery](./bigquery.md), [Amazon Redshift](./redshift.md), [Postgres](./postgres.md), [Unity Catalog](./unity.md), and [AWS Glue](./glue.md) importers can connect directly to the live system and introspect your tables — no export files needed. Snowflake, BigQuery, Redshift, Postgres, and Unity Catalog also generate a ready-to-test `servers` block, so `datacontract test` works right after the import.
 
 Run `datacontract import <format> --help` to see the format-specific options (e.g. `datacontract import sql --help`). If a format you need is missing, [open an issue on GitHub](https://github.com/datacontract/datacontract-cli/issues).
 
@@ -99,6 +99,10 @@ Each import page shows a runnable example: a small source file under [`examples/
   <a className="doc-card" href="/imports/snowflake">
     <img src="/img/icons/snowflake.svg" alt="" />
     <span><span className="doc-card-title">snowflake</span><span className="doc-card-desc">A Snowflake workspace.</span></span>
+  </a>
+  <a className="doc-card" href="/imports/postgres">
+    <img src="/img/icons/postgres.svg" alt="" />
+    <span><span className="doc-card-title">postgres</span><span className="doc-card-desc">A Postgres schema.</span></span>
   </a>
   <a className="doc-card" href="/imports/redshift">
     <img src="/img/icons/redshift.svg" alt="" />

--- a/docs/docs/imports/jsonschema.md
+++ b/docs/docs/imports/jsonschema.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 10
 title: "Import: JSON Schema"
 description: "Create a data contract from a JSON Schema file."
 ---

--- a/docs/docs/imports/odcs.md
+++ b/docs/docs/imports/odcs.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 11
 title: "Import: ODCS"
 description: "Create a data contract from an existing ODCS file."
 ---

--- a/docs/docs/imports/parquet.md
+++ b/docs/docs/imports/parquet.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 title: "Import: Parquet"
 description: "Create a data contract from a Parquet file."
 ---

--- a/docs/docs/imports/postgres.md
+++ b/docs/docs/imports/postgres.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 20
+sidebar_position: 13
 title: "Import: Postgres"
 description: "Create a data contract from a Postgres schema."
 ---

--- a/docs/docs/imports/postgres.md
+++ b/docs/docs/imports/postgres.md
@@ -1,0 +1,25 @@
+---
+sidebar_position: 20
+title: "Import: Postgres"
+description: "Create a data contract from a Postgres schema."
+---
+
+# <img className="page-icon" src="/img/icons/postgres.svg" alt="" /> Import: Postgres
+
+Creates a data contract from a Postgres schema by reading table metadata from `information_schema` — including column types with length and precision, nullability, primary keys, and the comments stored in `pg_description`. Works with Postgres and Postgres-compatible databases (e.g. RisingWave).
+
+```bash
+datacontract import postgres \
+  --source localhost \
+  --database postgres \
+  --schema public \
+  --output datacontract.yaml
+```
+
+`--source` is the host of your Postgres server. Add `--port` if it doesn't listen on the default `5432`, and repeat `--table` to import only specific tables (by default every table and view in the schema is imported). `--schema` defaults to `public`.
+
+The generated contract includes a ready-to-test `servers` block, so you can run `datacontract test datacontract.yaml` immediately afterwards — see the **[Postgres connection guide](../testing/postgres.md)** for the full 5-minute walkthrough and troubleshooting.
+
+Credentials are provided as environment variables and are the same ones `datacontract test` uses: `DATACONTRACT_POSTGRES_USERNAME` and `DATACONTRACT_POSTGRES_PASSWORD` — see the [Postgres Reference](../reference/postgres.md).
+
+Working from a DDL file instead of a live database? Use [`datacontract import sql --dialect postgres`](./sql.md).

--- a/docs/docs/imports/powerbi.md
+++ b/docs/docs/imports/powerbi.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 17
+sidebar_position: 14
 title: "Import: Power BI"
 description: "Create a data contract from a Power BI semantic model (.pbit, .bim, or .json)."
 ---

--- a/docs/docs/imports/protobuf.md
+++ b/docs/docs/imports/protobuf.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 15
 title: "Import: Protobuf"
 description: "Create a data contract from a Protobuf schema file."
 ---

--- a/docs/docs/imports/redshift.md
+++ b/docs/docs/imports/redshift.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 19
+sidebar_position: 16
 title: "Import: Amazon Redshift"
 description: "Create a data contract from an Amazon Redshift schema."
 ---

--- a/docs/docs/imports/snowflake.md
+++ b/docs/docs/imports/snowflake.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 18
+sidebar_position: 17
 title: "Import: Snowflake"
 description: "Create a data contract from a Snowflake workspace."
 ---

--- a/docs/docs/imports/spark.md
+++ b/docs/docs/imports/spark.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 18
 title: "Import: Spark"
 description: "Create a data contract from Spark tables or DataFrames (programmatic)."
 ---

--- a/docs/docs/imports/sql.md
+++ b/docs/docs/imports/sql.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 19
 title: "Import: SQL DDL"
 description: "Create a data contract from a SQL DDL file."
 ---

--- a/docs/docs/imports/unity.md
+++ b/docs/docs/imports/unity.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 20
 title: "Import: Unity Catalog"
 description: "Create a data contract from Databricks Unity Catalog (file or HTTP endpoint)."
 ---

--- a/docs/docs/reference/postgres.md
+++ b/docs/docs/reference/postgres.md
@@ -16,11 +16,13 @@ Authentication options and data type handling for [Postgres connections](../test
 | `DATACONTRACT_POSTGRES_USERNAME` | `postgres` | Username |
 | `DATACONTRACT_POSTGRES_PASSWORD` | `mysecretpassword` | Password |
 
-`host`, `port` (default 5432), `database`, and `schema` come from the contract's `servers` block.
+`host`, `port` (default 5432), `database`, and `schema` come from the contract's `servers` block — or, for `datacontract import postgres`, from `--source`, `--port`, `--database`, and `--schema`.
 
 ## Data types
 
 ### Importing
+
+`datacontract import postgres` reads the declared type from `information_schema.columns` and keeps it as `physicalType` exactly as the test path reads it back (`character varying(36)`, `numeric(10,2)`, `timestamp with time zone`), so an imported contract passes `datacontract test` without hand-editing.
 
 `datacontract import sql --dialect postgres` maps DDL types as follows; the normalized SQL type is kept as `physicalType`.
 

--- a/docs/docs/testing/postgres.md
+++ b/docs/docs/testing/postgres.md
@@ -6,7 +6,7 @@ description: "Create a data contract from your Postgres tables and test the actu
 
 # <img className="page-icon" src="/img/icons/postgres.svg" alt="" /> Postgres
 
-Go from an existing Postgres table to a tested data contract in about five minutes. Works with Postgres and Postgres-compatible databases (e.g. RisingWave).
+Go from an existing Postgres table to a tested data contract in about five minutes: import the schema straight from Postgres, then test the actual data against it. Works with Postgres and Postgres-compatible databases (e.g. RisingWave).
 
 ## 1. Install
 
@@ -16,7 +16,7 @@ uv tool install --python python3.11 --upgrade 'datacontract-cli[postgres]'
 
 See [Installation](../installation.md) for pip, pipx, and Docker.
 
-## 2. Set credentials
+## 2. Authenticate
 
 Create a `.env` file in your working directory (or export the variables):
 
@@ -26,26 +26,24 @@ DATACONTRACT_POSTGRES_USERNAME=postgres
 DATACONTRACT_POSTGRES_PASSWORD=mysecretpassword
 ```
 
+The database user needs `USAGE` on the schema and `SELECT` on the tables. `import` and `test` use the same two variables.
+
 ## 3. Create a contract from your tables
 
-Dump the DDL of a table and import it:
+Import the table metadata directly from the Postgres catalog. This also generates a ready-to-test `servers` block:
 
 ```bash
-pg_dump --schema-only --table orders "$DATABASE_URL" > orders.sql
-datacontract import sql --source orders.sql --dialect postgres --output datacontract.yaml
+datacontract import postgres \
+  --source localhost \
+  --database postgres \
+  --schema public \
+  --table orders \
+  --output datacontract.yaml
 ```
 
-The SQL import can't know your connection details, so it writes a `servers` block with placeholder values. Open `datacontract.yaml` and fill in your host, port, database, and schema:
+`--source` is the host of your Postgres server. Add `--port` if it doesn't listen on the default `5432`, repeat `--table` for multiple tables, or omit it to import every table in the schema. `--schema` defaults to `public`.
 
-```yaml
-servers:
-  - server: postgres
-    type: postgres
-    host: localhost
-    port: 5432
-    database: postgres
-    schema: public
-```
+Only have a DDL file? `datacontract import sql --source orders.sql --dialect postgres` works too, but writes a `servers` block with placeholder values that you have to fill in by hand.
 
 ## 4. Test the actual data
 
@@ -87,6 +85,20 @@ schema:
 
 Run `datacontract test datacontract.yaml` again: every violation is listed as an error, and the command exits with code `1` — ready for [CI/CD scheduling](../ci-cd.md) so you catch drift before your consumers do.
 
+## Server reference
+
+Connection details live in the contract's `servers` block; `host`, `port`, `database`, and `schema` come from there:
+
+```yaml
+servers:
+  - server: postgres
+    type: postgres
+    host: localhost
+    port: 5432
+    database: postgres
+    schema: public
+```
+
 ## Reference
 
 All authentication options and the data type mappings: **[Postgres Reference](../reference/postgres.md)**.
@@ -96,3 +108,4 @@ All authentication options and the data type mappings: **[Postgres Reference](..
 - **`password authentication failed`** — check the two environment variables above; note that values from an already-set shell variable take precedence over `.env`.
 - **`connection refused`** — host/port in the `servers` block are wrong, or the database isn't reachable from your machine (VPN, firewall, `pg_hba.conf`).
 - **`relation does not exist`** — the `schema` in the `servers` block doesn't match where the table lives, or the user lacks `USAGE`/`SELECT` grants.
+- **The import finds no tables** — `--schema` is case-sensitive and must match the schema as stored in the catalog.

--- a/tests/fixtures/postgres/data/import.sql
+++ b/tests/fixtures/postgres/data/import.sql
@@ -1,0 +1,17 @@
+CREATE TABLE public.orders (
+    order_id VARCHAR(36) PRIMARY KEY,
+    order_total NUMERIC(10, 2),
+    line_count INT NOT NULL,
+    ordered_at TIMESTAMPTZ,
+    payload JSONB
+);
+
+COMMENT ON TABLE public.orders IS 'All orders';
+COMMENT ON COLUMN public.orders.order_id IS 'The order id';
+
+INSERT INTO public.orders (order_id, order_total, line_count, ordered_at, payload) VALUES
+    ('CX-263-DU', 50.00, 2, '2023-06-16 13:12:56', '{"channel": "web"}'),
+    ('IK-894-MN', 47.50, 1, '2023-10-08 22:40:57', '{"channel": "app"}');
+
+CREATE VIEW public.open_orders AS
+    SELECT order_id FROM public.orders WHERE line_count > 1;

--- a/tests/test_import_postgres.py
+++ b/tests/test_import_postgres.py
@@ -1,0 +1,181 @@
+"""Tests for the Postgres importer, run against a real Postgres container."""
+
+from unittest.mock import patch
+
+import pytest
+import yaml
+from open_data_contract_standard.model import OpenDataContractStandard
+from testcontainers.postgres import PostgresContainer
+from typer.testing import CliRunner
+
+from datacontract.cli import app
+from datacontract.data_contract import DataContract
+from datacontract.model.exceptions import DataContractException
+from datacontract.model.run import ResultEnum
+
+postgres = PostgresContainer("postgres:16")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def postgres_container(request):
+    postgres.start()
+    request.addfinalizer(postgres.stop)
+    _init_sql("fixtures/postgres/data/import.sql")
+
+
+@pytest.fixture(autouse=True)
+def credentials(monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_POSTGRES_USERNAME", postgres.username)
+    monkeypatch.setenv("DATACONTRACT_POSTGRES_PASSWORD", postgres.password)
+
+
+def _import(**kwargs):
+    kwargs.setdefault("database", postgres.dbname)
+    kwargs.setdefault("port", postgres.get_exposed_port(5432))
+    return DataContract.import_from_source("postgres", postgres.get_container_host_ip(), **kwargs)
+
+
+def test_import_postgres():
+    result = _import(schema="public", postgres_table=["orders"])
+
+    expected = f"""
+apiVersion: v3.1.0
+kind: DataContract
+id: my-data-contract
+name: My Data Contract
+version: 1.0.0
+status: draft
+servers:
+  - server: postgres
+    type: postgres
+    host: {postgres.get_container_host_ip()}
+    port: {postgres.get_exposed_port(5432)}
+    database: {postgres.dbname}
+    schema: public
+schema:
+  - name: orders
+    physicalName: orders
+    logicalType: object
+    physicalType: table
+    description: All orders
+    properties:
+      - name: order_id
+        logicalType: string
+        logicalTypeOptions:
+          maxLength: 36
+        physicalType: character varying(36)
+        description: The order id
+        required: true
+        primaryKey: true
+        primaryKeyPosition: 1
+      - name: order_total
+        logicalType: number
+        physicalType: numeric(10,2)
+        customProperties:
+          - property: precision
+            value: 10
+          - property: scale
+            value: 2
+      - name: line_count
+        logicalType: integer
+        physicalType: integer
+        required: true
+      - name: ordered_at
+        logicalType: timestamp
+        physicalType: timestamp with time zone
+      - name: payload
+        physicalType: jsonb
+    """
+
+    print("Result", result.to_yaml())
+    assert yaml.safe_load(result.to_yaml()) == yaml.safe_load(expected)
+
+
+def test_import_postgres_produces_a_valid_contract():
+    result = _import(schema="public")
+
+    run = DataContract(data_contract_str=result.to_yaml()).lint()
+
+    assert run.result == ResultEnum.passed
+
+
+def test_imported_contract_passes_test_without_editing():
+    """The whole point of the native import: import, then test, no hand-editing."""
+    result = _import(postgres_table=["orders"])
+
+    run = DataContract(data_contract_str=result.to_yaml()).test()
+
+    print(run.pretty())
+    assert run.result == ResultEnum.passed
+
+
+def test_import_postgres_imports_all_tables_by_default():
+    result = _import()
+
+    assert [schema.name for schema in result.schema_] == ["open_orders", "orders"]
+    assert result.schema_[0].physicalType == "view"
+
+
+def test_import_postgres_defaults_to_the_public_schema():
+    result = _import(schema=None)
+
+    assert result.servers[0].schema_ == "public"
+
+
+def test_import_postgres_fails_on_an_unknown_table():
+    with pytest.raises(DataContractException) as exc_info:
+        _import(schema="public", postgres_table=["does_not_exist"])
+
+    assert "No tables found" in exc_info.value.reason
+
+
+def test_import_postgres_requires_a_database():
+    with pytest.raises(DataContractException) as exc_info:
+        DataContract.import_from_source("postgres", postgres.get_container_host_ip(), database=None)
+
+    assert "database is required" in exc_info.value.reason
+
+
+def test_import_postgres_requires_a_host():
+    with pytest.raises(DataContractException) as exc_info:
+        DataContract.import_from_source("postgres", None, database="postgres")
+
+    assert "host is required" in exc_info.value.reason
+
+
+def test_import_postgres_requires_credentials(monkeypatch):
+    monkeypatch.delenv("DATACONTRACT_POSTGRES_PASSWORD")
+
+    with pytest.raises(DataContractException) as exc_info:
+        _import()
+
+    assert "DATACONTRACT_POSTGRES_PASSWORD is not set" in exc_info.value.reason
+
+
+def test_cli_schema_option_is_not_rewritten_to_json_schema():
+    """`--schema` means the database schema here, not the v0.12.0 `--json-schema`."""
+    with patch("datacontract.imports.postgres_importer.import_postgres_from_connector") as mock_import:
+        mock_import.return_value = OpenDataContractStandard(id="test", kind="DataContract", apiVersion="v3.1.0")
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["import", "postgres", "--source", "localhost", "--database", "postgres", "--schema", "analytics"],
+        )
+
+    assert result.exit_code == 0
+    assert mock_import.call_args.kwargs["schema"] == "analytics"
+    assert "--json-schema" not in result.output
+
+
+def _init_sql(file_path):
+    import psycopg
+
+    with psycopg.connect(
+        dbname=postgres.dbname,
+        user=postgres.username,
+        password=postgres.password,
+        host=postgres.get_container_host_ip(),
+        port=postgres.get_exposed_port(5432),
+    ) as connection:
+        with open(file_path) as sql_file:
+            connection.execute(sql_file.read())

--- a/tests/test_import_postgres.py
+++ b/tests/test_import_postgres.py
@@ -1,5 +1,6 @@
 """Tests for the Postgres importer, run against a real Postgres container."""
 
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -15,12 +16,16 @@ from datacontract.model.run import ResultEnum
 
 postgres = PostgresContainer("postgres:16")
 
+# This module-scoped fixture is instantiated before conftest's function-scoped
+# chdir into the test directory, so the seed file is addressed from this file.
+SEED_SQL = Path(__file__).parent / "fixtures" / "postgres" / "data" / "import.sql"
+
 
 @pytest.fixture(scope="module", autouse=True)
 def postgres_container(request):
     postgres.start()
     request.addfinalizer(postgres.stop)
-    _init_sql("fixtures/postgres/data/import.sql")
+    _init_sql(SEED_SQL)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

Adds `datacontract import postgres`, which creates a data contract from a live Postgres schema:

```bash
datacontract import postgres --source localhost --database postgres --schema public --output datacontract.yaml
```

Postgres was the odd one out among the relational sources: Snowflake, BigQuery, Redshift, and Unity Catalog all introspect the live system, while the Postgres guide routed users through `pg_dump --schema-only`, `datacontract import sql --dialect postgres`, and then a hand-edited `servers` block with placeholder values before `datacontract test` could run. This closes that gap — the generated contract is testable as-is.

**What it reads.** Tables and views from `information_schema.tables`/`.columns`, comments from `pg_description` via `obj_description` / `col_description` (which `information_schema` does not expose), and primary keys from `information_schema.table_constraints`. A user without access to the constraint views still gets a usable contract, just without primary keys.

**Physical types.** Reconstructed from the same catalog columns (`data_type` plus length / precision / scale) that the test path reads back, so `physicalType` matches on the first `datacontract test` — `character varying(36)`, `numeric(10,2)`, `timestamp with time zone`. Using `format_type()` would yield prettier types for arrays (`text[]` instead of `ARRAY`) but a failing physical-type check, since the test path still reads `ARRAY` from `information_schema`.

**Connection.** Same `DATACONTRACT_POSTGRES_USERNAME` / `DATACONTRACT_POSTGRES_PASSWORD` variables as `datacontract test`, via psycopg, which the `postgres` extra already ships — no new dependency. `--schema` defaults to `public`, `--port` to `5432`. Postgres is added to `DATABASE_SCHEMA_IMPORTS` so `--schema` is not rewritten to `--json-schema` by the v0.12.0 migration hints.

## Testing

`tests/test_import_postgres.py` runs against a real `postgres:16` testcontainer, including a round trip that imports a contract and then runs `datacontract test` on it unedited.

Also verified by hand against a standalone container with a primary key, `NUMERIC(10,2)`, `TIMESTAMPTZ`, `TEXT[]`, and table/column comments: the import filled in the `servers` block, primary key, `maxLength`, precision/scale, `required`, and both descriptions; `datacontract test` then passed all 15 checks with exit code 0 on the unmodified file.

## Docs

New `imports/postgres.md`, and `testing/postgres.md` restructured to match the BigQuery and Redshift guides (step 2 is now "Authenticate", step 3 is the one-command import, plus a "Server reference" section). The SQL DDL path is kept as a one-line fallback for users working from a file.