### PR TITLE
Infer the Redshift authentication method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `datacontract import unity` is now `datacontract import databricks`; the `unity` format name keeps working
+- Redshift infers the authentication method: a password means a database login, otherwise your AWS session is used for IAM. `DATACONTRACT_REDSHIFT_AUTHENTICATION` is no longer required and remains as an override
 - `datacontract import postgres` creates a data contract from a live Postgres schema, including a ready-to-test `servers` block
 - `datacontract import redshift` creates a data contract from an Amazon Redshift schema, including a ready-to-test `servers` block
-- Redshift supports IAM authentication with `DATACONTRACT_REDSHIFT_AUTHENTICATION=iam`, using temporary credentials from your AWS session instead of a database password
+- Redshift supports IAM authentication, using temporary credentials from your AWS session instead of a database password
 - `datacontract import bigquery` now generates a `servers` block, so `datacontract test` works right after the import
 - `datacontract test` verifies declared primary keys: each key column must have no missing values, and the key must have no duplicates (a composite key is checked as a tuple) (#1220 @DMZ22)
 

--- a/datacontract/engines/ibis/connections/redshift_credentials.py
+++ b/datacontract/engines/ibis/connections/redshift_credentials.py
@@ -43,8 +43,14 @@ class RedshiftLogin:
 
 
 def resolve_redshift_login(host: Optional[str], database: Optional[str]) -> RedshiftLogin:
-    """Return the database login to connect with, per DATACONTRACT_REDSHIFT_AUTHENTICATION."""
-    authentication = os.getenv("DATACONTRACT_REDSHIFT_AUTHENTICATION", "password").strip().lower()
+    """Return the database login to connect with.
+
+    The method is inferred from what is configured, so the common cases need no
+    extra variable. ``DATACONTRACT_REDSHIFT_AUTHENTICATION`` stays as an
+    override for when the inference guesses wrong, matching the equivalent
+    variables on Databricks, Snowflake, SQL Server and Trino.
+    """
+    authentication = os.getenv("DATACONTRACT_REDSHIFT_AUTHENTICATION", "").strip().lower() or _infer_authentication()
 
     if authentication == "password":
         return RedshiftLogin(
@@ -73,6 +79,42 @@ def resolve_redshift_login(host: Optional[str], database: Optional[str]) -> Reds
         ),
         engine="datacontract",
     )
+
+
+def _infer_authentication() -> str:
+    """Pick the authentication method from what is configured.
+
+    Keyed on the password, not the username: IAM on a provisioned cluster also
+    reads ``DATACONTRACT_REDSHIFT_USERNAME`` as the database user, so a set
+    username says nothing about which method was intended.
+    """
+    if os.getenv("DATACONTRACT_REDSHIFT_PASSWORD"):
+        return "password"
+    if _aws_credentials_available():
+        return "iam"
+    raise DataContractException(
+        type="redshift-connection",
+        name="no_authentication_available",
+        reason=(
+            "Could not determine how to authenticate with Redshift. Set DATACONTRACT_REDSHIFT_USERNAME and "
+            "DATACONTRACT_REDSHIFT_PASSWORD for a database login, or sign in to AWS (e.g. aws sso login) to use "
+            "IAM authentication."
+        ),
+        engine="datacontract",
+    )
+
+
+def _aws_credentials_available() -> bool:
+    """True when boto3 can resolve credentials from anywhere in its chain."""
+    if os.getenv("DATACONTRACT_S3_ACCESS_KEY_ID") and os.getenv("DATACONTRACT_S3_SECRET_ACCESS_KEY"):
+        return True
+    try:
+        import boto3
+
+        return boto3.Session().get_credentials() is not None
+    except Exception as e:  # boto3 missing, or a broken profile/config file
+        logger.debug("could not resolve AWS credentials: %s", e)
+        return False
 
 
 def _mint_iam_credentials(host: Optional[str], database: Optional[str]) -> Tuple[str, str]:

--- a/docs/docs/reference/redshift.md
+++ b/docs/docs/reference/redshift.md
@@ -27,14 +27,14 @@ servers:
 
 | Variable | Example | Description |
 |---|---|---|
-| `DATACONTRACT_REDSHIFT_AUTHENTICATION` | `iam` | `password` (default) or `iam` |
+| `DATACONTRACT_REDSHIFT_AUTHENTICATION` | `iam` | `password` or `iam`; only needed to override what is inferred |
 | `DATACONTRACT_REDSHIFT_USERNAME` | `awsuser` | Database user. Required for `password`; in `iam` mode it selects the legacy API (see below) |
 | `DATACONTRACT_REDSHIFT_PASSWORD` | `mysecretpassword` | Password (`password` mode only) |
 | `DATACONTRACT_REDSHIFT_SSLMODE` | `verify-full` | TLS mode passed to the driver. Defaults to `require` in `iam` mode, and to the driver's own default (`prefer`) otherwise |
 
 ### IAM authentication
 
-With `DATACONTRACT_REDSHIFT_AUTHENTICATION=iam`, the CLI asks AWS for temporary database credentials and uses them to log in — no database password anywhere. The AWS credentials themselves come from the same variables Athena uses (`DATACONTRACT_S3_ACCESS_KEY_ID`, `DATACONTRACT_S3_SECRET_ACCESS_KEY`, `DATACONTRACT_S3_SESSION_TOKEN`, `DATACONTRACT_S3_REGION`), and fall back to the standard AWS chain: `aws sso login`, `AWS_PROFILE`, EC2/ECS/EKS instance roles, or GitHub OIDC in CI.
+The method is inferred: setting `DATACONTRACT_REDSHIFT_PASSWORD` selects a database login, otherwise resolvable AWS credentials select IAM. Set `DATACONTRACT_REDSHIFT_AUTHENTICATION` explicitly only to override that. With IAM, the CLI asks AWS for temporary database credentials and uses them to log in — no database password anywhere. The AWS credentials themselves come from the same variables Athena uses (`DATACONTRACT_S3_ACCESS_KEY_ID`, `DATACONTRACT_S3_SECRET_ACCESS_KEY`, `DATACONTRACT_S3_SESSION_TOKEN`, `DATACONTRACT_S3_REGION`), and fall back to the standard AWS chain: `aws sso login`, `AWS_PROFILE`, EC2/ECS/EKS instance roles, or GitHub OIDC in CI.
 
 Which AWS API is called depends on the endpoint and whether a username is set:
 

--- a/docs/docs/testing/redshift.md
+++ b/docs/docs/testing/redshift.md
@@ -18,20 +18,15 @@ See [Installation](../installation.md) for pip, pipx, and Docker.
 
 ## 2. Authenticate
 
-The easiest way is IAM — sign in to AWS once and the CLI requests temporary database credentials itself, so no database password is stored anywhere:
+The easiest way is IAM — sign in to AWS once and the CLI requests temporary database credentials itself, so no database password is stored anywhere and nothing else has to be configured:
 
 ```bash
 aws sso login   # or any other way of getting an AWS session
 ```
 
-```bash
-# .env
-DATACONTRACT_REDSHIFT_AUTHENTICATION=iam
-```
-
 Your AWS identity needs `redshift-serverless:GetCredentials` (Serverless) or `redshift:GetClusterCredentialsWithIAM` (provisioned cluster), and the resulting database user needs `USAGE` on the schema plus `SELECT` on the tables.
 
-Prefer a database user? Leave the authentication variable unset and provide the credentials directly:
+Prefer a database user? Set the credentials directly and they are used instead:
 
 ```bash
 # .env
@@ -39,7 +34,7 @@ DATACONTRACT_REDSHIFT_USERNAME=awsuser
 DATACONTRACT_REDSHIFT_PASSWORD=mysecretpassword
 ```
 
-Either way, `import` and `test` use the same setup. For custom domains, VPC endpoints, and the full list of options, see the [Redshift Reference](../reference/redshift.md).
+The CLI picks the method from what you configured: a password means a database login, otherwise it uses your AWS session. Either way, `import` and `test` use the same setup. For custom domains, VPC endpoints, and the full list of options, see the [Redshift Reference](../reference/redshift.md).
 
 ## 3. Create a contract from your tables
 
@@ -99,7 +94,7 @@ All authentication options and the data type mappings: **[Redshift Reference](..
 ## Troubleshooting
 
 - **Connection timeout** — the cluster/workgroup must be reachable from your machine: check **Publicly accessible**, the VPC security group's inbound rule for port `5439`, and VPN routing.
-- **`password authentication failed`** — with `password` authentication, Redshift Serverless expects the namespace's admin credentials or a database user; an IAM user name is not a database user. Set `DATACONTRACT_REDSHIFT_AUTHENTICATION=iam` to sign in with your AWS identity instead.
+- **`password authentication failed`** — Redshift Serverless expects the namespace's admin credentials or a database user; an IAM user name is not a database user. Unset `DATACONTRACT_REDSHIFT_PASSWORD` to sign in with your AWS identity instead.
 - **`Could not obtain temporary Redshift credentials`** — the AWS identity may call the wrong region (set `DATACONTRACT_REDSHIFT_REGION`) or lack `GetCredentials` / `GetClusterCredentialsWithIAM` permission.
 - **`Using the login credential provider requires an additional dependency`** — your AWS profile uses the `aws login` flow, which needs `pip install "botocore[crt]"` in the same environment as the CLI.
 - **`relation does not exist`** — check the `schema` in the `servers` block and the user's `USAGE` grant on it.

--- a/tests/test_redshift_credentials.py
+++ b/tests/test_redshift_credentials.py
@@ -30,8 +30,24 @@ REDSHIFT_ENV = [
 
 
 @pytest.fixture(autouse=True)
-def clean_env(monkeypatch):
-    """A developer's own AWS/Redshift variables must not leak into these tests."""
+def clean_env(monkeypatch, tmp_path):
+    """A developer's own AWS/Redshift variables must not leak into these tests.
+
+    Authentication is now inferred, so an ambient `aws sso login` would other-
+    wise decide the outcome. Point boto3 at empty config files and switch the
+    metadata service off so its chain resolves nothing, deterministically.
+    """
+    for name in (
+        "AWS_PROFILE",
+        "AWS_DEFAULT_PROFILE",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "no-config"))
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(tmp_path / "no-credentials"))
+    monkeypatch.setenv("AWS_EC2_METADATA_DISABLED", "true")
     for name in REDSHIFT_ENV:
         monkeypatch.delenv(name, raising=False)
 
@@ -58,7 +74,9 @@ def test_password_authentication_is_the_default(monkeypatch):
     assert login.sslmode is None
 
 
-def test_password_authentication_requires_a_username():
+def test_password_authentication_requires_a_username(monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_PASSWORD", "secret")
+
     with pytest.raises(DataContractException) as exc_info:
         resolve_redshift_login(SERVERLESS_HOST, "dev")
 
@@ -194,3 +212,62 @@ def test_unsupported_authentication_mode(monkeypatch):
         resolve_redshift_login(SERVERLESS_HOST, "dev")
 
     assert "Supported values are: password, iam" in exc_info.value.reason
+
+
+# ---------------------------------------------------------------------------
+# Inferring the authentication method
+# ---------------------------------------------------------------------------
+def test_password_is_inferred_from_the_password_variable(monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_USERNAME", "awsuser")
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_PASSWORD", "secret")
+
+    login = resolve_redshift_login(SERVERLESS_HOST, "dev")
+
+    assert (login.user, login.password) == ("awsuser", "secret")
+
+
+def test_iam_is_inferred_from_an_aws_session(monkeypatch):
+    """No Redshift variable at all: AWS credentials are enough."""
+    monkeypatch.setenv("DATACONTRACT_S3_ACCESS_KEY_ID", "AKIA_TEST")
+    monkeypatch.setenv("DATACONTRACT_S3_SECRET_ACCESS_KEY", "secret")
+    aws = MagicMock()
+    aws.get_credentials.return_value = {"dbUser": "IAM:alice", "dbPassword": "temporary"}
+
+    with patch("boto3.client", return_value=aws):
+        login = resolve_redshift_login(SERVERLESS_HOST, "dev")
+
+    assert (login.user, login.password) == ("IAM:alice", "temporary")
+
+
+def test_a_username_alone_does_not_force_password_auth(monkeypatch):
+    """IAM on a provisioned cluster reads USERNAME as the database user."""
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_USERNAME", "awsuser")
+    monkeypatch.setenv("DATACONTRACT_S3_ACCESS_KEY_ID", "AKIA_TEST")
+    monkeypatch.setenv("DATACONTRACT_S3_SECRET_ACCESS_KEY", "secret")
+    aws = MagicMock()
+    aws.get_cluster_credentials.return_value = {"DbUser": "IAM:awsuser", "DbPassword": "temporary"}
+
+    with patch("boto3.client", return_value=aws):
+        login = resolve_redshift_login(PROVISIONED_HOST, "dev")
+
+    assert login.user == "IAM:awsuser"
+    aws.get_cluster_credentials.assert_called_once()
+
+
+def test_the_override_still_wins(monkeypatch):
+    """The explicit variable stays available when inference guesses wrong."""
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_AUTHENTICATION", "password")
+    monkeypatch.setenv("DATACONTRACT_REDSHIFT_USERNAME", "awsuser")
+
+    login = resolve_redshift_login(SERVERLESS_HOST, "dev")
+
+    assert (login.user, login.password) == ("awsuser", None)
+
+
+def test_no_password_and_no_aws_session_explains_both_options():
+    with pytest.raises(DataContractException) as exc_info:
+        resolve_redshift_login(SERVERLESS_HOST, "dev")
+
+    reason = exc_info.value.reason
+    assert "DATACONTRACT_REDSHIFT_PASSWORD" in reason
+    assert "aws sso login" in reason


### PR DESCRIPTION
## Summary

`DATACONTRACT_REDSHIFT_AUTHENTICATION` is no longer required. The method is resolved from what is configured:

1. `DATACONTRACT_REDSHIFT_AUTHENTICATION`, if set — unchanged override
2. `DATACONTRACT_REDSHIFT_PASSWORD` set → database login
3. AWS credentials resolvable → IAM
4. neither → one error naming both options

Redshift was the only backend that made you declare the method up front. `DATACONTRACT_DATABRICKS_AUTH_TYPE`, `DATACONTRACT_SNOWFLAKE_AUTHENTICATOR`, `DATACONTRACT_SQLSERVER_AUTHENTICATION` and `DATACONTRACT_TRINO_AUTHENTICATION` are all overrides on top of a working default; this brings Redshift in line rather than removing the escape hatch.

The previous failure mode was actively misleading: a user with a valid AWS session but no `DATACONTRACT_REDSHIFT_USERNAME` was told `Required environment variable DATACONTRACT_REDSHIFT_USERNAME is not set`, when IAM would have worked with no variable at all.

**The inference keys on the password, not the username.** IAM on a provisioned cluster reads `DATACONTRACT_REDSHIFT_USERNAME` as the database user (`_mint_iam_credentials` falls back to it when `DB_USER` is unset), so a set username says nothing about the intended method. Keying on the username would silently re-route existing IAM users to password auth — a test covers exactly that case.

## Compatibility

Fully backward compatible. An explicit `DATACONTRACT_REDSHIFT_AUTHENTICATION` still wins, `USERNAME` + `PASSWORD` still means password auth, and `=iam` setups keep working whether or not they set a username.

## Testing

Five new tests: inference from a password, inference from AWS credentials, a username alone not forcing password auth, the override still winning, and the error naming both options.

The credential tests are now hermetic — they point boto3 at empty config files and disable the metadata service, so an ambient `aws sso login` cannot decide their outcome. That was not theoretical: before this, the suite consulted the developer's real AWS chain and took 61 seconds on an expired session. It now runs in under a second.