### PR TITLE
Sort the export docs alphabetically

### DIFF
--- a/docs/docs/commands/export.md
+++ b/docs/docs/commands/export.md
@@ -20,4 +20,4 @@ datacontract export html datacontract.yaml --output datacontract.html
 
 For SQL dialects (`postgres`, `mysql`, `snowflake`, `databricks`, `sqlserver`, `trino`, `oracle`, `clickhouse`), use `datacontract export sql --dialect <dialect>`.
 
-Available formats: `sql`, `sql-query`, `dbt-models`, `dbt-sources`, `dbt-staging-sql`, `avro`, `avro-idl`, `jsonschema`, `pydantic-model`, `protobuf`, `odcs`, `rdf`, `html`, `markdown`, `mermaid`, `bigquery`, `dbml`, `go`, `spark`, `sqlalchemy`, `iceberg`, `sodacl`, `great-expectations`, `data-caterer`, `dcs`, `dqx`, `excel`, `custom`.
+Available formats: `avro`, `avro-idl`, `bigquery`, `custom`, `data-caterer`, `dbml`, `dbt-models`, `dbt-sources`, `dbt-staging-sql`, `dcs`, `dqx`, `excel`, `go`, `great-expectations`, `html`, `iceberg`, `jsonschema`, `markdown`, `mermaid`, `odcs`, `protobuf`, `pydantic-model`, `rdf`, `sodacl`, `spark`, `sql`, `sql-query`, `sqlalchemy`.

--- a/docs/docs/exports/avro-idl.md
+++ b/docs/docs/exports/avro-idl.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 2
 title: "Export: Avro IDL"
 description: "Export a data contract to an Avro IDL (.avdl) schema definition."
 ---

--- a/docs/docs/exports/avro.md
+++ b/docs/docs/exports/avro.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 1
 title: "Export: Avro"
 description: "Export a data contract to an Avro schema, with custom logicalType and default support."
 ---

--- a/docs/docs/exports/bigquery.md
+++ b/docs/docs/exports/bigquery.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 3
 title: "Export: BigQuery"
 description: "Export a data contract to a BigQuery schema."
 ---

--- a/docs/docs/exports/custom.md
+++ b/docs/docs/exports/custom.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 28
+sidebar_position: 4
 title: "Export: Custom (Jinja)"
 description: "Export a data contract to any format using a custom Jinja template."
 ---

--- a/docs/docs/exports/data-caterer.md
+++ b/docs/docs/exports/data-caterer.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 24
+sidebar_position: 5
 title: "Export: Data Caterer"
 description: "Export a data contract to a Data Caterer data-generation task."
 ---

--- a/docs/docs/exports/dbml.md
+++ b/docs/docs/exports/dbml.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 17
+sidebar_position: 6
 title: "Export: DBML"
 description: "Export a data contract to DBML (Database Markup Language) for diagrams and documentation."
 ---

--- a/docs/docs/exports/dbt-models.md
+++ b/docs/docs/exports/dbt-models.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 7
 title: "Export: dbt Models"
 description: "Export a data contract to dbt model schema YAML."
 ---

--- a/docs/docs/exports/dbt-sources.md
+++ b/docs/docs/exports/dbt-sources.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 8
 title: "Export: dbt Sources"
 description: "Export a data contract to dbt sources YAML."
 ---

--- a/docs/docs/exports/dbt-staging-sql.md
+++ b/docs/docs/exports/dbt-staging-sql.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 9
 title: "Export: dbt Staging SQL"
 description: "Export a data contract to a dbt staging SQL file."
 ---

--- a/docs/docs/exports/dcs.md
+++ b/docs/docs/exports/dcs.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 25
+sidebar_position: 10
 title: "Export: DCS"
 description: "Export a data contract to the DCS format."
 ---

--- a/docs/docs/exports/dqx.md
+++ b/docs/docs/exports/dqx.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 26
+sidebar_position: 11
 title: "Export: DQX"
 description: "Export a data contract to Databricks DQX checks."
 ---

--- a/docs/docs/exports/excel.md
+++ b/docs/docs/exports/excel.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 27
+sidebar_position: 12
 title: "Export: Excel"
 description: "Export a data contract to an ODCS Excel template."
 ---

--- a/docs/docs/exports/go.md
+++ b/docs/docs/exports/go.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 18
+sidebar_position: 13
 title: "Export: Go"
 description: "Generate Go struct type definitions from a data contract's schema."
 ---

--- a/docs/docs/exports/great-expectations.md
+++ b/docs/docs/exports/great-expectations.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 23
+sidebar_position: 14
 title: "Export: Great Expectations"
 description: "Export a data contract to a Great Expectations suite."
 ---

--- a/docs/docs/exports/html.md
+++ b/docs/docs/exports/html.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 15
 title: "Export: HTML"
 description: "Export a data contract to a standalone HTML page."
 ---

--- a/docs/docs/exports/iceberg.md
+++ b/docs/docs/exports/iceberg.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 21
+sidebar_position: 16
 title: "Export: Iceberg"
 description: "Export a data contract to an Apache Iceberg schema."
 ---

--- a/docs/docs/exports/index.md
+++ b/docs/docs/exports/index.md
@@ -29,13 +29,29 @@ Download a file and run the commands below against it to reproduce the output.
 ## Available exporters
 
 <div className="card-grid">
-  <a className="doc-card" href="/exports/sql">
-    <img src="/img/icons/database.svg" alt="" />
-    <span><span className="doc-card-title">sql</span><span className="doc-card-desc">SQL DDL (CREATE TABLE).</span></span>
+  <a className="doc-card" href="/exports/avro">
+    <img src="/img/icons/avro.svg" alt="" />
+    <span><span className="doc-card-title">avro</span><span className="doc-card-desc">Avro schema.</span></span>
   </a>
-  <a className="doc-card" href="/exports/sql-query">
-    <img src="/img/icons/database.svg" alt="" />
-    <span><span className="doc-card-title">sql-query</span><span className="doc-card-desc">A SQL SELECT query.</span></span>
+  <a className="doc-card" href="/exports/avro-idl">
+    <img src="/img/icons/avro.svg" alt="" />
+    <span><span className="doc-card-title">avro-idl</span><span className="doc-card-desc">Avro IDL.</span></span>
+  </a>
+  <a className="doc-card" href="/exports/bigquery">
+    <img src="/img/icons/bigquery.svg" alt="" />
+    <span><span className="doc-card-title">bigquery</span><span className="doc-card-desc">BigQuery schema.</span></span>
+  </a>
+  <a className="doc-card" href="/exports/custom">
+    <img src="/img/icons/custom.svg" alt="" />
+    <span><span className="doc-card-title">custom</span><span className="doc-card-desc">Any format, via a custom Jinja template.</span></span>
+  </a>
+  <a className="doc-card" href="/exports/data-caterer">
+    <img src="/img/icons/data-caterer.svg" alt="" />
+    <span><span className="doc-card-title">data-caterer</span><span className="doc-card-desc">Data Caterer data-generation task.</span></span>
+  </a>
+  <a className="doc-card" href="/exports/dbml">
+    <img src="/img/icons/dbml.svg" alt="" />
+    <span><span className="doc-card-title">dbml</span><span className="doc-card-desc">DBML.</span></span>
   </a>
   <a className="doc-card" href="/exports/dbt-models">
     <img src="/img/icons/dbt.svg" alt="" />
@@ -49,82 +65,6 @@ Download a file and run the commands below against it to reproduce the output.
     <img src="/img/icons/dbt.svg" alt="" />
     <span><span className="doc-card-title">dbt-staging-sql</span><span className="doc-card-desc">A dbt staging SQL file.</span></span>
   </a>
-  <a className="doc-card" href="/exports/avro">
-    <img src="/img/icons/avro.svg" alt="" />
-    <span><span className="doc-card-title">avro</span><span className="doc-card-desc">Avro schema.</span></span>
-  </a>
-  <a className="doc-card" href="/exports/avro-idl">
-    <img src="/img/icons/avro.svg" alt="" />
-    <span><span className="doc-card-title">avro-idl</span><span className="doc-card-desc">Avro IDL.</span></span>
-  </a>
-  <a className="doc-card" href="/exports/jsonschema">
-    <img src="/img/icons/jsonschema.svg" alt="" />
-    <span><span className="doc-card-title">jsonschema</span><span className="doc-card-desc">JSON Schema.</span></span>
-  </a>
-  <a className="doc-card" href="/exports/pydantic-model">
-    <img src="/img/icons/pydantic.svg" alt="" />
-    <span><span className="doc-card-title">pydantic-model</span><span className="doc-card-desc">A Pydantic model.</span></span>
-  </a>
-  <a className="doc-card" href="/exports/protobuf">
-    <img src="/img/icons/custom.svg" alt="" />
-    <span><span className="doc-card-title">protobuf</span><span className="doc-card-desc">Protobuf schema.</span></span>
-  </a>
-  <a className="doc-card" href="/exports/odcs">
-    <img src="/img/icons/odcs.svg" alt="" />
-    <span><span className="doc-card-title">odcs</span><span className="doc-card-desc">ODCS format.</span></span>
-  </a>
-  <a className="doc-card" href="/exports/rdf">
-    <img src="/img/icons/rdf.svg" alt="" />
-    <span><span className="doc-card-title">rdf</span><span className="doc-card-desc">RDF representation.</span></span>
-  </a>
-  <a className="doc-card" href="/exports/html">
-    <img src="/img/icons/custom.svg" alt="" />
-    <span><span className="doc-card-title">html</span><span className="doc-card-desc">A standalone HTML page.</span></span>
-  </a>
-  <a className="doc-card" href="/exports/markdown">
-    <img src="/img/icons/markdown.svg" alt="" />
-    <span><span className="doc-card-title">markdown</span><span className="doc-card-desc">Markdown documentation.</span></span>
-  </a>
-  <a className="doc-card" href="/exports/mermaid">
-    <img src="/img/icons/mermaid.svg" alt="" />
-    <span><span className="doc-card-title">mermaid</span><span className="doc-card-desc">A Mermaid diagram.</span></span>
-  </a>
-  <a className="doc-card" href="/exports/bigquery">
-    <img src="/img/icons/bigquery.svg" alt="" />
-    <span><span className="doc-card-title">bigquery</span><span className="doc-card-desc">BigQuery schema.</span></span>
-  </a>
-  <a className="doc-card" href="/exports/dbml">
-    <img src="/img/icons/dbml.svg" alt="" />
-    <span><span className="doc-card-title">dbml</span><span className="doc-card-desc">DBML.</span></span>
-  </a>
-  <a className="doc-card" href="/exports/go">
-    <img src="/img/icons/go.svg" alt="" />
-    <span><span className="doc-card-title">go</span><span className="doc-card-desc">Go structs.</span></span>
-  </a>
-  <a className="doc-card" href="/exports/spark">
-    <img src="/img/icons/spark.svg" alt="" />
-    <span><span className="doc-card-title">spark</span><span className="doc-card-desc">Spark StructType schema.</span></span>
-  </a>
-  <a className="doc-card" href="/exports/sqlalchemy">
-    <img src="/img/icons/sqlalchemy.svg" alt="" />
-    <span><span className="doc-card-title">sqlalchemy</span><span className="doc-card-desc">SQLAlchemy models.</span></span>
-  </a>
-  <a className="doc-card" href="/exports/iceberg">
-    <img src="/img/icons/iceberg.svg" alt="" />
-    <span><span className="doc-card-title">iceberg</span><span className="doc-card-desc">Iceberg schema.</span></span>
-  </a>
-  <a className="doc-card" href="/exports/sodacl">
-    <img src="/img/icons/soda.svg" alt="" />
-    <span><span className="doc-card-title">sodacl</span><span className="doc-card-desc">SodaCL checks.</span></span>
-  </a>
-  <a className="doc-card" href="/exports/great-expectations">
-    <img src="/img/icons/great-expectations.svg" alt="" />
-    <span><span className="doc-card-title">great-expectations</span><span className="doc-card-desc">Great Expectations suite.</span></span>
-  </a>
-  <a className="doc-card" href="/exports/data-caterer">
-    <img src="/img/icons/data-caterer.svg" alt="" />
-    <span><span className="doc-card-title">data-caterer</span><span className="doc-card-desc">Data Caterer data-generation task.</span></span>
-  </a>
   <a className="doc-card" href="/exports/dcs">
     <img src="/img/icons/custom.svg" alt="" />
     <span><span className="doc-card-title">dcs</span><span className="doc-card-desc">DCS format.</span></span>
@@ -137,9 +77,69 @@ Download a file and run the commands below against it to reproduce the output.
     <img src="/img/icons/excel.svg" alt="" />
     <span><span className="doc-card-title">excel</span><span className="doc-card-desc">ODCS Excel template.</span></span>
   </a>
-  <a className="doc-card" href="/exports/custom">
+  <a className="doc-card" href="/exports/go">
+    <img src="/img/icons/go.svg" alt="" />
+    <span><span className="doc-card-title">go</span><span className="doc-card-desc">Go structs.</span></span>
+  </a>
+  <a className="doc-card" href="/exports/great-expectations">
+    <img src="/img/icons/great-expectations.svg" alt="" />
+    <span><span className="doc-card-title">great-expectations</span><span className="doc-card-desc">Great Expectations suite.</span></span>
+  </a>
+  <a className="doc-card" href="/exports/html">
     <img src="/img/icons/custom.svg" alt="" />
-    <span><span className="doc-card-title">custom</span><span className="doc-card-desc">Any format, via a custom Jinja template.</span></span>
+    <span><span className="doc-card-title">html</span><span className="doc-card-desc">A standalone HTML page.</span></span>
+  </a>
+  <a className="doc-card" href="/exports/iceberg">
+    <img src="/img/icons/iceberg.svg" alt="" />
+    <span><span className="doc-card-title">iceberg</span><span className="doc-card-desc">Iceberg schema.</span></span>
+  </a>
+  <a className="doc-card" href="/exports/jsonschema">
+    <img src="/img/icons/jsonschema.svg" alt="" />
+    <span><span className="doc-card-title">jsonschema</span><span className="doc-card-desc">JSON Schema.</span></span>
+  </a>
+  <a className="doc-card" href="/exports/markdown">
+    <img src="/img/icons/markdown.svg" alt="" />
+    <span><span className="doc-card-title">markdown</span><span className="doc-card-desc">Markdown documentation.</span></span>
+  </a>
+  <a className="doc-card" href="/exports/mermaid">
+    <img src="/img/icons/mermaid.svg" alt="" />
+    <span><span className="doc-card-title">mermaid</span><span className="doc-card-desc">A Mermaid diagram.</span></span>
+  </a>
+  <a className="doc-card" href="/exports/odcs">
+    <img src="/img/icons/odcs.svg" alt="" />
+    <span><span className="doc-card-title">odcs</span><span className="doc-card-desc">ODCS format.</span></span>
+  </a>
+  <a className="doc-card" href="/exports/protobuf">
+    <img src="/img/icons/custom.svg" alt="" />
+    <span><span className="doc-card-title">protobuf</span><span className="doc-card-desc">Protobuf schema.</span></span>
+  </a>
+  <a className="doc-card" href="/exports/pydantic-model">
+    <img src="/img/icons/pydantic.svg" alt="" />
+    <span><span className="doc-card-title">pydantic-model</span><span className="doc-card-desc">A Pydantic model.</span></span>
+  </a>
+  <a className="doc-card" href="/exports/rdf">
+    <img src="/img/icons/rdf.svg" alt="" />
+    <span><span className="doc-card-title">rdf</span><span className="doc-card-desc">RDF representation.</span></span>
+  </a>
+  <a className="doc-card" href="/exports/sodacl">
+    <img src="/img/icons/soda.svg" alt="" />
+    <span><span className="doc-card-title">sodacl</span><span className="doc-card-desc">SodaCL checks.</span></span>
+  </a>
+  <a className="doc-card" href="/exports/spark">
+    <img src="/img/icons/spark.svg" alt="" />
+    <span><span className="doc-card-title">spark</span><span className="doc-card-desc">Spark StructType schema.</span></span>
+  </a>
+  <a className="doc-card" href="/exports/sql">
+    <img src="/img/icons/database.svg" alt="" />
+    <span><span className="doc-card-title">sql</span><span className="doc-card-desc">SQL DDL (CREATE TABLE).</span></span>
+  </a>
+  <a className="doc-card" href="/exports/sql-query">
+    <img src="/img/icons/database.svg" alt="" />
+    <span><span className="doc-card-title">sql-query</span><span className="doc-card-desc">A SQL SELECT query.</span></span>
+  </a>
+  <a className="doc-card" href="/exports/sqlalchemy">
+    <img src="/img/icons/sqlalchemy.svg" alt="" />
+    <span><span className="doc-card-title">sqlalchemy</span><span className="doc-card-desc">SQLAlchemy models.</span></span>
   </a>
 </div>
 

--- a/docs/docs/exports/jsonschema.md
+++ b/docs/docs/exports/jsonschema.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 17
 title: "Export: JSON Schema"
 description: "Export a data contract to a JSON Schema document for validating JSON data."
 ---

--- a/docs/docs/exports/markdown.md
+++ b/docs/docs/exports/markdown.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 18
 title: "Export: Markdown"
 description: "Export a data contract to Markdown documentation."
 ---

--- a/docs/docs/exports/mermaid.md
+++ b/docs/docs/exports/mermaid.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 19
 title: "Export: Mermaid"
 description: "Export a data contract to a Mermaid diagram."
 ---

--- a/docs/docs/exports/odcs.md
+++ b/docs/docs/exports/odcs.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 20
 title: "Export: ODCS"
 description: "Export a data contract to the Open Data Contract Standard (ODCS) format."
 ---

--- a/docs/docs/exports/protobuf.md
+++ b/docs/docs/exports/protobuf.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 21
 title: "Export: Protobuf"
 description: "Export a data contract to a Protobuf schema."
 ---

--- a/docs/docs/exports/pydantic-model.md
+++ b/docs/docs/exports/pydantic-model.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 22
 title: "Export: Pydantic Model"
 description: "Export a data contract to a Pydantic model."
 ---

--- a/docs/docs/exports/rdf.md
+++ b/docs/docs/exports/rdf.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 23
 title: "Export: RDF"
 description: "Export a data contract to an RDF representation."
 ---

--- a/docs/docs/exports/sodacl.md
+++ b/docs/docs/exports/sodacl.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 22
+sidebar_position: 24
 title: "Export: SodaCL"
 description: "Export a data contract to SodaCL checks."
 ---

--- a/docs/docs/exports/spark.md
+++ b/docs/docs/exports/spark.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 19
+sidebar_position: 25
 title: "Export: Spark"
 description: "Export a data contract to a Spark StructType schema."
 ---

--- a/docs/docs/exports/sql-query.md
+++ b/docs/docs/exports/sql-query.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 27
 title: "Export: SQL Query"
 description: "Export a data contract to a SQL SELECT query."
 ---

--- a/docs/docs/exports/sql.md
+++ b/docs/docs/exports/sql.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 26
 title: "Export: SQL DDL"
 description: "Convert a data contract into a SQL data definition language (DDL) file."
 ---

--- a/docs/docs/exports/sqlalchemy.md
+++ b/docs/docs/exports/sqlalchemy.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 20
+sidebar_position: 28
 title: "Export: SQLAlchemy"
 description: "Export a data contract to SQLAlchemy models."
 ---


### PR DESCRIPTION
## Summary

The exports docs followed the order the exporters happened to be added in (`sql`, `sql-query`, `dbt-models`, … `excel`, `custom`). All three listings are now alphabetical and consistent with each other:

- the sidebar (`sidebar_position` across 28 pages)
- the card grid on the exports index
- `Available formats:` on the `export` command page

Order: `avro`, `avro-idl`, `bigquery`, `custom`, `data-caterer`, `dbml`, `dbt-models`, `dbt-sources`, `dbt-staging-sql`, `dcs`, `dqx`, `excel`, `go`, `great-expectations`, `html`, `iceberg`, `jsonschema`, `markdown`, `mermaid`, `odcs`, `protobuf`, `pydantic-model`, `rdf`, `sodacl`, `spark`, `sql`, `sql-query`, `sqlalchemy`.

**The sidebar is keyed on the title it renders, not the file name.** Both produce the same order here, but only because no export title diverges from its format name — unlike imports, where `glue` renders as "AWS Glue" and `redshift` as "Amazon Redshift", so a file-name sort put them under G and R.

Cross-checked that the three listings agree: every page appears in the card grid and in the format list, and nothing is listed without a page.

Docs only.