### PR TITLE
Add Trino import and check its physical types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `datacontract import trino` creates a data contract from a Trino catalog, including a ready-to-test `servers` block
 - `datacontract import oracle` creates a data contract from a live Oracle database, including a ready-to-test `servers` block
 - `datacontract import gcs` and `datacontract import adls` create a data contract from files in Google Cloud Storage or Azure Blob Storage, including a ready-to-test `servers` block
 - `datacontract import sqlserver` creates a data contract from a live SQL Server database, including a ready-to-test `servers` block
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract test` verifies declared primary keys: each key column must have no missing values, and the key must have no duplicates (a composite key is checked as a tuple) (#1220 @DMZ22)
 
 ### Fixed
+- Trino physical type checks were silently skipped: its `information_schema` has no length or precision columns, so the catalog query failed and a wrong `physicalType` still passed
 - `datacontract import athena` and `datacontract import glue` now honour `DATACONTRACT_S3_ACCESS_KEY_ID` and `DATACONTRACT_S3_SECRET_ACCESS_KEY`; the Glue catalog was read with ambient AWS credentials only
 - S3 now uses an existing AWS session (`aws sso login`, `AWS_PROFILE`, instance roles) when no access key is configured; previously such a setup failed with `403 Forbidden`
 - Documented that Athena authenticates with an existing AWS session (`aws sso login`, `AWS_PROFILE`, instance roles); static access keys were presented as the only option

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -50,7 +50,7 @@ class OrderedCommandsWithMigrationHints(OrderedCommands):
 
     # Import formats where `--schema` still means the database schema, so it must
     # not be rewritten to the v0.12.0 `--json-schema`.
-    DATABASE_SCHEMA_IMPORTS = {"snowflake", "redshift", "postgres", "athena", "sqlserver", "oracle"}
+    DATABASE_SCHEMA_IMPORTS = {"snowflake", "redshift", "postgres", "athena", "sqlserver", "oracle", "trino"}
 
     RENAMED_FLAGS = {
         "--format": None,

--- a/datacontract/command_import.py
+++ b/datacontract/command_import.py
@@ -622,6 +622,39 @@ def import_adls(
 
 
 @import_app.command(
+    name="trino",
+    epilog="Example: datacontract import trino --source localhost --catalog my_catalog --schema my_schema --output datacontract.yaml",
+)
+def import_trino(
+    source: Annotated[Optional[str], typer.Option(help="The host of the Trino coordinator.")] = None,
+    port: Annotated[Optional[int], typer.Option(help="The Trino port (default 8080).")] = None,
+    catalog: Annotated[Optional[str], typer.Option(help="The Trino catalog.")] = None,
+    schema: Annotated[Optional[str], typer.Option("--schema", help="The Trino schema.")] = None,
+    table: Annotated[
+        Optional[List[str]],
+        typer.Option(help="Name of a table to import (repeat for multiple tables, omit for all tables)."),
+    ] = None,
+    output: output_option = None,
+    owner: owner_option = None,
+    id: id_option = None,
+    debug: debug_option = None,
+):
+    """Import a data contract from a Trino catalog."""
+    enable_debug_logging(debug)
+    result = DataContract.import_from_source(
+        format="trino",
+        source=source,
+        port=port,
+        catalog=catalog,
+        schema=schema,
+        trino_table=table,
+        owner=owner,
+        id=id,
+    )
+    _write_result(result, output)
+
+
+@import_app.command(
     name="oracle",
     epilog="Example: datacontract import oracle --source localhost --service-name XEPDB1 --schema ADMIN --output datacontract.yaml",
 )

--- a/datacontract/engines/ibis/native_type.py
+++ b/datacontract/engines/ibis/native_type.py
@@ -43,9 +43,9 @@ _CATALOG_STRATEGY = {
     "redshift": "information_schema",
     "snowflake": "information_schema",
     "databricks": "information_schema",
-    "trino": "information_schema",
     "oracle": "oracle",
-    "athena": "athena",
+    "athena": "full_type",
+    "trino": "full_type",
     "bigquery": "bigquery",
 }
 
@@ -205,8 +205,12 @@ def _read_oracle(con, server: Server, model: str) -> Optional[dict[str, str]]:
     return _map_reconstructed(con, query, oracle_length=True)
 
 
-def _read_athena(con, server: Server, model: str) -> Optional[dict[str, str]]:
-    """Athena's information_schema.data_type is already a full type string."""
+def _read_full_type_information_schema(con, server: Server, model: str) -> Optional[dict[str, str]]:
+    """Athena and Trino report a complete type string in ``data_type``.
+
+    Their ``information_schema.columns`` has no length or precision columns at
+    all, so asking for them fails the whole query and silently skips the check.
+    """
     schema_filter = f" AND table_schema = '{_quote(server.schema_)}'" if server.schema_ else ""
     query = (
         "SELECT column_name, data_type FROM information_schema.columns "
@@ -231,7 +235,7 @@ def _read_bigquery(con, server: Server, model: str) -> Optional[dict[str, str]]:
 _READERS = {
     "information_schema": _read_information_schema,
     "oracle": _read_oracle,
-    "athena": _read_athena,
+    "full_type": _read_full_type_information_schema,
     "bigquery": _read_bigquery,
 }
 

--- a/datacontract/imports/importer.py
+++ b/datacontract/imports/importer.py
@@ -50,6 +50,7 @@ class ImportFormat(str, Enum):
     gcs = "gcs"
     adls = "adls"
     oracle = "oracle"
+    trino = "trino"
 
     @classmethod
     def get_supported_formats(cls):

--- a/datacontract/imports/importer_factory.py
+++ b/datacontract/imports/importer_factory.py
@@ -150,6 +150,11 @@ importer_factory.register_lazy_importer(
     class_name="AthenaImporter",
 )
 importer_factory.register_lazy_importer(
+    name=ImportFormat.trino,
+    module_path="datacontract.imports.trino_importer",
+    class_name="TrinoImporter",
+)
+importer_factory.register_lazy_importer(
     name=ImportFormat.oracle,
     module_path="datacontract.imports.oracle_importer",
     class_name="OracleImporter",

--- a/datacontract/imports/trino_importer.py
+++ b/datacontract/imports/trino_importer.py
@@ -1,0 +1,193 @@
+"""Create a data contract from a live Trino catalog.
+
+Reads ``information_schema``, the same catalog ``datacontract test`` reads back
+to verify physical types. Trino reports a complete type string in ``data_type``
+(``varchar(36)``, ``decimal(10,2)``, ``array(varchar)``), so it is taken
+verbatim and an imported contract passes on the first run.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from open_data_contract_standard.model import OpenDataContractStandard, SchemaObject, SchemaProperty, Server
+
+from datacontract.imports.importer import Importer
+from datacontract.imports.odcs_helper import create_odcs, create_property, create_schema_object, create_server
+from datacontract.imports.sql_importer import map_type_from_sql
+from datacontract.model.exceptions import DataContractException
+
+DEFAULT_PORT = 8080
+
+_TABLES_QUERY = """
+    SELECT table_name, table_type
+    FROM {catalog}.information_schema.tables
+    WHERE table_schema = '{schema}'
+"""
+
+_COLUMNS_QUERY = """
+    SELECT table_name, column_name, data_type, is_nullable
+    FROM {catalog}.information_schema.columns
+    WHERE table_schema = '{schema}'
+    ORDER BY table_name, ordinal_position
+"""
+
+
+class TrinoImporter(Importer):
+    def import_source(self, source: str, import_args: dict) -> OpenDataContractStandard:
+        if source is None:
+            raise DataContractException(
+                type="source",
+                name="trino import source",
+                reason="The host is required for the trino import, e.g. --source localhost",
+                engine="datacontract",
+            )
+        return import_trino(
+            host=source,
+            port=import_args.get("port"),
+            catalog=import_args.get("catalog"),
+            schema=import_args.get("schema"),
+            tables=import_args.get("trino_table"),
+        )
+
+
+def import_trino(
+    host: str,
+    catalog: Optional[str],
+    schema: Optional[str] = None,
+    port: Optional[int] = None,
+    tables: Optional[List[str]] = None,
+) -> OpenDataContractStandard:
+    if not catalog:
+        raise DataContractException(
+            type="source",
+            name="trino import catalog",
+            reason="The catalog is required for the trino import, e.g. --catalog my_catalog",
+            engine="datacontract",
+        )
+    if not schema:
+        raise DataContractException(
+            type="source",
+            name="trino import schema",
+            reason="The schema is required for the trino import, e.g. --schema my_schema",
+            engine="datacontract",
+        )
+
+    port = int(port) if port else DEFAULT_PORT
+    server = create_server(name="trino", server_type="trino", host=host, port=port, catalog=catalog, schema=schema)
+
+    connection = trino_connection(server)
+    try:
+        table_rows = _fetch(connection, _TABLES_QUERY.format(catalog=_identifier(catalog), schema=_escape(schema)))
+        column_rows = _fetch(connection, _COLUMNS_QUERY.format(catalog=_identifier(catalog), schema=_escape(schema)))
+    finally:
+        _close(connection)
+
+    selected = _select_tables(table_rows, tables)
+    if not selected:
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="no tables found",
+            reason=f"No tables found in schema '{schema}' of catalog '{catalog}'.",
+            engine="datacontract",
+        )
+
+    odcs = create_odcs()
+    odcs.servers = [server]
+    odcs.schema_ = [
+        _create_schema(table, column_rows) for table in sorted(selected, key=lambda row: row["table_name"].lower())
+    ]
+    return odcs
+
+
+def trino_connection(server: Server):
+    """Connect exactly as `datacontract test` does, so both support the same auth modes."""
+    try:
+        import ibis  # noqa: F401
+    except ImportError as e:
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="trino extra missing",
+            reason="Install the extra datacontract-cli[trino] to use trino",
+            engine="datacontract",
+            original_exception=e,
+        )
+
+    from datacontract.engines.ibis.connections.connect import _connect_trino
+
+    try:
+        return _connect_trino(ibis, server)
+    except Exception as e:
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="trino connection failed",
+            reason=f"Could not connect to Trino at {server.host}:{server.port}: {e}",
+            engine="datacontract",
+            original_exception=e,
+        )
+
+
+def _fetch(connection, query: str) -> List[Dict[str, Any]]:
+    """Run a catalog query and return its rows as dicts keyed by column name."""
+    try:
+        cursor = connection.raw_sql(query)
+        columns = [description[0].lower() for description in cursor.description]
+        return [dict(zip(columns, row)) for row in cursor.fetchall()]
+    except Exception as e:
+        raise DataContractException(
+            type="schema",
+            result="failed",
+            name="trino catalog query failed",
+            reason=f"Could not read the Trino catalog: {e}",
+            engine="datacontract",
+            original_exception=e,
+        )
+
+
+def _close(connection) -> None:
+    try:
+        connection.disconnect()
+    except Exception:  # pragma: no cover - best effort
+        pass
+
+
+def _escape(value: str) -> str:
+    return value.replace("'", "''")
+
+
+def _identifier(value: str) -> str:
+    """The catalog is an identifier, not a literal, so it is quoted rather than escaped."""
+    return '"' + value.replace('"', '""') + '"'
+
+
+def _select_tables(table_rows: List[Dict[str, Any]], tables: Optional[List[str]]) -> List[Dict[str, Any]]:
+    if not tables:
+        return table_rows
+    wanted = {table.lower() for table in tables}
+    return [row for row in table_rows if row["table_name"].lower() in wanted]
+
+
+def _create_schema(table: Dict[str, Any], column_rows: List[Dict[str, Any]]) -> SchemaObject:
+    table_name = table["table_name"]
+    columns = [row for row in column_rows if row["table_name"] == table_name]
+    return create_schema_object(
+        name=table_name,
+        physical_type="view" if "VIEW" in (table.get("table_type") or "").upper() else "table",
+        properties=[_create_property(row) for row in columns] or None,
+    )
+
+
+def _create_property(row: Dict[str, Any]) -> SchemaProperty:
+    # Trino's data_type is already the complete declared type
+    physical_type = row.get("data_type")
+    logical_type, format = map_type_from_sql(physical_type)
+    return create_property(
+        name=row["column_name"],
+        logical_type=logical_type,
+        physical_type=physical_type,
+        required=row.get("is_nullable") in ("NO", False) or None,
+        format=format,
+    )

--- a/docs/docs/commands/import.md
+++ b/docs/docs/commands/import.md
@@ -18,4 +18,4 @@ Run `datacontract import <format> --help` to see format-specific options.
 datacontract import sql --source ddl.sql --dialect postgres --output datacontract.yaml
 ```
 
-Available formats: `adls`, `athena`, `avro`, `bigquery`, `csv`, `databricks`, `dbml`, `dbt`, `excel`, `gcs`, `glue`, `iceberg`, `json`, `jsonschema`, `mysql`, `odcs`, `oracle`, `parquet`, `postgres`, `powerbi`, `protobuf`, `redshift`, `s3`, `snowflake`, `spark`, `sql`, `sqlserver`.
+Available formats: `adls`, `athena`, `avro`, `bigquery`, `csv`, `databricks`, `dbml`, `dbt`, `excel`, `gcs`, `glue`, `iceberg`, `json`, `jsonschema`, `mysql`, `odcs`, `oracle`, `parquet`, `postgres`, `powerbi`, `protobuf`, `redshift`, `s3`, `snowflake`, `spark`, `sql`, `sqlserver`, `trino`.

--- a/docs/docs/imports/index.md
+++ b/docs/docs/imports/index.md
@@ -17,7 +17,7 @@ datacontract import sql --source my_ddl.sql --dialect postgres
 datacontract import sql --source my_ddl.sql --dialect postgres --output datacontract.yaml
 ```
 
-The [Snowflake](./snowflake.md), [BigQuery](./bigquery.md), [Amazon Redshift](./redshift.md), [Postgres](./postgres.md), [MySQL](./mysql.md), [SQL Server](./sqlserver.md), [Oracle](./oracle.md), [Amazon Athena](./athena.md), [Amazon S3](./s3.md), [Google Cloud Storage](./gcs.md), [Azure Blob / ADLS](./adls.md), [Databricks](./databricks.md), and [AWS Glue](./glue.md) importers can connect directly to the live system and introspect your tables — no export files needed. Snowflake, BigQuery, Redshift, Postgres, MySQL, SQL Server, Oracle, Athena, S3, GCS, ADLS, and Databricks also generate a ready-to-test `servers` block, so `datacontract test` works right after the import.
+The [Snowflake](./snowflake.md), [BigQuery](./bigquery.md), [Amazon Redshift](./redshift.md), [Postgres](./postgres.md), [MySQL](./mysql.md), [SQL Server](./sqlserver.md), [Oracle](./oracle.md), [Trino](./trino.md), [Amazon Athena](./athena.md), [Amazon S3](./s3.md), [Google Cloud Storage](./gcs.md), [Azure Blob / ADLS](./adls.md), [Databricks](./databricks.md), and [AWS Glue](./glue.md) importers can connect directly to the live system and introspect your tables — no export files needed. Snowflake, BigQuery, Redshift, Postgres, MySQL, SQL Server, Oracle, Trino, Athena, S3, GCS, ADLS, and Databricks also generate a ready-to-test `servers` block, so `datacontract test` works right after the import.
 
 Run `datacontract import <format> --help` to see the format-specific options (e.g. `datacontract import sql --help`). If a format you need is missing, [open an issue on GitHub](https://github.com/datacontract/datacontract-cli/issues).
 
@@ -135,6 +135,10 @@ Each import page shows a runnable example: a small source file under [`examples/
   <a className="doc-card" href="/imports/sqlserver">
     <img src="/img/icons/sqlserver.svg" alt="" />
     <span><span className="doc-card-title">sqlserver</span><span className="doc-card-desc">A SQL Server database.</span></span>
+  </a>
+  <a className="doc-card" href="/imports/trino">
+    <img src="/img/icons/trino.svg" alt="" />
+    <span><span className="doc-card-title">trino</span><span className="doc-card-desc">A Trino catalog.</span></span>
   </a>
 </div>
 

--- a/docs/docs/imports/trino.md
+++ b/docs/docs/imports/trino.md
@@ -1,0 +1,27 @@
+---
+sidebar_position: 28
+title: "Import: Trino"
+description: "Create a data contract from a Trino catalog."
+---
+
+# <img className="page-icon" src="/img/icons/trino.svg" alt="" /> Import: Trino
+
+Creates a data contract from a Trino catalog by reading `information_schema`, including the declared column types and nullability.
+
+```bash
+datacontract import trino \
+  --source localhost \
+  --catalog my_catalog \
+  --schema my_schema \
+  --output datacontract.yaml
+```
+
+`--source` is the host of your Trino coordinator. Add `--port` if it doesn't listen on the default `8080`, and repeat `--table` to import only specific tables.
+
+Trino reports a complete type string, so `varchar(36)`, `decimal(10,2)` and `array(varchar)` are taken verbatim and match what `datacontract test` reads back.
+
+The generated contract includes a ready-to-test `servers` block, so you can run `datacontract test datacontract.yaml` immediately afterwards — see the **[Trino connection guide](../testing/trino.md)** for the full 5-minute walkthrough and troubleshooting.
+
+Credentials are the same ones `datacontract test` uses — see the [Trino Reference](../reference/trino.md).
+
+Only have a DDL script? Use [`datacontract import sql --dialect postgres`](./sql.md); Trino's ANSI-style DDL generally parses with that dialect.

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -27,6 +27,7 @@ marked as such in the entry.
 ## Unreleased {#unreleased}
 
 ### Added
+- `datacontract import trino` creates a data contract from a Trino catalog, including a ready-to-test `servers` block
 - `datacontract import oracle` creates a data contract from a live Oracle database, including a ready-to-test `servers` block
 - `datacontract import gcs` and `datacontract import adls` create a data contract from files in Google Cloud Storage or Azure Blob Storage, including a ready-to-test `servers` block
 - `datacontract import sqlserver` creates a data contract from a live SQL Server database, including a ready-to-test `servers` block
@@ -44,6 +45,7 @@ marked as such in the entry.
 - `datacontract test` verifies declared primary keys: each key column must have no missing values, and the key must have no duplicates (a composite key is checked as a tuple) ([#1220](https://github.com/datacontract/datacontract-cli/issues/1220) [@DMZ22](https://github.com/DMZ22))
 
 ### Fixed
+- Trino physical type checks were silently skipped: its `information_schema` has no length or precision columns, so the catalog query failed and a wrong `physicalType` still passed
 - `datacontract import athena` and `datacontract import glue` now honour `DATACONTRACT_S3_ACCESS_KEY_ID` and `DATACONTRACT_S3_SECRET_ACCESS_KEY`; the Glue catalog was read with ambient AWS credentials only
 - S3 now uses an existing AWS session (`aws sso login`, `AWS_PROFILE`, instance roles) when no access key is configured; previously such a setup failed with `403 Forbidden`
 - Documented that Athena authenticates with an existing AWS session (`aws sso login`, `AWS_PROFILE`, instance roles); static access keys were presented as the only option

--- a/docs/docs/testing/trino.md
+++ b/docs/docs/testing/trino.md
@@ -16,7 +16,7 @@ uv tool install --python python3.11 --upgrade 'datacontract-cli[trino]'
 
 See [Installation](../installation.md) for pip, pipx, and Docker.
 
-## 2. Set credentials
+## 2. Authenticate
 
 Create a `.env` file in your working directory (or export the variables):
 
@@ -30,23 +30,20 @@ The default is `basic` auth; JWT and OAuth2 are also supported — see the [Trin
 
 ## 3. Create a contract from your tables
 
-Get the DDL of a table (`SHOW CREATE TABLE my_catalog.my_schema.orders;`), save it to a file, and import it. Trino's ANSI-style DDL generally parses well with the `postgres` dialect:
+Import the table metadata directly from the catalog. This also generates a ready-to-test `servers` block:
 
 ```bash
-datacontract import sql --source orders.sql --dialect postgres --output datacontract.yaml
+datacontract import trino \
+  --source localhost \
+  --catalog my_catalog \
+  --schema my_schema \
+  --table orders \
+  --output datacontract.yaml
 ```
 
-The SQL import can't know your connection details, so it writes a `servers` block with placeholder values. Open `datacontract.yaml` and fill in your cluster:
+Repeat `--table` for multiple tables, or omit it to import every table in the schema.
 
-```yaml
-servers:
-  - server: trino
-    type: trino
-    host: localhost
-    port: 8080
-    catalog: my_catalog
-    schema: my_schema
-```
+Only have a DDL script? `datacontract import sql --source orders.sql --dialect postgres` works too — Trino's ANSI-style DDL generally parses with that dialect — but writes a `servers` block with placeholder values that you have to fill in by hand.
 
 ## 4. Test the actual data
 
@@ -55,7 +52,16 @@ datacontract test datacontract.yaml
 ```
 
 ```
-🟢 data contract is valid. Run 24 checks. Took 4.4 seconds.
+Testing datacontract.yaml
+Server: trino (type=trino, host=localhost, port=8080, catalog=my_catalog, schema=my_schema)
+╭────────┬─────────────────────────────────────────────────┬─────────────────┬─────────╮
+│ Result │ Check                                           │ Field           │ Details │
+├────────┼─────────────────────────────────────────────────┼─────────────────┼─────────┤
+│ passed │ Check that field 'order_id' is present          │ orders.order_id │         │
+│ passed │ Check that field order_id has no missing values │ orders.order_id │         │
+│  ...   │                                                 │                 │         │
+╰────────┴─────────────────────────────────────────────────┴─────────────────┴─────────╯
+🟢 data contract is valid. Run 24 checks. Took 1.9 seconds.
 ```
 
 ## 5. Let it catch a violation

--- a/tests/test_import_trino.py
+++ b/tests/test_import_trino.py
@@ -1,0 +1,139 @@
+"""Tests for the Trino importer, run against a real Trino container.
+
+The container helper is the one the other Trino suite uses: waiting for the logs
+is not enough, the catalog has to answer.
+"""
+
+import pytest
+import trino as trino_client
+
+from datacontract.data_contract import DataContract
+from datacontract.model.exceptions import DataContractException
+from datacontract.model.run import ResultEnum
+from tests.test_test_trino import TrinoContainer
+
+TRINO_PORT = 8080
+CATALOG = "memory"
+SCHEMA = "shop"
+
+SEED = [
+    f"CREATE SCHEMA IF NOT EXISTS {CATALOG}.{SCHEMA}",
+    f"""CREATE TABLE IF NOT EXISTS {CATALOG}.{SCHEMA}.orders (
+          order_id varchar(36), order_total decimal(10,2), line_count integer,
+          ordered_at timestamp(3), tags array(varchar), notes varchar)""",
+    f"INSERT INTO {CATALOG}.{SCHEMA}.orders VALUES ('CX-263-DU', 50.00, 2, current_timestamp(3), ARRAY['a'], 'hi')",
+    f"CREATE TABLE IF NOT EXISTS {CATALOG}.{SCHEMA}.customers (id integer)",
+]
+
+trino_container = TrinoContainer()
+
+
+@pytest.fixture(scope="module")
+def trino_server(request):
+    trino_container.start()
+    request.addfinalizer(trino_container.stop)
+    _seed()
+
+
+@pytest.fixture
+def credentials(monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_TRINO_USERNAME", "my_user")
+    monkeypatch.setenv("DATACONTRACT_TRINO_PASSWORD", "")
+
+
+def _port():
+    return int(trino_container.get_exposed_port(TRINO_PORT))
+
+
+def _seed():
+    connection = trino_client.dbapi.connect(
+        host=trino_container.get_container_host_ip(), port=_port(), user="my_user", catalog=CATALOG
+    )
+    cursor = connection.cursor()
+    for statement in SEED:
+        cursor.execute(statement)
+        cursor.fetchall()
+    connection.close()
+
+
+def _import(**kwargs):
+    kwargs.setdefault("catalog", CATALOG)
+    kwargs.setdefault("schema", SCHEMA)
+    kwargs.setdefault("port", _port())
+    return DataContract.import_from_source("trino", trino_container.get_container_host_ip(), **kwargs)
+
+
+def test_import_trino_takes_the_declared_type_verbatim(trino_server, credentials):
+    result = _import(trino_table=["orders"])
+    types = {prop.name: prop.physicalType for prop in result.schema_[0].properties}
+
+    assert types == {
+        "order_id": "varchar(36)",
+        "order_total": "decimal(10,2)",
+        "line_count": "integer",
+        "ordered_at": "timestamp(3)",
+        "tags": "array(varchar)",
+        "notes": "varchar",
+    }
+
+
+def test_imported_contract_passes_test_without_editing(trino_server, credentials):
+    """The point of the native import: import, then test, no hand-editing."""
+    result = _import(trino_table=["orders"])
+
+    run = DataContract(data_contract_str=result.to_yaml()).test()
+
+    print(run.pretty())
+    assert run.result == ResultEnum.passed
+
+
+def test_a_wrong_physical_type_is_caught(trino_server, credentials):
+    """Trino's information_schema has no length columns, so asking for them used
+    to fail the whole query and skip this check silently."""
+    result = _import(trino_table=["orders"])
+    result.schema_[0].properties[0].physicalType = "integer"
+
+    run = DataContract(data_contract_str=result.to_yaml()).test()
+
+    assert run.result == ResultEnum.failed
+    assert any("varchar(36)" in (check.reason or "") for check in run.checks)
+
+
+def test_import_trino_produces_a_valid_contract(trino_server, credentials):
+    result = _import()
+
+    assert DataContract(data_contract_str=result.to_yaml()).lint().result == ResultEnum.passed
+
+
+def test_import_trino_imports_all_tables_by_default(trino_server, credentials):
+    result = _import()
+
+    assert [schema.name for schema in result.schema_] == ["customers", "orders"]
+
+
+def test_import_trino_fails_on_an_unknown_table(trino_server, credentials):
+    with pytest.raises(DataContractException) as exc_info:
+        _import(trino_table=["does_not_exist"])
+
+    assert "No tables found" in exc_info.value.reason
+
+
+def test_import_trino_requires_a_catalog():
+    with pytest.raises(DataContractException) as exc_info:
+        DataContract.import_from_source("trino", "localhost", schema="s")
+
+    assert "catalog is required" in exc_info.value.reason
+
+
+def test_import_trino_requires_a_schema():
+    with pytest.raises(DataContractException) as exc_info:
+        DataContract.import_from_source("trino", "localhost", catalog="c")
+
+    assert "schema is required" in exc_info.value.reason
+
+
+def test_import_trino_requires_a_host():
+    with pytest.raises(DataContractException) as exc_info:
+        DataContract.import_from_source("trino", None, catalog="c", schema="s")
+
+    assert "host is required" in exc_info.value.reason


### PR DESCRIPTION
## Summary

Adds `datacontract import trino`, and fixes a silent hole in Trino testing found while building it.

```bash
datacontract import trino --source localhost --catalog my_catalog --schema my_schema --output datacontract.yaml
```

The guide previously said: run `SHOW CREATE TABLE`, save the DDL, import it with the `postgres` dialect, then fill in a `servers` block of placeholder values.

## Trino physical type checks never ran

`_CATALOG_STRATEGY` mapped Trino to the `information_schema` reader, which selects `character_maximum_length`, `numeric_precision` and `numeric_scale`. Trino's `information_schema.columns` has none of those — it has eight columns and no length or precision at all:

```
table_catalog, table_schema, table_name, column_name,
ordinal_position, column_default, is_nullable, data_type
```

So the query failed with `COLUMN_NOT_FOUND`, `_rows()` swallowed it, and the check was skipped with a debug log nobody sees.

**Demonstrated against a real Trino.** A contract declaring `order_id` as `integer` when the column is `varchar(36)`:

| strategy | result |
|---|---|
| before (`information_schema`) | 🟢 passes — check silently skipped |
| after (`full_type`) | 🔴 `expected physical type 'integer' but the column is 'varchar(36)'` |

Trino's `data_type` is already a complete type string, the same shape Athena reports, so both now share that reader — renamed from `_read_athena` to `_read_full_type_information_schema` since it is no longer Athena-specific.

## Verified against a real Trino

Import followed by `datacontract test` on the unedited file: **12/12 checks passed**, with the types taken verbatim:

```
varchar(36)   decimal(10,2)   integer   timestamp(3)   array(varchar)   varchar
```

Those physical type checks are now genuinely evaluated rather than skipped.

## Testing

`tests/test_import_trino.py` — 9 tests against a real Trino container, reusing the container helper the existing suite defines. One pins the fix directly: a wrong `physicalType` must now fail. The existing Trino suites pass unchanged (17 tests total).

## Docs

New `imports/trino.md`; `testing/trino.md` gets the one-command step 3, step 2 renamed to "Authenticate", and step 4 now shows the check table like the other guides instead of only the summary line.