### PR TITLE
Guard the alphabetical order of the importer and exporter docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,3 +159,4 @@ The project uses factory patterns for extensibility:
 - Type hints throughout the codebase
 - Follows PEP 8 style guidelines with some adjustments (120 character line length)
 - `CHANGELOG.md` entries should be one line each: what changed (user-facing), not how or why. Append the fixed issue, if exists, as `(#NNN)`. No details on mechanism, rationale, or edge cases.
+- The docs list every importer and exporter three times (sidebar, card grid, `Available formats:`), all alphabetical, enforced by `tests/test_docs_ordering.py`. The sidebar is ordered by the label it **renders**, not the file name — `Import: AWS Glue` belongs under A, not G.

--- a/tests/docs_paths.py
+++ b/tests/docs_paths.py
@@ -1,0 +1,10 @@
+"""Absolute path to the docs content root.
+
+Resolved from this file rather than the working directory: the docs tests must
+pass whether pytest is invoked from the repository root (as CI does) or from
+tests/.
+"""
+
+from pathlib import Path
+
+DOCS = Path(__file__).resolve().parents[1] / "docs" / "docs"

--- a/tests/test_docs_ordering.py
+++ b/tests/test_docs_ordering.py
@@ -1,0 +1,74 @@
+"""The docs list every importer and exporter three times; all three stay alphabetical.
+
+The order has drifted twice: once by appending new pages at the end, and once by
+sorting on the file name when the sidebar renders the page title, which put
+``Import: AWS Glue`` under G and ``Import: Amazon Redshift`` under R. Each list
+is checked against the text it actually displays.
+"""
+
+import re
+
+import pytest
+
+from tests.docs_paths import DOCS
+
+FOLDERS = [("imports", "Import: ", "import"), ("exports", "Export: ", "export")]
+IDS = [folder for folder, _, _ in FOLDERS]
+
+
+def pages(folder: str):
+    """Every listed page of the folder, index and unlisted stubs excluded."""
+    listed = [
+        page
+        for page in (DOCS / folder).glob("*.md")
+        if page.stem != "index" and "unlisted: true" not in page.read_text()
+    ]
+    # by stem, not by file name: "avro-idl.md" sorts before "avro.md" ("-" < ".")
+    return sorted(listed, key=lambda page: page.stem)
+
+
+def sidebar_label(page, prefix: str) -> str:
+    """The text Docusaurus renders in the sidebar for this page."""
+    text = page.read_text()
+    label = re.search(r'^sidebar_label: "(.*)"$', text, re.M)
+    rendered = label.group(1) if label else re.search(r'^title: "(.*)"$', text, re.M).group(1)
+    return rendered.removeprefix(prefix)
+
+
+def sidebar_position(page) -> int:
+    return int(re.search(r"^sidebar_position: (\d+)$", page.read_text(), re.M).group(1))
+
+
+@pytest.mark.parametrize("folder, prefix, _command", FOLDERS, ids=IDS)
+def test_sidebar_is_ordered_by_the_label_it_renders(folder, prefix, _command):
+    ordered = [sidebar_label(page, prefix) for page in sorted(pages(folder), key=sidebar_position)]
+
+    assert ordered == sorted(ordered, key=str.lower)
+
+
+@pytest.mark.parametrize("folder, prefix, _command", FOLDERS, ids=IDS)
+def test_sidebar_positions_are_a_gapless_sequence(folder, prefix, _command):
+    """A duplicate or a gap makes the rendered order depend on the file name again."""
+    positions = sorted(sidebar_position(page) for page in pages(folder))
+
+    assert positions == list(range(1, len(positions) + 1))
+
+
+@pytest.mark.parametrize("folder, prefix, _command", FOLDERS, ids=IDS)
+def test_card_grid_lists_every_page_in_order(folder, prefix, _command):
+    index = (DOCS / folder / "index.md").read_text()
+    grid = re.search(r'<div className="card-grid">(.*?)</div>', index, re.S).group(1)
+    # the cards show the format name, so that is what has to be in order here
+    titles = re.findall(r'doc-card-title">([^<]+)<', grid)
+
+    assert titles == sorted(titles)
+    assert titles == [page.stem for page in pages(folder)]
+
+
+@pytest.mark.parametrize("folder, prefix, command", FOLDERS, ids=IDS)
+def test_command_page_lists_every_format_in_order(folder, prefix, command):
+    page = (DOCS / "commands" / f"{command}.md").read_text()
+    listed = re.findall(r"`([^`]+)`", re.search(r"Available formats: (.+?)\.\n", page).group(1))
+
+    assert listed == sorted(listed)
+    assert listed == [page.stem for page in pages(folder)]


### PR DESCRIPTION
## Summary

The docs list every importer and exporter three times — the sidebar, the card grid on the index page, and `Available formats:` on the command page. That order has drifted twice: once by appending new pages at the end, and once by sorting on the file name when the sidebar renders the page **title**, which put `Import: AWS Glue` under G and `Import: Amazon Redshift` under R.

`tests/test_docs_ordering.py` checks four properties for both `imports` and `exports`:

1. **sidebar order equals label order** — reads `sidebar_label` if present, else `title`, so it checks the text Docusaurus actually renders. This is the one that catches the file-name mistake.
2. **`sidebar_position` is a gapless 1..N sequence** — a duplicate or a gap silently hands ordering back to the file name.
3. **the card grid lists every page, in order** — keyed on the format name the cards display.
4. **the command page lists every format, in order** — and matches the set of pages exactly, so a new importer cannot be added without appearing there.

## Why a test and not a note in AGENTS.md

A note only holds if whoever edits the docs reads it, and it cannot fail. This property is mechanically checkable, so it belongs in CI. The note is still there, as a pointer to the test and to the sort key, but it is not the guard.

Writing it surfaced two things a note would not have:

- `sorted(glob("*.md"))` orders by file name *including the extension*, so `avro-idl.md` sorts before `avro.md` (`-` < `.`). The first version of the guard was itself wrong; it keys on `.stem` now.
- Verified against a deliberately reintroduced regression: re-sorting the imports by file name fails with `At index 1 diff: 'Avro' != 'Amazon Redshift'`.

Paths resolve from the test file rather than the working directory, so the tests pass whether pytest runs from the repository root (as CI does) or from `tests/`.