### PR TITLE
Use an existing AWS session for S3, add the S3 import, and resolve AWS credentials in one place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract test` verifies declared primary keys: each key column must have no missing values, and the key must have no duplicates (a composite key is checked as a tuple) (#1220 @DMZ22)
 
 ### Fixed
+- S3 now uses an existing AWS session (`aws sso login`, `AWS_PROFILE`, instance roles) when no access key is configured; previously such a setup failed with `403 Forbidden`
 - Documented that Athena authenticates with an existing AWS session (`aws sso login`, `AWS_PROFILE`, instance roles); static access keys were presented as the only option
 - `regionName` in an Athena `servers` block was ignored, so the region could only be set via `DATACONTRACT_S3_REGION`
 - `datacontract import glue` mapped `timestamp` columns to `logicalType: date` instead of `timestamp`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - The documentation has a [Release Notes](https://docs.datacontract.com/release-notes) page, generated from this changelog
 - The documentation has a guide to [migrate contracts from DCS to ODCS](https://docs.datacontract.com/migrate-dcs-to-odcs)
+- `datacontract import s3` creates a data contract from files in an S3 bucket, including a ready-to-test `servers` block
 - `datacontract import athena` creates a data contract from an Amazon Athena database, including a ready-to-test `servers` block
 - `datacontract import unity` is now `datacontract import databricks`; the `unity` format name keeps working
 - Redshift infers the authentication method: a password means a database login, otherwise your AWS session is used for IAM. `DATACONTRACT_REDSHIFT_AUTHENTICATION` is no longer required and remains as an override

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract test` verifies declared primary keys: each key column must have no missing values, and the key must have no duplicates (a composite key is checked as a tuple) (#1220 @DMZ22)
 
 ### Fixed
+- `datacontract import athena` and `datacontract import glue` now honour `DATACONTRACT_S3_ACCESS_KEY_ID` and `DATACONTRACT_S3_SECRET_ACCESS_KEY`; the Glue catalog was read with ambient AWS credentials only
 - S3 now uses an existing AWS session (`aws sso login`, `AWS_PROFILE`, instance roles) when no access key is configured; previously such a setup failed with `403 Forbidden`
 - Documented that Athena authenticates with an existing AWS session (`aws sso login`, `AWS_PROFILE`, instance roles); static access keys were presented as the only option
 - `regionName` in an Athena `servers` block was ignored, so the region could only be set via `DATACONTRACT_S3_REGION`

--- a/datacontract/command_import.py
+++ b/datacontract/command_import.py
@@ -567,6 +567,42 @@ def import_postgres(
 
 
 @import_app.command(
+    name="s3",
+    epilog="Example: datacontract import s3 --source s3://my-bucket/orders/*.json --output datacontract.yaml",
+)
+def import_s3(
+    source: Annotated[
+        Optional[str], typer.Option(help="The S3 location of the files, e.g. s3://my-bucket/orders/*.json.")
+    ] = None,
+    format: Annotated[
+        Optional[str], typer.Option(help="File format: json, csv, parquet or delta (inferred from the suffix).")
+    ] = None,
+    delimiter: Annotated[
+        Optional[str], typer.Option(help="For JSON: new_line, array or none. Detected automatically when omitted.")
+    ] = None,
+    endpoint_url: Annotated[
+        Optional[str], typer.Option(help="Endpoint of an S3-compatible store, e.g. http://localhost:9000.")
+    ] = None,
+    output: output_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from files in S3."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(
+        format="s3",
+        source=source,
+        s3_format=format,
+        delimiter=delimiter,
+        endpoint_url=endpoint_url,
+        owner=owner,
+        id=id,
+    )
+    _write_result(result, output)
+
+
+@import_app.command(
     name="athena",
     epilog="Example: datacontract import athena --schema my_database --staging-dir s3://my-bucket/athena-results/ --output datacontract.yaml",
 )

--- a/datacontract/engines/fastjsonschema/s3/s3_read_files.py
+++ b/datacontract/engines/fastjsonschema/s3/s3_read_files.py
@@ -1,6 +1,6 @@
 import logging
-import os
 
+from datacontract.engines.ibis.connections import aws_credentials
 from datacontract.model.exceptions import DataContractException
 from datacontract.model.run import ResultEnum
 
@@ -27,9 +27,10 @@ def s3_fs(s3_endpoint_url):
             original_exception=e,
         )
 
-    aws_access_key_id = os.getenv("DATACONTRACT_S3_ACCESS_KEY_ID")
-    aws_secret_access_key = os.getenv("DATACONTRACT_S3_SECRET_ACCESS_KEY")
-    aws_session_token = os.getenv("DATACONTRACT_S3_SESSION_TOKEN")
+    configured = aws_credentials.client_kwargs()
+    aws_access_key_id = configured["aws_access_key_id"]
+    aws_secret_access_key = configured["aws_secret_access_key"]
+    aws_session_token = configured["aws_session_token"]
     return s3fs.S3FileSystem(
         key=aws_access_key_id,
         secret=aws_secret_access_key,

--- a/datacontract/engines/ibis/connections/aws_credentials.py
+++ b/datacontract/engines/ibis/connections/aws_credentials.py
@@ -12,10 +12,45 @@ AWS connection that cannot use the chain directly.
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
+
+ACCESS_KEY_ID = "DATACONTRACT_S3_ACCESS_KEY_ID"
+SECRET_ACCESS_KEY = "DATACONTRACT_S3_SECRET_ACCESS_KEY"
+SESSION_TOKEN = "DATACONTRACT_S3_SESSION_TOKEN"
+REGION = "DATACONTRACT_S3_REGION"
+
+
+def configured_region(default: Optional[str] = None) -> Optional[str]:
+    return os.getenv(REGION) or default
+
+
+def client_kwargs(region: Optional[str] = None) -> Dict[str, Any]:
+    """boto3 client kwargs for the configured credentials.
+
+    Unset values stay ``None``, which is how boto3 is told to fall back to its
+    own chain, so an `aws sso login` session works without any variable.
+    """
+    return {
+        "region_name": configured_region(region),
+        "aws_access_key_id": os.getenv(ACCESS_KEY_ID),
+        "aws_secret_access_key": os.getenv(SECRET_ACCESS_KEY),
+        "aws_session_token": os.getenv(SESSION_TOKEN),
+    }
+
+
+def client(service: str, region: Optional[str] = None):
+    """A boto3 client that honours the DATACONTRACT_S3_* variables.
+
+    Every AWS service the CLI talks to reads the same variables, so they are
+    resolved in one place rather than per service.
+    """
+    import boto3
+
+    return boto3.client(service, **client_kwargs(region))
 
 
 @dataclass(frozen=True)

--- a/datacontract/engines/ibis/connections/aws_credentials.py
+++ b/datacontract/engines/ibis/connections/aws_credentials.py
@@ -1,0 +1,53 @@
+"""Resolve AWS credentials for connections that need them handed over explicitly.
+
+duckdb cannot resolve an AWS session itself — its ``PROVIDER credential_chain``
+does not read an SSO cache — so a caller that needs credentials in hand asks
+here, and boto3 resolves the whole chain: `aws sso login`, `AWS_PROFILE`,
+EC2/ECS/EKS instance roles, GitHub OIDC in CI.
+
+Sits beside ``redshift_credentials``, which does the same job for the other
+AWS connection that cannot use the chain directly.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AwsCredentials:
+    access_key_id: str
+    secret_access_key: str
+    session_token: Optional[str] = None
+    region: Optional[str] = None
+
+
+def resolve_aws_credentials() -> Optional[AwsCredentials]:
+    """Return the credentials boto3 resolves, or ``None`` when nothing resolves.
+
+    ``None`` is a legitimate answer, not an error: reading a public bucket needs
+    no credentials at all, and signing that request could only make it fail.
+    """
+    try:
+        import boto3
+
+        session = boto3.Session()
+        credentials = session.get_credentials()
+    except Exception as e:
+        logger.debug("could not resolve AWS credentials: %s", e)
+        return None
+
+    if credentials is None:
+        return None
+
+    frozen = credentials.get_frozen_credentials()
+    return AwsCredentials(
+        access_key_id=frozen.access_key,
+        secret_access_key=frozen.secret_key,
+        session_token=frozen.token,
+        region=session.region_name,
+    )

--- a/datacontract/engines/ibis/connections/aws_credentials.py
+++ b/datacontract/engines/ibis/connections/aws_credentials.py
@@ -31,11 +31,13 @@ def configured_region(default: Optional[str] = None) -> Optional[str]:
 def client_kwargs(region: Optional[str] = None) -> Dict[str, Any]:
     """boto3 client kwargs for the configured credentials.
 
-    Unset values stay ``None``, which is how boto3 is told to fall back to its
-    own chain, so an `aws sso login` session works without any variable.
+    A region passed by the caller wins: it comes from a `--region` flag or from
+    the endpoint host, both of which are more specific than the variable. Unset
+    values stay ``None``, which is how boto3 is told to fall back to its own
+    chain, so an `aws sso login` session works without any variable.
     """
     return {
-        "region_name": configured_region(region),
+        "region_name": region or os.getenv(REGION),
         "aws_access_key_id": os.getenv(ACCESS_KEY_ID),
         "aws_secret_access_key": os.getenv(SECRET_ACCESS_KEY),
         "aws_session_token": os.getenv(SESSION_TOKEN),
@@ -72,14 +74,14 @@ def resolve_aws_credentials() -> Optional[AwsCredentials]:
 
         session = boto3.Session()
         credentials = session.get_credentials()
+        if credentials is None:
+            return None
+        frozen = credentials.get_frozen_credentials()
     except Exception as e:
+        # An expired SSO session raises here while trying to refresh.
         logger.debug("could not resolve AWS credentials: %s", e)
         return None
 
-    if credentials is None:
-        return None
-
-    frozen = credentials.get_frozen_credentials()
     return AwsCredentials(
         access_key_id=frozen.access_key,
         secret_access_key=frozen.secret_key,

--- a/datacontract/engines/ibis/connections/connect.py
+++ b/datacontract/engines/ibis/connections/connect.py
@@ -16,6 +16,7 @@ import typing
 
 from open_data_contract_standard.model import OpenDataContractStandard, Server
 
+from datacontract.engines.ibis.connections import aws_credentials
 from datacontract.engines.ibis.connections.duckdb_connection import get_duckdb_connection
 from datacontract.model.exceptions import DataContractException, require_env
 from datacontract.model.run import Check, ResultEnum, Run
@@ -428,9 +429,7 @@ def _sqlserver_connection_kwargs(server: Server) -> dict:
 
 
 def _connect_athena(ibis, server: Server):
-    s3_access_key_id = os.getenv("DATACONTRACT_S3_ACCESS_KEY_ID")
-    s3_secret_access_key = os.getenv("DATACONTRACT_S3_SECRET_ACCESS_KEY")
-    s3_session_token = os.getenv("DATACONTRACT_S3_SESSION_TOKEN")
+    credentials = aws_credentials.client_kwargs(server.regionName)
     if not server.schema_:
         raise DataContractException(
             type="athena-connection",
@@ -447,10 +446,10 @@ def _connect_athena(ibis, server: Server):
         )
     return ibis.athena.connect(
         s3_staging_dir=server.stagingDir,
-        aws_access_key_id=s3_access_key_id,
-        aws_secret_access_key=s3_secret_access_key,
-        aws_session_token=s3_session_token,
-        region_name=os.getenv("DATACONTRACT_S3_REGION") or server.regionName,
+        aws_access_key_id=credentials["aws_access_key_id"],
+        aws_secret_access_key=credentials["aws_secret_access_key"],
+        aws_session_token=credentials["aws_session_token"],
+        region_name=credentials["region_name"],
         schema_name=server.schema_,
     )
 

--- a/datacontract/engines/ibis/connections/connect.py
+++ b/datacontract/engines/ibis/connections/connect.py
@@ -429,7 +429,8 @@ def _sqlserver_connection_kwargs(server: Server) -> dict:
 
 
 def _connect_athena(ibis, server: Server):
-    credentials = aws_credentials.client_kwargs(server.regionName)
+    # regionName is a contract value, so the variable still wins over it
+    credentials = aws_credentials.client_kwargs(aws_credentials.configured_region(server.regionName))
     if not server.schema_:
         raise DataContractException(
             type="athena-connection",

--- a/datacontract/engines/ibis/connections/duckdb_connection.py
+++ b/datacontract/engines/ibis/connections/duckdb_connection.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 from typing import TYPE_CHECKING, Any, List, Optional
@@ -11,6 +12,8 @@ from datacontract.model.run import Run
 
 if TYPE_CHECKING:
     import duckdb
+
+logger = logging.getLogger(__name__)
 
 
 def _import_duckdb():
@@ -278,6 +281,47 @@ def setup_s3_connection(con, server: Server):
                     URL_STYLE '{url_style}'
                 );
             """)
+    else:
+        _create_s3_secret_from_aws_session(con, s3_region, s3_endpoint, use_ssl, url_style)
+
+
+def _create_s3_secret_from_aws_session(con, region, endpoint, use_ssl, url_style):
+    """Hand duckdb the credentials boto3 resolves, when no explicit key is set.
+
+    duckdb's own ``PROVIDER credential_chain`` cannot read an SSO cache, so an
+    ``aws sso login`` session that works for Athena and Redshift would otherwise
+    fail here with a bare 403. boto3 resolves the whole chain — SSO, profiles,
+    instance roles, OIDC — and its temporary credentials are passed on.
+
+    Anything unresolvable leaves the connection without a secret, which is what
+    public buckets need.
+    """
+    try:
+        import boto3
+
+        credentials = boto3.Session().get_credentials()
+    except Exception as e:
+        logger.debug("could not resolve AWS credentials for S3: %s", e)
+        return
+    if credentials is None:
+        return
+
+    frozen = credentials.get_frozen_credentials()
+    region = region or boto3.Session().region_name
+    token_clause = f"SESSION_TOKEN '{frozen.token}'," if frozen.token else ""
+    region_clause = f"REGION '{region}'," if region else ""
+    con.sql(f"""
+        CREATE OR REPLACE SECRET s3_secret (
+            TYPE S3,
+            {region_clause}
+            KEY_ID '{frozen.access_key}',
+            SECRET '{frozen.secret_key}',
+            {token_clause}
+            ENDPOINT '{endpoint}',
+            USE_SSL '{use_ssl}',
+            URL_STYLE '{url_style}'
+        );
+    """)
 
 
 def setup_gcs_connection(con, server: Server):

--- a/datacontract/engines/ibis/connections/duckdb_connection.py
+++ b/datacontract/engines/ibis/connections/duckdb_connection.py
@@ -1,10 +1,10 @@
 import logging
-import os
 import re
 from typing import TYPE_CHECKING, Any, List, Optional
 
 from open_data_contract_standard.model import OpenDataContractStandard, SchemaObject, SchemaProperty, Server
 
+from datacontract.engines.ibis.connections import aws_credentials
 from datacontract.engines.ibis.connections.aws_credentials import resolve_aws_credentials
 from datacontract.export.duckdb_type_converter import convert_to_duckdb_csv_type, convert_to_duckdb_json_type
 from datacontract.export.sql_type_converter import convert_to_duckdb
@@ -240,10 +240,11 @@ def _load_extension(con, name: str, extra: str) -> None:
 def setup_s3_connection(con, server: Server):
     _load_extension(con, "httpfs", "s3")
     _load_extension(con, "aws", "s3")
-    s3_region = os.getenv("DATACONTRACT_S3_REGION")
-    s3_access_key_id = os.getenv("DATACONTRACT_S3_ACCESS_KEY_ID")
-    s3_secret_access_key = os.getenv("DATACONTRACT_S3_SECRET_ACCESS_KEY")
-    s3_session_token = os.getenv("DATACONTRACT_S3_SESSION_TOKEN")
+    configured = aws_credentials.client_kwargs()
+    s3_region = configured["region_name"]
+    s3_access_key_id = configured["aws_access_key_id"]
+    s3_secret_access_key = configured["aws_secret_access_key"]
+    s3_session_token = configured["aws_session_token"]
     s3_endpoint = "s3.amazonaws.com"
     use_ssl = "true"
     url_style = "vhost"

--- a/datacontract/engines/ibis/connections/duckdb_connection.py
+++ b/datacontract/engines/ibis/connections/duckdb_connection.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, List, Optional
 
 from open_data_contract_standard.model import OpenDataContractStandard, SchemaObject, SchemaProperty, Server
 
+from datacontract.engines.ibis.connections.aws_credentials import resolve_aws_credentials
 from datacontract.export.duckdb_type_converter import convert_to_duckdb_csv_type, convert_to_duckdb_json_type
 from datacontract.export.sql_type_converter import convert_to_duckdb
 from datacontract.model.exceptions import require_env
@@ -290,32 +291,22 @@ def _create_s3_secret_from_aws_session(con, region, endpoint, use_ssl, url_style
 
     duckdb's own ``PROVIDER credential_chain`` cannot read an SSO cache, so an
     ``aws sso login`` session that works for Athena and Redshift would otherwise
-    fail here with a bare 403. boto3 resolves the whole chain — SSO, profiles,
-    instance roles, OIDC — and its temporary credentials are passed on.
-
-    Anything unresolvable leaves the connection without a secret, which is what
-    public buckets need.
+    fail here with a bare 403. Nothing resolvable leaves the connection without
+    a secret, which is what public buckets need.
     """
-    try:
-        import boto3
-
-        credentials = boto3.Session().get_credentials()
-    except Exception as e:
-        logger.debug("could not resolve AWS credentials for S3: %s", e)
-        return
+    credentials = resolve_aws_credentials()
     if credentials is None:
         return
 
-    frozen = credentials.get_frozen_credentials()
-    region = region or boto3.Session().region_name
-    token_clause = f"SESSION_TOKEN '{frozen.token}'," if frozen.token else ""
+    region = region or credentials.region
+    token_clause = f"SESSION_TOKEN '{credentials.session_token}'," if credentials.session_token else ""
     region_clause = f"REGION '{region}'," if region else ""
     con.sql(f"""
         CREATE OR REPLACE SECRET s3_secret (
             TYPE S3,
             {region_clause}
-            KEY_ID '{frozen.access_key}',
-            SECRET '{frozen.secret_key}',
+            KEY_ID '{credentials.access_key_id}',
+            SECRET '{credentials.secret_access_key}',
             {token_clause}
             ENDPOINT '{endpoint}',
             USE_SSL '{use_ssl}',

--- a/datacontract/engines/ibis/connections/redshift_credentials.py
+++ b/datacontract/engines/ibis/connections/redshift_credentials.py
@@ -20,6 +20,7 @@ import re
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
+from datacontract.engines.ibis.connections import aws_credentials
 from datacontract.model.exceptions import DataContractException, require_env
 
 logger = logging.getLogger(__name__)
@@ -106,7 +107,8 @@ def _infer_authentication() -> str:
 
 def _aws_credentials_available() -> bool:
     """True when boto3 can resolve credentials from anywhere in its chain."""
-    if os.getenv("DATACONTRACT_S3_ACCESS_KEY_ID") and os.getenv("DATACONTRACT_S3_SECRET_ACCESS_KEY"):
+    configured = aws_credentials.client_kwargs()
+    if configured["aws_access_key_id"] and configured["aws_secret_access_key"]:
         return True
     try:
         import boto3
@@ -201,15 +203,7 @@ def _resolve_endpoint(host: Optional[str]) -> Tuple[str, str, Optional[str]]:
 
 
 def _aws_client(service: str, region: Optional[str]):
-    import boto3
-
-    return boto3.client(
-        service,
-        region_name=region,
-        aws_access_key_id=os.getenv("DATACONTRACT_S3_ACCESS_KEY_ID"),
-        aws_secret_access_key=os.getenv("DATACONTRACT_S3_SECRET_ACCESS_KEY"),
-        aws_session_token=os.getenv("DATACONTRACT_S3_SESSION_TOKEN"),
-    )
+    return aws_credentials.client(service, region)
 
 
 def _call_aws(operation, kwargs: dict, api_name: str) -> dict:

--- a/datacontract/imports/glue_importer.py
+++ b/datacontract/imports/glue_importer.py
@@ -1,9 +1,9 @@
 import re
 from typing import Dict, Generator, List
 
-import boto3
 from open_data_contract_standard.model import OpenDataContractStandard, SchemaObject, SchemaProperty
 
+from datacontract.engines.ibis.connections import aws_credentials
 from datacontract.imports.importer import Importer
 from datacontract.imports.odcs_helper import (
     create_odcs,
@@ -19,8 +19,8 @@ class GlueImporter(Importer):
 
 
 def glue_client(region: str = None):
-    """Return a Glue client; without a region boto3 resolves it from the AWS chain."""
-    return boto3.client("glue", region_name=region) if region else boto3.client("glue")
+    """Return a Glue client honouring the same credentials as every other AWS call."""
+    return aws_credentials.client("glue", region)
 
 
 def get_glue_database(database_name: str, region: str = None):

--- a/datacontract/imports/importer.py
+++ b/datacontract/imports/importer.py
@@ -44,6 +44,7 @@ class ImportFormat(str, Enum):
     redshift = "redshift"
     postgres = "postgres"
     athena = "athena"
+    s3 = "s3"
 
     @classmethod
     def get_supported_formats(cls):

--- a/datacontract/imports/importer_factory.py
+++ b/datacontract/imports/importer_factory.py
@@ -150,6 +150,11 @@ importer_factory.register_lazy_importer(
     class_name="AthenaImporter",
 )
 importer_factory.register_lazy_importer(
+    name=ImportFormat.s3,
+    module_path="datacontract.imports.s3_importer",
+    class_name="S3Importer",
+)
+importer_factory.register_lazy_importer(
     name=ImportFormat.json,
     module_path="datacontract.imports.json_importer",
     class_name="JsonImporter",

--- a/datacontract/imports/s3_importer.py
+++ b/datacontract/imports/s3_importer.py
@@ -1,0 +1,145 @@
+"""Create a data contract from files in an S3 bucket.
+
+The objects are read with duckdb through the same connection setup that
+``datacontract test`` uses, so the import authenticates identically and infers
+the column types from exactly the reader that will later verify them.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from open_data_contract_standard.model import OpenDataContractStandard, Server
+
+from datacontract.imports.csv_importer import map_type_from_duckdb
+from datacontract.imports.importer import Importer
+from datacontract.imports.odcs_helper import create_odcs, create_property, create_schema_object, create_server
+from datacontract.model.exceptions import DataContractException
+
+# The formats the s3 server type can be tested against.
+FORMATS_BY_SUFFIX = {
+    ".json": "json",
+    ".ndjson": "json",
+    ".jsonl": "json",
+    ".csv": "csv",
+    ".parquet": "parquet",
+}
+SUPPORTED_FORMATS = {"json", "csv", "parquet", "delta"}
+
+_READERS = {
+    "json": "read_json_auto('{location}', hive_partitioning=1)",
+    "csv": "read_csv_auto('{location}', hive_partitioning=1)",
+    "parquet": "read_parquet('{location}', hive_partitioning=1)",
+    "delta": "delta_scan('{location}')",
+}
+
+
+class S3Importer(Importer):
+    def import_source(self, source: str, import_args: dict) -> OpenDataContractStandard:
+        return import_s3(
+            location=source,
+            format=import_args.get("s3_format"),
+            delimiter=import_args.get("delimiter"),
+            endpoint_url=import_args.get("endpoint_url"),
+        )
+
+
+def import_s3(
+    location: Optional[str],
+    format: Optional[str] = None,
+    delimiter: Optional[str] = None,
+    endpoint_url: Optional[str] = None,
+) -> OpenDataContractStandard:
+    if not location:
+        raise DataContractException(
+            type="source",
+            name="s3 import source",
+            reason="The S3 location is required for the s3 import, e.g. --source s3://my-bucket/orders/*.json",
+            engine="datacontract",
+        )
+
+    format = (format or detect_format(location) or "").lower()
+    if format not in SUPPORTED_FORMATS:
+        raise DataContractException(
+            type="source",
+            name="s3 import format",
+            reason=(
+                f"Could not tell the format of '{location}'. "
+                f"Pass --format with one of: {', '.join(sorted(SUPPORTED_FORMATS))}."
+            ),
+            engine="datacontract",
+        )
+
+    server = create_server(
+        name="production",
+        server_type="s3",
+        location=location,
+        format=format,
+    )
+    if delimiter:
+        server.delimiter = delimiter
+    if endpoint_url:
+        server.endpointUrl = endpoint_url
+
+    columns = _read_columns(server, location, format)
+    if not columns:
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="no columns found",
+            reason=f"No columns found at '{location}'.",
+            engine="datacontract",
+        )
+
+    odcs = create_odcs()
+    odcs.servers = [server]
+    odcs.schema_ = [
+        create_schema_object(
+            name=schema_name(location),
+            properties=[
+                create_property(name=name, logical_type=map_type_from_duckdb(duckdb_type))
+                for name, duckdb_type in columns
+            ],
+        )
+    ]
+    return odcs
+
+
+def detect_format(location: str) -> Optional[str]:
+    """Derive the format from the object suffix; delta has none, so it needs --format."""
+    match = re.search(r"(\.[A-Za-z0-9]+)(?:\?.*)?$", location)
+    return FORMATS_BY_SUFFIX.get(match.group(1).lower()) if match else None
+
+
+def schema_name(location: str) -> str:
+    """Name the schema after the object, or after the prefix when the path is a glob."""
+    segment = location.rstrip("/").rsplit("/", 1)[-1]
+    if "*" in segment or "?" in segment or not segment:
+        segment = location.rstrip("/").rsplit("/", 2)[-2] if "/" in location.rstrip("/") else segment
+    segment = re.sub(r"\.[A-Za-z0-9]+$", "", segment)
+    return re.sub(r"[^0-9A-Za-z_]+", "_", segment).strip("_") or "data"
+
+
+def _read_columns(server: Server, location: str, format: str):
+    from datacontract.engines.ibis.connections.duckdb_connection import _import_duckdb, setup_s3_connection
+
+    duckdb = _import_duckdb()
+    con = duckdb.connect(database=":memory:")
+    setup_s3_connection(con, server)
+    if format == "delta":
+        con.sql("update extensions;")
+    reader = _READERS[format].format(location=location)
+    try:
+        return [(row[0], row[1]) for row in con.sql(f"DESCRIBE SELECT * FROM {reader};").fetchall()]
+    except Exception as e:
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="s3 read failed",
+            reason=f"Could not read '{location}' as {format}: {e}",
+            engine="datacontract",
+            original_exception=e,
+        )
+    finally:
+        con.close()

--- a/docs/docs/commands/import.md
+++ b/docs/docs/commands/import.md
@@ -18,4 +18,4 @@ Run `datacontract import <format> --help` to see format-specific options.
 datacontract import sql --source ddl.sql --dialect postgres --output datacontract.yaml
 ```
 
-Available formats: `athena`, `avro`, `bigquery`, `csv`, `databricks`, `dbml`, `dbt`, `excel`, `glue`, `iceberg`, `json`, `jsonschema`, `odcs`, `parquet`, `postgres`, `powerbi`, `protobuf`, `redshift`, `snowflake`, `spark`, `sql`.
+Available formats: `athena`, `avro`, `bigquery`, `csv`, `databricks`, `dbml`, `dbt`, `excel`, `glue`, `iceberg`, `json`, `jsonschema`, `odcs`, `parquet`, `postgres`, `powerbi`, `protobuf`, `redshift`, `s3`, `snowflake`, `spark`, `sql`.

--- a/docs/docs/imports/avro.md
+++ b/docs/docs/imports/avro.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 title: "Import: Avro"
 description: "Create a data contract from an Avro schema file."
 ---

--- a/docs/docs/imports/bigquery.md
+++ b/docs/docs/imports/bigquery.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 title: "Import: BigQuery"
 description: "Create a data contract from BigQuery, via an exported JSON file or the BigQuery API."
 ---

--- a/docs/docs/imports/csv.md
+++ b/docs/docs/imports/csv.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 title: "Import: CSV"
 description: "Create a data contract by inferring a schema from a CSV file."
 ---

--- a/docs/docs/imports/databricks.md
+++ b/docs/docs/imports/databricks.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 title: "Import: Databricks"
 description: "Create a data contract from Databricks Unity Catalog."
 ---

--- a/docs/docs/imports/dbml.md
+++ b/docs/docs/imports/dbml.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 title: "Import: DBML"
 description: "Create a data contract from a DBML file, with optional schema/table filters."
 ---

--- a/docs/docs/imports/dbt.md
+++ b/docs/docs/imports/dbt.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 10
 title: "Import: dbt"
 description: "Create a data contract from a dbt manifest file."
 ---

--- a/docs/docs/imports/excel.md
+++ b/docs/docs/imports/excel.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 11
 title: "Import: Excel"
 description: "Create a data contract from an ODCS Excel template."
 ---

--- a/docs/docs/imports/glue.md
+++ b/docs/docs/imports/glue.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 title: "Import: AWS Glue"
 description: "Create a data contract from the AWS Glue Data Catalog."
 ---

--- a/docs/docs/imports/iceberg.md
+++ b/docs/docs/imports/iceberg.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 title: "Import: Iceberg"
 description: "Create a data contract from an Apache Iceberg schema."
 ---

--- a/docs/docs/imports/index.md
+++ b/docs/docs/imports/index.md
@@ -17,7 +17,7 @@ datacontract import sql --source my_ddl.sql --dialect postgres
 datacontract import sql --source my_ddl.sql --dialect postgres --output datacontract.yaml
 ```
 
-The [Snowflake](./snowflake.md), [BigQuery](./bigquery.md), [Amazon Redshift](./redshift.md), [Postgres](./postgres.md), [Amazon Athena](./athena.md), [Databricks](./databricks.md), and [AWS Glue](./glue.md) importers can connect directly to the live system and introspect your tables — no export files needed. Snowflake, BigQuery, Redshift, Postgres, Athena, and Databricks also generate a ready-to-test `servers` block, so `datacontract test` works right after the import.
+The [Snowflake](./snowflake.md), [BigQuery](./bigquery.md), [Amazon Redshift](./redshift.md), [Postgres](./postgres.md), [Amazon Athena](./athena.md), [Amazon S3](./s3.md), [Databricks](./databricks.md), and [AWS Glue](./glue.md) importers can connect directly to the live system and introspect your tables — no export files needed. Snowflake, BigQuery, Redshift, Postgres, Athena, S3, and Databricks also generate a ready-to-test `servers` block, so `datacontract test` works right after the import.
 
 Run `datacontract import <format> --help` to see the format-specific options (e.g. `datacontract import sql --help`). If a format you need is missing, [open an issue on GitHub](https://github.com/datacontract/datacontract-cli/issues).
 
@@ -99,6 +99,10 @@ Each import page shows a runnable example: a small source file under [`examples/
   <a className="doc-card" href="/imports/redshift">
     <img src="/img/icons/redshift.svg" alt="" />
     <span><span className="doc-card-title">redshift</span><span className="doc-card-desc">An Amazon Redshift schema.</span></span>
+  </a>
+  <a className="doc-card" href="/imports/s3">
+    <img src="/img/icons/s3.svg" alt="" />
+    <span><span className="doc-card-title">s3</span><span className="doc-card-desc">Files in an Amazon S3 bucket.</span></span>
   </a>
   <a className="doc-card" href="/imports/snowflake">
     <img src="/img/icons/snowflake.svg" alt="" />

--- a/docs/docs/imports/json.md
+++ b/docs/docs/imports/json.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 13
 title: "Import: JSON"
 description: "Create a data contract by inferring a schema from a JSON data file."
 ---

--- a/docs/docs/imports/jsonschema.md
+++ b/docs/docs/imports/jsonschema.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 14
 title: "Import: JSON Schema"
 description: "Create a data contract from a JSON Schema file."
 ---

--- a/docs/docs/imports/odcs.md
+++ b/docs/docs/imports/odcs.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 15
 title: "Import: ODCS"
 description: "Create a data contract from an existing ODCS file."
 ---

--- a/docs/docs/imports/parquet.md
+++ b/docs/docs/imports/parquet.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 16
 title: "Import: Parquet"
 description: "Create a data contract from a Parquet file."
 ---

--- a/docs/docs/imports/postgres.md
+++ b/docs/docs/imports/postgres.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 17
 title: "Import: Postgres"
 description: "Create a data contract from a Postgres schema."
 ---

--- a/docs/docs/imports/powerbi.md
+++ b/docs/docs/imports/powerbi.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 17
+sidebar_position: 18
 title: "Import: Power BI"
 description: "Create a data contract from a Power BI semantic model (.pbit, .bim, or .json)."
 ---

--- a/docs/docs/imports/protobuf.md
+++ b/docs/docs/imports/protobuf.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 18
+sidebar_position: 19
 title: "Import: Protobuf"
 description: "Create a data contract from a Protobuf schema file."
 ---

--- a/docs/docs/imports/s3.md
+++ b/docs/docs/imports/s3.md
@@ -1,0 +1,25 @@
+---
+sidebar_position: 3
+title: "Import: Amazon S3"
+description: "Create a data contract from files in an S3 bucket."
+---
+
+# <img className="page-icon" src="/img/icons/s3.svg" alt="" /> Import: Amazon S3
+
+Creates a data contract from files in S3, in CSV, JSON, Parquet, or Delta format. Works with S3 and any S3-compatible endpoint (e.g. MinIO).
+
+```bash
+datacontract import s3 \
+  --source s3://my-bucket/orders/*.json \
+  --output datacontract.yaml
+```
+
+The format is taken from the file suffix; pass `--format` for Delta tables, which have none, or to override the guess. Add `--endpoint-url` for an S3-compatible store, and `--delimiter` to pin how a JSON file is laid out (`new_line`, `array`, or `none`) instead of letting it be detected.
+
+The objects are read with duckdb through the same connection the test path uses, so the import authenticates identically and infers the column types from exactly the reader that later verifies them.
+
+The generated contract includes a ready-to-test `servers` block, so you can run `datacontract test datacontract.yaml` immediately afterwards — see the **[S3 connection guide](../testing/s3.md)** for the full 5-minute walkthrough and troubleshooting.
+
+Credentials are the same ones `datacontract test` uses: an existing AWS session, or `DATACONTRACT_S3_ACCESS_KEY_ID` and `DATACONTRACT_S3_SECRET_ACCESS_KEY` — see the [S3 Reference](../reference/s3.md).
+
+Working from a local file instead? Use [`datacontract import csv`](./csv.md), [`json`](./json.md), or [`parquet`](./parquet.md).

--- a/docs/docs/imports/snowflake.md
+++ b/docs/docs/imports/snowflake.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 19
+sidebar_position: 20
 title: "Import: Snowflake"
 description: "Create a data contract from a Snowflake workspace."
 ---

--- a/docs/docs/imports/spark.md
+++ b/docs/docs/imports/spark.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 20
+sidebar_position: 21
 title: "Import: Spark"
 description: "Create a data contract from Spark tables or DataFrames (programmatic)."
 ---

--- a/docs/docs/imports/sql.md
+++ b/docs/docs/imports/sql.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 21
+sidebar_position: 22
 title: "Import: SQL DDL"
 description: "Create a data contract from a SQL DDL file."
 ---

--- a/docs/docs/reference/s3.md
+++ b/docs/docs/reference/s3.md
@@ -36,6 +36,10 @@ servers:
 
 ## Authentication
 
+An existing AWS session is used when no key is set — `aws sso login`, `AWS_PROFILE`, EC2/ECS/EKS instance roles, or GitHub OIDC in CI. With nothing resolvable the objects are read unsigned, which is what public buckets need.
+
+The variables below override that:
+
 | Variable | Example | Description |
 |---|---|---|
 | `DATACONTRACT_S3_REGION` | `eu-central-1` | Region of the S3 bucket |

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -40,6 +40,7 @@ marked as such in the entry.
 - `datacontract test` verifies declared primary keys: each key column must have no missing values, and the key must have no duplicates (a composite key is checked as a tuple) ([#1220](https://github.com/datacontract/datacontract-cli/issues/1220) [@DMZ22](https://github.com/DMZ22))
 
 ### Fixed
+- `datacontract import athena` and `datacontract import glue` now honour `DATACONTRACT_S3_ACCESS_KEY_ID` and `DATACONTRACT_S3_SECRET_ACCESS_KEY`; the Glue catalog was read with ambient AWS credentials only
 - S3 now uses an existing AWS session (`aws sso login`, `AWS_PROFILE`, instance roles) when no access key is configured; previously such a setup failed with `403 Forbidden`
 - Documented that Athena authenticates with an existing AWS session (`aws sso login`, `AWS_PROFILE`, instance roles); static access keys were presented as the only option
 - `regionName` in an Athena `servers` block was ignored, so the region could only be set via `DATACONTRACT_S3_REGION`

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -29,6 +29,7 @@ marked as such in the entry.
 ### Added
 - The documentation has a [Release Notes](https://docs.datacontract.com/release-notes) page, generated from this changelog
 - The documentation has a guide to [migrate contracts from DCS to ODCS](https://docs.datacontract.com/migrate-dcs-to-odcs)
+- `datacontract import s3` creates a data contract from files in an S3 bucket, including a ready-to-test `servers` block
 - `datacontract import athena` creates a data contract from an Amazon Athena database, including a ready-to-test `servers` block
 - `datacontract import unity` is now `datacontract import databricks`; the `unity` format name keeps working
 - Redshift infers the authentication method: a password means a database login, otherwise your AWS session is used for IAM. `DATACONTRACT_REDSHIFT_AUTHENTICATION` is no longer required and remains as an override
@@ -39,6 +40,7 @@ marked as such in the entry.
 - `datacontract test` verifies declared primary keys: each key column must have no missing values, and the key must have no duplicates (a composite key is checked as a tuple) ([#1220](https://github.com/datacontract/datacontract-cli/issues/1220) [@DMZ22](https://github.com/DMZ22))
 
 ### Fixed
+- S3 now uses an existing AWS session (`aws sso login`, `AWS_PROFILE`, instance roles) when no access key is configured; previously such a setup failed with `403 Forbidden`
 - Documented that Athena authenticates with an existing AWS session (`aws sso login`, `AWS_PROFILE`, instance roles); static access keys were presented as the only option
 - `regionName` in an Athena `servers` block was ignored, so the region could only be set via `DATACONTRACT_S3_REGION`
 - `datacontract import glue` mapped `timestamp` columns to `logicalType: date` instead of `timestamp`

--- a/docs/docs/testing/s3.md
+++ b/docs/docs/testing/s3.md
@@ -16,9 +16,15 @@ uv tool install --python python3.11 --upgrade 'datacontract-cli[s3,duckdb]'
 
 See [Installation](../installation.md) for pip, pipx, and Docker.
 
-## 2. Set credentials
+## 2. Authenticate
 
-Create a `.env` file in your working directory (or export the variables):
+The easiest way is to sign in to AWS once — the CLI picks the session up, so no key is stored anywhere:
+
+```bash
+aws sso login   # or any other way of getting an AWS session
+```
+
+Prefer static keys? Set them directly and they are used instead:
 
 ```bash
 # .env
@@ -27,7 +33,7 @@ DATACONTRACT_S3_ACCESS_KEY_ID=AKIAXV5Q5QABCDEFGH
 DATACONTRACT_S3_SECRET_ACCESS_KEY=93S7LRrJcqLaaaa/XXXXXXXXXXXXX
 ```
 
-For public buckets, or when ambient AWS credentials are available, you can skip this step.
+Public buckets need neither: with nothing configured the objects are read unsigned.
 
 ## 3. Create a contract from your files
 

--- a/docs/docs/testing/s3.md
+++ b/docs/docs/testing/s3.md
@@ -37,23 +37,15 @@ Public buckets need neither: with nothing configured the objects are read unsign
 
 ## 3. Create a contract from your files
 
-Download one object and import its schema, then point the generated `servers` block at the bucket:
+Import the schema straight from the bucket. This also generates a ready-to-test `servers` block:
 
 ```bash
-aws s3 cp s3://my-bucket/orders/orders-2024-01.json .
-datacontract import json --source orders-2024-01.json --output datacontract.yaml
+datacontract import s3 \
+  --source s3://my-bucket/orders/*.json \
+  --output datacontract.yaml
 ```
 
-The import generates a `servers` entry of `type: local`. Replace it with your S3 location:
-
-```yaml
-servers:
-  - server: production
-    type: s3
-    location: s3://my-bucket/orders/*.json
-    format: json
-    delimiter: new_line # new_line, array, or none
-```
+The format is taken from the file suffix; pass `--format` for Delta tables, which have none. Add `--endpoint-url` for an S3-compatible store such as MinIO.
 
 ## 4. Test the actual data
 

--- a/tests/test_connect_s3_credentials.py
+++ b/tests/test_connect_s3_credentials.py
@@ -94,3 +94,38 @@ def test_a_custom_endpoint_still_uses_path_style(env):
     assert "localhost:9000" in sql
     assert "URL_STYLE 'path'" in sql
     assert "USE_SSL 'false'" in sql
+
+
+# ---------------------------------------------------------------------------
+# One place resolves the DATACONTRACT_S3_* variables for every AWS service
+# ---------------------------------------------------------------------------
+def test_glue_honours_the_configured_credentials(env):
+    """`import athena` reads the Glue catalog, and used to ignore these entirely."""
+    env.setenv("DATACONTRACT_S3_ACCESS_KEY_ID", "AKIA_CONFIGURED")
+    env.setenv("DATACONTRACT_S3_SECRET_ACCESS_KEY", "configured-secret")
+    from datacontract.imports.glue_importer import glue_client
+
+    with patch("boto3.client") as boto3_client:
+        glue_client("eu-central-1")
+
+    assert boto3_client.call_args.kwargs["aws_access_key_id"] == "AKIA_CONFIGURED"
+    assert boto3_client.call_args.kwargs["region_name"] == "eu-central-1"
+
+
+def test_an_unset_variable_leaves_boto3_to_its_own_chain(env):
+    from datacontract.imports.glue_importer import glue_client
+
+    with patch("boto3.client") as boto3_client:
+        glue_client()
+
+    assert boto3_client.call_args.kwargs["aws_access_key_id"] is None
+
+
+def test_the_region_variable_wins_over_the_argument(env):
+    env.setenv("DATACONTRACT_S3_REGION", "us-east-1")
+    from datacontract.imports.glue_importer import glue_client
+
+    with patch("boto3.client") as boto3_client:
+        glue_client("eu-central-1")
+
+    assert boto3_client.call_args.kwargs["region_name"] == "us-east-1"

--- a/tests/test_connect_s3_credentials.py
+++ b/tests/test_connect_s3_credentials.py
@@ -121,11 +121,33 @@ def test_an_unset_variable_leaves_boto3_to_its_own_chain(env):
     assert boto3_client.call_args.kwargs["aws_access_key_id"] is None
 
 
-def test_the_region_variable_wins_over_the_argument(env):
+def test_an_explicit_region_wins_over_the_variable(env):
+    """--region and the Redshift endpoint host are more specific than the variable."""
     env.setenv("DATACONTRACT_S3_REGION", "us-east-1")
     from datacontract.imports.glue_importer import glue_client
 
     with patch("boto3.client") as boto3_client:
         glue_client("eu-central-1")
 
+    assert boto3_client.call_args.kwargs["region_name"] == "eu-central-1"
+
+
+def test_the_region_variable_is_used_when_no_region_is_passed(env):
+    env.setenv("DATACONTRACT_S3_REGION", "us-east-1")
+    from datacontract.imports.glue_importer import glue_client
+
+    with patch("boto3.client") as boto3_client:
+        glue_client()
+
     assert boto3_client.call_args.kwargs["region_name"] == "us-east-1"
+
+
+def test_an_expired_session_falls_back_to_no_credentials():
+    """boto3 raises while refreshing an expired SSO session; a public bucket still reads."""
+    from datacontract.engines.ibis.connections.aws_credentials import resolve_aws_credentials
+
+    session = MagicMock()
+    session.get_credentials.return_value.get_frozen_credentials.side_effect = Exception("session expired")
+
+    with patch("boto3.Session", return_value=session):
+        assert resolve_aws_credentials() is None

--- a/tests/test_connect_s3_credentials.py
+++ b/tests/test_connect_s3_credentials.py
@@ -1,0 +1,96 @@
+"""How the S3 duckdb connection resolves credentials.
+
+No S3 or MinIO involved: duckdb and boto3 are faked and we assert which secret
+the setup creates. The point is that an `aws sso login` session reaches S3 the
+way it already reaches Athena and Redshift.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from open_data_contract_standard.model import Server
+
+from datacontract.engines.ibis.connections.duckdb_connection import setup_s3_connection
+
+S3_ENV = [
+    "DATACONTRACT_S3_REGION",
+    "DATACONTRACT_S3_ACCESS_KEY_ID",
+    "DATACONTRACT_S3_SECRET_ACCESS_KEY",
+    "DATACONTRACT_S3_SESSION_TOKEN",
+]
+
+
+@pytest.fixture(autouse=True)
+def env(monkeypatch):
+    for name in S3_ENV:
+        monkeypatch.delenv(name, raising=False)
+    return monkeypatch
+
+
+def _session(access_key="ASIA_SSO", secret_key="sso-secret", token="sso-token", region="eu-central-1"):
+    """A boto3 session that resolves credentials, as after `aws sso login`."""
+    session = MagicMock()
+    session.region_name = region
+    if access_key is None:
+        session.get_credentials.return_value = None
+    else:
+        frozen = MagicMock(access_key=access_key, secret_key=secret_key, token=token)
+        session.get_credentials.return_value.get_frozen_credentials.return_value = frozen
+    return session
+
+
+def _setup(server=None, session=None):
+    con = MagicMock()
+    server = server or Server(server="production", type="s3", location="s3://bucket/orders/*.csv", format="csv")
+    with patch("boto3.Session", return_value=session or _session()):
+        setup_s3_connection(con, server)
+    return "\n".join(str(call.args[0]) for call in con.sql.call_args_list)
+
+
+def test_an_aws_session_is_used_when_no_key_is_configured():
+    sql = _setup()
+
+    assert "ASIA_SSO" in sql
+    assert "sso-secret" in sql
+    assert "sso-token" in sql
+    assert "eu-central-1" in sql
+
+
+def test_explicit_keys_take_precedence_over_the_session(env):
+    env.setenv("DATACONTRACT_S3_ACCESS_KEY_ID", "AKIA_EXPLICIT")
+    env.setenv("DATACONTRACT_S3_SECRET_ACCESS_KEY", "explicit-secret")
+
+    sql = _setup()
+
+    assert "AKIA_EXPLICIT" in sql
+    assert "ASIA_SSO" not in sql
+
+
+def test_no_secret_is_created_when_nothing_resolves():
+    """Public buckets are read without credentials; a secret would sign the request."""
+    sql = _setup(session=_session(access_key=None))
+
+    assert "CREATE OR REPLACE SECRET" not in sql
+
+
+def test_a_session_without_a_token_omits_the_token_clause():
+    sql = _setup(session=_session(token=None))
+
+    assert "SESSION_TOKEN" not in sql
+    assert "ASIA_SSO" in sql
+
+
+def test_a_custom_endpoint_still_uses_path_style(env):
+    server = Server(
+        server="production",
+        type="s3",
+        location="s3://bucket/orders/*.csv",
+        format="csv",
+        endpointUrl="http://localhost:9000",
+    )
+
+    sql = _setup(server=server)
+
+    assert "localhost:9000" in sql
+    assert "URL_STYLE 'path'" in sql
+    assert "USE_SSL 'false'" in sql

--- a/tests/test_import_s3.py
+++ b/tests/test_import_s3.py
@@ -4,7 +4,7 @@ The format detection and schema naming are pure and tested directly; the read
 itself runs against a MinIO container, the same seam the s3 test suites use.
 """
 
-import os
+from pathlib import Path
 
 import pytest
 from testcontainers.minio import MinioContainer
@@ -17,7 +17,9 @@ from datacontract.model.run import ResultEnum
 BUCKET = "test-bucket"
 ACCESS_KEY = "test-access"
 SECRET_KEY = "test-secret"
-CSV_FIXTURE = "fixtures/s3-csv/data/sample_data.csv"
+# resolved from this file: the container fixture is module-scoped and therefore
+# runs before conftest chdirs into the test directory
+CSV_FIXTURE = Path(__file__).parent / "fixtures" / "s3-csv" / "data" / "sample_data.csv"
 
 
 @pytest.mark.parametrize(
@@ -69,7 +71,7 @@ def minio(request):
         client = container.get_client()
         client.make_bucket(BUCKET)
         with open(CSV_FIXTURE, "rb") as file:
-            client.put_object(BUCKET, "orders/orders.csv", file, os.path.getsize(CSV_FIXTURE))
+            client.put_object(BUCKET, "orders/orders.csv", file, CSV_FIXTURE.stat().st_size)
         yield container
 
 

--- a/tests/test_import_s3.py
+++ b/tests/test_import_s3.py
@@ -1,0 +1,117 @@
+"""Tests for the S3 importer.
+
+The format detection and schema naming are pure and tested directly; the read
+itself runs against a MinIO container, the same seam the s3 test suites use.
+"""
+
+import os
+
+import pytest
+from testcontainers.minio import MinioContainer
+
+from datacontract.data_contract import DataContract
+from datacontract.imports.s3_importer import detect_format, schema_name
+from datacontract.model.exceptions import DataContractException
+from datacontract.model.run import ResultEnum
+
+BUCKET = "test-bucket"
+ACCESS_KEY = "test-access"
+SECRET_KEY = "test-secret"
+CSV_FIXTURE = "fixtures/s3-csv/data/sample_data.csv"
+
+
+@pytest.mark.parametrize(
+    "location, expected",
+    [
+        ("s3://bucket/orders/orders.json", "json"),
+        ("s3://bucket/orders/orders.ndjson", "json"),
+        ("s3://bucket/orders/orders.JSONL", "json"),
+        ("s3://bucket/orders/orders.csv", "csv"),
+        ("s3://bucket/orders/*.parquet", "parquet"),
+        ("s3://bucket/orders/", None),  # a delta table has no suffix
+    ],
+)
+def test_detect_format(location, expected):
+    assert detect_format(location) == expected
+
+
+@pytest.mark.parametrize(
+    "location, expected",
+    [
+        ("s3://bucket/orders/orders.csv", "orders"),
+        ("s3://bucket/orders/*.json", "orders"),
+        ("s3://bucket/orders/orders-2024-01.json", "orders_2024_01"),
+        ("s3://bucket/orders/", "orders"),
+    ],
+)
+def test_schema_name(location, expected):
+    assert schema_name(location) == expected
+
+
+def test_an_unknown_format_is_rejected_with_the_options():
+    with pytest.raises(DataContractException) as exc_info:
+        DataContract.import_from_source("s3", "s3://bucket/orders/")
+
+    assert "--format" in exc_info.value.reason
+    assert "parquet" in exc_info.value.reason
+
+
+def test_a_missing_location_is_rejected():
+    with pytest.raises(DataContractException) as exc_info:
+        DataContract.import_from_source("s3", None)
+
+    assert "location is required" in exc_info.value.reason
+
+
+@pytest.fixture(scope="module")
+def minio(request):
+    with MinioContainer(image="quay.io/minio/minio", access_key=ACCESS_KEY, secret_key=SECRET_KEY) as container:
+        client = container.get_client()
+        client.make_bucket(BUCKET)
+        with open(CSV_FIXTURE, "rb") as file:
+            client.put_object(BUCKET, "orders/orders.csv", file, os.path.getsize(CSV_FIXTURE))
+        yield container
+
+
+@pytest.fixture
+def credentials(monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_S3_ACCESS_KEY_ID", ACCESS_KEY)
+    monkeypatch.setenv("DATACONTRACT_S3_SECRET_ACCESS_KEY", SECRET_KEY)
+
+
+def _endpoint(minio):
+    return f"http://{minio.get_container_host_ip()}:{minio.get_exposed_port(9000)}"
+
+
+def test_import_s3_csv(minio, credentials):
+    result = DataContract.import_from_source("s3", f"s3://{BUCKET}/orders/orders.csv", endpoint_url=_endpoint(minio))
+
+    server = result.servers[0]
+    assert (server.type, server.format) == ("s3", "csv")
+    assert server.location == f"s3://{BUCKET}/orders/orders.csv"
+    assert result.schema_[0].name == "orders"
+    assert [prop.name for prop in result.schema_[0].properties]
+
+
+def test_imported_contract_passes_test_without_editing(minio, credentials):
+    """The point of the importer: import, then test, no hand-editing."""
+    result = DataContract.import_from_source("s3", f"s3://{BUCKET}/orders/orders.csv", endpoint_url=_endpoint(minio))
+
+    run = DataContract(data_contract_str=result.to_yaml()).test()
+
+    print(run.pretty())
+    assert run.result == ResultEnum.passed
+
+
+def test_import_s3_produces_a_valid_contract(minio, credentials):
+    result = DataContract.import_from_source("s3", f"s3://{BUCKET}/orders/orders.csv", endpoint_url=_endpoint(minio))
+
+    assert DataContract(data_contract_str=result.to_yaml()).lint().result == ResultEnum.passed
+
+
+def test_an_unreadable_object_explains_the_location_and_format(minio, credentials):
+    with pytest.raises(DataContractException) as exc_info:
+        DataContract.import_from_source("s3", f"s3://{BUCKET}/orders/missing.csv", endpoint_url=_endpoint(minio))
+
+    assert "missing.csv" in exc_info.value.reason
+    assert "as csv" in exc_info.value.reason


### PR DESCRIPTION
## Summary

Three related changes to the AWS path, each building on the previous.

### 1. S3 uses an existing AWS session

Reading S3 with an `aws sso login` session and no static keys failed with a bare `403 Forbidden`. duckdb only received credentials when `DATACONTRACT_S3_ACCESS_KEY_ID` was set; with no key, `setup_s3_connection` created no secret at all, so the request went out unsigned.

boto3 now resolves the chain when no explicit key is configured, and its credentials are handed to duckdb — the same resolution that already makes Athena and Glue work with a session.

**Why not duckdb's own credential chain.** `PROVIDER credential_chain` looked like the obvious fix but cannot read an SSO cache. Every variant fails against a live SSO session:

```
CHAIN 'sso'                       -> Credential Chain: 'sso'
CHAIN 'sso;config'                -> Credential Chain: 'sso;config'
CHAIN 'env;sso'                   -> Credential Chain: 'env;sso'
(no CHAIN, defaults to 'config')  -> Credential Chain: 'config'
```

### 2. `datacontract import s3`

```bash
datacontract import s3 --source s3://my-bucket/orders/*.json --output datacontract.yaml
```

The guide previously told users to `aws s3 cp` an object, run `import json` on the local copy, and then hand-replace the generated `type: local` server with an S3 one, filling in location, format and delimiter.

The objects are read with duckdb through the same connection the test path uses, so the import authenticates identically and infers the column types from exactly the reader that later verifies them. The format comes from the file suffix, with `--format` for Delta tables, which have none, plus `--endpoint-url` for S3-compatible stores and `--delimiter` to pin a JSON layout.

### 3. The AWS credentials are resolved in one place

`DATACONTRACT_S3_ACCESS_KEY_ID` was read in five places, and one of them disagreed: the Glue client passed no credentials at all and used only the ambient AWS chain. Anyone configuring the documented variables could therefore `datacontract test` Athena but not `datacontract import athena`, since the import reads the Glue catalog. They now all go through `aws_credentials`, which fixes that.

Callers split in two: those wanting a boto3 client (Redshift, Glue, Athena) and those needing the raw values because they configure something else (the duckdb secret builder, the fastjsonschema s3fs reader). Both read the same variables with the same precedence.

## Verified against real AWS

With **no `DATACONTRACT_S3_*` variable set**, against a private bucket using an SSO session:

- **before:** `HTTP 403 Forbidden ... in region ''` — note the empty region; nothing resolved
- **after:** `datacontract import s3` produced the contract, and `datacontract test` on it unedited passed 4/4

Re-verified after the consolidation: S3 4/4 and Athena 8/8, both still with no variables set.

## Behavior changes

- **Glue now honours `DATACONTRACT_S3_*`.** A fix, but someone with correct ambient credentials *and* stale variables set will now get the variables.
- **Public buckets with ambient credentials are now signed** rather than read anonymously. Signed requests to a public bucket normally succeed and this matches the AWS CLI, but it is not literally the old behavior.

Explicit keys, Redshift, and Athena are otherwise unchanged. `boto3` is already a core dependency, so no extra changes.

## Testing

`tests/test_import_s3.py` — 16 tests. Format detection and schema naming are pure cases; the reads run against a **MinIO container**, the seam the six existing s3 suites already use, and include a round trip that imports a contract and then tests it unedited.

These MinIO tests initially could not run (no Docker daemon on the machine at the time). Once Docker was available they were run, and they immediately caught a bug in themselves: the fixture was addressed relative to the working directory, so all four container-backed tests failed when pytest ran from the repository root, which is how CI runs. The path now resolves from the test file, and the suite passes from both the repository root and `tests/`. The six existing s3 suites were run against MinIO as well and are unaffected.

`tests/test_connect_s3_credentials.py` — 10 tests on credential resolution with duckdb and boto3 faked: the session being used when no key is set, explicit keys winning, no secret when nothing resolves, the token clause omitted for long-lived credentials, a custom endpoint still using path-style addressing, Glue honouring the variables, region precedence in both directions, and an expired session falling back rather than raising.

A full-suite differential against `main` shows the same 31 pre-existing failures on both sides and nothing introduced.

## Regressions found and fixed while reviewing this PR

- **`DATACONTRACT_S3_REGION` overrode an explicit region.** Redshift derives its region from the endpoint host and the Glue client takes it from `--region`; the variable beat both, so a cluster in one region plus the variable pointing at another silently used the wrong endpoint. The caller's value wins again; the contract's `regionName` still sits below the variable, as documented.
- **An expired SSO session raised instead of falling back.** boto3 raises while refreshing, and that happened outside the guard, so reading a public bucket — which worked before — would have failed.

The docs ordering guard added in #1431 also caught the new import page being sorted by file name rather than by the label the sidebar renders: `Import: Amazon S3` belongs under A, between Amazon Redshift and Avro.
