### PR TITLE
Serve context7.json from the docs site

### DIFF
--- a/docs/static/context7.json
+++ b/docs/static/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/websites/datacontract",
+  "public_key": "pk_t1B8AMRc2HhxqeSHdGgui"
+}

--- a/docs/static/staticwebapp.config.json
+++ b/docs/static/staticwebapp.config.json
@@ -38,6 +38,13 @@
       "headers": {
         "Cache-Control": "public, max-age=3600"
       }
+    },
+    {
+      "route": "/context7.json",
+      "headers": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Cache-Control": "public, max-age=3600"
+      }
     }
   ],
   "globalHeaders": {


### PR DESCRIPTION
## Summary

Adds `docs/static/context7.json` so it is served at https://docs.datacontract.com/context7.json, which is where Context7 looks for the project verification file.

Docusaurus copies `static/` to the site root verbatim, and `staticwebapp.config.json` already maps `.json` to `application/json`, so no build or routing changes are needed. Verified with a local `npm run build` — the file lands at `build/context7.json`.

This is the docs-site counterpart to the existing repo-root `context7.json` (which covers the GitHub repo source at cli.datacontract.com); the two point at different Context7 entries.