### PR TITLE
Sort the import format list alphabetically

### DIFF
--- a/docs/docs/commands/import.md
+++ b/docs/docs/commands/import.md
@@ -18,4 +18,4 @@ Run `datacontract import <format> --help` to see format-specific options.
 datacontract import sql --source ddl.sql --dialect postgres --output datacontract.yaml
 ```
 
-Available formats: `dbt`, `sql`, `avro`, `dbml`, `glue`, `bigquery`, `databricks`, `jsonschema`, `json`, `odcs`, `parquet`, `csv`, `protobuf`, `spark`, `iceberg`, `excel`, `powerbi`, `snowflake`, `redshift`, `postgres`, `athena`.
+Available formats: `athena`, `avro`, `bigquery`, `csv`, `databricks`, `dbml`, `dbt`, `excel`, `glue`, `iceberg`, `json`, `jsonschema`, `odcs`, `parquet`, `postgres`, `powerbi`, `protobuf`, `redshift`, `snowflake`, `spark`, `sql`.

--- a/docs/docs/imports/avro.md
+++ b/docs/docs/imports/avro.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 title: "Import: Avro"
 description: "Create a data contract from an Avro schema file."
 ---

--- a/docs/docs/imports/bigquery.md
+++ b/docs/docs/imports/bigquery.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 5
 title: "Import: BigQuery"
 description: "Create a data contract from BigQuery, via an exported JSON file or the BigQuery API."
 ---

--- a/docs/docs/imports/csv.md
+++ b/docs/docs/imports/csv.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 6
 title: "Import: CSV"
 description: "Create a data contract by inferring a schema from a CSV file."
 ---

--- a/docs/docs/imports/databricks.md
+++ b/docs/docs/imports/databricks.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 7
 title: "Import: Databricks"
 description: "Create a data contract from Databricks Unity Catalog."
 ---

--- a/docs/docs/imports/dbml.md
+++ b/docs/docs/imports/dbml.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 8
 title: "Import: DBML"
 description: "Create a data contract from a DBML file, with optional schema/table filters."
 ---

--- a/docs/docs/imports/dbt.md
+++ b/docs/docs/imports/dbt.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 9
 title: "Import: dbt"
 description: "Create a data contract from a dbt manifest file."
 ---

--- a/docs/docs/imports/excel.md
+++ b/docs/docs/imports/excel.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 10
 title: "Import: Excel"
 description: "Create a data contract from an ODCS Excel template."
 ---

--- a/docs/docs/imports/glue.md
+++ b/docs/docs/imports/glue.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 4
 title: "Import: AWS Glue"
 description: "Create a data contract from the AWS Glue Data Catalog."
 ---

--- a/docs/docs/imports/iceberg.md
+++ b/docs/docs/imports/iceberg.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 11
 title: "Import: Iceberg"
 description: "Create a data contract from an Apache Iceberg schema."
 ---

--- a/docs/docs/imports/json.md
+++ b/docs/docs/imports/json.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 title: "Import: JSON"
 description: "Create a data contract by inferring a schema from a JSON data file."
 ---

--- a/docs/docs/imports/jsonschema.md
+++ b/docs/docs/imports/jsonschema.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 13
 title: "Import: JSON Schema"
 description: "Create a data contract from a JSON Schema file."
 ---

--- a/docs/docs/imports/odcs.md
+++ b/docs/docs/imports/odcs.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 14
 title: "Import: ODCS"
 description: "Create a data contract from an existing ODCS file."
 ---

--- a/docs/docs/imports/parquet.md
+++ b/docs/docs/imports/parquet.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 15
 title: "Import: Parquet"
 description: "Create a data contract from a Parquet file."
 ---

--- a/docs/docs/imports/postgres.md
+++ b/docs/docs/imports/postgres.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 16
 title: "Import: Postgres"
 description: "Create a data contract from a Postgres schema."
 ---

--- a/docs/docs/imports/powerbi.md
+++ b/docs/docs/imports/powerbi.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 17
 title: "Import: Power BI"
 description: "Create a data contract from a Power BI semantic model (.pbit, .bim, or .json)."
 ---

--- a/docs/docs/imports/protobuf.md
+++ b/docs/docs/imports/protobuf.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 17
+sidebar_position: 18
 title: "Import: Protobuf"
 description: "Create a data contract from a Protobuf schema file."
 ---

--- a/docs/docs/imports/redshift.md
+++ b/docs/docs/imports/redshift.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 18
+sidebar_position: 2
 title: "Import: Amazon Redshift"
 description: "Create a data contract from an Amazon Redshift schema."
 ---


### PR DESCRIPTION
## Summary

`Available formats:` on the `import` command page followed the order the formats happened to be added in (`dbt`, `sql`, `avro`, … `postgres`, `athena`). The sidebar and the card grid on the imports pages already follow the format name, so this was the last import list in the docs still unsorted.

Now: `athena`, `avro`, `bigquery`, `csv`, `databricks`, `dbml`, `dbt`, `excel`, `glue`, `iceberg`, `json`, `jsonschema`, `odcs`, `parquet`, `postgres`, `powerbi`, `protobuf`, `redshift`, `snowflake`, `spark`, `sql`.

Also cross-checked the list against the pages that exist: nothing is listed without a page, and no page is missing from the list.

Docs only.