### PR TITLE
Add Athena import and use regionName from the servers block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `datacontract import athena` creates a data contract from an Amazon Athena database, including a ready-to-test `servers` block
 - `datacontract import unity` is now `datacontract import databricks`; the `unity` format name keeps working
 - Redshift infers the authentication method: a password means a database login, otherwise your AWS session is used for IAM. `DATACONTRACT_REDSHIFT_AUTHENTICATION` is no longer required and remains as an override
 - `datacontract import postgres` creates a data contract from a live Postgres schema, including a ready-to-test `servers` block
@@ -17,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract test` verifies declared primary keys: each key column must have no missing values, and the key must have no duplicates (a composite key is checked as a tuple) (#1220 @DMZ22)
 
 ### Fixed
+- `regionName` in an Athena `servers` block was ignored, so the region could only be set via `DATACONTRACT_S3_REGION`
+- `datacontract import glue` mapped `timestamp` columns to `logicalType: date` instead of `timestamp`
 - Testing and importing Redshift failed with `codec not available in Python: 'UNICODE'`
 - Error messages no longer drop bracketed text such as `pip install "botocore[crt]"`
 - BigQuery export failed on fields with `logicalType: time`

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -50,7 +50,7 @@ class OrderedCommandsWithMigrationHints(OrderedCommands):
 
     # Import formats where `--schema` still means the database schema, so it must
     # not be rewritten to the v0.12.0 `--json-schema`.
-    DATABASE_SCHEMA_IMPORTS = {"snowflake", "redshift", "postgres"}
+    DATABASE_SCHEMA_IMPORTS = {"snowflake", "redshift", "postgres", "athena"}
 
     RENAMED_FLAGS = {
         "--format": None,

--- a/datacontract/command_import.py
+++ b/datacontract/command_import.py
@@ -564,3 +564,41 @@ def import_postgres(
         id=id,
     )
     _write_result(result, output)
+
+
+@import_app.command(
+    name="athena",
+    epilog="Example: datacontract import athena --schema my_database --staging-dir s3://my-bucket/athena-results/ --output datacontract.yaml",
+)
+def import_athena(
+    schema: Annotated[
+        Optional[str], typer.Option("--schema", help="The Athena database name (called schema in the contract).")
+    ] = None,
+    staging_dir: Annotated[
+        Optional[str],
+        typer.Option(help="S3 location where Athena writes query results, e.g. s3://my-bucket/athena-results/."),
+    ] = None,
+    region: Annotated[Optional[str], typer.Option(help="The AWS region the Glue Data Catalog lives in.")] = None,
+    catalog: Annotated[Optional[str], typer.Option(help="The Athena catalog (default awsdatacatalog).")] = None,
+    table: Annotated[
+        Optional[List[str]],
+        typer.Option(help="Name of a table to import (repeat for multiple tables, omit for all tables in the schema)."),
+    ] = None,
+    output: output_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from an Amazon Athena database."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(
+        format="athena",
+        schema=schema,
+        staging_dir=staging_dir,
+        region=region,
+        catalog=catalog,
+        athena_table=table,
+        owner=owner,
+        id=id,
+    )
+    _write_result(result, output)

--- a/datacontract/engines/ibis/connections/connect.py
+++ b/datacontract/engines/ibis/connections/connect.py
@@ -450,7 +450,7 @@ def _connect_athena(ibis, server: Server):
         aws_access_key_id=s3_access_key_id,
         aws_secret_access_key=s3_secret_access_key,
         aws_session_token=s3_session_token,
-        region_name=os.getenv("DATACONTRACT_S3_REGION") or getattr(server, "region_name", None),
+        region_name=os.getenv("DATACONTRACT_S3_REGION") or server.regionName,
         schema_name=server.schema_,
     )
 

--- a/datacontract/imports/athena_importer.py
+++ b/datacontract/imports/athena_importer.py
@@ -1,0 +1,114 @@
+"""Create a data contract from an Amazon Athena database.
+
+Athena has no catalog of its own: its tables live in the AWS Glue Data Catalog,
+so the metadata is read with the shared Glue reader rather than by querying
+Athena. Reading the catalog costs nothing, needs only ``glue:GetTables``, and
+avoids the S3 staging round-trip an ``information_schema`` query would need.
+
+The one thing Glue and Athena disagree on is the name of two types: Glue stores
+the Hive spelling, Athena reports the Trino spelling. Everything else already
+compares equal in the Athena dialect (``int``/``integer``, ``array<int>``/
+``array(integer)``, ``struct``/``row(...)``, ``decimal``/``decimal(10,2)``), so
+only those two tokens are rewritten — otherwise every string column would fail
+its physical type check on the first `datacontract test`.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from open_data_contract_standard.model import OpenDataContractStandard, SchemaProperty
+
+from datacontract.imports.glue_importer import create_schema_objects, get_glue_tables
+from datacontract.imports.importer import Importer
+from datacontract.imports.odcs_helper import create_odcs, create_server
+from datacontract.model.exceptions import DataContractException
+
+DEFAULT_CATALOG = "awsdatacatalog"
+
+# Glue (Hive) spelling -> what Athena reports back from its catalog.
+HIVE_TO_ATHENA_TYPES = {
+    "string": "varchar",
+    "binary": "varbinary",
+}
+
+
+class AthenaImporter(Importer):
+    def import_source(self, source: str, import_args: dict) -> OpenDataContractStandard:
+        return import_athena(
+            schema=import_args.get("schema"),
+            staging_dir=import_args.get("staging_dir"),
+            region=import_args.get("region"),
+            catalog=import_args.get("catalog"),
+            tables=import_args.get("athena_table"),
+        )
+
+
+def import_athena(
+    schema: Optional[str],
+    staging_dir: Optional[str],
+    region: Optional[str] = None,
+    catalog: Optional[str] = None,
+    tables: Optional[List[str]] = None,
+) -> OpenDataContractStandard:
+    if not schema:
+        raise DataContractException(
+            type="source",
+            name="athena import schema",
+            reason="The Athena database is required for the athena import, e.g. --schema my_database",
+            engine="datacontract",
+        )
+    if not staging_dir:
+        raise DataContractException(
+            type="source",
+            name="athena import staging dir",
+            reason=(
+                "An S3 staging directory is required for the athena import so the contract can be tested, "
+                "e.g. --staging-dir s3://my-bucket/athena-results/"
+            ),
+            engine="datacontract",
+        )
+
+    selected = _select_tables(get_glue_tables(schema, region), tables)
+    if not selected:
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="no tables found",
+            reason=f"No tables found in the Athena database '{schema}'.",
+            engine="datacontract",
+        )
+
+    odcs = create_odcs()
+    odcs.servers = [
+        create_server(
+            name="athena",
+            server_type="athena",
+            catalog=catalog or DEFAULT_CATALOG,
+            schema=schema,
+            region_name=region,
+            staging_dir=staging_dir,
+        )
+    ]
+    odcs.schema_ = create_schema_objects(schema, selected, region)
+    for schema_object in odcs.schema_:
+        for prop in schema_object.properties or []:
+            _to_athena_types(prop)
+    return odcs
+
+
+def _select_tables(table_names: List[str], tables: Optional[List[str]]) -> List[str]:
+    if not tables:
+        return sorted(table_names, key=str.lower)
+    wanted = {table.lower() for table in tables}
+    return sorted((name for name in table_names if name.lower() in wanted), key=str.lower)
+
+
+def _to_athena_types(prop: SchemaProperty) -> None:
+    """Rewrite the Hive-only type names, in place, through the whole property tree."""
+    if prop.physicalType:
+        prop.physicalType = HIVE_TO_ATHENA_TYPES.get(prop.physicalType.lower(), prop.physicalType)
+    for child in prop.properties or []:
+        _to_athena_types(child)
+    if prop.items:
+        _to_athena_types(prop.items)

--- a/datacontract/imports/glue_importer.py
+++ b/datacontract/imports/glue_importer.py
@@ -2,7 +2,7 @@ import re
 from typing import Dict, Generator, List
 
 import boto3
-from open_data_contract_standard.model import OpenDataContractStandard, SchemaProperty
+from open_data_contract_standard.model import OpenDataContractStandard, SchemaObject, SchemaProperty
 
 from datacontract.imports.importer import Importer
 from datacontract.imports.odcs_helper import (
@@ -18,9 +18,14 @@ class GlueImporter(Importer):
         return import_glue(source, import_args.get("glue_table"))
 
 
-def get_glue_database(database_name: str):
+def glue_client(region: str = None):
+    """Return a Glue client; without a region boto3 resolves it from the AWS chain."""
+    return boto3.client("glue", region_name=region) if region else boto3.client("glue")
+
+
+def get_glue_database(database_name: str, region: str = None):
     """Get the details Glue database."""
-    glue = boto3.client("glue")
+    glue = glue_client(region)
     try:
         response = glue.get_database(Name=database_name)
     except glue.exceptions.EntityNotFoundException:
@@ -36,9 +41,9 @@ def get_glue_database(database_name: str):
     )
 
 
-def get_glue_tables(database_name: str) -> List[str]:
+def get_glue_tables(database_name: str, region: str = None) -> List[str]:
     """Get the list of tables in a Glue database."""
-    glue = boto3.client("glue")
+    glue = glue_client(region)
     paginator = glue.get_paginator("get_tables")
     table_names = []
 
@@ -55,9 +60,9 @@ def get_glue_tables(database_name: str) -> List[str]:
     return table_names
 
 
-def get_glue_table_schema(database_name: str, table_name: str) -> List[Dict]:
+def get_glue_table_schema(database_name: str, table_name: str, region: str = None) -> List[Dict]:
     """Get the schema of a Glue table."""
-    glue = boto3.client("glue")
+    glue = glue_client(region)
 
     try:
         response = glue.get_table(DatabaseName=database_name, Name=table_name)
@@ -108,10 +113,17 @@ def import_glue(
     )
     odcs.servers = [server]
 
-    odcs.schema_ = []
+    odcs.schema_ = create_schema_objects(source, table_names)
+
+    return odcs
+
+
+def create_schema_objects(database_name: str, table_names: List[str], region: str = None) -> List[SchemaObject]:
+    """Read each table from the Glue Data Catalog and turn it into a schema object."""
+    schemas = []
 
     for table_name in table_names:
-        table_schema = get_glue_table_schema(source, table_name)
+        table_schema = get_glue_table_schema(database_name, table_name, region)
 
         properties = []
         for column in table_schema:
@@ -126,15 +138,15 @@ def import_glue(
 
             properties.append(prop)
 
-        schema_obj = create_schema_object(
-            name=table_name,
-            physical_type="table",
-            properties=properties,
+        schemas.append(
+            create_schema_object(
+                name=table_name,
+                physical_type="table",
+                properties=properties,
+            )
         )
 
-        odcs.schema_.append(schema_obj)
-
-    return odcs
+    return schemas
 
 
 def create_typed_property(name: str, dtype: str) -> SchemaProperty:
@@ -234,7 +246,7 @@ def map_glue_type_to_odcs(sql_type: str) -> str:
         "float": "number",
         "double": "number",
         "boolean": "boolean",
-        "timestamp": "date",
+        "timestamp": "timestamp",
         "date": "date",
     }
 

--- a/datacontract/imports/importer.py
+++ b/datacontract/imports/importer.py
@@ -43,6 +43,7 @@ class ImportFormat(str, Enum):
     snowflake = "snowflake"
     redshift = "redshift"
     postgres = "postgres"
+    athena = "athena"
 
     @classmethod
     def get_supported_formats(cls):

--- a/datacontract/imports/importer_factory.py
+++ b/datacontract/imports/importer_factory.py
@@ -145,6 +145,11 @@ importer_factory.register_lazy_importer(
     class_name="PostgresImporter",
 )
 importer_factory.register_lazy_importer(
+    name=ImportFormat.athena,
+    module_path="datacontract.imports.athena_importer",
+    class_name="AthenaImporter",
+)
+importer_factory.register_lazy_importer(
     name=ImportFormat.json,
     module_path="datacontract.imports.json_importer",
     class_name="JsonImporter",

--- a/datacontract/imports/odcs_helper.py
+++ b/datacontract/imports/odcs_helper.py
@@ -171,6 +171,8 @@ def create_server(
     format: str = None,
     roles: List[Role] = None,
     warehouse: str = None,
+    region_name: str = None,
+    staging_dir: str = None,
 ) -> Server:
     """Create a Server object.
 
@@ -212,6 +214,10 @@ def create_server(
         server.roles = roles
     if warehouse:
         server.warehouse = warehouse
+    if region_name:
+        server.regionName = region_name
+    if staging_dir:
+        server.stagingDir = staging_dir
     return server
 
 

--- a/docs/docs/commands/import.md
+++ b/docs/docs/commands/import.md
@@ -18,4 +18,4 @@ Run `datacontract import <format> --help` to see format-specific options.
 datacontract import sql --source ddl.sql --dialect postgres --output datacontract.yaml
 ```
 
-Available formats: `dbt`, `sql`, `avro`, `dbml`, `glue`, `bigquery`, `databricks`, `jsonschema`, `json`, `odcs`, `parquet`, `csv`, `protobuf`, `spark`, `iceberg`, `excel`, `powerbi`, `snowflake`, `redshift`, `postgres`.
+Available formats: `dbt`, `sql`, `avro`, `dbml`, `glue`, `bigquery`, `databricks`, `jsonschema`, `json`, `odcs`, `parquet`, `csv`, `protobuf`, `spark`, `iceberg`, `excel`, `powerbi`, `snowflake`, `redshift`, `postgres`, `athena`.

--- a/docs/docs/imports/athena.md
+++ b/docs/docs/imports/athena.md
@@ -1,0 +1,29 @@
+---
+sidebar_position: 1
+title: "Import: Amazon Athena"
+description: "Create a data contract from an Amazon Athena database."
+---
+
+# <img className="page-icon" src="/img/icons/athena.svg" alt="" /> Import: Amazon Athena
+
+Creates a data contract from an Amazon Athena database, including column types, partition keys, and comments.
+
+```bash
+datacontract import athena \
+  --schema my_database \
+  --staging-dir s3://my-bucket/athena-results/ \
+  --region eu-central-1 \
+  --output datacontract.yaml
+```
+
+`--schema` is the Athena database. Repeat `--table` to import only specific tables (by default every table in the database is imported), and set `--catalog` if you don't use `awsdatacatalog`.
+
+`--staging-dir` is the S3 location Athena writes query results to. `datacontract test` needs it, so the import writes it into the `servers` block.
+
+Athena keeps its table metadata in the AWS Glue Data Catalog, so the import reads the catalog rather than querying Athena — it needs only `glue:GetTables`, costs nothing to run, and requires no query results to be staged. Glue stores the Hive spelling of two types, which the import rewrites to what Athena reports back (`string` → `varchar`, `binary` → `varbinary`) so the physical type checks pass on the first test run.
+
+The generated contract includes a ready-to-test `servers` block, so you can run `datacontract test datacontract.yaml` immediately afterwards — see the **[Athena connection guide](../testing/athena.md)** for the full 5-minute walkthrough and troubleshooting.
+
+Credentials are provided as environment variables and are the same ones `datacontract test` uses: `DATACONTRACT_S3_REGION`, `DATACONTRACT_S3_ACCESS_KEY_ID`, and `DATACONTRACT_S3_SECRET_ACCESS_KEY` — see the [Athena Reference](../reference/athena.md).
+
+Want the Glue Data Catalog itself rather than Athena? Use [`datacontract import glue`](./glue.md).

--- a/docs/docs/imports/avro.md
+++ b/docs/docs/imports/avro.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 title: "Import: Avro"
 description: "Create a data contract from an Avro schema file."
 ---

--- a/docs/docs/imports/bigquery.md
+++ b/docs/docs/imports/bigquery.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 title: "Import: BigQuery"
 description: "Create a data contract from BigQuery, via an exported JSON file or the BigQuery API."
 ---

--- a/docs/docs/imports/csv.md
+++ b/docs/docs/imports/csv.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 title: "Import: CSV"
 description: "Create a data contract by inferring a schema from a CSV file."
 ---

--- a/docs/docs/imports/databricks.md
+++ b/docs/docs/imports/databricks.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 title: "Import: Databricks"
 description: "Create a data contract from Databricks Unity Catalog."
 ---

--- a/docs/docs/imports/dbml.md
+++ b/docs/docs/imports/dbml.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 title: "Import: DBML"
 description: "Create a data contract from a DBML file, with optional schema/table filters."
 ---

--- a/docs/docs/imports/dbt.md
+++ b/docs/docs/imports/dbt.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 title: "Import: dbt"
 description: "Create a data contract from a dbt manifest file."
 ---

--- a/docs/docs/imports/excel.md
+++ b/docs/docs/imports/excel.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 title: "Import: Excel"
 description: "Create a data contract from an ODCS Excel template."
 ---

--- a/docs/docs/imports/glue.md
+++ b/docs/docs/imports/glue.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 title: "Import: AWS Glue"
 description: "Create a data contract from the AWS Glue Data Catalog."
 ---

--- a/docs/docs/imports/iceberg.md
+++ b/docs/docs/imports/iceberg.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 10
 title: "Import: Iceberg"
 description: "Create a data contract from an Apache Iceberg schema."
 ---

--- a/docs/docs/imports/index.md
+++ b/docs/docs/imports/index.md
@@ -17,7 +17,7 @@ datacontract import sql --source my_ddl.sql --dialect postgres
 datacontract import sql --source my_ddl.sql --dialect postgres --output datacontract.yaml
 ```
 
-The [Snowflake](./snowflake.md), [BigQuery](./bigquery.md), [Amazon Redshift](./redshift.md), [Postgres](./postgres.md), [Databricks](./databricks.md), and [AWS Glue](./glue.md) importers can connect directly to the live system and introspect your tables — no export files needed. Snowflake, BigQuery, Redshift, Postgres, and Databricks also generate a ready-to-test `servers` block, so `datacontract test` works right after the import.
+The [Snowflake](./snowflake.md), [BigQuery](./bigquery.md), [Amazon Redshift](./redshift.md), [Postgres](./postgres.md), [Amazon Athena](./athena.md), [Databricks](./databricks.md), and [AWS Glue](./glue.md) importers can connect directly to the live system and introspect your tables — no export files needed. Snowflake, BigQuery, Redshift, Postgres, Athena, and Databricks also generate a ready-to-test `servers` block, so `datacontract test` works right after the import.
 
 Run `datacontract import <format> --help` to see the format-specific options (e.g. `datacontract import sql --help`). If a format you need is missing, [open an issue on GitHub](https://github.com/datacontract/datacontract-cli/issues).
 
@@ -28,6 +28,10 @@ Each import page shows a runnable example: a small source file under [`examples/
 ## Available importers
 
 <div className="card-grid">
+  <a className="doc-card" href="/imports/athena">
+    <img src="/img/icons/athena.svg" alt="" />
+    <span><span className="doc-card-title">athena</span><span className="doc-card-desc">An Amazon Athena database.</span></span>
+  </a>
   <a className="doc-card" href="/imports/avro">
     <img src="/img/icons/avro.svg" alt="" />
     <span><span className="doc-card-title">avro</span><span className="doc-card-desc">An Avro schema file.</span></span>

--- a/docs/docs/imports/json.md
+++ b/docs/docs/imports/json.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 11
 title: "Import: JSON"
 description: "Create a data contract by inferring a schema from a JSON data file."
 ---

--- a/docs/docs/imports/jsonschema.md
+++ b/docs/docs/imports/jsonschema.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 title: "Import: JSON Schema"
 description: "Create a data contract from a JSON Schema file."
 ---

--- a/docs/docs/imports/odcs.md
+++ b/docs/docs/imports/odcs.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 13
 title: "Import: ODCS"
 description: "Create a data contract from an existing ODCS file."
 ---

--- a/docs/docs/imports/parquet.md
+++ b/docs/docs/imports/parquet.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 14
 title: "Import: Parquet"
 description: "Create a data contract from a Parquet file."
 ---

--- a/docs/docs/imports/postgres.md
+++ b/docs/docs/imports/postgres.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 15
 title: "Import: Postgres"
 description: "Create a data contract from a Postgres schema."
 ---

--- a/docs/docs/imports/powerbi.md
+++ b/docs/docs/imports/powerbi.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 16
 title: "Import: Power BI"
 description: "Create a data contract from a Power BI semantic model (.pbit, .bim, or .json)."
 ---

--- a/docs/docs/imports/protobuf.md
+++ b/docs/docs/imports/protobuf.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 17
 title: "Import: Protobuf"
 description: "Create a data contract from a Protobuf schema file."
 ---

--- a/docs/docs/imports/redshift.md
+++ b/docs/docs/imports/redshift.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 17
+sidebar_position: 18
 title: "Import: Amazon Redshift"
 description: "Create a data contract from an Amazon Redshift schema."
 ---

--- a/docs/docs/imports/snowflake.md
+++ b/docs/docs/imports/snowflake.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 18
+sidebar_position: 19
 title: "Import: Snowflake"
 description: "Create a data contract from a Snowflake workspace."
 ---

--- a/docs/docs/imports/spark.md
+++ b/docs/docs/imports/spark.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 19
+sidebar_position: 20
 title: "Import: Spark"
 description: "Create a data contract from Spark tables or DataFrames (programmatic)."
 ---

--- a/docs/docs/imports/sql.md
+++ b/docs/docs/imports/sql.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 20
+sidebar_position: 21
 title: "Import: SQL DDL"
 description: "Create a data contract from a SQL DDL file."
 ---

--- a/docs/docs/reference/athena.md
+++ b/docs/docs/reference/athena.md
@@ -9,6 +9,18 @@ description: "All Athena authentication options and data type handling."
 
 Authentication options and data type handling for [Athena connections](../testing/athena.md).
 
+## Server
+
+```yaml
+servers:
+  - server: athena
+    type: athena
+    catalog: awsdatacatalog # default
+    schema: my_database     # in Athena, this is called "database"
+    regionName: eu-central-1
+    stagingDir: s3://my-bucket/athena-results/
+```
+
 ## Authentication
 
 Athena uses the S3 environment variables:

--- a/docs/docs/reference/athena.md
+++ b/docs/docs/reference/athena.md
@@ -20,13 +20,15 @@ Athena uses the S3 environment variables:
 | `DATACONTRACT_S3_SECRET_ACCESS_KEY` | `93S7LRrJ...` | AWS Secret Access Key |
 | `DATACONTRACT_S3_SESSION_TOKEN` | `AQoDYXdzEJr...` | AWS temporary session token (optional) |
 
-`catalog`, `schema` (the Athena database), `regionName`, and `stagingDir` (required, for query results) come from the contract's `servers` block. The credentials need `athena:StartQueryExecution` plus read access to the data and write access to `stagingDir`.
+`catalog`, `schema` (the Athena database), `regionName`, and `stagingDir` (required, for query results) come from the contract's `servers` block; `DATACONTRACT_S3_REGION` takes precedence over `regionName` when both are set. The credentials need `athena:StartQueryExecution` plus read access to the data and write access to `stagingDir`, and `glue:GetTables` to import.
 
 ## Data types
 
 ### Importing
 
-There is no direct Athena importer. Since Athena tables live in the AWS Glue Data Catalog, use `datacontract import glue --database my_database` — Glue/Hive types map through the shared SQL mapping: `string`/`varchar`/`char` → `string`, `int`/`bigint`/`smallint`/`tinyint` → `integer`, `float`/`double`/`decimal` → `number`, `boolean` → `boolean`, `date` → `date`, `timestamp` → `timestamp`, `array<...>` → `array`, `struct<...>` → `object`, `binary` → `string` (format `binary`), `map<...>` → no logical type.
+`datacontract import athena` reads the table metadata from the AWS Glue Data Catalog, where Athena keeps it. Glue stores the Hive spelling of two types, which the import rewrites to what Athena reports back — `string` → `varchar` and `binary` → `varbinary` — so the physical type checks pass on the first test run. Every other type already compares equal in the Athena dialect (`int`/`integer`, `array<int>`/`array(integer)`, `struct`/`row(...)`, `decimal`/`decimal(10,2)`).
+
+Types map through the shared Glue mapping: `string`/`varchar`/`char` → `string`, `int`/`bigint`/`smallint`/`tinyint` → `integer`, `float`/`double`/`decimal` → `number`, `boolean` → `boolean`, `date` → `date`, `timestamp` → `timestamp`, `array<...>` → `array`, `struct<...>` → `object`, `binary` → `string` (format `binary`), `map<...>` → no logical type.
 
 ### Testing
 

--- a/docs/docs/testing/athena.md
+++ b/docs/docs/testing/athena.md
@@ -82,22 +82,6 @@ schema:
 
 Run `datacontract test datacontract.yaml` again: every violation is listed as an error, and the command exits with code `1` — ready for [CI/CD scheduling](../ci-cd.md) so you catch drift before your consumers do.
 
-## Server reference
-
-Connection details live in the contract's `servers` block; `catalog`, `schema`, `regionName`, and `stagingDir` come from there:
-
-```yaml
-servers:
-  - server: athena
-    type: athena
-    catalog: awsdatacatalog # default
-    schema: my_database     # in Athena, this is called "database"
-    regionName: eu-central-1
-    stagingDir: s3://my-bucket/athena-results/
-```
-
-`DATACONTRACT_S3_REGION` takes precedence over `regionName` when both are set.
-
 ## Reference
 
 All authentication options and the data type mappings: **[Athena Reference](../reference/athena.md)**.

--- a/docs/docs/testing/athena.md
+++ b/docs/docs/testing/athena.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 1
 title: "Amazon Athena"
-description: "Create a data contract from your Athena tables and test the actual data against it."
+description: "Create a data contract from your Athena tables and test the actual data against it — in about 5 minutes."
 ---
 
 # <img className="page-icon" src="/img/icons/athena.svg" alt="" /> Amazon Athena
 
-Test data in AWS Athena stored in S3. Supports formats such as Iceberg, Parquet, JSON, and CSV.
+Go from an existing Athena table to a tested data contract in about five minutes: import the schema straight from the catalog, then test the actual data against it. Athena reads data in S3, so this covers formats such as Iceberg, Parquet, JSON, and CSV.
 
 ## 1. Install
 
@@ -16,7 +16,7 @@ uv tool install --python python3.11 --upgrade 'datacontract-cli[athena]'
 
 See [Installation](../installation.md) for pip, pipx, and Docker.
 
-## 2. Set credentials
+## 2. Authenticate
 
 Athena uses the S3 environment variables. Create a `.env` file in your working directory (or export the variables):
 
@@ -27,25 +27,24 @@ DATACONTRACT_S3_ACCESS_KEY_ID=AKIAXV5Q5QABCDEFGH
 DATACONTRACT_S3_SECRET_ACCESS_KEY=93S7LRrJcqLaaaa/XXXXXXXXXXXXX
 ```
 
+The credentials need `glue:GetTables` to import, and `athena:StartQueryExecution` plus write access to the staging directory to test. `import` and `test` use the same variables.
+
 ## 3. Create a contract from your tables
 
-Athena tables live in the AWS Glue Data Catalog, so import them from Glue:
+Import the table metadata directly from the catalog. This also generates a ready-to-test `servers` block:
 
 ```bash
-datacontract import glue --database my_database --table orders --output datacontract.yaml
+datacontract import athena \
+  --schema my_database \
+  --staging-dir s3://my-bucket/athena-results/ \
+  --region eu-central-1 \
+  --table orders \
+  --output datacontract.yaml
 ```
 
-The Glue import writes a `servers` entry of `type: glue`, which `datacontract test` cannot connect to directly. Replace it with an Athena server:
+`--schema` is the Athena database. Repeat `--table` for multiple tables, or omit it to import every table in the database. `--catalog` defaults to `awsdatacatalog`.
 
-```yaml
-servers:
-  - server: athena
-    type: athena
-    catalog: awsdatacatalog # default
-    schema: my_database     # in Athena, this is called "database"
-    regionName: eu-central-1
-    stagingDir: s3://my-bucket/athena-results/
-```
+`--staging-dir` is where Athena writes query results; `datacontract test` needs it, so the import asks for it up front and writes it into the contract.
 
 ## 4. Test the actual data
 
@@ -54,6 +53,15 @@ datacontract test datacontract.yaml
 ```
 
 ```
+Testing datacontract.yaml
+Server: athena (type=athena, catalog=awsdatacatalog, schema=my_database, regionName=eu-central-1)
+╭────────┬─────────────────────────────────────────────────┬─────────────────┬─────────╮
+│ Result │ Check                                           │ Field           │ Details │
+├────────┼─────────────────────────────────────────────────┼─────────────────┼─────────┤
+│ passed │ Check that field 'order_id' is present          │ orders.order_id │         │
+│ passed │ Check that field order_id has no missing values │ orders.order_id │         │
+│  ...   │                                                 │                 │         │
+╰────────┴─────────────────────────────────────────────────┴─────────────────┴─────────╯
 🟢 data contract is valid. Run 24 checks. Took 7.8 seconds.
 ```
 
@@ -73,6 +81,22 @@ schema:
 ```
 
 Run `datacontract test datacontract.yaml` again: every violation is listed as an error, and the command exits with code `1` — ready for [CI/CD scheduling](../ci-cd.md) so you catch drift before your consumers do.
+
+## Server reference
+
+Connection details live in the contract's `servers` block; `catalog`, `schema`, `regionName`, and `stagingDir` come from there:
+
+```yaml
+servers:
+  - server: athena
+    type: athena
+    catalog: awsdatacatalog # default
+    schema: my_database     # in Athena, this is called "database"
+    regionName: eu-central-1
+    stagingDir: s3://my-bucket/athena-results/
+```
+
+`DATACONTRACT_S3_REGION` takes precedence over `regionName` when both are set.
 
 ## Reference
 

--- a/tests/fixtures/glue/datacontract.yaml
+++ b/tests/fixtures/glue/datacontract.yaml
@@ -25,7 +25,7 @@ schema:
     logicalType: integer
   - name: field_three
     physicalType: timestamp
-    logicalType: date
+    logicalType: timestamp
   - name: field_four
     physicalType: decimal
     customProperties:
@@ -82,7 +82,7 @@ schema:
     logicalType: number
   - name: field_thirteen
     physicalType: timestamp
-    logicalType: date
+    logicalType: timestamp
   - name: field_fourteen
     physicalType: date
     logicalType: date

--- a/tests/test_connect_athena.py
+++ b/tests/test_connect_athena.py
@@ -1,0 +1,93 @@
+"""Unit tests for how connect_ibis builds the Athena connection.
+
+These do not hit Athena or AWS: ``ibis.athena.connect`` is patched, and we only
+assert which connection kwargs the dispatch passes for a given server block and
+set of env vars.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from open_data_contract_standard.model import Server
+
+from datacontract.engines.ibis.connections.connect import connect_ibis
+from datacontract.model.exceptions import DataContractException
+from datacontract.model.run import Run
+
+ATHENA_ENV_VARS = [
+    "DATACONTRACT_S3_REGION",
+    "DATACONTRACT_S3_ACCESS_KEY_ID",
+    "DATACONTRACT_S3_SECRET_ACCESS_KEY",
+    "DATACONTRACT_S3_SESSION_TOKEN",
+]
+
+STAGING_DIR = "s3://my-bucket/athena-results/"
+
+
+@pytest.fixture
+def env(monkeypatch):
+    for name in ATHENA_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    return monkeypatch
+
+
+def _server(**kwargs):
+    return Server(server="athena", type="athena", schema="my_database", stagingDir=STAGING_DIR, **kwargs)
+
+
+def _connect(server):
+    with patch("ibis.athena.connect") as connect:
+        connect_ibis(Run.create_run(), None, server)
+    return connect.call_args.kwargs
+
+
+def test_region_comes_from_the_server_block(env):
+    """regionName is documented as part of the servers block, so it must be used."""
+    kwargs = _connect(_server(regionName="eu-central-1"))
+
+    assert kwargs["region_name"] == "eu-central-1"
+
+
+def test_environment_region_wins_over_the_server_block(env):
+    env.setenv("DATACONTRACT_S3_REGION", "us-east-1")
+
+    kwargs = _connect(_server(regionName="eu-central-1"))
+
+    assert kwargs["region_name"] == "us-east-1"
+
+
+def test_staging_dir_and_schema_are_passed(env):
+    kwargs = _connect(_server(regionName="eu-central-1"))
+
+    assert kwargs["s3_staging_dir"] == STAGING_DIR
+    assert kwargs["schema_name"] == "my_database"
+
+
+def test_credentials_come_from_the_s3_variables(env):
+    env.setenv("DATACONTRACT_S3_ACCESS_KEY_ID", "AKIA_TEST")
+    env.setenv("DATACONTRACT_S3_SECRET_ACCESS_KEY", "secret")
+    env.setenv("DATACONTRACT_S3_SESSION_TOKEN", "token")
+
+    kwargs = _connect(_server())
+
+    assert kwargs["aws_access_key_id"] == "AKIA_TEST"
+    assert kwargs["aws_secret_access_key"] == "secret"
+    assert kwargs["aws_session_token"] == "token"
+
+
+def test_missing_staging_dir_is_rejected(env):
+    server = Server(server="athena", type="athena", schema="my_database")
+
+    with pytest.raises(DataContractException) as exc_info:
+        _connect(server)
+
+    assert "staging directory is required" in exc_info.value.reason
+
+
+def test_missing_schema_is_rejected(env):
+    server = Server(server="athena", type="athena", stagingDir=STAGING_DIR)
+
+    with pytest.raises(DataContractException) as exc_info:
+        _connect(server)
+
+    assert "Schema is required" in exc_info.value.reason

--- a/tests/test_import_athena.py
+++ b/tests/test_import_athena.py
@@ -1,0 +1,209 @@
+"""Tests for the Athena importer, run against a moto-mocked Glue Data Catalog."""
+
+import boto3
+import pytest
+import yaml
+from moto import mock_aws
+from typer.testing import CliRunner
+
+from datacontract.cli import app
+from datacontract.data_contract import DataContract
+from datacontract.engines.checks.physical_type_match import physical_type_matches
+from datacontract.model.exceptions import DataContractException
+from datacontract.model.run import ResultEnum
+
+DATABASE = "my_database"
+STAGING_DIR = "s3://my-bucket/athena-results/"
+
+
+@pytest.fixture
+def aws_credentials(monkeypatch):
+    """Mocked AWS Credentials for moto."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-central-1")
+
+
+@pytest.fixture
+def setup_mock_glue(aws_credentials):
+    with mock_aws():
+        client = boto3.client("glue")
+        client.create_database(DatabaseInput={"Name": DATABASE, "LocationUri": "s3://my-bucket/warehouse"})
+        client.create_table(
+            DatabaseName=DATABASE,
+            TableInput={
+                "Name": "orders",
+                "StorageDescriptor": {
+                    "Columns": [
+                        {"Name": "order_id", "Type": "string", "Comment": "The order id"},
+                        {"Name": "order_total", "Type": "decimal(10,2)"},
+                        {"Name": "line_count", "Type": "int"},
+                        {"Name": "ordered_at", "Type": "timestamp"},
+                        {"Name": "tags", "Type": "array<string>"},
+                        {"Name": "payload", "Type": "binary"},
+                    ]
+                },
+                "PartitionKeys": [{"Name": "order_date", "Type": "date"}],
+            },
+        )
+        client.create_table(
+            DatabaseName=DATABASE,
+            TableInput={"Name": "customers", "StorageDescriptor": {"Columns": [{"Name": "id", "Type": "string"}]}},
+        )
+        yield client
+
+
+def _import(**kwargs):
+    kwargs.setdefault("schema", DATABASE)
+    kwargs.setdefault("staging_dir", STAGING_DIR)
+    return DataContract.import_from_source("athena", **kwargs)
+
+
+@mock_aws
+def test_import_athena(setup_mock_glue):
+    result = _import(region="eu-central-1", athena_table=["orders"])
+
+    expected = """
+apiVersion: v3.1.0
+kind: DataContract
+id: my-data-contract
+name: My Data Contract
+version: 1.0.0
+status: draft
+servers:
+  - server: athena
+    type: athena
+    catalog: awsdatacatalog
+    schema: my_database
+    regionName: eu-central-1
+    stagingDir: s3://my-bucket/athena-results/
+schema:
+  - name: orders
+    physicalName: orders
+    logicalType: object
+    physicalType: table
+    properties:
+      - name: order_id
+        logicalType: string
+        physicalType: varchar
+        description: The order id
+      - name: order_total
+        logicalType: number
+        physicalType: decimal
+        customProperties:
+          - property: precision
+            value: 10
+          - property: scale
+            value: 2
+      - name: line_count
+        logicalType: integer
+        physicalType: int
+      - name: ordered_at
+        logicalType: timestamp
+        physicalType: timestamp
+      - name: tags
+        logicalType: array
+        physicalType: array<string>
+        items:
+          name: items
+          logicalType: string
+          physicalType: varchar
+      - name: payload
+        logicalType: string
+        physicalType: varbinary
+      - name: order_date
+        logicalType: date
+        physicalType: date
+        required: true
+    """
+
+    print("Result", result.to_yaml())
+    assert yaml.safe_load(result.to_yaml()) == yaml.safe_load(expected)
+
+
+@mock_aws
+def test_imported_physical_types_match_what_athena_reports(setup_mock_glue):
+    """Glue stores the Hive spelling; the contract must carry what Athena reports back."""
+    result = _import(athena_table=["orders"])
+    properties = {prop.name: prop.physicalType for prop in result.schema_[0].properties}
+
+    # what Athena's catalog returns for these columns
+    reported = {
+        "order_id": "varchar",
+        "order_total": "decimal(10,2)",
+        "line_count": "integer",
+        "ordered_at": "timestamp(3)",
+        "tags": "array(varchar)",
+        "payload": "varbinary",
+        "order_date": "date",
+    }
+    for name, actual in reported.items():
+        matches, reason = physical_type_matches(properties[name], actual, "athena")
+        assert matches is True, f"{name}: declared '{properties[name]}' vs Athena '{actual}' -> {reason}"
+
+
+@mock_aws
+def test_import_athena_produces_a_valid_contract(setup_mock_glue):
+    result = _import()
+
+    run = DataContract(data_contract_str=result.to_yaml()).lint()
+
+    assert run.result == ResultEnum.passed
+
+
+@mock_aws
+def test_import_athena_imports_all_tables_by_default(setup_mock_glue):
+    result = _import()
+
+    assert [schema.name for schema in result.schema_] == ["customers", "orders"]
+
+
+@mock_aws
+def test_import_athena_defaults_the_catalog(setup_mock_glue):
+    result = _import()
+
+    assert result.servers[0].catalog == "awsdatacatalog"
+
+
+@mock_aws
+def test_import_athena_omits_an_unset_region(setup_mock_glue):
+    result = _import()
+
+    assert result.servers[0].regionName is None
+
+
+@mock_aws
+def test_import_athena_fails_on_an_unknown_table(setup_mock_glue):
+    with pytest.raises(DataContractException) as exc_info:
+        _import(athena_table=["does_not_exist"])
+
+    assert "No tables found" in exc_info.value.reason
+
+
+def test_import_athena_requires_a_schema():
+    with pytest.raises(DataContractException) as exc_info:
+        DataContract.import_from_source("athena", staging_dir=STAGING_DIR)
+
+    assert "Athena database is required" in exc_info.value.reason
+
+
+def test_import_athena_requires_a_staging_dir():
+    with pytest.raises(DataContractException) as exc_info:
+        DataContract.import_from_source("athena", schema=DATABASE)
+
+    assert "staging directory is required" in exc_info.value.reason
+
+
+@mock_aws
+def test_cli(setup_mock_glue):
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["import", "athena", "--schema", DATABASE, "--staging-dir", STAGING_DIR],
+    )
+
+    assert result.exit_code == 0
+    # `--schema` is the Athena database here, not the v0.12.0 `--json-schema`
+    assert "--json-schema" not in result.output
+    assert "schema: my_database" in result.output


### PR DESCRIPTION
## Summary

Adds `datacontract import athena`, which creates a data contract from an Amazon Athena database:

```bash
datacontract import athena \
  --schema my_database \
  --staging-dir s3://my-bucket/athena-results/ \
  --region eu-central-1 \
  --output datacontract.yaml
```

Until now the Athena guide told users to import from Glue and then hand-write an Athena `servers` block. That workaround does not actually work: Glue stores the Hive spelling of column types, so every `string` column fails its physical type check against Athena, which reports `varchar`.

**Athena reads the Glue Data Catalog, not Athena.** Athena keeps its table metadata in Glue, so the import reuses the existing Glue reader instead of querying Athena. It needs only `glue:GetTables`, costs nothing to run, and requires no staged query results. `import glue` is unchanged; the shared per-table read was extracted into `create_schema_objects`, and the client helpers gained an optional `region`.

**Only two type names are rewritten.** `string` → `varchar` and `binary` → `varbinary`. Everything else already compares equal in the Athena dialect (`int`/`integer`, `array<int>`/`array(integer)`, `struct`/`row(...)`, `decimal`/`decimal(10,2)`, `timestamp`/`timestamp(3)`), so nothing else is touched.

## Fixes

- **`regionName` in an Athena `servers` block was silently ignored.** `_connect_athena` read `server.region_name`, but the ODCS field is `regionName`, so the value was always `None` and only `DATACONTRACT_S3_REGION` had any effect — contradicting both doc pages.
- **`datacontract import glue` mapped `timestamp` columns to `logicalType: date`.** Fixed at the shared mapping; this changes `import glue` output for timestamp columns.

## Testing

Verified against real AWS (`jakob_datacontract_test` Glue database, eu-central-1):

- `import athena` followed by `datacontract test` on the unedited file: 8/8 checks passed, exit 0, including the `varchar` physical type checks.
- The previously documented workflow, reproduced exactly, fails on every string column: `expected physical type 'string' but the column is 'varchar'`.
- The `regionName` fix was confirmed by A/B: with `regionName: us-east-1` and no env var, the pre-fix code passes green (silently connecting to the wrong region), while the fixed code correctly reaches us-east-1 and errors.

Automated: 10 importer tests against a moto-mocked Glue catalog (one asserts every imported `physicalType` matches what Athena reports, using the real comparator) and 6 connect tests covering region precedence, staging dir, and credentials. The `regionName` fix was written test-first.

## Docs

New `imports/athena.md`; `testing/athena.md` restructured to match the BigQuery/Redshift/Postgres guides, dropping the hand-written server block step; `reference/athena.md` no longer states there is no Athena importer. The imports index is re-sorted alphabetically with the new page included.