### PR TITLE
Move the servers block to the reference pages and prune obvious troubleshooting

### DIFF
--- a/docs/docs/reference/azure.md
+++ b/docs/docs/reference/azure.md
@@ -9,6 +9,16 @@ description: "All Azure storage authentication options and data type handling."
 
 Authentication options and data type handling for [Azure storage connections](../testing/azure.md).
 
+## Server
+
+```yaml
+servers:
+  - server: production
+    type: azure
+    location: abfss://datameshdatabricksdemo.dfs.core.windows.net/inventory_events/*.parquet
+    format: parquet
+```
+
 ## Authentication
 
 Authentication uses an Azure Service Principal (App Registration) with a secret:

--- a/docs/docs/reference/bigquery.md
+++ b/docs/docs/reference/bigquery.md
@@ -9,6 +9,16 @@ description: "All BigQuery authentication options and data type mappings."
 
 Authentication options and data type handling for [BigQuery connections](../testing/bigquery.md).
 
+## Server
+
+```yaml
+servers:
+  - server: production
+    type: bigquery
+    project: datameshexample-product
+    dataset: datacontract_cli_test_dataset
+```
+
 ## Authentication
 
 Authentication uses a Service Account Key or Application Default Credentials (ADC) — including Workload Identity Federation (WIF), the GCE metadata server, and `gcloud auth application-default login`. The account needs the **BigQuery Job User** and **BigQuery Data Viewer** roles.

--- a/docs/docs/reference/databricks.md
+++ b/docs/docs/reference/databricks.md
@@ -9,6 +9,16 @@ description: "All Databricks authentication options and data type mappings."
 
 Authentication options and data type handling for [Databricks connections](../testing/databricks.md).
 
+## Server
+
+```yaml
+servers:
+  - server: production
+    type: databricks
+    catalog: acme_catalog_prod
+    schema: orders_latest
+```
+
 ## Authentication
 
 | Variable | Example | Description |

--- a/docs/docs/reference/local.md
+++ b/docs/docs/reference/local.md
@@ -9,6 +9,18 @@ description: "Data type handling for local CSV, JSON, Parquet, and Delta files."
 
 Data type handling for [local file connections](../testing/local.md). No environment variables are needed.
 
+## Server
+
+```yaml
+servers:
+  - server: local
+    type: local
+    path: ./*.parquet # glob patterns and a {model} placeholder are supported
+    format: parquet   # parquet, json, csv, or delta
+```
+
+No environment variables are needed for local files. Data type inference and per-format type handling: **[Local Files Reference](../reference/local.md)**.
+
 ## Data types
 
 ### Importing

--- a/docs/docs/reference/postgres.md
+++ b/docs/docs/reference/postgres.md
@@ -9,6 +9,18 @@ description: "All Postgres authentication options and data type mappings."
 
 Authentication options and data type handling for [Postgres connections](../testing/postgres.md).
 
+## Server
+
+```yaml
+servers:
+  - server: postgres
+    type: postgres
+    host: localhost
+    port: 5432
+    database: postgres
+    schema: public
+```
+
 ## Authentication
 
 | Variable | Example | Description |

--- a/docs/docs/reference/redshift.md
+++ b/docs/docs/reference/redshift.md
@@ -9,6 +9,18 @@ description: "All Redshift authentication options and data type mappings."
 
 Authentication options and data type handling for [Redshift connections](../testing/redshift.md).
 
+## Server
+
+```yaml
+servers:
+  - server: redshift
+    type: redshift
+    host: my-workgroup.123456789012.us-east-1.redshift-serverless.amazonaws.com
+    port: 5439
+    database: dev
+    schema: analytics
+```
+
 ## Authentication
 
 `datacontract test` and `datacontract import redshift` authenticate identically. `host`, `port` (default 5439), `database`, and `schema` come from the contract's `servers` block; for the import they are passed as `--source`, `--port`, `--database`, and `--schema`.

--- a/docs/docs/reference/s3.md
+++ b/docs/docs/reference/s3.md
@@ -9,6 +9,31 @@ description: "All S3 authentication options and data type handling for files on 
 
 Authentication options and data type handling for [S3 connections](../testing/s3.md).
 
+## Server
+
+### JSON
+
+```yaml
+servers:
+  - server: production
+    type: s3
+    endpointUrl: https://minio.example.com # not needed with AWS S3
+    location: s3://bucket-name/path/*/*.json
+    format: json
+    delimiter: new_line # new_line, array, or none
+```
+
+### Delta
+
+```yaml
+servers:
+  - server: production
+    type: s3
+    endpointUrl: https://minio.example.com # not needed with AWS S3
+    location: s3://bucket-name/path/table.delta # folder with parquet files and _delta_log
+    format: delta
+```
+
 ## Authentication
 
 | Variable | Example | Description |

--- a/docs/docs/reference/snowflake.md
+++ b/docs/docs/reference/snowflake.md
@@ -9,6 +9,17 @@ description: "All Snowflake authentication options and data type mappings."
 
 Authentication options and data type handling for [Snowflake connections](../testing/snowflake.md).
 
+## Server
+
+```yaml
+servers:
+  - server: snowflake
+    type: snowflake
+    account: abcdefg-xn12345
+    database: ORDER_DB
+    schema: ORDERS_PII_V2
+```
+
 ## Authentication
 
 Any `DATACONTRACT_SNOWFLAKE_`-prefixed variable is passed (lowercased, prefix stripped) as a connection parameter to the [snowflake-connector-python](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-api#connect) driver. Set the variables required by your workspace's `authenticator` mode.

--- a/docs/docs/testing/athena.md
+++ b/docs/docs/testing/athena.md
@@ -82,4 +82,3 @@ All authentication options and the data type mappings: **[Athena Reference](../r
 
 - **`Access Denied` on query start** — the credentials need `athena:StartQueryExecution` plus write access to the `stagingDir` bucket.
 - **`Table not found`** — `schema` in the `servers` block must be the Athena *database* name (as shown in the Glue Data Catalog), and `regionName` must match where the catalog lives.
-- **Query results land in the wrong place** — `stagingDir` is required; Athena writes query results there before the CLI reads them.

--- a/docs/docs/testing/azure.md
+++ b/docs/docs/testing/azure.md
@@ -74,16 +74,6 @@ schema:
 
 Run `datacontract test datacontract.yaml` again: every violation is listed as an error, and the command exits with code `1` — ready for [CI/CD scheduling](../ci-cd.md) so you catch drift before your consumers do.
 
-## Server reference
-
-```yaml
-servers:
-  - server: production
-    type: azure
-    location: abfss://datameshdatabricksdemo.dfs.core.windows.net/inventory_events/*.parquet
-    format: parquet
-```
-
 ## Reference
 
 All authentication options (service principal, connection string, account key), supported location URL formats, and the data type handling per file format: **[Azure Reference](../reference/azure.md)**.

--- a/docs/docs/testing/bigquery.md
+++ b/docs/docs/testing/bigquery.md
@@ -76,18 +76,6 @@ schema:
 
 Run `datacontract test datacontract.yaml` again: every violation is listed as an error, and the command exits with code `1` — ready for [CI/CD scheduling](../ci-cd.md) so you catch drift before your consumers do.
 
-## Server reference
-
-Connection details live in the contract's `servers` block; `project` and `dataset` come from there:
-
-```yaml
-servers:
-  - server: production
-    type: bigquery
-    project: datameshexample-product
-    dataset: datacontract_cli_test_dataset
-```
-
 ## Reference
 
 All authentication options (service-account keys, WIF, billing project) and the data type mappings: **[BigQuery Reference](../reference/bigquery.md)**.

--- a/docs/docs/testing/databricks.md
+++ b/docs/docs/testing/databricks.md
@@ -77,18 +77,6 @@ schema:
 
 Run `datacontract test datacontract.yaml` again: every violation is listed as an error, and the command exits with code `1` — ready for [CI/CD scheduling](../ci-cd.md) so you catch drift before your consumers do.
 
-## Server reference
-
-Connection details live in the contract's `servers` block; `catalog` and `schema` come from there:
-
-```yaml
-servers:
-  - server: production
-    type: databricks
-    catalog: acme_catalog_prod
-    schema: orders_latest
-```
-
 ## Reference
 
 All authentication options (PAT, OAuth M2M, profiles, precedence order) and the data type mappings: **[Databricks Reference](../reference/databricks.md)**.

--- a/docs/docs/testing/local.md
+++ b/docs/docs/testing/local.md
@@ -73,15 +73,3 @@ invalid_count(order_total) was 1, expected = 0
 The command exits with code `1`, so the same call works as a gate in [CI/CD pipelines](../ci-cd.md).
 
 Ready for your real data? Do the same against [Snowflake](./snowflake.md), [BigQuery](./bigquery.md), or [Databricks](./databricks.md).
-
-## Server reference
-
-```yaml
-servers:
-  - server: local
-    type: local
-    path: ./*.parquet # glob patterns and a {model} placeholder are supported
-    format: parquet   # parquet, json, csv, or delta
-```
-
-No environment variables are needed for local files. Data type inference and per-format type handling: **[Local Files Reference](../reference/local.md)**.

--- a/docs/docs/testing/postgres.md
+++ b/docs/docs/testing/postgres.md
@@ -85,20 +85,6 @@ schema:
 
 Run `datacontract test datacontract.yaml` again: every violation is listed as an error, and the command exits with code `1` — ready for [CI/CD scheduling](../ci-cd.md) so you catch drift before your consumers do.
 
-## Server reference
-
-Connection details live in the contract's `servers` block; `host`, `port`, `database`, and `schema` come from there:
-
-```yaml
-servers:
-  - server: postgres
-    type: postgres
-    host: localhost
-    port: 5432
-    database: postgres
-    schema: public
-```
-
 ## Reference
 
 All authentication options and the data type mappings: **[Postgres Reference](../reference/postgres.md)**.
@@ -106,6 +92,4 @@ All authentication options and the data type mappings: **[Postgres Reference](..
 ## Troubleshooting
 
 - **`password authentication failed`** — check the two environment variables above; note that values from an already-set shell variable take precedence over `.env`.
-- **`connection refused`** — host/port in the `servers` block are wrong, or the database isn't reachable from your machine (VPN, firewall, `pg_hba.conf`).
-- **`relation does not exist`** — the `schema` in the `servers` block doesn't match where the table lives, or the user lacks `USAGE`/`SELECT` grants.
-- **The import finds no tables** — `--schema` is case-sensitive and must match the schema as stored in the catalog.
+- **`relation does not exist`** — the user lacks `USAGE` on the schema or `SELECT` on the table; a missing grant reads as a missing relation.

--- a/docs/docs/testing/redshift.md
+++ b/docs/docs/testing/redshift.md
@@ -92,20 +92,6 @@ schema:
 
 Run `datacontract test datacontract.yaml` again: every violation is listed as an error, and the command exits with code `1` — ready for [CI/CD scheduling](../ci-cd.md) so you catch drift before your consumers do.
 
-## Server reference
-
-Connection details live in the contract's `servers` block; `host`, `port`, `database`, and `schema` come from there:
-
-```yaml
-servers:
-  - server: redshift
-    type: redshift
-    host: my-workgroup.123456789012.us-east-1.redshift-serverless.amazonaws.com
-    port: 5439
-    database: dev
-    schema: analytics
-```
-
 ## Reference
 
 All authentication options and the data type mappings: **[Redshift Reference](../reference/redshift.md)**.

--- a/docs/docs/testing/s3.md
+++ b/docs/docs/testing/s3.md
@@ -85,31 +85,6 @@ schema:
 
 Run `datacontract test datacontract.yaml` again: every violation is listed as an error, and the command exits with code `1` — ready for [CI/CD scheduling](../ci-cd.md) so you catch drift before your consumers do.
 
-## Server reference
-
-### JSON
-
-```yaml
-servers:
-  - server: production
-    type: s3
-    endpointUrl: https://minio.example.com # not needed with AWS S3
-    location: s3://bucket-name/path/*/*.json
-    format: json
-    delimiter: new_line # new_line, array, or none
-```
-
-### Delta
-
-```yaml
-servers:
-  - server: production
-    type: s3
-    endpointUrl: https://minio.example.com # not needed with AWS S3
-    location: s3://bucket-name/path/table.delta # folder with parquet files and _delta_log
-    format: delta
-```
-
 ## Reference
 
 All authentication options and the data type handling per file format: **[S3 Reference](../reference/s3.md)**.

--- a/docs/docs/testing/snowflake.md
+++ b/docs/docs/testing/snowflake.md
@@ -80,19 +80,6 @@ schema:
 
 Run `datacontract test datacontract.yaml` again: every violation is listed as an error, and the command exits with code `1` — ready for [CI/CD scheduling](../ci-cd.md) so you catch drift before your consumers do.
 
-## Server reference
-
-Connection details live in the contract's `servers` block; `account`, `database`, and `schema` come from there:
-
-```yaml
-servers:
-  - server: snowflake
-    type: snowflake
-    account: abcdefg-xn12345
-    database: ORDER_DB
-    schema: ORDERS_PII_V2
-```
-
 ## Reference
 
 All authentication options (key-pair, SSO, connections.toml) and the data type mappings: **[Snowflake Reference](../reference/snowflake.md)**.


### PR DESCRIPTION
## Summary

Two related cleanups to the connection docs.

**`## Server reference` moves from the testing pages to the reference pages.** It was on 8 of 19 testing pages, which is the worst of both worlds. On the pages that had it, step 3 now generates the `servers` block for you, so showing it again three sections later restated output the reader already has in their file. The reference pages, meanwhile, documented every field in prose but showed no complete block anywhere. Now they do, as `## Server`, and all 19 testing pages share one shape:

```
1. Install → 2. Authenticate → 3. Create a contract → 4. Test → 5. Catch a violation → Reference → Troubleshooting
```

Where the moved lead-in ("Connection details live in the contract's `servers` block; `host`, `port` … come from there") duplicated a sentence already in the reference page's Authentication section, it was dropped and only the block kept.

**Troubleshooting entries now have to earn their place.** The rule: an entry qualifies only if it tells you something you could not infer from the error text itself. `403 Forbidden → the key lacks s3:GetObject` qualifies; `connection refused → host/port are wrong` does not. Audited all 19 pages against it and removed three entries:

- postgres: `connection refused` — restated the error
- postgres: "The import finds no tables" — restated the flag
- athena: "Query results land in the wrong place" — `stagingDir` is already covered in step 3

and trimmed one (postgres `relation does not exist`) down to the part that is genuinely non-obvious: a missing grant surfaces as a missing relation.

The entries that stay are the ones that encode real product knowledge — the Snowflake account-identifier format, GCS needing `s3://` rather than `gs://`, Azure's Storage Blob Data Reader role assignment, BigQuery's billing project, Oracle thick mode, a shell variable silently beating `.env`.

Docs only; no code changes.