### PR TITLE
Add GCS and ADLS import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `datacontract import gcs` and `datacontract import azure` create a data contract from files in Google Cloud Storage or Azure Blob Storage, including a ready-to-test `servers` block
 - `datacontract import sqlserver` creates a data contract from a live SQL Server database, including a ready-to-test `servers` block
 - `datacontract import mysql` creates a data contract from a live MySQL database, including a ready-to-test `servers` block
 - The documentation has a [Release Notes](https://docs.datacontract.com/release-notes) page, generated from this changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `datacontract import gcs` and `datacontract import azure` create a data contract from files in Google Cloud Storage or Azure Blob Storage, including a ready-to-test `servers` block
+- `datacontract import gcs` and `datacontract import adls` create a data contract from files in Google Cloud Storage or Azure Blob Storage, including a ready-to-test `servers` block
 - `datacontract import sqlserver` creates a data contract from a live SQL Server database, including a ready-to-test `servers` block
 - `datacontract import mysql` creates a data contract from a live MySQL database, including a ready-to-test `servers` block
 - The documentation has a [Release Notes](https://docs.datacontract.com/release-notes) page, generated from this changelog

--- a/datacontract/command_import.py
+++ b/datacontract/command_import.py
@@ -567,6 +567,61 @@ def import_postgres(
 
 
 @import_app.command(
+    name="gcs",
+    epilog="Example: datacontract import gcs --source s3://my-bucket/orders/*.json --output datacontract.yaml",
+)
+def import_gcs(
+    source: Annotated[
+        Optional[str],
+        typer.Option(help="The location of the files. duckdb reads GCS over the S3-compatible endpoint, so use s3://."),
+    ] = None,
+    format: Annotated[
+        Optional[str], typer.Option(help="File format: json, csv, parquet or delta (inferred from the suffix).")
+    ] = None,
+    delimiter: Annotated[
+        Optional[str], typer.Option(help="For JSON: new_line, array or none. Detected automatically when omitted.")
+    ] = None,
+    output: output_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from files in Google Cloud Storage."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(
+        format="gcs", source=source, file_format=format, delimiter=delimiter, owner=owner, id=id
+    )
+    _write_result(result, output)
+
+
+@import_app.command(
+    name="azure",
+    epilog="Example: datacontract import azure --source abfss://my-container/orders/*.json --output datacontract.yaml",
+)
+def import_azure(
+    source: Annotated[
+        Optional[str], typer.Option(help="The location of the files, e.g. abfss://my-container/orders/*.json.")
+    ] = None,
+    format: Annotated[
+        Optional[str], typer.Option(help="File format: json, csv, parquet or delta (inferred from the suffix).")
+    ] = None,
+    delimiter: Annotated[
+        Optional[str], typer.Option(help="For JSON: new_line, array or none. Detected automatically when omitted.")
+    ] = None,
+    output: output_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from files in Azure Blob Storage."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(
+        format="azure", source=source, file_format=format, delimiter=delimiter, owner=owner, id=id
+    )
+    _write_result(result, output)
+
+
+@import_app.command(
     name="sqlserver",
     epilog="Example: datacontract import sqlserver --source localhost --database mydb --output datacontract.yaml",
 )
@@ -657,7 +712,7 @@ def import_s3(
     result = DataContract.import_from_source(
         format="s3",
         source=source,
-        s3_format=format,
+        file_format=format,
         delimiter=delimiter,
         endpoint_url=endpoint_url,
         owner=owner,

--- a/datacontract/command_import.py
+++ b/datacontract/command_import.py
@@ -595,10 +595,10 @@ def import_gcs(
 
 
 @import_app.command(
-    name="azure",
-    epilog="Example: datacontract import azure --source abfss://my-container/orders/*.json --output datacontract.yaml",
+    name="adls",
+    epilog="Example: datacontract import adls --source abfss://my-container/orders/*.json --output datacontract.yaml",
 )
-def import_azure(
+def import_adls(
     source: Annotated[
         Optional[str], typer.Option(help="The location of the files, e.g. abfss://my-container/orders/*.json.")
     ] = None,
@@ -613,10 +613,10 @@ def import_azure(
     id: id_option = None,
     debug: debug_option = None,
 ):
-    """Import a data contract from files in Azure Blob Storage."""
+    """Import a data contract from files in Azure Blob Storage / ADLS."""
     enable_debug_logging(debug)
     result = DataContract.import_from_source(
-        format="azure", source=source, file_format=format, delimiter=delimiter, owner=owner, id=id
+        format="adls", source=source, file_format=format, delimiter=delimiter, owner=owner, id=id
     )
     _write_result(result, output)
 

--- a/datacontract/imports/importer.py
+++ b/datacontract/imports/importer.py
@@ -47,6 +47,8 @@ class ImportFormat(str, Enum):
     s3 = "s3"
     mysql = "mysql"
     sqlserver = "sqlserver"
+    gcs = "gcs"
+    azure = "azure"
 
     @classmethod
     def get_supported_formats(cls):

--- a/datacontract/imports/importer.py
+++ b/datacontract/imports/importer.py
@@ -48,7 +48,7 @@ class ImportFormat(str, Enum):
     mysql = "mysql"
     sqlserver = "sqlserver"
     gcs = "gcs"
-    azure = "azure"
+    adls = "adls"
 
     @classmethod
     def get_supported_formats(cls):

--- a/datacontract/imports/importer_factory.py
+++ b/datacontract/imports/importer_factory.py
@@ -161,7 +161,7 @@ importer_factory.register_lazy_importer(
 )
 # one importer, registered once per object storage; it reads the server type
 # from the format it was registered under
-for _storage in (ImportFormat.s3, ImportFormat.gcs, ImportFormat.azure):
+for _storage in (ImportFormat.s3, ImportFormat.gcs, ImportFormat.adls):
     importer_factory.register_lazy_importer(
         name=_storage,
         module_path="datacontract.imports.object_storage_importer",

--- a/datacontract/imports/importer_factory.py
+++ b/datacontract/imports/importer_factory.py
@@ -159,11 +159,14 @@ importer_factory.register_lazy_importer(
     module_path="datacontract.imports.mysql_importer",
     class_name="MysqlImporter",
 )
-importer_factory.register_lazy_importer(
-    name=ImportFormat.s3,
-    module_path="datacontract.imports.s3_importer",
-    class_name="S3Importer",
-)
+# one importer, registered once per object storage; it reads the server type
+# from the format it was registered under
+for _storage in (ImportFormat.s3, ImportFormat.gcs, ImportFormat.azure):
+    importer_factory.register_lazy_importer(
+        name=_storage,
+        module_path="datacontract.imports.object_storage_importer",
+        class_name="ObjectStorageImporter",
+    )
 importer_factory.register_lazy_importer(
     name=ImportFormat.json,
     module_path="datacontract.imports.json_importer",

--- a/datacontract/imports/object_storage_importer.py
+++ b/datacontract/imports/object_storage_importer.py
@@ -1,8 +1,10 @@
-"""Create a data contract from files in an S3 bucket.
+"""Create a data contract from files in object storage: S3, GCS or Azure.
 
 The objects are read with duckdb through the same connection setup that
 ``datacontract test`` uses, so the import authenticates identically and infers
-the column types from exactly the reader that will later verify them.
+the column types from exactly the reader that will later verify them. One
+importer serves all three: it takes the server type from the format it was
+registered under.
 """
 
 from __future__ import annotations
@@ -27,6 +29,13 @@ FORMATS_BY_SUFFIX = {
 }
 SUPPORTED_FORMATS = {"json", "csv", "parquet", "delta"}
 
+# duckdb reads GCS through the S3-compatible endpoint, hence the s3:// scheme there.
+_EXAMPLE_LOCATIONS = {
+    "s3": "s3://my-bucket/orders/*.json",
+    "gcs": "s3://my-bucket/orders/*.json",
+    "azure": "abfss://my-container/orders/*.json",
+}
+
 _READERS = {
     "json": "read_json_auto('{location}', hive_partitioning=1)",
     "csv": "read_csv_auto('{location}', hive_partitioning=1)",
@@ -35,18 +44,21 @@ _READERS = {
 }
 
 
-class S3Importer(Importer):
+class ObjectStorageImporter(Importer):
     def import_source(self, source: str, import_args: dict) -> OpenDataContractStandard:
-        return import_s3(
+        return import_object_storage(
             location=source,
-            format=import_args.get("s3_format"),
+            # registered once per storage, so the format is the server type
+            server_type=self.import_format,
+            format=import_args.get("file_format"),
             delimiter=import_args.get("delimiter"),
             endpoint_url=import_args.get("endpoint_url"),
         )
 
 
-def import_s3(
+def import_object_storage(
     location: Optional[str],
+    server_type: str = "s3",
     format: Optional[str] = None,
     delimiter: Optional[str] = None,
     endpoint_url: Optional[str] = None,
@@ -54,8 +66,11 @@ def import_s3(
     if not location:
         raise DataContractException(
             type="source",
-            name="s3 import source",
-            reason="The S3 location is required for the s3 import, e.g. --source s3://my-bucket/orders/*.json",
+            name=f"{server_type} import source",
+            reason=(
+                f"The location is required for the {server_type} import, "
+                f"e.g. --source {_EXAMPLE_LOCATIONS[server_type]}"
+            ),
             engine="datacontract",
         )
 
@@ -63,7 +78,7 @@ def import_s3(
     if format not in SUPPORTED_FORMATS:
         raise DataContractException(
             type="source",
-            name="s3 import format",
+            name=f"{server_type} import format",
             reason=(
                 f"Could not tell the format of '{location}'. "
                 f"Pass --format with one of: {', '.join(sorted(SUPPORTED_FORMATS))}."
@@ -73,7 +88,7 @@ def import_s3(
 
     server = create_server(
         name="production",
-        server_type="s3",
+        server_type=server_type,
         location=location,
         format=format,
     )
@@ -122,11 +137,17 @@ def schema_name(location: str) -> str:
 
 
 def _read_columns(server: Server, location: str, format: str):
-    from datacontract.engines.ibis.connections.duckdb_connection import _import_duckdb, setup_s3_connection
+    from datacontract.engines.ibis.connections.duckdb_connection import (
+        _import_duckdb,
+        setup_azure_connection,
+        setup_gcs_connection,
+        setup_s3_connection,
+    )
 
+    setup = {"s3": setup_s3_connection, "gcs": setup_gcs_connection, "azure": setup_azure_connection}[server.type]
     duckdb = _import_duckdb()
     con = duckdb.connect(database=":memory:")
-    setup_s3_connection(con, server)
+    setup(con, server)
     if format == "delta":
         con.sql("update extensions;")
     reader = _READERS[format].format(location=location)

--- a/datacontract/imports/object_storage_importer.py
+++ b/datacontract/imports/object_storage_importer.py
@@ -29,6 +29,10 @@ FORMATS_BY_SUFFIX = {
 }
 SUPPORTED_FORMATS = {"json", "csv", "parquet", "delta"}
 
+# The import format is the name a user types; the server type is what goes into
+# the contract. They differ for ADLS, which ODCS calls `azure`.
+SERVER_TYPES = {"s3": "s3", "gcs": "gcs", "adls": "azure"}
+
 # duckdb reads GCS through the S3-compatible endpoint, hence the s3:// scheme there.
 _EXAMPLE_LOCATIONS = {
     "s3": "s3://my-bucket/orders/*.json",
@@ -48,8 +52,7 @@ class ObjectStorageImporter(Importer):
     def import_source(self, source: str, import_args: dict) -> OpenDataContractStandard:
         return import_object_storage(
             location=source,
-            # registered once per storage, so the format is the server type
-            server_type=self.import_format,
+            server_type=SERVER_TYPES[self.import_format],
             format=import_args.get("file_format"),
             delimiter=import_args.get("delimiter"),
             endpoint_url=import_args.get("endpoint_url"),

--- a/docs/docs/commands/import.md
+++ b/docs/docs/commands/import.md
@@ -18,4 +18,4 @@ Run `datacontract import <format> --help` to see format-specific options.
 datacontract import sql --source ddl.sql --dialect postgres --output datacontract.yaml
 ```
 
-Available formats: `athena`, `avro`, `bigquery`, `csv`, `databricks`, `dbml`, `dbt`, `excel`, `glue`, `iceberg`, `json`, `jsonschema`, `mysql`, `odcs`, `parquet`, `postgres`, `powerbi`, `protobuf`, `redshift`, `s3`, `snowflake`, `spark`, `sql`, `sqlserver`.
+Available formats: `athena`, `avro`, `azure`, `bigquery`, `csv`, `databricks`, `dbml`, `dbt`, `excel`, `gcs`, `glue`, `iceberg`, `json`, `jsonschema`, `mysql`, `odcs`, `parquet`, `postgres`, `powerbi`, `protobuf`, `redshift`, `s3`, `snowflake`, `spark`, `sql`, `sqlserver`.

--- a/docs/docs/commands/import.md
+++ b/docs/docs/commands/import.md
@@ -18,4 +18,4 @@ Run `datacontract import <format> --help` to see format-specific options.
 datacontract import sql --source ddl.sql --dialect postgres --output datacontract.yaml
 ```
 
-Available formats: `athena`, `avro`, `azure`, `bigquery`, `csv`, `databricks`, `dbml`, `dbt`, `excel`, `gcs`, `glue`, `iceberg`, `json`, `jsonschema`, `mysql`, `odcs`, `parquet`, `postgres`, `powerbi`, `protobuf`, `redshift`, `s3`, `snowflake`, `spark`, `sql`, `sqlserver`.
+Available formats: `adls`, `athena`, `avro`, `bigquery`, `csv`, `databricks`, `dbml`, `dbt`, `excel`, `gcs`, `glue`, `iceberg`, `json`, `jsonschema`, `mysql`, `odcs`, `parquet`, `postgres`, `powerbi`, `protobuf`, `redshift`, `s3`, `snowflake`, `spark`, `sql`, `sqlserver`.

--- a/docs/docs/imports/adls.md
+++ b/docs/docs/imports/adls.md
@@ -1,15 +1,15 @@
 ---
 sidebar_position: 6
-title: "Import: Azure Blob Storage"
+title: "Import: Azure Blob / ADLS"
 description: "Create a data contract from files in Azure Blob Storage."
 ---
 
-# <img className="page-icon" src="/img/icons/azure.svg" alt="" /> Import: Azure Blob Storage
+# <img className="page-icon" src="/img/icons/azure.svg" alt="" /> Import: Azure Blob / ADLS
 
 Creates a data contract from files in Azure Blob Storage, in CSV, JSON, Parquet, or Delta format.
 
 ```bash
-datacontract import azure \
+datacontract import adls \
   --source abfss://my-container/orders/*.json \
   --output datacontract.yaml
 ```
@@ -18,6 +18,6 @@ The format is taken from the file suffix; pass `--format` for Delta tables, whic
 
 The objects are read with duckdb through the same connection the test path uses, so the import authenticates identically and infers the column types from exactly the reader that later verifies them.
 
-The generated contract includes a ready-to-test `servers` block, so you can run `datacontract test datacontract.yaml` immediately afterwards — see the **[Azure Blob Storage connection guide](../testing/azure.md)** for the full 5-minute walkthrough and troubleshooting.
+The generated contract includes a ready-to-test `servers` block, so you can run `datacontract test datacontract.yaml` immediately afterwards — see the **[Azure Blob / ADLS connection guide](../testing/azure.md)** for the full 5-minute walkthrough and troubleshooting.
 
 Credentials are the same ones `datacontract test` uses — see the [Azure Blob Storage Reference](../reference/azure.md).

--- a/docs/docs/imports/azure.md
+++ b/docs/docs/imports/azure.md
@@ -1,0 +1,23 @@
+---
+sidebar_position: 6
+title: "Import: Azure Blob Storage"
+description: "Create a data contract from files in Azure Blob Storage."
+---
+
+# <img className="page-icon" src="/img/icons/azure.svg" alt="" /> Import: Azure Blob Storage
+
+Creates a data contract from files in Azure Blob Storage, in CSV, JSON, Parquet, or Delta format.
+
+```bash
+datacontract import azure \
+  --source abfss://my-container/orders/*.json \
+  --output datacontract.yaml
+```
+
+The format is taken from the file suffix; pass `--format` for Delta tables, which have none, or to override the guess. `--delimiter` pins how a JSON file is laid out (`new_line`, `array`, or `none`) instead of letting it be detected.
+
+The objects are read with duckdb through the same connection the test path uses, so the import authenticates identically and infers the column types from exactly the reader that later verifies them.
+
+The generated contract includes a ready-to-test `servers` block, so you can run `datacontract test datacontract.yaml` immediately afterwards — see the **[Azure Blob Storage connection guide](../testing/azure.md)** for the full 5-minute walkthrough and troubleshooting.
+
+Credentials are the same ones `datacontract test` uses — see the [Azure Blob Storage Reference](../reference/azure.md).

--- a/docs/docs/imports/bigquery.md
+++ b/docs/docs/imports/bigquery.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 title: "Import: BigQuery"
 description: "Create a data contract from BigQuery, via an exported JSON file or the BigQuery API."
 ---

--- a/docs/docs/imports/csv.md
+++ b/docs/docs/imports/csv.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 title: "Import: CSV"
 description: "Create a data contract by inferring a schema from a CSV file."
 ---

--- a/docs/docs/imports/databricks.md
+++ b/docs/docs/imports/databricks.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 title: "Import: Databricks"
 description: "Create a data contract from Databricks Unity Catalog."
 ---

--- a/docs/docs/imports/dbml.md
+++ b/docs/docs/imports/dbml.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 10
 title: "Import: DBML"
 description: "Create a data contract from a DBML file, with optional schema/table filters."
 ---

--- a/docs/docs/imports/dbt.md
+++ b/docs/docs/imports/dbt.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 11
 title: "Import: dbt"
 description: "Create a data contract from a dbt manifest file."
 ---

--- a/docs/docs/imports/excel.md
+++ b/docs/docs/imports/excel.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 title: "Import: Excel"
 description: "Create a data contract from an ODCS Excel template."
 ---

--- a/docs/docs/imports/gcs.md
+++ b/docs/docs/imports/gcs.md
@@ -1,0 +1,25 @@
+---
+sidebar_position: 13
+title: "Import: Google Cloud Storage"
+description: "Create a data contract from files in Google Cloud Storage."
+---
+
+# <img className="page-icon" src="/img/icons/gcs.svg" alt="" /> Import: Google Cloud Storage
+
+Creates a data contract from files in Google Cloud Storage, in CSV, JSON, Parquet, or Delta format.
+
+```bash
+datacontract import gcs \
+  --source s3://my-bucket/orders/*.json \
+  --output datacontract.yaml
+```
+
+The format is taken from the file suffix; pass `--format` for Delta tables, which have none, or to override the guess. `--delimiter` pins how a JSON file is laid out (`new_line`, `array`, or `none`) instead of letting it be detected.
+
+duckdb reads Google Cloud Storage through its S3-compatible endpoint, so the location uses the `s3://` scheme rather than `gs://`.
+
+The objects are read with duckdb through the same connection the test path uses, so the import authenticates identically and infers the column types from exactly the reader that later verifies them.
+
+The generated contract includes a ready-to-test `servers` block, so you can run `datacontract test datacontract.yaml` immediately afterwards — see the **[Google Cloud Storage connection guide](../testing/gcs.md)** for the full 5-minute walkthrough and troubleshooting.
+
+Credentials are the same ones `datacontract test` uses — see the [Google Cloud Storage Reference](../reference/gcs.md).

--- a/docs/docs/imports/iceberg.md
+++ b/docs/docs/imports/iceberg.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 14
 title: "Import: Iceberg"
 description: "Create a data contract from an Apache Iceberg schema."
 ---

--- a/docs/docs/imports/index.md
+++ b/docs/docs/imports/index.md
@@ -17,7 +17,7 @@ datacontract import sql --source my_ddl.sql --dialect postgres
 datacontract import sql --source my_ddl.sql --dialect postgres --output datacontract.yaml
 ```
 
-The [Snowflake](./snowflake.md), [BigQuery](./bigquery.md), [Amazon Redshift](./redshift.md), [Postgres](./postgres.md), [MySQL](./mysql.md), [SQL Server](./sqlserver.md), [Amazon Athena](./athena.md), [Amazon S3](./s3.md), [Google Cloud Storage](./gcs.md), [Azure Blob Storage](./azure.md), [Databricks](./databricks.md), and [AWS Glue](./glue.md) importers can connect directly to the live system and introspect your tables — no export files needed. Snowflake, BigQuery, Redshift, Postgres, MySQL, SQL Server, Athena, S3, GCS, Azure, and Databricks also generate a ready-to-test `servers` block, so `datacontract test` works right after the import.
+The [Snowflake](./snowflake.md), [BigQuery](./bigquery.md), [Amazon Redshift](./redshift.md), [Postgres](./postgres.md), [MySQL](./mysql.md), [SQL Server](./sqlserver.md), [Amazon Athena](./athena.md), [Amazon S3](./s3.md), [Google Cloud Storage](./gcs.md), [Azure Blob / ADLS](./adls.md), [Databricks](./databricks.md), and [AWS Glue](./glue.md) importers can connect directly to the live system and introspect your tables — no export files needed. Snowflake, BigQuery, Redshift, Postgres, MySQL, SQL Server, Athena, S3, GCS, ADLS, and Databricks also generate a ready-to-test `servers` block, so `datacontract test` works right after the import.
 
 Run `datacontract import <format> --help` to see the format-specific options (e.g. `datacontract import sql --help`). If a format you need is missing, [open an issue on GitHub](https://github.com/datacontract/datacontract-cli/issues).
 
@@ -28,6 +28,10 @@ Each import page shows a runnable example: a small source file under [`examples/
 ## Available importers
 
 <div className="card-grid">
+  <a className="doc-card" href="/imports/adls">
+    <img src="/img/icons/azure.svg" alt="" />
+    <span><span className="doc-card-title">adls</span><span className="doc-card-desc">Files in Azure Blob Storage.</span></span>
+  </a>
   <a className="doc-card" href="/imports/athena">
     <img src="/img/icons/athena.svg" alt="" />
     <span><span className="doc-card-title">athena</span><span className="doc-card-desc">An Amazon Athena database.</span></span>
@@ -35,10 +39,6 @@ Each import page shows a runnable example: a small source file under [`examples/
   <a className="doc-card" href="/imports/avro">
     <img src="/img/icons/avro.svg" alt="" />
     <span><span className="doc-card-title">avro</span><span className="doc-card-desc">An Avro schema file.</span></span>
-  </a>
-  <a className="doc-card" href="/imports/azure">
-    <img src="/img/icons/azure.svg" alt="" />
-    <span><span className="doc-card-title">azure</span><span className="doc-card-desc">Files in Azure Blob Storage.</span></span>
   </a>
   <a className="doc-card" href="/imports/bigquery">
     <img src="/img/icons/bigquery.svg" alt="" />

--- a/docs/docs/imports/index.md
+++ b/docs/docs/imports/index.md
@@ -17,7 +17,7 @@ datacontract import sql --source my_ddl.sql --dialect postgres
 datacontract import sql --source my_ddl.sql --dialect postgres --output datacontract.yaml
 ```
 
-The [Snowflake](./snowflake.md), [BigQuery](./bigquery.md), [Amazon Redshift](./redshift.md), [Postgres](./postgres.md), [MySQL](./mysql.md), [SQL Server](./sqlserver.md), [Amazon Athena](./athena.md), [Amazon S3](./s3.md), [Databricks](./databricks.md), and [AWS Glue](./glue.md) importers can connect directly to the live system and introspect your tables — no export files needed. Snowflake, BigQuery, Redshift, Postgres, MySQL, SQL Server, Athena, S3, and Databricks also generate a ready-to-test `servers` block, so `datacontract test` works right after the import.
+The [Snowflake](./snowflake.md), [BigQuery](./bigquery.md), [Amazon Redshift](./redshift.md), [Postgres](./postgres.md), [MySQL](./mysql.md), [SQL Server](./sqlserver.md), [Amazon Athena](./athena.md), [Amazon S3](./s3.md), [Google Cloud Storage](./gcs.md), [Azure Blob Storage](./azure.md), [Databricks](./databricks.md), and [AWS Glue](./glue.md) importers can connect directly to the live system and introspect your tables — no export files needed. Snowflake, BigQuery, Redshift, Postgres, MySQL, SQL Server, Athena, S3, GCS, Azure, and Databricks also generate a ready-to-test `servers` block, so `datacontract test` works right after the import.
 
 Run `datacontract import <format> --help` to see the format-specific options (e.g. `datacontract import sql --help`). If a format you need is missing, [open an issue on GitHub](https://github.com/datacontract/datacontract-cli/issues).
 
@@ -35,6 +35,10 @@ Each import page shows a runnable example: a small source file under [`examples/
   <a className="doc-card" href="/imports/avro">
     <img src="/img/icons/avro.svg" alt="" />
     <span><span className="doc-card-title">avro</span><span className="doc-card-desc">An Avro schema file.</span></span>
+  </a>
+  <a className="doc-card" href="/imports/azure">
+    <img src="/img/icons/azure.svg" alt="" />
+    <span><span className="doc-card-title">azure</span><span className="doc-card-desc">Files in Azure Blob Storage.</span></span>
   </a>
   <a className="doc-card" href="/imports/bigquery">
     <img src="/img/icons/bigquery.svg" alt="" />
@@ -59,6 +63,10 @@ Each import page shows a runnable example: a small source file under [`examples/
   <a className="doc-card" href="/imports/excel">
     <img src="/img/icons/excel.svg" alt="" />
     <span><span className="doc-card-title">excel</span><span className="doc-card-desc">An ODCS Excel template.</span></span>
+  </a>
+  <a className="doc-card" href="/imports/gcs">
+    <img src="/img/icons/gcs.svg" alt="" />
+    <span><span className="doc-card-title">gcs</span><span className="doc-card-desc">Files in Google Cloud Storage.</span></span>
   </a>
   <a className="doc-card" href="/imports/glue">
     <img src="/img/icons/glue.svg" alt="" />

--- a/docs/docs/imports/json.md
+++ b/docs/docs/imports/json.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 15
 title: "Import: JSON"
 description: "Create a data contract by inferring a schema from a JSON data file."
 ---

--- a/docs/docs/imports/jsonschema.md
+++ b/docs/docs/imports/jsonschema.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 16
 title: "Import: JSON Schema"
 description: "Create a data contract from a JSON Schema file."
 ---

--- a/docs/docs/imports/mysql.md
+++ b/docs/docs/imports/mysql.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 17
 title: "Import: MySQL"
 description: "Create a data contract from a MySQL database."
 ---

--- a/docs/docs/imports/odcs.md
+++ b/docs/docs/imports/odcs.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 18
 title: "Import: ODCS"
 description: "Create a data contract from an existing ODCS file."
 ---

--- a/docs/docs/imports/parquet.md
+++ b/docs/docs/imports/parquet.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 17
+sidebar_position: 19
 title: "Import: Parquet"
 description: "Create a data contract from a Parquet file."
 ---

--- a/docs/docs/imports/postgres.md
+++ b/docs/docs/imports/postgres.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 18
+sidebar_position: 20
 title: "Import: Postgres"
 description: "Create a data contract from a Postgres schema."
 ---

--- a/docs/docs/imports/powerbi.md
+++ b/docs/docs/imports/powerbi.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 19
+sidebar_position: 21
 title: "Import: Power BI"
 description: "Create a data contract from a Power BI semantic model (.pbit, .bim, or .json)."
 ---

--- a/docs/docs/imports/protobuf.md
+++ b/docs/docs/imports/protobuf.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 20
+sidebar_position: 22
 title: "Import: Protobuf"
 description: "Create a data contract from a Protobuf schema file."
 ---

--- a/docs/docs/imports/snowflake.md
+++ b/docs/docs/imports/snowflake.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 21
+sidebar_position: 23
 title: "Import: Snowflake"
 description: "Create a data contract from a Snowflake workspace."
 ---

--- a/docs/docs/imports/spark.md
+++ b/docs/docs/imports/spark.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 22
+sidebar_position: 24
 title: "Import: Spark"
 description: "Create a data contract from Spark tables or DataFrames (programmatic)."
 ---

--- a/docs/docs/imports/sql.md
+++ b/docs/docs/imports/sql.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 23
+sidebar_position: 25
 title: "Import: SQL DDL"
 description: "Create a data contract from a SQL DDL file."
 ---

--- a/docs/docs/imports/sqlserver.md
+++ b/docs/docs/imports/sqlserver.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 24
+sidebar_position: 26
 title: "Import: SQL Server"
 description: "Create a data contract from a SQL Server database."
 ---

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -27,6 +27,7 @@ marked as such in the entry.
 ## Unreleased {#unreleased}
 
 ### Added
+- `datacontract import gcs` and `datacontract import azure` create a data contract from files in Google Cloud Storage or Azure Blob Storage, including a ready-to-test `servers` block
 - `datacontract import sqlserver` creates a data contract from a live SQL Server database, including a ready-to-test `servers` block
 - `datacontract import mysql` creates a data contract from a live MySQL database, including a ready-to-test `servers` block
 - The documentation has a [Release Notes](https://docs.datacontract.com/release-notes) page, generated from this changelog

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -27,7 +27,7 @@ marked as such in the entry.
 ## Unreleased {#unreleased}
 
 ### Added
-- `datacontract import gcs` and `datacontract import azure` create a data contract from files in Google Cloud Storage or Azure Blob Storage, including a ready-to-test `servers` block
+- `datacontract import gcs` and `datacontract import adls` create a data contract from files in Google Cloud Storage or Azure Blob Storage, including a ready-to-test `servers` block
 - `datacontract import sqlserver` creates a data contract from a live SQL Server database, including a ready-to-test `servers` block
 - `datacontract import mysql` creates a data contract from a live MySQL database, including a ready-to-test `servers` block
 - The documentation has a [Release Notes](https://docs.datacontract.com/release-notes) page, generated from this changelog

--- a/docs/docs/testing/azure.md
+++ b/docs/docs/testing/azure.md
@@ -32,7 +32,7 @@ DATACONTRACT_AZURE_CLIENT_SECRET=yZK8Q~GWO1MMXXXXXXXXXXXXX
 Import the schema straight from the container. This also generates a ready-to-test `servers` block:
 
 ```bash
-datacontract import azure \
+datacontract import adls \
   --source abfss://my-container/orders/*.json \
   --output datacontract.yaml
 ```

--- a/docs/docs/testing/azure.md
+++ b/docs/docs/testing/azure.md
@@ -29,23 +29,15 @@ DATACONTRACT_AZURE_CLIENT_SECRET=yZK8Q~GWO1MMXXXXXXXXXXXXX
 
 ## 3. Create a contract from your files
 
-Download one blob and import its schema, then point the generated `servers` block at the storage account:
+Import the schema straight from the container. This also generates a ready-to-test `servers` block:
 
 ```bash
-az storage blob download --account-name myaccount --container-name inventory \
-  --name inventory_events/part-000.parquet --file part-000.parquet
-datacontract import parquet --source part-000.parquet --output datacontract.yaml
+datacontract import azure \
+  --source abfss://my-container/orders/*.json \
+  --output datacontract.yaml
 ```
 
-The import generates a `servers` entry of `type: local`. Replace it with your Azure location:
-
-```yaml
-servers:
-  - server: production
-    type: azure
-    location: abfss://inventory@myaccount.dfs.core.windows.net/inventory_events/*.parquet
-    format: parquet
-```
+The format is taken from the file suffix; pass `--format` for Delta tables, which have none.
 
 ## 4. Test the actual data
 

--- a/docs/docs/testing/gcs.md
+++ b/docs/docs/testing/gcs.md
@@ -28,24 +28,15 @@ DATACONTRACT_S3_SECRET_ACCESS_KEY=PDWWpbXXXXXXXXXXXXX
 
 ## 3. Create a contract from your files
 
-Download one object and import its schema, then point the generated `servers` block at the bucket:
+Import the schema straight from the bucket. This also generates a ready-to-test `servers` block:
 
 ```bash
-gcloud storage cp gs://my-bucket/orders/orders-2024-01.json .
-datacontract import json --source orders-2024-01.json --output datacontract.yaml
+datacontract import gcs \
+  --source s3://my-bucket/orders/*.json \
+  --output datacontract.yaml
 ```
 
-The import generates a `servers` entry of `type: local`. Replace it with your GCS location:
-
-```yaml
-servers:
-  - server: production
-    type: s3
-    endpointUrl: https://storage.googleapis.com
-    location: s3://my-bucket/orders/*.json # use s3:// instead of gs://
-    format: json
-    delimiter: new_line # new_line, array, or none
-```
+duckdb reads Google Cloud Storage through its S3-compatible endpoint, so the location uses the `s3://` scheme rather than `gs://`. The format is taken from the file suffix; pass `--format` for Delta tables, which have none.
 
 ## 4. Test the actual data
 

--- a/tests/test_import_object_storage.py
+++ b/tests/test_import_object_storage.py
@@ -10,7 +10,7 @@ import pytest
 from testcontainers.minio import MinioContainer
 
 from datacontract.data_contract import DataContract
-from datacontract.imports.s3_importer import detect_format, schema_name
+from datacontract.imports.object_storage_importer import detect_format, schema_name
 from datacontract.model.exceptions import DataContractException
 from datacontract.model.run import ResultEnum
 
@@ -117,3 +117,53 @@ def test_an_unreadable_object_explains_the_location_and_format(minio, credential
 
     assert "missing.csv" in exc_info.value.reason
     assert "as csv" in exc_info.value.reason
+
+
+# ---------------------------------------------------------------------------
+# One importer serves S3, GCS and Azure; it takes the server type from the
+# format it was registered under. The GCS and Azure reads need real credentials,
+# which is how the existing gcs/azure suites are gated, so only the dispatch is
+# checked here.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("storage", ["s3", "gcs", "azure"])
+def test_each_storage_writes_its_own_server_type(storage, monkeypatch):
+    from datacontract.imports import object_storage_importer
+
+    captured = {}
+
+    def fake_read_columns(server, location, file_format):
+        captured["server"] = server
+        return [("id", "BIGINT")]
+
+    monkeypatch.setattr(object_storage_importer, "_read_columns", fake_read_columns)
+    result = DataContract.import_from_source(storage, "s3://bucket/orders/orders.csv")
+
+    assert captured["server"].type == storage
+    assert result.servers[0].type == storage
+    assert result.servers[0].format == "csv"
+
+
+@pytest.mark.parametrize("storage", ["s3", "gcs", "azure"])
+def test_each_storage_names_its_own_location_in_the_error(storage):
+    with pytest.raises(DataContractException) as exc_info:
+        DataContract.import_from_source(storage, None)
+
+    assert "location is required" in exc_info.value.reason
+    assert f"the {storage} import" in exc_info.value.reason
+
+
+def test_azure_uses_the_azure_connection_setup(monkeypatch):
+    """Each storage must reach duckdb through its own credential setup."""
+    from datacontract.imports import object_storage_importer
+
+    calls = []
+    for name in ("setup_s3_connection", "setup_gcs_connection", "setup_azure_connection"):
+        monkeypatch.setattr(
+            "datacontract.engines.ibis.connections.duckdb_connection." + name,
+            lambda con, server, _n=name: calls.append(_n),
+        )
+    monkeypatch.setattr(object_storage_importer, "_READERS", {"csv": "(SELECT 1 AS id)"})
+
+    DataContract.import_from_source("azure", "abfss://container/orders/orders.csv")
+
+    assert calls == ["setup_azure_connection"]

--- a/tests/test_import_object_storage.py
+++ b/tests/test_import_object_storage.py
@@ -125,8 +125,8 @@ def test_an_unreadable_object_explains_the_location_and_format(minio, credential
 # which is how the existing gcs/azure suites are gated, so only the dispatch is
 # checked here.
 # ---------------------------------------------------------------------------
-@pytest.mark.parametrize("storage", ["s3", "gcs", "azure"])
-def test_each_storage_writes_its_own_server_type(storage, monkeypatch):
+@pytest.mark.parametrize("storage, server_type", [("s3", "s3"), ("gcs", "gcs"), ("adls", "azure")])
+def test_each_storage_writes_its_own_server_type(storage, server_type, monkeypatch):
     from datacontract.imports import object_storage_importer
 
     captured = {}
@@ -138,21 +138,22 @@ def test_each_storage_writes_its_own_server_type(storage, monkeypatch):
     monkeypatch.setattr(object_storage_importer, "_read_columns", fake_read_columns)
     result = DataContract.import_from_source(storage, "s3://bucket/orders/orders.csv")
 
-    assert captured["server"].type == storage
-    assert result.servers[0].type == storage
+    # ODCS calls the Azure server type `azure`, so the format name and the
+    # server type deliberately differ for adls
+    assert captured["server"].type == server_type
+    assert result.servers[0].type == server_type
     assert result.servers[0].format == "csv"
 
 
-@pytest.mark.parametrize("storage", ["s3", "gcs", "azure"])
+@pytest.mark.parametrize("storage", ["s3", "gcs", "adls"])
 def test_each_storage_names_its_own_location_in_the_error(storage):
     with pytest.raises(DataContractException) as exc_info:
         DataContract.import_from_source(storage, None)
 
     assert "location is required" in exc_info.value.reason
-    assert f"the {storage} import" in exc_info.value.reason
 
 
-def test_azure_uses_the_azure_connection_setup(monkeypatch):
+def test_adls_uses_the_azure_connection_setup(monkeypatch):
     """Each storage must reach duckdb through its own credential setup."""
     from datacontract.imports import object_storage_importer
 
@@ -164,6 +165,6 @@ def test_azure_uses_the_azure_connection_setup(monkeypatch):
         )
     monkeypatch.setattr(object_storage_importer, "_READERS", {"csv": "(SELECT 1 AS id)"})
 
-    DataContract.import_from_source("azure", "abfss://container/orders/orders.csv")
+    DataContract.import_from_source("adls", "abfss://container/orders/orders.csv")
 
     assert calls == ["setup_azure_connection"]


### PR DESCRIPTION
## Summary

Adds `datacontract import gcs` and `datacontract import adls`, closing the last two file sources that still told users to download an object by hand:

```bash
datacontract import gcs  --source s3://my-bucket/orders/*.json       --output datacontract.yaml
datacontract import adls --source abfss://my-container/orders/*.json --output datacontract.yaml
```

Both guides previously said: download one object with `gsutil`/`az`, run `import json` or `import parquet` on the local copy, then replace the generated `type: local` server with the real one, filling in location, format and delimiter.

**Almost no new machinery.** The S3 importer already read objects through the same duckdb connection the test path uses, and that connection already knew how to authenticate against GCS (`setup_gcs_connection`) and Azure (`setup_azure_connection`). One importer now serves all three, so `s3_importer.py` became `object_storage_importer.py`. `import s3` is unchanged.

**The import format and the ODCS server type are deliberately not the same string.** ODCS has no `adls` server type — only `azure`, which is also the only one the engine dispatches on — so a contract written by `import adls` still says `type: azure` and connects as before:

```python
SERVER_TYPES = {"s3": "s3", "gcs": "gcs", "adls": "azure"}
```

The command is named for what the docs already call this source, "Azure Blob / ADLS", rather than for the server type.

## Verification

**S3 is verified three ways** on the refactored code:

- the MinIO-backed suite, including a round trip that imports a contract and tests it unedited
- a real AWS import against a private bucket with only an SSO session, then `datacontract test` on the unedited file: 4/4 passed
- the produced contract is **byte-identical** to the one the pre-refactor importer produced, so the generalisation is provably a no-op for S3

**GCS and ADLS reads are not verified against real storage.** The repo's existing `test_test_gcs_*` and `test_test_azure_*` suites are gated on credentials being set and skip everywhere, including CI, so there was no seam to reuse. The new tests cover what can be checked without a cloud account:

- each storage writes the right server type into the contract, including `adls` → `azure`
- each reaches duckdb through its own credential setup, not S3's
- each rejects a missing location

That is weaker than the end-to-end proof the other importers have, and worth weighing before merging. One real import against each would close it.

31 tests pass.

## Docs

New `imports/gcs.md` and `imports/adls.md`; both testing guides get the one-command step 3. The GCS pages note that duckdb reads Google Cloud Storage through its S3-compatible endpoint, so the location uses `s3://` rather than `gs://` — a long-standing trap that already had its own troubleshooting entry.