### PR TITLE
Document that Athena authenticates with an AWS session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract test` verifies declared primary keys: each key column must have no missing values, and the key must have no duplicates (a composite key is checked as a tuple) (#1220 @DMZ22)
 
 ### Fixed
+- Documented that Athena authenticates with an existing AWS session (`aws sso login`, `AWS_PROFILE`, instance roles); static access keys were presented as the only option
 - `regionName` in an Athena `servers` block was ignored, so the region could only be set via `DATACONTRACT_S3_REGION`
 - `datacontract import glue` mapped `timestamp` columns to `logicalType: date` instead of `timestamp`
 - Testing and importing Redshift failed with `codec not available in Python: 'UNICODE'`

--- a/docs/docs/reference/athena.md
+++ b/docs/docs/reference/athena.md
@@ -23,7 +23,9 @@ servers:
 
 ## Authentication
 
-Athena uses the S3 environment variables:
+Athena authenticates as an AWS principal, so an existing AWS session is enough — `aws sso login`, `AWS_PROFILE`, EC2/ECS/EKS instance roles, or GitHub OIDC in CI. Unlike Redshift, no database user is involved, so nothing has to be minted or configured.
+
+Set the variables below only to override that with static keys:
 
 | Variable | Example | Description |
 |---|---|---|

--- a/docs/docs/testing/athena.md
+++ b/docs/docs/testing/athena.md
@@ -18,7 +18,13 @@ See [Installation](../installation.md) for pip, pipx, and Docker.
 
 ## 2. Authenticate
 
-Athena uses the S3 environment variables. Create a `.env` file in your working directory (or export the variables):
+The easiest way is to sign in to AWS once — the CLI picks the session up, so no key is stored anywhere and nothing else has to be configured:
+
+```bash
+aws sso login   # or any other way of getting an AWS session
+```
+
+Prefer static keys? Set them directly and they are used instead:
 
 ```bash
 # .env
@@ -27,7 +33,7 @@ DATACONTRACT_S3_ACCESS_KEY_ID=AKIAXV5Q5QABCDEFGH
 DATACONTRACT_S3_SECRET_ACCESS_KEY=93S7LRrJcqLaaaa/XXXXXXXXXXXXX
 ```
 
-The credentials need `glue:GetTables` to import, and `athena:StartQueryExecution` plus write access to the staging directory to test. `import` and `test` use the same variables.
+Either way, your AWS identity needs `glue:GetTables` to import, and `athena:StartQueryExecution` plus read access to the data and write access to the staging directory to test. `import` and `test` use the same setup.
 
 ## 3. Create a contract from your tables
 
@@ -90,3 +96,4 @@ All authentication options and the data type mappings: **[Athena Reference](../r
 
 - **`Access Denied` on query start** — the credentials need `athena:StartQueryExecution` plus write access to the `stagingDir` bucket.
 - **`Table not found`** — `schema` in the `servers` block must be the Athena *database* name (as shown in the Glue Data Catalog), and `regionName` must match where the catalog lives.
+- **`Your session has expired`** — the AWS session has lapsed; run `aws sso login` again. No `DATACONTRACT_S3_*` variable is needed when a session is present.


### PR DESCRIPTION
## Summary

The Athena guide presented static access keys as the only way in:

```bash
DATACONTRACT_S3_ACCESS_KEY_ID=AKIAXV5Q5QABCDEFGH
DATACONTRACT_S3_SECRET_ACCESS_KEY=93S7LRrJcqLaaaa/XXXXXXXXXXXXX
```

That was never the only way. Athena authenticates as an AWS principal, so the unset variables are passed to pyathena as `None` and boto3 resolves them from its standard chain — `aws sso login`, `AWS_PROFILE`, EC2/ECS/EKS instance roles, GitHub OIDC in CI. Readers following the guide were storing long-lived credentials for a connection that already accepted their existing session.

Step 2 now leads with the AWS session, mirroring the Redshift guide, and keeps static keys as the alternative.

**Why Redshift needed code for this and Athena did not.** Redshift keeps a database identity separate from the AWS one, so an IAM principal is not a database user and temporary credentials have to be minted through `GetCredentials` / `GetClusterCredentialsWithIAM`. Athena has no such second identity — the AWS principal is the whole story. The asymmetry is inherent, not an oversight; only the documentation was behind.

## Verified against real AWS

With **no `DATACONTRACT_S3_*` variable set at all**, against a live Athena database (credentials from an SSO session, region from the contract's `regionName`):

- `datacontract import athena` produced the contract
- `datacontract test` passed 8/8 checks

## Also

- The reference page states that the variables are an override on the standard chain, not a requirement.
- Added one troubleshooting entry: `Your session has expired` → run `aws sso login`. That failure becomes reachable now that the guide steers people to sessions, and the error text does not name the cause.