### PR TITLE
Match the quickstart import example to the extra it installs

### DIFF
--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -60,9 +60,11 @@ The CLI verified that the YAML itself is valid, that all records comply with the
 The real magic moment is when a contract catches drift in *your* data. Import a contract straight from an existing table — the import generates the schema and a ready-to-test `servers` block — then test the actual data against it:
 
 ```bash
-datacontract import snowflake --source <account> --database ORDER_DB --schema PUBLIC --output datacontract.yaml
+datacontract import postgres --source localhost --database mydb --output datacontract.yaml
 datacontract test datacontract.yaml
 ```
+
+That example uses Postgres because it matches the extra installed above. For another source, install its extra first — `uv tool install --python python3.11 --upgrade 'datacontract-cli[snowflake]'` — and use the matching import, e.g. `datacontract import snowflake`.
 
 Follow the copy-paste guide for your data source, including credentials setup and troubleshooting:
 


### PR DESCRIPTION
## Summary

The quickstart installs one extra and then demonstrates a different one:

- line 16: `uv tool install ... 'datacontract-cli[postgres]'`
- the "Test your own data" step: `datacontract import snowflake --source <account> ...`

Anyone following the page in order hits a missing-extra error at exactly the step the page frames as *"the real magic moment"*.

The example now uses `postgres`, matching the install, with one line pointing out that another source needs its own extra installed first.

Docs only.