### PR TITLE
Add Oracle import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `datacontract import oracle` creates a data contract from a live Oracle database, including a ready-to-test `servers` block
 - `datacontract import gcs` and `datacontract import adls` create a data contract from files in Google Cloud Storage or Azure Blob Storage, including a ready-to-test `servers` block
 - `datacontract import sqlserver` creates a data contract from a live SQL Server database, including a ready-to-test `servers` block
 - `datacontract import mysql` creates a data contract from a live MySQL database, including a ready-to-test `servers` block

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -50,7 +50,7 @@ class OrderedCommandsWithMigrationHints(OrderedCommands):
 
     # Import formats where `--schema` still means the database schema, so it must
     # not be rewritten to the v0.12.0 `--json-schema`.
-    DATABASE_SCHEMA_IMPORTS = {"snowflake", "redshift", "postgres", "athena", "sqlserver"}
+    DATABASE_SCHEMA_IMPORTS = {"snowflake", "redshift", "postgres", "athena", "sqlserver", "oracle"}
 
     RENAMED_FLAGS = {
         "--format": None,

--- a/datacontract/command_import.py
+++ b/datacontract/command_import.py
@@ -622,6 +622,41 @@ def import_adls(
 
 
 @import_app.command(
+    name="oracle",
+    epilog="Example: datacontract import oracle --source localhost --service-name XEPDB1 --schema ADMIN --output datacontract.yaml",
+)
+def import_oracle(
+    source: Annotated[Optional[str], typer.Option(help="The host of the Oracle database.")] = None,
+    port: Annotated[Optional[int], typer.Option(help="The Oracle port (default 1521).")] = None,
+    service_name: Annotated[Optional[str], typer.Option(help="The Oracle service name, e.g. XEPDB1.")] = None,
+    schema: Annotated[
+        Optional[str], typer.Option("--schema", help="The owning schema, e.g. ADMIN (Oracle upper-cases it).")
+    ] = None,
+    table: Annotated[
+        Optional[List[str]],
+        typer.Option(help="Name of a table to import (repeat for multiple tables, omit for all tables)."),
+    ] = None,
+    output: output_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from an Oracle database."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(
+        format="oracle",
+        source=source,
+        port=port,
+        service_name=service_name,
+        schema=schema,
+        oracle_table=table,
+        owner=owner,
+        id=id,
+    )
+    _write_result(result, output)
+
+
+@import_app.command(
     name="sqlserver",
     epilog="Example: datacontract import sqlserver --source localhost --database mydb --output datacontract.yaml",
 )

--- a/datacontract/engines/ibis/native_type.py
+++ b/datacontract/engines/ibis/native_type.py
@@ -66,6 +66,13 @@ _DECIMAL_TYPES = {"decimal", "numeric", "number", "dec"}
 _ORACLE_LENGTH_TYPES = {"char", "nchar", "varchar", "varchar2", "nvarchar2", "raw"}
 
 
+def oracle_char_length(data_type: Optional[str], data_length):
+    """Oracle reports DATA_LENGTH for every column, but the length is only part
+    of the declared type for character and raw types; appending it elsewhere
+    would corrupt types such as ROWID or DATE."""
+    return data_length if (data_type or "").strip().lower() in _ORACLE_LENGTH_TYPES else None
+
+
 def reconstruct_native_type(
     data_type: Optional[str],
     char_len=None,
@@ -155,9 +162,7 @@ def _map_reconstructed(con, query: str, oracle_length: bool = False) -> Optional
         column_name, data_type = row[0], row[1]
         char_len = row[2]
         if oracle_length:
-            # Oracle reports DATA_LENGTH for every column; keep it only for the
-            # types where it is really part of the declared type.
-            char_len = char_len if (data_type or "").strip().lower() in _ORACLE_LENGTH_TYPES else None
+            char_len = oracle_char_length(data_type, char_len)
         native = reconstruct_native_type(data_type, char_len, row[3], row[4])
         if column_name and native:
             result[str(column_name).lower()] = native

--- a/datacontract/imports/importer.py
+++ b/datacontract/imports/importer.py
@@ -49,6 +49,7 @@ class ImportFormat(str, Enum):
     sqlserver = "sqlserver"
     gcs = "gcs"
     adls = "adls"
+    oracle = "oracle"
 
     @classmethod
     def get_supported_formats(cls):

--- a/datacontract/imports/importer_factory.py
+++ b/datacontract/imports/importer_factory.py
@@ -150,6 +150,11 @@ importer_factory.register_lazy_importer(
     class_name="AthenaImporter",
 )
 importer_factory.register_lazy_importer(
+    name=ImportFormat.oracle,
+    module_path="datacontract.imports.oracle_importer",
+    class_name="OracleImporter",
+)
+importer_factory.register_lazy_importer(
     name=ImportFormat.sqlserver,
     module_path="datacontract.imports.sqlserver_importer",
     class_name="SqlServerImporter",

--- a/datacontract/imports/odcs_helper.py
+++ b/datacontract/imports/odcs_helper.py
@@ -173,6 +173,7 @@ def create_server(
     warehouse: str = None,
     region_name: str = None,
     staging_dir: str = None,
+    service_name: str = None,
 ) -> Server:
     """Create a Server object.
 
@@ -218,6 +219,8 @@ def create_server(
         server.regionName = region_name
     if staging_dir:
         server.stagingDir = staging_dir
+    if service_name:
+        server.serviceName = service_name
     return server
 
 

--- a/datacontract/imports/oracle_importer.py
+++ b/datacontract/imports/oracle_importer.py
@@ -1,0 +1,245 @@
+"""Create a data contract from a live Oracle schema.
+
+Reads ``ALL_TAB_COLUMNS``, the same catalog ``datacontract test`` reads back to
+verify physical types, and applies the same rule about which types carry a
+length — Oracle reports ``DATA_LENGTH`` for every column, but it is only part of
+the declared type for character and raw types. An imported contract therefore
+passes on the first run without hand-editing.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from open_data_contract_standard.model import OpenDataContractStandard, SchemaObject, SchemaProperty, Server
+
+from datacontract.engines.ibis.native_type import oracle_char_length, reconstruct_native_type
+from datacontract.imports.importer import Importer
+from datacontract.imports.odcs_helper import create_odcs, create_property, create_schema_object, create_server
+from datacontract.imports.sql_importer import map_type_from_sql
+from datacontract.model.exceptions import DataContractException
+
+DEFAULT_PORT = 1521
+
+# Oracle keeps object names upper case, and the owner is what other engines call
+# the schema.
+_TABLES_QUERY = """
+    SELECT table_name, 'table' AS object_type FROM all_tables WHERE owner = '{schema}'
+    UNION ALL
+    SELECT view_name AS table_name, 'view' AS object_type FROM all_views WHERE owner = '{schema}'
+"""
+
+_COLUMNS_QUERY = """
+    SELECT table_name, column_name, data_type, data_length, data_precision, data_scale, nullable
+    FROM all_tab_columns
+    WHERE owner = '{schema}'
+    ORDER BY table_name, column_id
+"""
+
+_PRIMARY_KEYS_QUERY = """
+    SELECT cols.table_name, cols.column_name, cols.position
+    FROM all_constraints cons
+    JOIN all_cons_columns cols
+      ON cons.constraint_name = cols.constraint_name
+     AND cons.owner = cols.owner
+    WHERE cons.constraint_type = 'P'
+      AND cons.owner = '{schema}'
+    ORDER BY cols.table_name, cols.position
+"""
+
+
+class OracleImporter(Importer):
+    def import_source(self, source: str, import_args: dict) -> OpenDataContractStandard:
+        if source is None:
+            raise DataContractException(
+                type="source",
+                name="oracle import source",
+                reason="The host is required for the oracle import, e.g. --source localhost",
+                engine="datacontract",
+            )
+        return import_oracle(
+            host=source,
+            port=import_args.get("port"),
+            service_name=import_args.get("service_name"),
+            schema=import_args.get("schema"),
+            tables=import_args.get("oracle_table"),
+        )
+
+
+def import_oracle(
+    host: str,
+    service_name: Optional[str],
+    schema: Optional[str] = None,
+    port: Optional[int] = None,
+    tables: Optional[List[str]] = None,
+) -> OpenDataContractStandard:
+    if not service_name:
+        raise DataContractException(
+            type="source",
+            name="oracle import service name",
+            reason="The service name is required for the oracle import, e.g. --service-name XEPDB1",
+            engine="datacontract",
+        )
+    if not schema:
+        raise DataContractException(
+            type="source",
+            name="oracle import schema",
+            reason="The schema is required for the oracle import, e.g. --schema ADMIN",
+            engine="datacontract",
+        )
+
+    port = int(port) if port else DEFAULT_PORT
+    # Oracle stores identifiers upper case, so a lower-case --schema would match nothing
+    schema = schema.upper()
+    server = create_server(
+        name="oracle",
+        server_type="oracle",
+        host=host,
+        port=port,
+        schema=schema,
+        service_name=service_name,
+    )
+
+    connection = oracle_connection(server)
+    try:
+        table_rows = _fetch(connection, _TABLES_QUERY.format(schema=_escape(schema)))
+        column_rows = _fetch(connection, _COLUMNS_QUERY.format(schema=_escape(schema)))
+        # A user without access to the constraint views still gets a usable
+        # contract, just without primary keys.
+        primary_key_rows = _fetch(connection, _PRIMARY_KEYS_QUERY.format(schema=_escape(schema)), optional=True)
+    finally:
+        _close(connection)
+
+    selected = _select_tables(table_rows, tables)
+    if not selected:
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="no tables found",
+            reason=f"No tables found in schema '{schema}'.",
+            engine="datacontract",
+        )
+
+    odcs = create_odcs()
+    odcs.servers = [server]
+    odcs.schema_ = [
+        _create_schema(table, column_rows, primary_key_rows)
+        for table in sorted(selected, key=lambda row: row["table_name"].lower())
+    ]
+    return odcs
+
+
+def oracle_connection(server: Server):
+    """Connect exactly as `datacontract test` does, including the compatibility patch."""
+    try:
+        import ibis  # noqa: F401
+    except ImportError as e:
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="oracle extra missing",
+            reason="Install the extra datacontract-cli[oracle] to use oracle",
+            engine="datacontract",
+            original_exception=e,
+        )
+
+    from datacontract.engines.ibis.connections.connect import connect_ibis
+    from datacontract.model.run import Run
+
+    try:
+        return connect_ibis(Run.create_run(), None, server)
+    except Exception as e:
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="oracle connection failed",
+            reason=f"Could not connect to Oracle at {server.host}:{server.port}: {e}",
+            engine="datacontract",
+            original_exception=e,
+        )
+
+
+def _fetch(connection, query: str, optional: bool = False) -> List[Dict[str, Any]]:
+    """Run a catalog query and return its rows as dicts keyed by column name."""
+    try:
+        cursor = connection.raw_sql(query)
+        columns = [description[0].lower() for description in cursor.description]
+        return [dict(zip(columns, row)) for row in cursor.fetchall()]
+    except Exception as e:
+        if optional:
+            return []
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="oracle catalog query failed",
+            reason=f"Could not read the Oracle catalog: {e}",
+            engine="datacontract",
+            original_exception=e,
+        )
+
+
+def _close(connection) -> None:
+    try:
+        connection.disconnect()
+    except Exception:  # pragma: no cover - best effort
+        pass
+
+
+def _escape(value: str) -> str:
+    return value.replace("'", "''")
+
+
+def _as_int(value: Any) -> Optional[int]:
+    """Oracle returns catalog numbers as Decimal, which YAML would serialise as a
+    Python-specific tag, leaving a contract no other tool could read."""
+    return int(value) if value is not None else None
+
+
+def _select_tables(table_rows: List[Dict[str, Any]], tables: Optional[List[str]]) -> List[Dict[str, Any]]:
+    if not tables:
+        return table_rows
+    wanted = {table.lower() for table in tables}
+    return [row for row in table_rows if row["table_name"].lower() in wanted]
+
+
+def _create_schema(
+    table: Dict[str, Any],
+    column_rows: List[Dict[str, Any]],
+    primary_key_rows: List[Dict[str, Any]],
+) -> SchemaObject:
+    table_name = table["table_name"]
+    primary_keys = {
+        row["column_name"]: index + 1
+        for index, row in enumerate(row for row in primary_key_rows if row["table_name"] == table_name)
+    }
+    properties = [_create_property(row, primary_keys) for row in column_rows if row["table_name"] == table_name]
+    return create_schema_object(
+        name=table_name,
+        physical_type=table.get("object_type") or "table",
+        properties=properties or None,
+    )
+
+
+def _create_property(row: Dict[str, Any], primary_keys: Dict[str, int]) -> SchemaProperty:
+    name = row["column_name"]
+    data_type = row.get("data_type")
+    precision = _as_int(row.get("data_precision"))
+    scale = _as_int(row.get("data_scale"))
+    # the same length rule the test path applies when reading this catalog back
+    char_length = _as_int(oracle_char_length(data_type, row.get("data_length")))
+    physical_type = reconstruct_native_type(data_type, char_length, precision, scale)
+    logical_type, format = map_type_from_sql(physical_type)
+    is_decimal = physical_type is not None and physical_type.lower().startswith(("decimal", "numeric", "number"))
+
+    return create_property(
+        name=name,
+        logical_type=logical_type,
+        physical_type=physical_type,
+        required=row.get("nullable") == "N" or None,
+        primary_key=name in primary_keys or None,
+        primary_key_position=primary_keys.get(name),
+        max_length=char_length,
+        precision=precision if is_decimal else None,
+        scale=scale if is_decimal else None,
+        format=format,
+    )

--- a/docs/docs/commands/import.md
+++ b/docs/docs/commands/import.md
@@ -18,4 +18,4 @@ Run `datacontract import <format> --help` to see format-specific options.
 datacontract import sql --source ddl.sql --dialect postgres --output datacontract.yaml
 ```
 
-Available formats: `adls`, `athena`, `avro`, `bigquery`, `csv`, `databricks`, `dbml`, `dbt`, `excel`, `gcs`, `glue`, `iceberg`, `json`, `jsonschema`, `mysql`, `odcs`, `parquet`, `postgres`, `powerbi`, `protobuf`, `redshift`, `s3`, `snowflake`, `spark`, `sql`, `sqlserver`.
+Available formats: `adls`, `athena`, `avro`, `bigquery`, `csv`, `databricks`, `dbml`, `dbt`, `excel`, `gcs`, `glue`, `iceberg`, `json`, `jsonschema`, `mysql`, `odcs`, `oracle`, `parquet`, `postgres`, `powerbi`, `protobuf`, `redshift`, `s3`, `snowflake`, `spark`, `sql`, `sqlserver`.

--- a/docs/docs/imports/index.md
+++ b/docs/docs/imports/index.md
@@ -17,7 +17,7 @@ datacontract import sql --source my_ddl.sql --dialect postgres
 datacontract import sql --source my_ddl.sql --dialect postgres --output datacontract.yaml
 ```
 
-The [Snowflake](./snowflake.md), [BigQuery](./bigquery.md), [Amazon Redshift](./redshift.md), [Postgres](./postgres.md), [MySQL](./mysql.md), [SQL Server](./sqlserver.md), [Amazon Athena](./athena.md), [Amazon S3](./s3.md), [Google Cloud Storage](./gcs.md), [Azure Blob / ADLS](./adls.md), [Databricks](./databricks.md), and [AWS Glue](./glue.md) importers can connect directly to the live system and introspect your tables — no export files needed. Snowflake, BigQuery, Redshift, Postgres, MySQL, SQL Server, Athena, S3, GCS, ADLS, and Databricks also generate a ready-to-test `servers` block, so `datacontract test` works right after the import.
+The [Snowflake](./snowflake.md), [BigQuery](./bigquery.md), [Amazon Redshift](./redshift.md), [Postgres](./postgres.md), [MySQL](./mysql.md), [SQL Server](./sqlserver.md), [Oracle](./oracle.md), [Amazon Athena](./athena.md), [Amazon S3](./s3.md), [Google Cloud Storage](./gcs.md), [Azure Blob / ADLS](./adls.md), [Databricks](./databricks.md), and [AWS Glue](./glue.md) importers can connect directly to the live system and introspect your tables — no export files needed. Snowflake, BigQuery, Redshift, Postgres, MySQL, SQL Server, Oracle, Athena, S3, GCS, ADLS, and Databricks also generate a ready-to-test `servers` block, so `datacontract test` works right after the import.
 
 Run `datacontract import <format> --help` to see the format-specific options (e.g. `datacontract import sql --help`). If a format you need is missing, [open an issue on GitHub](https://github.com/datacontract/datacontract-cli/issues).
 
@@ -91,6 +91,10 @@ Each import page shows a runnable example: a small source file under [`examples/
   <a className="doc-card" href="/imports/odcs">
     <img src="/img/icons/odcs.svg" alt="" />
     <span><span className="doc-card-title">odcs</span><span className="doc-card-desc">An ODCS data contract file.</span></span>
+  </a>
+  <a className="doc-card" href="/imports/oracle">
+    <img src="/img/icons/oracle.svg" alt="" />
+    <span><span className="doc-card-title">oracle</span><span className="doc-card-desc">An Oracle database.</span></span>
   </a>
   <a className="doc-card" href="/imports/parquet">
     <img src="/img/icons/parquet.svg" alt="" />

--- a/docs/docs/imports/oracle.md
+++ b/docs/docs/imports/oracle.md
@@ -1,0 +1,27 @@
+---
+sidebar_position: 19
+title: "Import: Oracle"
+description: "Create a data contract from an Oracle database."
+---
+
+# <img className="page-icon" src="/img/icons/oracle.svg" alt="" /> Import: Oracle
+
+Creates a data contract from an Oracle database by reading `ALL_TAB_COLUMNS` — including column types with length and precision, nullability, and primary keys.
+
+```bash
+datacontract import oracle \
+  --source localhost \
+  --service-name XEPDB1 \
+  --schema ADMIN \
+  --output datacontract.yaml
+```
+
+`--source` is the host of your Oracle database and `--service-name` its service. Add `--port` if it doesn't listen on the default `1521`, and repeat `--table` to import only specific tables. Oracle stores identifiers in upper case, so `--schema` is upper-cased for you.
+
+Types are reconstructed exactly as the test path reads them back. Oracle reports a `DATA_LENGTH` for *every* column, but it is only part of the declared type for character and raw types — so a `DATE` stays `DATE` rather than becoming `DATE(7)`.
+
+The generated contract includes a ready-to-test `servers` block, so you can run `datacontract test datacontract.yaml` immediately afterwards — see the **[Oracle connection guide](../testing/oracle.md)** for the full 5-minute walkthrough and troubleshooting.
+
+Credentials are the same ones `datacontract test` uses: `DATACONTRACT_ORACLE_USERNAME` and `DATACONTRACT_ORACLE_PASSWORD` — see the [Oracle Reference](../reference/oracle.md).
+
+Only have a DDL script? Use [`datacontract import sql --dialect oracle`](./sql.md).

--- a/docs/docs/imports/parquet.md
+++ b/docs/docs/imports/parquet.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 19
+sidebar_position: 20
 title: "Import: Parquet"
 description: "Create a data contract from a Parquet file."
 ---

--- a/docs/docs/imports/postgres.md
+++ b/docs/docs/imports/postgres.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 20
+sidebar_position: 21
 title: "Import: Postgres"
 description: "Create a data contract from a Postgres schema."
 ---

--- a/docs/docs/imports/powerbi.md
+++ b/docs/docs/imports/powerbi.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 21
+sidebar_position: 22
 title: "Import: Power BI"
 description: "Create a data contract from a Power BI semantic model (.pbit, .bim, or .json)."
 ---

--- a/docs/docs/imports/protobuf.md
+++ b/docs/docs/imports/protobuf.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 22
+sidebar_position: 23
 title: "Import: Protobuf"
 description: "Create a data contract from a Protobuf schema file."
 ---

--- a/docs/docs/imports/snowflake.md
+++ b/docs/docs/imports/snowflake.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 23
+sidebar_position: 24
 title: "Import: Snowflake"
 description: "Create a data contract from a Snowflake workspace."
 ---

--- a/docs/docs/imports/spark.md
+++ b/docs/docs/imports/spark.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 24
+sidebar_position: 25
 title: "Import: Spark"
 description: "Create a data contract from Spark tables or DataFrames (programmatic)."
 ---

--- a/docs/docs/imports/sql.md
+++ b/docs/docs/imports/sql.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 25
+sidebar_position: 26
 title: "Import: SQL DDL"
 description: "Create a data contract from a SQL DDL file."
 ---

--- a/docs/docs/imports/sqlserver.md
+++ b/docs/docs/imports/sqlserver.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 26
+sidebar_position: 27
 title: "Import: SQL Server"
 description: "Create a data contract from a SQL Server database."
 ---

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -27,6 +27,7 @@ marked as such in the entry.
 ## Unreleased {#unreleased}
 
 ### Added
+- `datacontract import oracle` creates a data contract from a live Oracle database, including a ready-to-test `servers` block
 - `datacontract import gcs` and `datacontract import adls` create a data contract from files in Google Cloud Storage or Azure Blob Storage, including a ready-to-test `servers` block
 - `datacontract import sqlserver` creates a data contract from a live SQL Server database, including a ready-to-test `servers` block
 - `datacontract import mysql` creates a data contract from a live MySQL database, including a ready-to-test `servers` block

--- a/docs/docs/testing/oracle.md
+++ b/docs/docs/testing/oracle.md
@@ -16,7 +16,7 @@ uv tool install --python python3.11 --upgrade 'datacontract-cli[oracle]'
 
 See [Installation](../installation.md) for pip, pipx, and Docker.
 
-## 2. Set credentials
+## 2. Authenticate
 
 Create a `.env` file in your working directory (or export the variables):
 
@@ -28,23 +28,20 @@ DATACONTRACT_ORACLE_PASSWORD=mysecretpassword
 
 ## 3. Create a contract from your tables
 
-Get the DDL of a table (e.g. `SELECT DBMS_METADATA.GET_DDL('TABLE', 'ORDERS') FROM dual;` in SQL*Plus or SQL Developer), save it to a file, and import it:
+Import the table metadata directly from the database. This also generates a ready-to-test `servers` block:
 
 ```bash
-datacontract import sql --source orders.sql --dialect oracle --output datacontract.yaml
+datacontract import oracle \
+  --source localhost \
+  --service-name ORCL \
+  --schema ADMIN \
+  --table ORDERS \
+  --output datacontract.yaml
 ```
 
-The SQL import can't know your connection details, so it writes a `servers` block with placeholder values. Open `datacontract.yaml` and fill in your server:
+`--source` is the host and `--service-name` the service. Repeat `--table` for multiple tables, or omit it to import every table in the schema; Oracle upper-cases identifiers, so `--schema` is upper-cased for you.
 
-```yaml
-servers:
-  - server: oracle
-    type: oracle
-    host: localhost
-    port: 1521
-    service_name: ORCL
-    schema: ADMIN
-```
+Only have a DDL script? `datacontract import sql --source orders.sql --dialect oracle` works too, but writes a `servers` block with placeholder values that you have to fill in by hand.
 
 ## 4. Test the actual data
 

--- a/tests/test_import_oracle.py
+++ b/tests/test_import_oracle.py
@@ -1,0 +1,160 @@
+"""Tests for the Oracle importer, run against a real Oracle XE container.
+
+Marked slow like the other Oracle suite: the image is large, so these run in the
+dedicated CI job rather than on every invocation.
+"""
+
+import pytest
+from testcontainers.oracle import OracleDbContainer
+
+from datacontract.data_contract import DataContract
+from datacontract.model.exceptions import DataContractException
+from datacontract.model.run import ResultEnum
+
+# XE 21c: pre-23ai, and freely available unlike 19c.
+oracleContainer = OracleDbContainer("gvenzl/oracle-xe:21-slim-faststart")
+ORACLE_SERVER_PORT = 1521
+# XE's pluggable-database service name differs from oracle-free's FREEPDB1.
+_XE_SERVICE_NAME = "XEPDB1"
+SCHEMA = "SYSTEM"
+
+SEED = [
+    """CREATE TABLE orders (
+         order_id VARCHAR2(36) NOT NULL PRIMARY KEY,
+         order_total NUMBER(10,2),
+         line_count NUMBER(10) NOT NULL,
+         ordered_at TIMESTAMP,
+         notes CLOB,
+         created_on DATE
+       )""",
+    "INSERT INTO orders VALUES ('CX-263-DU', 50.00, 2, SYSTIMESTAMP, 'hello', SYSDATE)",
+    "CREATE TABLE customers (id NUMBER(10) NOT NULL PRIMARY KEY)",
+    "CREATE VIEW open_orders AS SELECT order_id FROM orders WHERE line_count > 1",
+]
+
+
+@pytest.fixture(scope="module")
+def oracle_container(request):
+    oracleContainer.start()
+    request.addfinalizer(oracleContainer.stop)
+    _seed()
+
+
+@pytest.fixture
+def credentials(monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_ORACLE_USERNAME", SCHEMA)
+    monkeypatch.setenv("DATACONTRACT_ORACLE_PASSWORD", oracleContainer.oracle_password)
+
+
+def _seed():
+    import oracledb
+
+    connection = oracledb.connect(
+        user=SCHEMA,
+        password=oracleContainer.oracle_password,
+        dsn=f"{oracleContainer.get_container_host_ip()}:"
+        f"{oracleContainer.get_exposed_port(ORACLE_SERVER_PORT)}/{_XE_SERVICE_NAME}",
+    )
+    cursor = connection.cursor()
+    for statement in SEED:
+        cursor.execute(statement)
+    connection.commit()
+    connection.close()
+
+
+def _import(**kwargs):
+    kwargs.setdefault("service_name", _XE_SERVICE_NAME)
+    kwargs.setdefault("schema", SCHEMA)
+    kwargs.setdefault("port", oracleContainer.get_exposed_port(ORACLE_SERVER_PORT))
+    return DataContract.import_from_source("oracle", oracleContainer.get_container_host_ip(), **kwargs)
+
+
+@pytest.mark.slow
+def test_import_oracle_reconstructs_the_declared_types(oracle_container, credentials):
+    """Oracle reports DATA_LENGTH for every column; only some types carry it."""
+    result = _import(oracle_table=["ORDERS"])
+    types = {prop.name: prop.physicalType for prop in result.schema_[0].properties}
+
+    assert types == {
+        "ORDER_ID": "VARCHAR2(36)",
+        "ORDER_TOTAL": "NUMBER(10,2)",
+        "LINE_COUNT": "NUMBER(10)",
+        "ORDERED_AT": "TIMESTAMP(6)",
+        # DATE reports length 7 and CLOB 4000; neither belongs in the type
+        "NOTES": "CLOB",
+        "CREATED_ON": "DATE",
+    }
+
+
+@pytest.mark.slow
+def test_catalog_numbers_are_plain_integers(oracle_container, credentials):
+    """Oracle returns Decimal, which YAML would write as a Python-specific tag."""
+    result = _import(oracle_table=["ORDERS"])
+
+    assert "!!python" not in result.to_yaml()
+    order_id = result.schema_[0].properties[0]
+    assert order_id.logicalTypeOptions["maxLength"] == 36
+    assert isinstance(order_id.logicalTypeOptions["maxLength"], int)
+
+
+@pytest.mark.slow
+def test_imported_contract_passes_test_without_editing(oracle_container, credentials):
+    """The point of the native import: import, then test, no hand-editing."""
+    result = _import(oracle_table=["ORDERS"])
+
+    run = DataContract(data_contract_str=result.to_yaml()).test()
+
+    print(run.pretty())
+    assert run.result == ResultEnum.passed
+
+
+@pytest.mark.slow
+def test_import_oracle_produces_a_valid_contract(oracle_container, credentials):
+    result = _import(oracle_table=["ORDERS"])
+
+    assert DataContract(data_contract_str=result.to_yaml()).lint().result == ResultEnum.passed
+
+
+@pytest.mark.slow
+def test_the_primary_key_is_imported(oracle_container, credentials):
+    result = _import(oracle_table=["ORDERS"])
+    order_id = result.schema_[0].properties[0]
+
+    assert (order_id.primaryKey, order_id.primaryKeyPosition, order_id.required) == (True, 1, True)
+
+
+@pytest.mark.slow
+def test_a_lower_case_schema_still_matches(oracle_container, credentials):
+    """Oracle stores identifiers upper case, so the importer upper-cases --schema."""
+    result = _import(schema=SCHEMA.lower(), oracle_table=["ORDERS"])
+
+    assert result.servers[0].schema_ == SCHEMA
+
+
+@pytest.mark.slow
+def test_import_oracle_fails_on_an_unknown_table(oracle_container, credentials):
+    with pytest.raises(DataContractException) as exc_info:
+        _import(oracle_table=["does_not_exist"])
+
+    assert "No tables found" in exc_info.value.reason
+
+
+def test_import_oracle_requires_a_service_name():
+    with pytest.raises(DataContractException) as exc_info:
+        DataContract.import_from_source("oracle", "localhost", schema="ADMIN")
+
+    assert "service name is required" in exc_info.value.reason
+
+
+def test_import_oracle_requires_a_schema():
+    with pytest.raises(DataContractException) as exc_info:
+        DataContract.import_from_source("oracle", "localhost", service_name="XEPDB1")
+
+    assert "schema is required" in exc_info.value.reason
+
+
+def test_import_oracle_requires_a_host():
+    with pytest.raises(DataContractException) as exc_info:
+        DataContract.import_from_source("oracle", None, service_name="XEPDB1", schema="ADMIN")
+
+    assert "host is required" in exc_info.value.reason


### PR DESCRIPTION
## Summary

Adds `datacontract import oracle`, which creates a data contract from a live Oracle database:

```bash
datacontract import oracle --source localhost --service-name XEPDB1 --schema ADMIN --output datacontract.yaml
```

The guide previously told users to pull the DDL out of `DBMS_METADATA.GET_DDL`, import the file with `import sql --dialect oracle`, and then fill in a `servers` block of placeholder values.

**The length rule is shared, not duplicated.** Oracle reports a `DATA_LENGTH` for *every* column, but it is only part of the declared type for character and raw types — otherwise a `DATE` (length 7) would become `DATE(7)` and a `CLOB` (length 4000) `CLOB(4000)`, neither of which matches what the test path reads back. That rule already existed inside `native_type._map_reconstructed`; it is now a named function both paths call.

`--schema` is upper-cased, since Oracle stores identifiers that way and a lower-case owner matches nothing.

## Verified against a real Oracle

Import followed by `datacontract test` on the unedited file: **16/16 checks passed**. The catalog for the seeded table shows why the length rule matters:

```
ORDER_ID    VARCHAR2      len 36    -> VARCHAR2(36)
ORDER_TOTAL NUMBER        len 22, precision 10, scale 2 -> NUMBER(10,2)
ORDERED_AT  TIMESTAMP(6)  len 11    -> TIMESTAMP(6)
NOTES       CLOB          len 4000  -> CLOB
CREATED_ON  DATE          len 7     -> DATE
```

**A bug only the real run could find:** Oracle returns catalog numbers as `Decimal`, and the first contract came out with

```yaml
maxLength: !!python/object/apply:decimal.Decimal
- '36'
```

— a Python-specific YAML tag that no other tool can read and `yaml.safe_load` rejects. They are coerced to `int`, and a test asserts no `!!python` tag appears in the output.

## Testing

`tests/test_import_oracle.py` — 10 tests. The seven that need a database are marked `slow`, matching `test_test_oracle_xe.py`, so they run in the dedicated CI job rather than on every invocation; the three argument-validation tests need no container. All ten pass locally against `gvenzl/oracle-xe:21-slim-faststart`, and the existing Oracle suite still passes.

## Docs

New `imports/oracle.md`; `testing/oracle.md` gets the one-command step 3 with the `DBMS_METADATA` recipe reduced to a fallback, and step 2 renamed to "Authenticate" for consistency.