### PR TITLE
Add MySQL import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `datacontract import mysql` creates a data contract from a live MySQL database, including a ready-to-test `servers` block
 - The documentation has a [Release Notes](https://docs.datacontract.com/release-notes) page, generated from this changelog
 - The documentation has a guide to [migrate contracts from DCS to ODCS](https://docs.datacontract.com/migrate-dcs-to-odcs)
 - `datacontract import s3` creates a data contract from files in an S3 bucket, including a ready-to-test `servers` block

--- a/datacontract/command_import.py
+++ b/datacontract/command_import.py
@@ -567,6 +567,37 @@ def import_postgres(
 
 
 @import_app.command(
+    name="mysql",
+    epilog="Example: datacontract import mysql --source localhost --database mydb --output datacontract.yaml",
+)
+def import_mysql(
+    source: Annotated[Optional[str], typer.Option(help="The host of the MySQL server.")] = None,
+    port: Annotated[Optional[int], typer.Option(help="The MySQL port (default 3306).")] = None,
+    database: database_option = None,
+    table: Annotated[
+        Optional[List[str]],
+        typer.Option(help="Name of a table to import (repeat for multiple tables, omit for all tables)."),
+    ] = None,
+    output: output_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from a MySQL database."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(
+        format="mysql",
+        source=source,
+        port=port,
+        database=database,
+        mysql_table=table,
+        owner=owner,
+        id=id,
+    )
+    _write_result(result, output)
+
+
+@import_app.command(
     name="s3",
     epilog="Example: datacontract import s3 --source s3://my-bucket/orders/*.json --output datacontract.yaml",
 )

--- a/datacontract/imports/importer.py
+++ b/datacontract/imports/importer.py
@@ -45,6 +45,7 @@ class ImportFormat(str, Enum):
     postgres = "postgres"
     athena = "athena"
     s3 = "s3"
+    mysql = "mysql"
 
     @classmethod
     def get_supported_formats(cls):

--- a/datacontract/imports/importer_factory.py
+++ b/datacontract/imports/importer_factory.py
@@ -150,6 +150,11 @@ importer_factory.register_lazy_importer(
     class_name="AthenaImporter",
 )
 importer_factory.register_lazy_importer(
+    name=ImportFormat.mysql,
+    module_path="datacontract.imports.mysql_importer",
+    class_name="MysqlImporter",
+)
+importer_factory.register_lazy_importer(
     name=ImportFormat.s3,
     module_path="datacontract.imports.s3_importer",
     class_name="S3Importer",

--- a/datacontract/imports/mysql_importer.py
+++ b/datacontract/imports/mysql_importer.py
@@ -1,0 +1,212 @@
+"""Create a data contract from a live MySQL schema.
+
+MySQL is reached the way ``datacontract test`` reaches it: duckdb ATTACHes the
+database through its ``mysql`` extension, so the import needs no extra driver
+and authenticates with the same variables. The catalog itself is read with
+``mysql_query``, which runs the statement on MySQL rather than through the
+scanner, so ``information_schema`` is available.
+
+``column_type`` is taken verbatim as the physicalType — it is the full declared
+type (``varchar(36)``, ``decimal(10,2)``), which is what a reader of the
+contract expects to see.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from open_data_contract_standard.model import OpenDataContractStandard, SchemaObject, SchemaProperty
+
+from datacontract.imports.importer import Importer
+from datacontract.imports.odcs_helper import create_odcs, create_property, create_schema_object, create_server
+from datacontract.imports.sql_importer import map_type_from_sql
+from datacontract.model.exceptions import DataContractException, require_env
+
+DEFAULT_PORT = 3306
+
+_TABLES_QUERY = """
+    SELECT table_name, table_type, table_comment
+    FROM information_schema.tables
+    WHERE table_schema = ''{database}''
+"""
+
+_COLUMNS_QUERY = """
+    SELECT table_name, column_name, column_type, is_nullable, column_key, column_comment,
+           character_maximum_length, numeric_precision, numeric_scale
+    FROM information_schema.columns
+    WHERE table_schema = ''{database}''
+    ORDER BY table_name, ordinal_position
+"""
+
+
+class MysqlImporter(Importer):
+    def import_source(self, source: str, import_args: dict) -> OpenDataContractStandard:
+        if source is None:
+            raise DataContractException(
+                type="source",
+                name="mysql import source",
+                reason="The host is required for the mysql import, e.g. --source localhost",
+                engine="datacontract",
+            )
+        return import_mysql(
+            host=source,
+            port=import_args.get("port"),
+            database=import_args.get("database"),
+            tables=import_args.get("mysql_table"),
+        )
+
+
+def import_mysql(
+    host: str,
+    database: Optional[str],
+    port: Optional[int] = None,
+    tables: Optional[List[str]] = None,
+) -> OpenDataContractStandard:
+    if not database:
+        raise DataContractException(
+            type="source",
+            name="mysql import database",
+            reason="The database is required for the mysql import, e.g. --database mydb",
+            engine="datacontract",
+        )
+
+    port = int(port) if port else DEFAULT_PORT
+    con = _attach(host, port, database)
+    try:
+        table_rows = _query(con, _TABLES_QUERY.format(database=_escape(database)))
+        column_rows = _query(con, _COLUMNS_QUERY.format(database=_escape(database)))
+    finally:
+        con.close()
+
+    selected = _select_tables(table_rows, tables)
+    if not selected:
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="no tables found",
+            reason=f"No tables found in the database '{database}'.",
+            engine="datacontract",
+        )
+
+    odcs = create_odcs()
+    odcs.servers = [create_server(name="mysql", server_type="mysql", host=host, port=port, database=database)]
+    odcs.schema_ = [
+        _create_schema(table, column_rows) for table in sorted(selected, key=lambda row: row["table_name"].lower())
+    ]
+    return odcs
+
+
+def _attach(host: str, port: int, database: str):
+    """ATTACH the database exactly as the test path does."""
+    try:
+        import duckdb
+    except ImportError as e:
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="mysql extra missing",
+            reason="Install the extra datacontract-cli[mysql] to use mysql",
+            engine="datacontract",
+            original_exception=e,
+        )
+
+    from datacontract.engines.ibis.connections.duckdb_connection import _load_extension
+
+    user = require_env("DATACONTRACT_MYSQL_USERNAME", server_type="mysql")
+    password = require_env("DATACONTRACT_MYSQL_PASSWORD", server_type="mysql")
+
+    con = duckdb.connect()
+    _load_extension(con, "mysql", "mysql")
+    connection_string = _escape(f"host={host} port={port} user={user} password={password} database={database}")
+    try:
+        con.execute(f"ATTACH '{connection_string}' AS mysqldb (TYPE mysql)")
+    except Exception as e:
+        con.close()
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="mysql connection failed",
+            reason=f"Could not connect to MySQL at {host}:{port}: {e}",
+            engine="datacontract",
+            original_exception=e,
+        )
+    return con
+
+
+def _query(con, sql: str) -> List[Dict[str, Any]]:
+    """Run a catalog statement on MySQL itself and return decoded rows."""
+    try:
+        result = con.sql(f"SELECT * FROM mysql_query('mysqldb', '{sql}')")
+        # MySQL 8 names its information_schema columns in upper case
+        columns = [description[0].lower() for description in result.description]
+        return [dict(zip(columns, (_decode(value) for value in row))) for row in result.fetchall()]
+    except Exception as e:
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="mysql catalog query failed",
+            reason=f"Could not read the MySQL catalog: {e}",
+            engine="datacontract",
+            original_exception=e,
+        )
+
+
+def _decode(value: Any) -> Any:
+    """MySQL returns catalog text as bytes through the duckdb scanner."""
+    return value.decode("utf-8") if isinstance(value, (bytes, bytearray)) else value
+
+
+def _escape(value: str) -> str:
+    return value.replace("'", "''")
+
+
+def _select_tables(table_rows: List[Dict[str, Any]], tables: Optional[List[str]]) -> List[Dict[str, Any]]:
+    if not tables:
+        return table_rows
+    wanted = {table.lower() for table in tables}
+    return [row for row in table_rows if row["table_name"].lower() in wanted]
+
+
+def _create_schema(table: Dict[str, Any], column_rows: List[Dict[str, Any]]) -> SchemaObject:
+    table_name = table["table_name"]
+    columns = [row for row in column_rows if row["table_name"] == table_name]
+    primary_keys = [row["column_name"] for row in columns if row.get("column_key") == "PRI"]
+    return create_schema_object(
+        name=table_name,
+        physical_type="view" if (table.get("table_type") or "").upper() == "VIEW" else "table",
+        description=_clean(table.get("table_comment")),
+        properties=[_create_property(row, primary_keys) for row in columns] or None,
+    )
+
+
+# duckdb's MySQL scanner surfaces JSON columns as text, so a contract declaring
+# `object` would fail its own type check on the first run. The physicalType still
+# records that the column really is JSON.
+_SCANNER_LOGICAL_TYPES = {"json": "string"}
+
+
+def _create_property(row: Dict[str, Any], primary_keys: List[str]) -> SchemaProperty:
+    name = row["column_name"]
+    physical_type = row.get("column_type")
+    logical_type, format = map_type_from_sql(physical_type)
+    if physical_type:
+        logical_type = _SCANNER_LOGICAL_TYPES.get(physical_type.lower(), logical_type)
+    is_decimal = physical_type is not None and physical_type.lower().startswith(("decimal", "numeric"))
+
+    return create_property(
+        name=name,
+        logical_type=logical_type,
+        physical_type=physical_type,
+        description=_clean(row.get("column_comment")),
+        required=row.get("is_nullable") == "NO" or None,
+        primary_key=name in primary_keys or None,
+        primary_key_position=primary_keys.index(name) + 1 if name in primary_keys else None,
+        max_length=row.get("character_maximum_length"),
+        precision=row.get("numeric_precision") if is_decimal else None,
+        scale=row.get("numeric_scale") if is_decimal else None,
+        format=format,
+    )
+
+
+def _clean(value: Optional[str]) -> Optional[str]:
+    return value.strip() if value and value.strip() else None

--- a/docs/docs/commands/import.md
+++ b/docs/docs/commands/import.md
@@ -18,4 +18,4 @@ Run `datacontract import <format> --help` to see format-specific options.
 datacontract import sql --source ddl.sql --dialect postgres --output datacontract.yaml
 ```
 
-Available formats: `athena`, `avro`, `bigquery`, `csv`, `databricks`, `dbml`, `dbt`, `excel`, `glue`, `iceberg`, `json`, `jsonschema`, `odcs`, `parquet`, `postgres`, `powerbi`, `protobuf`, `redshift`, `s3`, `snowflake`, `spark`, `sql`.
+Available formats: `athena`, `avro`, `bigquery`, `csv`, `databricks`, `dbml`, `dbt`, `excel`, `glue`, `iceberg`, `json`, `jsonschema`, `mysql`, `odcs`, `parquet`, `postgres`, `powerbi`, `protobuf`, `redshift`, `s3`, `snowflake`, `spark`, `sql`.

--- a/docs/docs/imports/index.md
+++ b/docs/docs/imports/index.md
@@ -17,7 +17,7 @@ datacontract import sql --source my_ddl.sql --dialect postgres
 datacontract import sql --source my_ddl.sql --dialect postgres --output datacontract.yaml
 ```
 
-The [Snowflake](./snowflake.md), [BigQuery](./bigquery.md), [Amazon Redshift](./redshift.md), [Postgres](./postgres.md), [Amazon Athena](./athena.md), [Amazon S3](./s3.md), [Databricks](./databricks.md), and [AWS Glue](./glue.md) importers can connect directly to the live system and introspect your tables — no export files needed. Snowflake, BigQuery, Redshift, Postgres, Athena, S3, and Databricks also generate a ready-to-test `servers` block, so `datacontract test` works right after the import.
+The [Snowflake](./snowflake.md), [BigQuery](./bigquery.md), [Amazon Redshift](./redshift.md), [Postgres](./postgres.md), [MySQL](./mysql.md), [Amazon Athena](./athena.md), [Amazon S3](./s3.md), [Databricks](./databricks.md), and [AWS Glue](./glue.md) importers can connect directly to the live system and introspect your tables — no export files needed. Snowflake, BigQuery, Redshift, Postgres, MySQL, Athena, S3, and Databricks also generate a ready-to-test `servers` block, so `datacontract test` works right after the import.
 
 Run `datacontract import <format> --help` to see the format-specific options (e.g. `datacontract import sql --help`). If a format you need is missing, [open an issue on GitHub](https://github.com/datacontract/datacontract-cli/issues).
 
@@ -75,6 +75,10 @@ Each import page shows a runnable example: a small source file under [`examples/
   <a className="doc-card" href="/imports/jsonschema">
     <img src="/img/icons/jsonschema.svg" alt="" />
     <span><span className="doc-card-title">jsonschema</span><span className="doc-card-desc">A JSON Schema file.</span></span>
+  </a>
+  <a className="doc-card" href="/imports/mysql">
+    <img src="/img/icons/mysql.svg" alt="" />
+    <span><span className="doc-card-title">mysql</span><span className="doc-card-desc">A MySQL database.</span></span>
   </a>
   <a className="doc-card" href="/imports/odcs">
     <img src="/img/icons/odcs.svg" alt="" />

--- a/docs/docs/imports/mysql.md
+++ b/docs/docs/imports/mysql.md
@@ -1,0 +1,26 @@
+---
+sidebar_position: 15
+title: "Import: MySQL"
+description: "Create a data contract from a MySQL database."
+---
+
+# <img className="page-icon" src="/img/icons/mysql.svg" alt="" /> Import: MySQL
+
+Creates a data contract from a MySQL database by reading `information_schema` — including the full declared column types, nullability, primary keys, and the comments on tables and columns.
+
+```bash
+datacontract import mysql \
+  --source localhost \
+  --database mydb \
+  --output datacontract.yaml
+```
+
+`--source` is the host of your MySQL server. Add `--port` if it doesn't listen on the default `3306`, and repeat `--table` to import only specific tables (by default every table and view in the database is imported).
+
+The database is reached the way `datacontract test` reaches it: duckdb attaches it through its `mysql` extension, so no extra driver is needed and the import authenticates with the same variables.
+
+The generated contract includes a ready-to-test `servers` block, so you can run `datacontract test datacontract.yaml` immediately afterwards — see the **[MySQL connection guide](../testing/mysql.md)** for the full 5-minute walkthrough and troubleshooting.
+
+Credentials are provided as environment variables and are the same ones `datacontract test` uses: `DATACONTRACT_MYSQL_USERNAME` and `DATACONTRACT_MYSQL_PASSWORD` — see the [MySQL Reference](../reference/mysql.md).
+
+Only have a DDL file? Use [`datacontract import sql --dialect mysql`](./sql.md).

--- a/docs/docs/imports/odcs.md
+++ b/docs/docs/imports/odcs.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 16
 title: "Import: ODCS"
 description: "Create a data contract from an existing ODCS file."
 ---

--- a/docs/docs/imports/parquet.md
+++ b/docs/docs/imports/parquet.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 17
 title: "Import: Parquet"
 description: "Create a data contract from a Parquet file."
 ---

--- a/docs/docs/imports/postgres.md
+++ b/docs/docs/imports/postgres.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 17
+sidebar_position: 18
 title: "Import: Postgres"
 description: "Create a data contract from a Postgres schema."
 ---

--- a/docs/docs/imports/powerbi.md
+++ b/docs/docs/imports/powerbi.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 18
+sidebar_position: 19
 title: "Import: Power BI"
 description: "Create a data contract from a Power BI semantic model (.pbit, .bim, or .json)."
 ---

--- a/docs/docs/imports/protobuf.md
+++ b/docs/docs/imports/protobuf.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 19
+sidebar_position: 20
 title: "Import: Protobuf"
 description: "Create a data contract from a Protobuf schema file."
 ---

--- a/docs/docs/imports/snowflake.md
+++ b/docs/docs/imports/snowflake.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 20
+sidebar_position: 21
 title: "Import: Snowflake"
 description: "Create a data contract from a Snowflake workspace."
 ---

--- a/docs/docs/imports/spark.md
+++ b/docs/docs/imports/spark.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 21
+sidebar_position: 22
 title: "Import: Spark"
 description: "Create a data contract from Spark tables or DataFrames (programmatic)."
 ---

--- a/docs/docs/imports/sql.md
+++ b/docs/docs/imports/sql.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 22
+sidebar_position: 23
 title: "Import: SQL DDL"
 description: "Create a data contract from a SQL DDL file."
 ---

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -27,6 +27,7 @@ marked as such in the entry.
 ## Unreleased {#unreleased}
 
 ### Added
+- `datacontract import mysql` creates a data contract from a live MySQL database, including a ready-to-test `servers` block
 - The documentation has a [Release Notes](https://docs.datacontract.com/release-notes) page, generated from this changelog
 - The documentation has a guide to [migrate contracts from DCS to ODCS](https://docs.datacontract.com/migrate-dcs-to-odcs)
 - `datacontract import s3` creates a data contract from files in an S3 bucket, including a ready-to-test `servers` block

--- a/docs/docs/testing/mysql.md
+++ b/docs/docs/testing/mysql.md
@@ -16,7 +16,7 @@ uv tool install --python python3.11 --upgrade 'datacontract-cli[mysql]'
 
 See [Installation](../installation.md) for pip, pipx, and Docker.
 
-## 2. Set credentials
+## 2. Authenticate
 
 Create a `.env` file in your working directory (or export the variables):
 
@@ -28,23 +28,19 @@ DATACONTRACT_MYSQL_PASSWORD=mysecretpassword
 
 ## 3. Create a contract from your tables
 
-Dump the DDL of a table and import it:
+Import the table metadata directly from the database. This also generates a ready-to-test `servers` block:
 
 ```bash
-mysqldump --no-data mydb orders > orders.sql
-datacontract import sql --source orders.sql --dialect mysql --output datacontract.yaml
+datacontract import mysql \
+  --source localhost \
+  --database mydb \
+  --table orders \
+  --output datacontract.yaml
 ```
 
-The SQL import can't know your connection details, so it writes a `servers` block with placeholder values. Open `datacontract.yaml` and fill in your server:
+`--source` is the host of your MySQL server. Add `--port` if it doesn't listen on the default `3306`, repeat `--table` for multiple tables, or omit it to import every table in the database.
 
-```yaml
-servers:
-  - server: mysql
-    type: mysql
-    host: localhost
-    port: 3306
-    database: mydb
-```
+Only have a DDL file? `datacontract import sql --source orders.sql --dialect mysql` works too, but writes a `servers` block with placeholder values that you have to fill in by hand.
 
 ## 4. Test the actual data
 

--- a/tests/test_import_mysql.py
+++ b/tests/test_import_mysql.py
@@ -1,0 +1,175 @@
+"""Tests for the MySQL importer, run against a real MySQL container."""
+
+import pytest
+import yaml
+from testcontainers.mysql import MySqlContainer
+
+from datacontract.data_contract import DataContract
+from datacontract.model.exceptions import DataContractException
+from datacontract.model.run import ResultEnum
+
+mysql = MySqlContainer("mysql:8")
+
+SEED = [
+    """CREATE TABLE orders (
+        order_id VARCHAR(36) NOT NULL PRIMARY KEY COMMENT 'The order id',
+        order_total DECIMAL(10,2),
+        line_count INT NOT NULL,
+        ordered_at TIMESTAMP NULL,
+        payload JSON
+    ) COMMENT='All orders'""",
+    "INSERT INTO orders VALUES ('CX-263-DU', 50.00, 2, NOW(), '{\"channel\": \"web\"}')",
+    "CREATE TABLE customers (id INT NOT NULL PRIMARY KEY)",
+    "CREATE VIEW open_orders AS SELECT order_id FROM orders WHERE line_count > 1",
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def mysql_container(request):
+    mysql.start()
+    request.addfinalizer(mysql.stop)
+    _seed()
+
+
+@pytest.fixture(autouse=True)
+def credentials(monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_MYSQL_USERNAME", mysql.username)
+    monkeypatch.setenv("DATACONTRACT_MYSQL_PASSWORD", mysql.password)
+
+
+def _seed():
+    import duckdb
+
+    con = duckdb.connect()
+    con.execute("INSTALL mysql; LOAD mysql;")
+    con.execute(f"ATTACH '{_connection_string()}' AS seed (TYPE mysql)")
+    for statement in SEED:
+        con.execute(f"CALL mysql_execute('seed', '{statement.replace(chr(39), chr(39) * 2)}')")
+    con.close()
+
+
+def _connection_string():
+    return (
+        f"host=127.0.0.1 port={mysql.get_exposed_port(3306)} "
+        f"user={mysql.username} password={mysql.password} database={mysql.dbname}"
+    )
+
+
+def _import(**kwargs):
+    kwargs.setdefault("database", mysql.dbname)
+    kwargs.setdefault("port", mysql.get_exposed_port(3306))
+    return DataContract.import_from_source("mysql", "127.0.0.1", **kwargs)
+
+
+def test_import_mysql():
+    result = _import(mysql_table=["orders"])
+
+    expected = f"""
+apiVersion: v3.1.0
+kind: DataContract
+id: my-data-contract
+name: My Data Contract
+version: 1.0.0
+status: draft
+servers:
+  - server: mysql
+    type: mysql
+    host: 127.0.0.1
+    port: {mysql.get_exposed_port(3306)}
+    database: {mysql.dbname}
+schema:
+  - name: orders
+    physicalName: orders
+    logicalType: object
+    physicalType: table
+    description: All orders
+    properties:
+      - name: order_id
+        logicalType: string
+        logicalTypeOptions:
+          maxLength: 36
+        physicalType: varchar(36)
+        description: The order id
+        required: true
+        primaryKey: true
+        primaryKeyPosition: 1
+      - name: order_total
+        logicalType: number
+        physicalType: decimal(10,2)
+        customProperties:
+          - property: precision
+            value: 10
+          - property: scale
+            value: 2
+      - name: line_count
+        logicalType: integer
+        physicalType: int
+        required: true
+      - name: ordered_at
+        logicalType: timestamp
+        physicalType: timestamp
+      - name: payload
+        logicalType: string
+        physicalType: json
+    """
+
+    print("Result", result.to_yaml())
+    assert yaml.safe_load(result.to_yaml()) == yaml.safe_load(expected)
+
+
+def test_imported_contract_passes_test_without_editing():
+    """The point of the native import: import, then test, no hand-editing."""
+    result = _import(mysql_table=["orders"])
+
+    run = DataContract(data_contract_str=result.to_yaml()).test()
+
+    print(run.pretty())
+    assert run.result == ResultEnum.passed
+
+
+def test_import_mysql_produces_a_valid_contract():
+    result = _import()
+
+    assert DataContract(data_contract_str=result.to_yaml()).lint().result == ResultEnum.passed
+
+
+def test_import_mysql_imports_all_tables_by_default():
+    result = _import()
+
+    assert [schema.name for schema in result.schema_] == ["customers", "open_orders", "orders"]
+
+
+def test_a_view_is_marked_as_one():
+    result = _import(mysql_table=["open_orders"])
+
+    assert result.schema_[0].physicalType == "view"
+
+
+def test_import_mysql_fails_on_an_unknown_table():
+    with pytest.raises(DataContractException) as exc_info:
+        _import(mysql_table=["does_not_exist"])
+
+    assert "No tables found" in exc_info.value.reason
+
+
+def test_import_mysql_requires_a_database():
+    with pytest.raises(DataContractException) as exc_info:
+        DataContract.import_from_source("mysql", "127.0.0.1", database=None)
+
+    assert "database is required" in exc_info.value.reason
+
+
+def test_import_mysql_requires_a_host():
+    with pytest.raises(DataContractException) as exc_info:
+        DataContract.import_from_source("mysql", None, database="mydb")
+
+    assert "host is required" in exc_info.value.reason
+
+
+def test_import_mysql_requires_credentials(monkeypatch):
+    monkeypatch.delenv("DATACONTRACT_MYSQL_PASSWORD")
+
+    with pytest.raises(DataContractException) as exc_info:
+        _import()
+
+    assert "DATACONTRACT_MYSQL_PASSWORD is not set" in exc_info.value.reason


### PR DESCRIPTION
## Summary

Adds `datacontract import mysql`, which creates a data contract from a live MySQL database:

```bash
datacontract import mysql --source localhost --database mydb --output datacontract.yaml
```

MySQL was the last relational source still routed through a DDL dump: the guide told users to run `mysqldump --no-data`, import the file with `import sql --dialect mysql`, and then fill in a `servers` block of placeholder values by hand before anything could be tested.

**Reached the way the test path reaches it.** ibis's native MySQL backend needs `mysqlclient`, a C extension with no wheels, which is why `datacontract test` attaches MySQL through duckdb's `mysql` extension. The import does the same, so it needs no extra driver and authenticates with the same `DATACONTRACT_MYSQL_USERNAME` / `DATACONTRACT_MYSQL_PASSWORD`. The catalog itself is read with `mysql_query`, which runs the statement on MySQL rather than through the scanner, so `information_schema` is reachable.

`column_type` is kept verbatim as the `physicalType`, so the contract shows the full declared type (`varchar(36)`, `decimal(10,2)`) rather than a normalized one. Primary keys come from `column_key`, and the comments on tables and columns become descriptions.

**JSON columns are declared as strings.** duckdb's MySQL scanner surfaces JSON as text, so a contract declaring `object` fails its own type check on the first run — the importer would produce something that cannot pass. The `physicalType` still records that the column really is `json`. This is the same rule the Athena import follows for `string` → `varchar`: declare what the reader reports.

## Testing

`tests/test_import_mysql.py` — 9 tests against a real MySQL 8 container, including a round trip that imports a contract and then runs `datacontract test` on it unedited. That round trip is what caught the JSON mapping; without it the importer would have shipped producing contracts that fail immediately.

The existing `test_test_mysql.py` suite passes unchanged.

## Docs

New `imports/mysql.md`; `testing/mysql.md` restructured to match the other guides, with step 2 renamed to "Authenticate" and the `mysqldump` recipe reduced to a one-line fallback for people working from a file. The imports index and the command page's format list are updated, and the ordering guard from #1431 verified the new page sorts by the label the sidebar renders.