### PR TITLE
Add SQL Server import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `datacontract import sqlserver` creates a data contract from a live SQL Server database, including a ready-to-test `servers` block
 - `datacontract import mysql` creates a data contract from a live MySQL database, including a ready-to-test `servers` block
 - The documentation has a [Release Notes](https://docs.datacontract.com/release-notes) page, generated from this changelog
 - The documentation has a guide to [migrate contracts from DCS to ODCS](https://docs.datacontract.com/migrate-dcs-to-odcs)

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -50,7 +50,7 @@ class OrderedCommandsWithMigrationHints(OrderedCommands):
 
     # Import formats where `--schema` still means the database schema, so it must
     # not be rewritten to the v0.12.0 `--json-schema`.
-    DATABASE_SCHEMA_IMPORTS = {"snowflake", "redshift", "postgres", "athena"}
+    DATABASE_SCHEMA_IMPORTS = {"snowflake", "redshift", "postgres", "athena", "sqlserver"}
 
     RENAMED_FLAGS = {
         "--format": None,

--- a/datacontract/command_import.py
+++ b/datacontract/command_import.py
@@ -567,6 +567,39 @@ def import_postgres(
 
 
 @import_app.command(
+    name="sqlserver",
+    epilog="Example: datacontract import sqlserver --source localhost --database mydb --output datacontract.yaml",
+)
+def import_sqlserver(
+    source: Annotated[Optional[str], typer.Option(help="The host of the SQL Server instance.")] = None,
+    port: Annotated[Optional[int], typer.Option(help="The SQL Server port (default 1433).")] = None,
+    database: database_option = None,
+    schema: Annotated[Optional[str], typer.Option("--schema", help="The schema name (default dbo).")] = None,
+    table: Annotated[
+        Optional[List[str]],
+        typer.Option(help="Name of a table to import (repeat for multiple tables, omit for all tables)."),
+    ] = None,
+    output: output_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from a SQL Server database."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(
+        format="sqlserver",
+        source=source,
+        port=port,
+        database=database,
+        schema=schema,
+        sqlserver_table=table,
+        owner=owner,
+        id=id,
+    )
+    _write_result(result, output)
+
+
+@import_app.command(
     name="mysql",
     epilog="Example: datacontract import mysql --source localhost --database mydb --output datacontract.yaml",
 )

--- a/datacontract/imports/importer.py
+++ b/datacontract/imports/importer.py
@@ -46,6 +46,7 @@ class ImportFormat(str, Enum):
     athena = "athena"
     s3 = "s3"
     mysql = "mysql"
+    sqlserver = "sqlserver"
 
     @classmethod
     def get_supported_formats(cls):

--- a/datacontract/imports/importer_factory.py
+++ b/datacontract/imports/importer_factory.py
@@ -150,6 +150,11 @@ importer_factory.register_lazy_importer(
     class_name="AthenaImporter",
 )
 importer_factory.register_lazy_importer(
+    name=ImportFormat.sqlserver,
+    module_path="datacontract.imports.sqlserver_importer",
+    class_name="SqlServerImporter",
+)
+importer_factory.register_lazy_importer(
     name=ImportFormat.mysql,
     module_path="datacontract.imports.mysql_importer",
     class_name="MysqlImporter",

--- a/datacontract/imports/sqlserver_importer.py
+++ b/datacontract/imports/sqlserver_importer.py
@@ -1,0 +1,246 @@
+"""Create a data contract from a live SQL Server schema.
+
+Reads ``information_schema``, the same catalog ``datacontract test`` reads back
+to verify physical types, so an imported contract passes on the first run
+without hand-editing. The connection is opened with the shared SQL Server
+helper, so the import supports every authentication mode the test path does —
+SQL logins, Windows integrated auth, the Entra ID modes and ``az login``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional
+
+from open_data_contract_standard.model import (
+    CustomProperty,
+    OpenDataContractStandard,
+    SchemaObject,
+    SchemaProperty,
+    Server,
+)
+
+from datacontract.engines.ibis.native_type import reconstruct_native_type
+from datacontract.imports.importer import Importer
+from datacontract.imports.odcs_helper import create_odcs, create_property, create_schema_object, create_server
+from datacontract.imports.sql_importer import map_type_from_sql
+from datacontract.model.exceptions import DataContractException
+
+DEFAULT_PORT = 1433
+DEFAULT_SCHEMA = "dbo"
+DEFAULT_DRIVER = "ODBC Driver 18 for SQL Server"
+
+_TABLES_QUERY = """
+    SELECT table_name, table_type
+    FROM information_schema.tables
+    WHERE table_schema = '{schema}'
+"""
+
+# SQL Server reports the type in parts (base type plus length / precision /
+# scale). reconstruct_native_type() reassembles them exactly as the test path
+# reads them back, including the -1 that means MAX, so an imported physicalType
+# matches on the first `datacontract test`.
+_COLUMNS_QUERY = """
+    SELECT table_name, column_name, data_type, character_maximum_length,
+           numeric_precision, numeric_scale, is_nullable
+    FROM information_schema.columns
+    WHERE table_schema = '{schema}'
+    ORDER BY table_name, ordinal_position
+"""
+
+_PRIMARY_KEYS_QUERY = """
+    SELECT kcu.table_name, kcu.column_name, kcu.ordinal_position
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name
+     AND tc.table_schema = kcu.table_schema
+    WHERE tc.constraint_type = 'PRIMARY KEY'
+      AND tc.table_schema = '{schema}'
+    ORDER BY kcu.table_name, kcu.ordinal_position
+"""
+
+
+class SqlServerImporter(Importer):
+    def import_source(self, source: str, import_args: dict) -> OpenDataContractStandard:
+        if source is None:
+            raise DataContractException(
+                type="source",
+                name="sqlserver import source",
+                reason="The host is required for the sqlserver import, e.g. --source localhost",
+                engine="datacontract",
+            )
+        return import_sqlserver(
+            host=source,
+            port=import_args.get("port"),
+            database=import_args.get("database"),
+            schema=import_args.get("schema"),
+            tables=import_args.get("sqlserver_table"),
+        )
+
+
+def import_sqlserver(
+    host: str,
+    database: Optional[str],
+    schema: Optional[str] = None,
+    port: Optional[int] = None,
+    tables: Optional[List[str]] = None,
+) -> OpenDataContractStandard:
+    if not database:
+        raise DataContractException(
+            type="source",
+            name="sqlserver import database",
+            reason="The database is required for the sqlserver import, e.g. --database mydb",
+            engine="datacontract",
+        )
+
+    port = int(port) if port else DEFAULT_PORT
+    schema = schema or DEFAULT_SCHEMA
+    driver = os.getenv("DATACONTRACT_SQLSERVER_DRIVER", DEFAULT_DRIVER)
+    server = create_server(
+        name="production",
+        server_type="sqlserver",
+        host=host,
+        port=port,
+        database=database,
+        schema=schema,
+    )
+    # the driver is a custom property, which is how the test path reads it back
+    server.customProperties = [CustomProperty(property="driver", value=driver)]
+
+    connection = sqlserver_connection(server)
+    try:
+        table_rows = _fetch(connection, _TABLES_QUERY.format(schema=_escape(schema)))
+        column_rows = _fetch(connection, _COLUMNS_QUERY.format(schema=_escape(schema)))
+        # A login without access to the constraint views still gets a usable
+        # contract, just without primary keys.
+        primary_key_rows = _fetch(connection, _PRIMARY_KEYS_QUERY.format(schema=_escape(schema)), optional=True)
+    finally:
+        _close(connection)
+
+    selected = _select_tables(table_rows, tables)
+    if not selected:
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="no tables found",
+            reason=f"No tables found in schema '{schema}' of database '{database}'.",
+            engine="datacontract",
+        )
+
+    odcs = create_odcs()
+    odcs.servers = [server]
+    odcs.schema_ = [
+        _create_schema(table, column_rows, primary_key_rows)
+        for table in sorted(selected, key=lambda row: row["table_name"].lower())
+    ]
+    return odcs
+
+
+def sqlserver_connection(server: Server):
+    """Connect exactly as `datacontract test` does, so both support the same auth modes."""
+    try:
+        import ibis  # noqa: F401
+    except ImportError as e:
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="sqlserver extra missing",
+            reason="Install the extra datacontract-cli[sqlserver] to use sqlserver",
+            engine="datacontract",
+            original_exception=e,
+        )
+
+    from datacontract.engines.ibis.connections.connect import _connect_sqlserver
+
+    try:
+        return _connect_sqlserver(ibis, server)
+    except Exception as e:
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="sqlserver connection failed",
+            reason=f"Could not connect to SQL Server at {server.host}:{server.port}: {e}",
+            engine="datacontract",
+            original_exception=e,
+        )
+
+
+def _fetch(connection, query: str, optional: bool = False) -> List[Dict[str, Any]]:
+    """Run a catalog query and return its rows as dicts keyed by column name."""
+    try:
+        cursor = connection.raw_sql(query)
+        columns = [description[0].lower() for description in cursor.description]
+        return [dict(zip(columns, row)) for row in cursor.fetchall()]
+    except Exception as e:
+        if optional:
+            return []
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="sqlserver catalog query failed",
+            reason=f"Could not read the SQL Server catalog: {e}",
+            engine="datacontract",
+            original_exception=e,
+        )
+
+
+def _close(connection) -> None:
+    try:
+        connection.disconnect()
+    except Exception:  # pragma: no cover - best effort
+        pass
+
+
+def _escape(value: str) -> str:
+    return value.replace("'", "''")
+
+
+def _select_tables(table_rows: List[Dict[str, Any]], tables: Optional[List[str]]) -> List[Dict[str, Any]]:
+    if not tables:
+        return table_rows
+    wanted = {table.lower() for table in tables}
+    return [row for row in table_rows if row["table_name"].lower() in wanted]
+
+
+def _create_schema(
+    table: Dict[str, Any],
+    column_rows: List[Dict[str, Any]],
+    primary_key_rows: List[Dict[str, Any]],
+) -> SchemaObject:
+    table_name = table["table_name"]
+    primary_keys = {
+        row["column_name"]: index + 1
+        for index, row in enumerate(row for row in primary_key_rows if row["table_name"] == table_name)
+    }
+    properties = [_create_property(row, primary_keys) for row in column_rows if row["table_name"] == table_name]
+    return create_schema_object(
+        name=table_name,
+        physical_type="view" if (table.get("table_type") or "").upper() == "VIEW" else "table",
+        properties=properties or None,
+    )
+
+
+def _create_property(row: Dict[str, Any], primary_keys: Dict[str, int]) -> SchemaProperty:
+    name = row["column_name"]
+    max_length = row.get("character_maximum_length")
+    precision = row.get("numeric_precision")
+    scale = row.get("numeric_scale")
+    physical_type = reconstruct_native_type(row.get("data_type"), max_length, precision, scale)
+    logical_type, format = map_type_from_sql(physical_type)
+    # Precision/scale describe the declared type of decimals only; integers also
+    # report a numeric_precision, which is not part of the type.
+    is_decimal = physical_type is not None and physical_type.lower().startswith(("decimal", "numeric"))
+
+    return create_property(
+        name=name,
+        logical_type=logical_type,
+        physical_type=physical_type,
+        required=row.get("is_nullable") == "NO" or None,
+        primary_key=name in primary_keys or None,
+        primary_key_position=primary_keys.get(name),
+        # -1 is the MAX length, which is not a bound the contract can check.
+        max_length=max_length if max_length is not None and max_length >= 0 else None,
+        precision=precision if is_decimal else None,
+        scale=scale if is_decimal else None,
+        format=format,
+    )

--- a/docs/docs/commands/import.md
+++ b/docs/docs/commands/import.md
@@ -18,4 +18,4 @@ Run `datacontract import <format> --help` to see format-specific options.
 datacontract import sql --source ddl.sql --dialect postgres --output datacontract.yaml
 ```
 
-Available formats: `athena`, `avro`, `bigquery`, `csv`, `databricks`, `dbml`, `dbt`, `excel`, `glue`, `iceberg`, `json`, `jsonschema`, `mysql`, `odcs`, `parquet`, `postgres`, `powerbi`, `protobuf`, `redshift`, `s3`, `snowflake`, `spark`, `sql`.
+Available formats: `athena`, `avro`, `bigquery`, `csv`, `databricks`, `dbml`, `dbt`, `excel`, `glue`, `iceberg`, `json`, `jsonschema`, `mysql`, `odcs`, `parquet`, `postgres`, `powerbi`, `protobuf`, `redshift`, `s3`, `snowflake`, `spark`, `sql`, `sqlserver`.

--- a/docs/docs/imports/index.md
+++ b/docs/docs/imports/index.md
@@ -17,7 +17,7 @@ datacontract import sql --source my_ddl.sql --dialect postgres
 datacontract import sql --source my_ddl.sql --dialect postgres --output datacontract.yaml
 ```
 
-The [Snowflake](./snowflake.md), [BigQuery](./bigquery.md), [Amazon Redshift](./redshift.md), [Postgres](./postgres.md), [MySQL](./mysql.md), [Amazon Athena](./athena.md), [Amazon S3](./s3.md), [Databricks](./databricks.md), and [AWS Glue](./glue.md) importers can connect directly to the live system and introspect your tables — no export files needed. Snowflake, BigQuery, Redshift, Postgres, MySQL, Athena, S3, and Databricks also generate a ready-to-test `servers` block, so `datacontract test` works right after the import.
+The [Snowflake](./snowflake.md), [BigQuery](./bigquery.md), [Amazon Redshift](./redshift.md), [Postgres](./postgres.md), [MySQL](./mysql.md), [SQL Server](./sqlserver.md), [Amazon Athena](./athena.md), [Amazon S3](./s3.md), [Databricks](./databricks.md), and [AWS Glue](./glue.md) importers can connect directly to the live system and introspect your tables — no export files needed. Snowflake, BigQuery, Redshift, Postgres, MySQL, SQL Server, Athena, S3, and Databricks also generate a ready-to-test `servers` block, so `datacontract test` works right after the import.
 
 Run `datacontract import <format> --help` to see the format-specific options (e.g. `datacontract import sql --help`). If a format you need is missing, [open an issue on GitHub](https://github.com/datacontract/datacontract-cli/issues).
 
@@ -119,6 +119,10 @@ Each import page shows a runnable example: a small source file under [`examples/
   <a className="doc-card" href="/imports/sql">
     <img src="/img/icons/database.svg" alt="" />
     <span><span className="doc-card-title">sql</span><span className="doc-card-desc">A SQL DDL file.</span></span>
+  </a>
+  <a className="doc-card" href="/imports/sqlserver">
+    <img src="/img/icons/sqlserver.svg" alt="" />
+    <span><span className="doc-card-title">sqlserver</span><span className="doc-card-desc">A SQL Server database.</span></span>
   </a>
 </div>
 

--- a/docs/docs/imports/sqlserver.md
+++ b/docs/docs/imports/sqlserver.md
@@ -1,0 +1,29 @@
+---
+sidebar_position: 24
+title: "Import: SQL Server"
+description: "Create a data contract from a SQL Server database."
+---
+
+# <img className="page-icon" src="/img/icons/sqlserver.svg" alt="" /> Import: SQL Server
+
+Creates a data contract from a SQL Server database by reading `information_schema` — including column types with length and precision, nullability, and primary keys.
+
+```bash
+datacontract import sqlserver \
+  --source localhost \
+  --database mydb \
+  --schema dbo \
+  --output datacontract.yaml
+```
+
+`--source` is the host of your SQL Server instance. Add `--port` if it doesn't listen on the default `1433`, repeat `--table` to import only specific tables, and set `--schema` if your tables don't live in `dbo`.
+
+The connection uses the same helper as `datacontract test`, so every authentication mode works for the import too: SQL logins, Windows integrated auth, the Entra ID modes, and `az login`.
+
+Types are reconstructed exactly as the test path reads them back, so `varchar(36)`, `decimal(10,2)`, `datetime2` and `varchar(max)` all match on the first run.
+
+The generated contract includes a ready-to-test `servers` block, so you can run `datacontract test datacontract.yaml` immediately afterwards — see the **[SQL Server connection guide](../testing/sqlserver.md)** for the full 5-minute walkthrough and troubleshooting.
+
+Credentials are the same ones `datacontract test` uses: `DATACONTRACT_SQLSERVER_USERNAME` and `DATACONTRACT_SQLSERVER_PASSWORD` — see the [SQL Server Reference](../reference/sqlserver.md).
+
+Only have a DDL script? Use [`datacontract import sql --dialect sqlserver`](./sql.md).

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -27,6 +27,7 @@ marked as such in the entry.
 ## Unreleased {#unreleased}
 
 ### Added
+- `datacontract import sqlserver` creates a data contract from a live SQL Server database, including a ready-to-test `servers` block
 - `datacontract import mysql` creates a data contract from a live MySQL database, including a ready-to-test `servers` block
 - The documentation has a [Release Notes](https://docs.datacontract.com/release-notes) page, generated from this changelog
 - The documentation has a guide to [migrate contracts from DCS to ODCS](https://docs.datacontract.com/migrate-dcs-to-odcs)

--- a/docs/docs/testing/sqlserver.md
+++ b/docs/docs/testing/sqlserver.md
@@ -16,7 +16,7 @@ uv tool install --python python3.11 --upgrade 'datacontract-cli[sqlserver]'
 
 The connection also requires the [Microsoft ODBC Driver 18 for SQL Server](https://learn.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server) on your machine. See [Installation](../installation.md) for pip, pipx, and Docker.
 
-## 2. Set credentials
+## 2. Authenticate
 
 Create a `.env` file in your working directory (or export the variables):
 
@@ -31,24 +31,20 @@ For Entra ID (Active Directory) authentication modes, see the [SQL Server Refere
 
 ## 3. Create a contract from your tables
 
-Script the DDL of a table (SSMS: right-click the table → **Script Table as → CREATE To**), save it to a file, and import it:
+Import the table metadata directly from the database. This also generates a ready-to-test `servers` block:
 
 ```bash
-datacontract import sql --source orders.sql --dialect sqlserver --output datacontract.yaml
+datacontract import sqlserver \
+  --source localhost \
+  --database mydb \
+  --schema dbo \
+  --table orders \
+  --output datacontract.yaml
 ```
 
-The SQL import can't know your connection details, so it writes a `servers` block with placeholder values. Open `datacontract.yaml` and fill in your server:
+`--source` is the host of your SQL Server instance. Add `--port` if it doesn't listen on the default `1433`, repeat `--table` for multiple tables, or omit it to import every table. `--schema` defaults to `dbo`.
 
-```yaml
-servers:
-  - server: production
-    type: sqlserver
-    host: localhost
-    port: 1433
-    database: mydb
-    schema: dbo
-    driver: ODBC Driver 18 for SQL Server
-```
+Only have a DDL script? `datacontract import sql --source orders.sql --dialect sqlserver` works too, but writes a `servers` block with placeholder values that you have to fill in by hand.
 
 ## 4. Test the actual data
 

--- a/tests/test_import_sqlserver.py
+++ b/tests/test_import_sqlserver.py
@@ -1,0 +1,115 @@
+"""Tests for the SQL Server importer.
+
+The catalog reads need the ODBC driver, which only CI installs, so those are
+gated the same way ``test_test_sqlserver.py`` gates its own — see that file for
+the local setup. The argument handling is checked unconditionally, because it
+rejects before any connection is opened.
+"""
+
+import os
+
+import pytest
+from testcontainers.mssql import SqlServerContainer
+
+from datacontract.data_contract import DataContract
+from datacontract.model.exceptions import DataContractException
+from datacontract.model.run import ResultEnum
+
+# Absolute paths so the module-scoped container fixture (which runs before the
+# function-scoped change_test_dir chdir) can find the fixtures from any cwd.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+SEED = os.path.join(_HERE, "fixtures/sqlserver/data/data.sql")
+
+sql_server = SqlServerContainer()
+SQL_SERVER_PORT = 1433
+
+requires_ci = pytest.mark.skipif(not os.getenv("CI"), reason="Skipping test outside CI/CD environment")
+
+
+@pytest.fixture(scope="module")
+def mssql_container(request):
+    sql_server.start()
+    request.addfinalizer(sql_server.stop)
+    _init_sql()
+
+
+@pytest.fixture
+def credentials(monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_SQLSERVER_USERNAME", sql_server.username)
+    monkeypatch.setenv("DATACONTRACT_SQLSERVER_PASSWORD", sql_server.password)
+    monkeypatch.setenv("DATACONTRACT_SQLSERVER_TRUST_SERVER_CERTIFICATE", "True")
+    monkeypatch.setenv("DATACONTRACT_SQLSERVER_DRIVER", "ODBC Driver 18 for SQL Server")
+
+
+def _init_sql():
+    import pyodbc
+
+    connection = pyodbc.connect(
+        f"DRIVER={{ODBC Driver 18 for SQL Server}};SERVER={sql_server.get_container_host_ip()},"
+        f"{sql_server.get_exposed_port(SQL_SERVER_PORT)};UID={sql_server.username};"
+        f"PWD={sql_server.password};TrustServerCertificate=yes",
+        autocommit=True,
+    )
+    with open(SEED) as file:
+        for statement in filter(None, (part.strip() for part in file.read().split("GO"))):
+            connection.execute(statement)
+    connection.close()
+
+
+def _import(**kwargs):
+    kwargs.setdefault("database", "master")
+    kwargs.setdefault("port", sql_server.get_exposed_port(SQL_SERVER_PORT))
+    return DataContract.import_from_source("sqlserver", sql_server.get_container_host_ip(), **kwargs)
+
+
+@requires_ci
+def test_import_sqlserver(mssql_container, credentials):
+    result = _import()
+
+    server = result.servers[0]
+    assert (server.type, server.schema_) == ("sqlserver", "dbo")
+    assert [prop.property for prop in server.customProperties] == ["driver"]
+    assert result.schema_, "expected at least one table"
+
+
+@requires_ci
+def test_imported_contract_passes_test_without_editing(mssql_container, credentials):
+    """The point of the native import: import, then test, no hand-editing."""
+    result = _import()
+
+    run = DataContract(data_contract_str=result.to_yaml()).test()
+
+    print(run.pretty())
+    assert run.result == ResultEnum.passed
+
+
+@requires_ci
+def test_import_sqlserver_produces_a_valid_contract(mssql_container, credentials):
+    result = _import()
+
+    assert DataContract(data_contract_str=result.to_yaml()).lint().result == ResultEnum.passed
+
+
+@requires_ci
+def test_import_sqlserver_fails_on_an_unknown_table(mssql_container, credentials):
+    with pytest.raises(DataContractException) as exc_info:
+        _import(sqlserver_table=["does_not_exist"])
+
+    assert "No tables found" in exc_info.value.reason
+
+
+# ---------------------------------------------------------------------------
+# Argument handling — rejected before a connection is opened, so no driver needed
+# ---------------------------------------------------------------------------
+def test_import_sqlserver_requires_a_database():
+    with pytest.raises(DataContractException) as exc_info:
+        DataContract.import_from_source("sqlserver", "localhost", database=None)
+
+    assert "database is required" in exc_info.value.reason
+
+
+def test_import_sqlserver_requires_a_host():
+    with pytest.raises(DataContractException) as exc_info:
+        DataContract.import_from_source("sqlserver", None, database="mydb")
+
+    assert "host is required" in exc_info.value.reason


### PR DESCRIPTION
## Summary

Adds `datacontract import sqlserver`, which creates a data contract from a live SQL Server database:

```bash
datacontract import sqlserver --source localhost --database mydb --schema dbo --output datacontract.yaml
```

The guide previously told users to script the DDL out of SSMS (right-click the table → **Script Table as → CREATE To**), import the file with `import sql --dialect sqlserver`, and then fill in a `servers` block of placeholder values — including the ODBC `driver` — before anything could be tested.

**Same connection as the test path.** The importer calls the shared SQL Server helper, so every authentication mode works for the import too: SQL logins, Windows integrated auth, the Entra ID modes, and `az login`. Types are reconstructed from the same `information_schema` columns the test path reads back, so the physical types match on the first run.

The `driver` is written as a **custom property**, which is where the test path reads it from — the ODCS `Server` model has no such field.

## Verified against a real SQL Server

Import followed by `datacontract test` on the unedited file: **16/16 checks passed**, including every physical type check:

```
varchar(36)   decimal(10,2)   int   datetime2   varchar(max)   uniqueidentifier
```

`varchar(max)` is worth calling out: SQL Server reports it as `character_maximum_length = -1`, so the type reconstructs to `varchar(max)` and the `-1` is kept out of `logicalTypeOptions.maxLength`, where it would have been a meaningless bound.

## Testing

`tests/test_import_sqlserver.py` — 6 tests. The four that read the catalog are gated on `CI`, exactly as `test_test_sqlserver.py` gates its own, because they need the ODBC driver that only CI installs. Argument handling is checked unconditionally, since it rejects before any connection is opened.

All six were run against a testcontainer-managed SQL Server before this PR was opened, inside a throwaway Linux image carrying `msodbcsql18` — so the CI-gated tests are not going into CI unrun.

## Docs

New `imports/sqlserver.md`; `testing/sqlserver.md` restructured to match the other guides, with the SSMS scripting recipe reduced to a one-line fallback. The imports index and the command page's format list are updated, and the ordering guard from #1431 caught two mistakes on the way: a card inserted before `sql` rather than after it, and the format list silently not updated because its last entry ends in a period rather than a comma.