### PR TITLE
Rename the unity importer to databricks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `datacontract import unity` is now `datacontract import databricks`; the `unity` format name keeps working
 - `datacontract import postgres` creates a data contract from a live Postgres schema, including a ready-to-test `servers` block
 - `datacontract import redshift` creates a data contract from an Amazon Redshift schema, including a ready-to-test `servers` block
 - Redshift supports IAM authentication with `DATACONTRACT_REDSHIFT_AUTHENTICATION=iam`, using temporary credentials from your AWS session instead of a database password

--- a/datacontract/command_import.py
+++ b/datacontract/command_import.py
@@ -231,21 +231,25 @@ def import_bigquery(
     _write_result(result, output)
 
 
+databricks_source_option = Annotated[
+    Optional[str],
+    typer.Option(
+        help="Path to a Unity Catalog TableInfo JSON file. If omitted, imports from the Unity API using --table."
+    ),
+]
+databricks_table_option = Annotated[
+    Optional[List[str]],
+    typer.Option(help="Full name of a table in the Unity Catalog (repeat for multiple tables)."),
+]
+
+
 @import_app.command(
-    name="unity",
-    epilog="Example: datacontract import unity --table catalog.schema.my_table --output datacontract.yaml",
+    name="databricks",
+    epilog="Example: datacontract import databricks --table catalog.schema.my_table --output datacontract.yaml",
 )
-def import_unity(
-    source: Annotated[
-        Optional[str],
-        typer.Option(
-            help="Path to a Unity Catalog TableInfo JSON file. If omitted, imports from the Unity API using --table."
-        ),
-    ] = None,
-    table: Annotated[
-        Optional[List[str]],
-        typer.Option(help="Full name of a table in the Unity Catalog (repeat for multiple tables)."),
-    ] = None,
+def import_databricks(
+    source: databricks_source_option = None,
+    table: databricks_table_option = None,
     output: output_option = None,
     schema: schema_option = None,
     owner: owner_option = None,
@@ -255,9 +259,29 @@ def import_unity(
     """Import a data contract from Databricks Unity Catalog."""
     enable_debug_logging(debug)
     result = DataContract.import_from_source(
-        format="unity", source=source, schema=schema, unity_table_full_name=table, owner=owner, id=id
+        format="databricks", source=source, schema=schema, unity_table_full_name=table, owner=owner, id=id
     )
     _write_result(result, output)
+
+
+# `unity` predates the `databricks` name and stays working; hidden so the help
+# lists one name for one importer.
+@import_app.command(
+    name="unity",
+    hidden=True,
+    epilog="Example: datacontract import databricks --table catalog.schema.my_table --output datacontract.yaml",
+)
+def import_unity(
+    source: databricks_source_option = None,
+    table: databricks_table_option = None,
+    output: output_option = None,
+    schema: schema_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from Databricks Unity Catalog (alias of `import databricks`)."""
+    import_databricks(source=source, table=table, output=output, schema=schema, owner=owner, id=id, debug=debug)
 
 
 @import_app.command(

--- a/datacontract/imports/importer.py
+++ b/datacontract/imports/importer.py
@@ -32,6 +32,7 @@ class ImportFormat(str, Enum):
     bigquery = "bigquery"
     odcs = "odcs"
     unity = "unity"
+    databricks = "databricks"
     spark = "spark"
     iceberg = "iceberg"
     parquet = "parquet"

--- a/datacontract/imports/importer_factory.py
+++ b/datacontract/imports/importer_factory.py
@@ -82,6 +82,11 @@ importer_factory.register_lazy_importer(
     class_name="UnityImporter",
 )
 importer_factory.register_lazy_importer(
+    name=ImportFormat.databricks,
+    module_path="datacontract.imports.unity_importer",
+    class_name="UnityImporter",
+)
+importer_factory.register_lazy_importer(
     name=ImportFormat.spark,
     module_path="datacontract.imports.spark_importer",
     class_name="SparkImporter",

--- a/docs/docs/commands/import.md
+++ b/docs/docs/commands/import.md
@@ -18,4 +18,4 @@ Run `datacontract import <format> --help` to see format-specific options.
 datacontract import sql --source ddl.sql --dialect postgres --output datacontract.yaml
 ```
 
-Available formats: `dbt`, `sql`, `avro`, `dbml`, `glue`, `bigquery`, `unity`, `jsonschema`, `json`, `odcs`, `parquet`, `csv`, `protobuf`, `spark`, `iceberg`, `excel`, `powerbi`, `snowflake`, `redshift`, `postgres`.
+Available formats: `dbt`, `sql`, `avro`, `dbml`, `glue`, `bigquery`, `databricks`, `jsonschema`, `json`, `odcs`, `parquet`, `csv`, `protobuf`, `spark`, `iceberg`, `excel`, `powerbi`, `snowflake`, `redshift`, `postgres`.

--- a/docs/docs/imports/databricks.md
+++ b/docs/docs/imports/databricks.md
@@ -1,0 +1,23 @@
+---
+sidebar_position: 4
+title: "Import: Databricks"
+description: "Create a data contract from Databricks Unity Catalog."
+---
+
+# <img className="page-icon" src="/img/icons/databricks.svg" alt="" /> Import: Databricks
+
+Creates a data contract from Databricks Unity Catalog, from an exported JSON file or via the HTTP endpoint.
+
+```bash
+# From the HTTP endpoint (repeat --table for multiple tables)
+datacontract import databricks --table my_catalog.my_schema.orders
+
+# From an exported Unity Catalog TableInfo JSON file
+datacontract import databricks --source unity_table.json
+```
+
+For the HTTP endpoint, authenticate either with a personal access token (`DATACONTRACT_DATABRICKS_SERVER_HOSTNAME` + `DATACONTRACT_DATABRICKS_TOKEN`) or with a profile from `~/.databrickscfg` (`DATACONTRACT_DATABRICKS_PROFILE`).
+
+The generated contract includes a ready-to-test `servers` block (`type: databricks` with catalog and schema). To run `datacontract test` afterwards, additionally set `DATACONTRACT_DATABRICKS_HTTP_PATH` to a running SQL warehouse — see the **[Databricks connection guide](../testing/databricks.md)** for the full 5-minute walkthrough and troubleshooting.
+
+The importer was previously called `unity`. That name still works, so existing scripts keep running.

--- a/docs/docs/imports/dbml.md
+++ b/docs/docs/imports/dbml.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 title: "Import: DBML"
 description: "Create a data contract from a DBML file, with optional schema/table filters."
 ---

--- a/docs/docs/imports/dbt.md
+++ b/docs/docs/imports/dbt.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 title: "Import: dbt"
 description: "Create a data contract from a dbt manifest file."
 ---

--- a/docs/docs/imports/excel.md
+++ b/docs/docs/imports/excel.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 title: "Import: Excel"
 description: "Create a data contract from an ODCS Excel template."
 ---

--- a/docs/docs/imports/glue.md
+++ b/docs/docs/imports/glue.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 title: "Import: AWS Glue"
 description: "Create a data contract from the AWS Glue Data Catalog."
 ---

--- a/docs/docs/imports/iceberg.md
+++ b/docs/docs/imports/iceberg.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 title: "Import: Iceberg"
 description: "Create a data contract from an Apache Iceberg schema."
 ---

--- a/docs/docs/imports/index.md
+++ b/docs/docs/imports/index.md
@@ -17,7 +17,7 @@ datacontract import sql --source my_ddl.sql --dialect postgres
 datacontract import sql --source my_ddl.sql --dialect postgres --output datacontract.yaml
 ```
 
-The [Snowflake](./snowflake.md), [BigQuery](./bigquery.md), [Amazon Redshift](./redshift.md), [Postgres](./postgres.md), [Unity Catalog](./unity.md), and [AWS Glue](./glue.md) importers can connect directly to the live system and introspect your tables — no export files needed. Snowflake, BigQuery, Redshift, Postgres, and Unity Catalog also generate a ready-to-test `servers` block, so `datacontract test` works right after the import.
+The [Snowflake](./snowflake.md), [BigQuery](./bigquery.md), [Amazon Redshift](./redshift.md), [Postgres](./postgres.md), [Databricks](./databricks.md), and [AWS Glue](./glue.md) importers can connect directly to the live system and introspect your tables — no export files needed. Snowflake, BigQuery, Redshift, Postgres, and Databricks also generate a ready-to-test `servers` block, so `datacontract test` works right after the import.
 
 Run `datacontract import <format> --help` to see the format-specific options (e.g. `datacontract import sql --help`). If a format you need is missing, [open an issue on GitHub](https://github.com/datacontract/datacontract-cli/issues).
 
@@ -39,6 +39,10 @@ Each import page shows a runnable example: a small source file under [`examples/
   <a className="doc-card" href="/imports/csv">
     <img src="/img/icons/custom.svg" alt="" />
     <span><span className="doc-card-title">csv</span><span className="doc-card-desc">A CSV file.</span></span>
+  </a>
+  <a className="doc-card" href="/imports/databricks">
+    <img src="/img/icons/databricks.svg" alt="" />
+    <span><span className="doc-card-title">databricks</span><span className="doc-card-desc">Databricks Unity Catalog.</span></span>
   </a>
   <a className="doc-card" href="/imports/dbml">
     <img src="/img/icons/dbml.svg" alt="" />
@@ -103,10 +107,6 @@ Each import page shows a runnable example: a small source file under [`examples/
   <a className="doc-card" href="/imports/sql">
     <img src="/img/icons/database.svg" alt="" />
     <span><span className="doc-card-title">sql</span><span className="doc-card-desc">A SQL DDL file.</span></span>
-  </a>
-  <a className="doc-card" href="/imports/unity">
-    <img src="/img/icons/databricks.svg" alt="" />
-    <span><span className="doc-card-title">unity</span><span className="doc-card-desc">Databricks Unity Catalog.</span></span>
   </a>
 </div>
 

--- a/docs/docs/imports/json.md
+++ b/docs/docs/imports/json.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 10
 title: "Import: JSON"
 description: "Create a data contract by inferring a schema from a JSON data file."
 ---

--- a/docs/docs/imports/jsonschema.md
+++ b/docs/docs/imports/jsonschema.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 11
 title: "Import: JSON Schema"
 description: "Create a data contract from a JSON Schema file."
 ---

--- a/docs/docs/imports/odcs.md
+++ b/docs/docs/imports/odcs.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 title: "Import: ODCS"
 description: "Create a data contract from an existing ODCS file."
 ---

--- a/docs/docs/imports/parquet.md
+++ b/docs/docs/imports/parquet.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 13
 title: "Import: Parquet"
 description: "Create a data contract from a Parquet file."
 ---

--- a/docs/docs/imports/postgres.md
+++ b/docs/docs/imports/postgres.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 14
 title: "Import: Postgres"
 description: "Create a data contract from a Postgres schema."
 ---

--- a/docs/docs/imports/powerbi.md
+++ b/docs/docs/imports/powerbi.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 15
 title: "Import: Power BI"
 description: "Create a data contract from a Power BI semantic model (.pbit, .bim, or .json)."
 ---

--- a/docs/docs/imports/protobuf.md
+++ b/docs/docs/imports/protobuf.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 16
 title: "Import: Protobuf"
 description: "Create a data contract from a Protobuf schema file."
 ---

--- a/docs/docs/imports/redshift.md
+++ b/docs/docs/imports/redshift.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 17
 title: "Import: Amazon Redshift"
 description: "Create a data contract from an Amazon Redshift schema."
 ---

--- a/docs/docs/imports/snowflake.md
+++ b/docs/docs/imports/snowflake.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 17
+sidebar_position: 18
 title: "Import: Snowflake"
 description: "Create a data contract from a Snowflake workspace."
 ---

--- a/docs/docs/imports/spark.md
+++ b/docs/docs/imports/spark.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 18
+sidebar_position: 19
 title: "Import: Spark"
 description: "Create a data contract from Spark tables or DataFrames (programmatic)."
 ---

--- a/docs/docs/imports/sql.md
+++ b/docs/docs/imports/sql.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 19
+sidebar_position: 20
 title: "Import: SQL DDL"
 description: "Create a data contract from a SQL DDL file."
 ---

--- a/docs/docs/imports/unity.md
+++ b/docs/docs/imports/unity.md
@@ -1,21 +1,10 @@
 ---
-sidebar_position: 20
 title: "Import: Unity Catalog"
-description: "Create a data contract from Databricks Unity Catalog (file or HTTP endpoint)."
+description: "Moved to Import: Databricks."
+unlisted: true
 ---
 
-# <img className="page-icon" src="/img/icons/databricks.svg" alt="" /> Import: Unity Catalog
+# Import: Unity Catalog
 
-Creates a data contract from Databricks Unity Catalog, from an exported JSON file or via the HTTP endpoint.
-
-```bash
-# From the HTTP endpoint (repeat --table for multiple tables)
-datacontract import unity --table my_catalog.my_schema.orders
-
-# From an exported Unity Catalog TableInfo JSON file
-datacontract import unity --source unity_table.json
-```
-
-For the HTTP endpoint, authenticate either with a personal access token (`DATACONTRACT_DATABRICKS_SERVER_HOSTNAME` + `DATACONTRACT_DATABRICKS_TOKEN`) or with a profile from `~/.databrickscfg` (`DATACONTRACT_DATABRICKS_PROFILE`).
-
-The generated contract includes a ready-to-test `servers` block (`type: databricks` with catalog and schema). To run `datacontract test` afterwards, additionally set `DATACONTRACT_DATABRICKS_HTTP_PATH` to a running SQL warehouse — see the **[Databricks connection guide](../testing/databricks.md)** for the full 5-minute walkthrough and troubleshooting.
+This importer is now documented as **[Import: Databricks](./databricks.md)**.
+The `unity` format name still works.

--- a/docs/docs/testing/databricks.md
+++ b/docs/docs/testing/databricks.md
@@ -34,7 +34,7 @@ Find the hostname and HTTP path under your SQL warehouse's **Connection details*
 Import the table metadata directly from Unity Catalog. This also generates a ready-to-test `servers` block:
 
 ```bash
-datacontract import unity \
+datacontract import databricks \
   --table my_catalog.my_schema.orders \
   --output datacontract.yaml
 ```
@@ -101,6 +101,6 @@ On Databricks LTS ML runtimes (15.4, 16.4), installing via `%pip install` in not
 
 ## Troubleshooting
 
-- **`Invalid HTTP path`, or the test hangs** — `DATACONTRACT_DATABRICKS_HTTP_PATH` must point at a running SQL warehouse or cluster (check the **Connection details** tab). `import unity` works without it, but `test` requires it.
+- **`Invalid HTTP path`, or the test hangs** — `DATACONTRACT_DATABRICKS_HTTP_PATH` must point at a running SQL warehouse or cluster (check the **Connection details** tab). `import databricks` works without it, but `test` requires it.
 - **`403 Invalid access token`** — the PAT is expired or belongs to a different workspace than `DATACONTRACT_DATABRICKS_SERVER_HOSTNAME`.
 - **`TABLE_OR_VIEW_NOT_FOUND`** — the token's principal lacks `USE CATALOG`/`USE SCHEMA`/`SELECT` privileges on the table.

--- a/tests/test_import_unity_file.py
+++ b/tests/test_import_unity_file.py
@@ -99,3 +99,28 @@ def test_cli_with_owner_and_id():
     # Verify owner and id are set correctly
     assert output_dict["id"] == "orders-v1"
     assert output_dict["team"]["name"] == "sales-team"
+
+
+SOURCE = "fixtures/databricks-unity/import/unity_table_schema.json"
+
+
+def test_cli_databricks():
+    """`databricks` is the documented name for this importer."""
+    result = CliRunner().invoke(app, ["import", "databricks", "--source", SOURCE])
+
+    assert result.exit_code == 0
+
+
+def test_databricks_and_unity_produce_the_same_contract():
+    """`unity` predates the name and has to keep working."""
+    assert DataContract.import_from_source("databricks", SOURCE).to_yaml() == (
+        DataContract.import_from_source("unity", SOURCE).to_yaml()
+    )
+
+
+def test_unity_stays_available_but_is_hidden_from_help():
+    help_output = CliRunner().invoke(app, ["import", "--help"]).output
+
+    assert "databricks" in help_output
+    assert "unity" not in help_output
+    assert CliRunner().invoke(app, ["import", "unity", "--source", SOURCE]).exit_code == 0


### PR DESCRIPTION
## Summary

`datacontract import unity` becomes `datacontract import databricks`. The old name keeps working.

The importer already spoke Databricks everywhere except its name: it uses the Databricks SDK `WorkspaceClient`, authenticates with `DATACONTRACT_DATABRICKS_*`, writes a `type: databricks` server block, and its own docs page sends readers to the **Databricks connection guide** to run the test. The testing page is `databricks.md`; the import page was `unity.md`. Anyone holding a `type: databricks` contract would look for `import databricks` and find nothing.

They are not literally identical — Unity Catalog is the specific API, and a workspace can still hold legacy `hive_metastore` tables that UC's three-level namespace addresses but does not own. In practice that seam costs more than it buys.

## Compatibility

- `import unity` still works and produces a byte-identical contract (asserted by a test).
- It is `hidden=True` in the CLI, so the help lists one name per importer.
- The `unity` format string is still registered, so `DataContract.import_from_source("unity", …)` is unaffected.
- `docs/imports/unity.md` stays as an unlisted stub pointing at the new page, so the published `/imports/unity` URL does not 404.

## Testing

Three new tests: `import databricks` via the CLI, both names producing identical output, and `unity` being absent from the help while still executing.