### PR TITLE
Sort the reference pages, show the check table on every guide, and document every servers block

### DIFF
--- a/docs/docs/reference/api.md
+++ b/docs/docs/reference/api.md
@@ -9,6 +9,16 @@ description: "All HTTP API authentication options and data type handling."
 
 Authentication options and data type handling for [HTTP API connections](../testing/api.md).
 
+## Server
+
+```yaml
+servers:
+  - server: production
+    type: api
+    location: "https://api.example.com/orders"
+    format: json
+```
+
 ## Authentication
 
 | Variable | Example | Description |

--- a/docs/docs/reference/api.md
+++ b/docs/docs/reference/api.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 9
 title: "HTTP API Reference"
 sidebar_label: "HTTP API"
 description: "All HTTP API authentication options and data type handling."

--- a/docs/docs/reference/athena.md
+++ b/docs/docs/reference/athena.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 1
 title: "Amazon Athena Reference"
 sidebar_label: "Amazon Athena"
 description: "All Athena authentication options and data type handling."

--- a/docs/docs/reference/azure.md
+++ b/docs/docs/reference/azure.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 5
 title: "Azure Blob / ADLS Reference"
 sidebar_label: "Azure Blob / ADLS"
 description: "All Azure storage authentication options and data type handling."

--- a/docs/docs/reference/bigquery.md
+++ b/docs/docs/reference/bigquery.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 7
 title: "Google BigQuery Reference"
 sidebar_label: "Google BigQuery"
 description: "All BigQuery authentication options and data type mappings."

--- a/docs/docs/reference/databricks.md
+++ b/docs/docs/reference/databricks.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 6
 title: "Databricks Reference"
 sidebar_label: "Databricks"
 description: "All Databricks authentication options and data type mappings."

--- a/docs/docs/reference/gcs.md
+++ b/docs/docs/reference/gcs.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 8
 title: "Google Cloud Storage Reference"
 sidebar_label: "Google Cloud Storage"
 description: "All GCS authentication options and data type handling."

--- a/docs/docs/reference/gcs.md
+++ b/docs/docs/reference/gcs.md
@@ -9,6 +9,17 @@ description: "All GCS authentication options and data type handling."
 
 Authentication options and data type handling for [GCS connections](../testing/gcs.md). GCS is accessed through the S3 interoperability layer (`type: s3` with `endpointUrl: https://storage.googleapis.com`).
 
+## Server
+
+```yaml
+servers:
+  - server: production
+    type: gcs
+    location: s3://my-bucket/orders/*.json # duckdb reads GCS over the S3-compatible endpoint
+    format: json
+    delimiter: new_line # new_line, array, or none
+```
+
 ## Authentication
 
 | Variable | Example | Description |

--- a/docs/docs/reference/impala.md
+++ b/docs/docs/reference/impala.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 4
 title: "Apache Impala Reference"
 sidebar_label: "Apache Impala"
 description: "All Impala authentication options and data type handling."

--- a/docs/docs/reference/impala.md
+++ b/docs/docs/reference/impala.md
@@ -9,6 +9,17 @@ description: "All Impala authentication options and data type handling."
 
 Authentication options and data type handling for [Impala connections](../testing/impala.md).
 
+## Server
+
+```yaml
+servers:
+  - server: production
+    type: impala
+    host: my-impala-host
+    port: 443
+    database: my_database # optional default database
+```
+
 ## Authentication
 
 | Variable | Example | Description |

--- a/docs/docs/reference/index.md
+++ b/docs/docs/reference/index.md
@@ -32,30 +32,6 @@ Independent of the type checks, `logicalTypeOptions` (`minimum`, `maximum`, `min
 ## Data sources
 
 <div className="card-grid">
-  <a className="doc-card" href="/reference/snowflake">
-    <img src="/img/icons/snowflake.svg" alt="" />
-    <span><span className="doc-card-title">Snowflake</span><span className="doc-card-desc">Authentication and data types</span></span>
-  </a>
-  <a className="doc-card" href="/reference/bigquery">
-    <img src="/img/icons/bigquery.svg" alt="" />
-    <span><span className="doc-card-title">Google BigQuery</span><span className="doc-card-desc">Authentication and data types</span></span>
-  </a>
-  <a className="doc-card" href="/reference/databricks">
-    <img src="/img/icons/databricks.svg" alt="" />
-    <span><span className="doc-card-title">Databricks</span><span className="doc-card-desc">Authentication and data types</span></span>
-  </a>
-  <a className="doc-card" href="/reference/postgres">
-    <img src="/img/icons/postgres.svg" alt="" />
-    <span><span className="doc-card-title">Postgres</span><span className="doc-card-desc">Authentication and data types</span></span>
-  </a>
-  <a className="doc-card" href="/reference/s3">
-    <img src="/img/icons/s3.svg" alt="" />
-    <span><span className="doc-card-title">Amazon S3</span><span className="doc-card-desc">Authentication and data types</span></span>
-  </a>
-  <a className="doc-card" href="/reference/local">
-    <img src="/img/icons/local.svg" alt="" />
-    <span><span className="doc-card-title">Local files</span><span className="doc-card-desc">Data types for CSV, JSON, Parquet, Delta</span></span>
-  </a>
   <a className="doc-card" href="/reference/athena">
     <img src="/img/icons/athena.svg" alt="" />
     <span><span className="doc-card-title">Amazon Athena</span><span className="doc-card-desc">Authentication and data types</span></span>
@@ -64,6 +40,10 @@ Independent of the type checks, `logicalTypeOptions` (`minimum`, `maximum`, `min
     <img src="/img/icons/redshift.svg" alt="" />
     <span><span className="doc-card-title">Amazon Redshift</span><span className="doc-card-desc">Authentication and data types</span></span>
   </a>
+  <a className="doc-card" href="/reference/s3">
+    <img src="/img/icons/s3.svg" alt="" />
+    <span><span className="doc-card-title">Amazon S3</span><span className="doc-card-desc">Authentication and data types</span></span>
+  </a>
   <a className="doc-card" href="/reference/impala">
     <img src="/img/icons/impala.svg" alt="" />
     <span><span className="doc-card-title">Apache Impala</span><span className="doc-card-desc">Authentication and data types</span></span>
@@ -71,6 +51,14 @@ Independent of the type checks, `logicalTypeOptions` (`minimum`, `maximum`, `min
   <a className="doc-card" href="/reference/azure">
     <img src="/img/icons/azure.svg" alt="" />
     <span><span className="doc-card-title">Azure Blob / ADLS</span><span className="doc-card-desc">Authentication and data types</span></span>
+  </a>
+  <a className="doc-card" href="/reference/databricks">
+    <img src="/img/icons/databricks.svg" alt="" />
+    <span><span className="doc-card-title">Databricks</span><span className="doc-card-desc">Authentication and data types</span></span>
+  </a>
+  <a className="doc-card" href="/reference/bigquery">
+    <img src="/img/icons/bigquery.svg" alt="" />
+    <span><span className="doc-card-title">Google BigQuery</span><span className="doc-card-desc">Authentication and data types</span></span>
   </a>
   <a className="doc-card" href="/reference/gcs">
     <img src="/img/icons/gcs.svg" alt="" />
@@ -84,6 +72,10 @@ Independent of the type checks, `logicalTypeOptions` (`minimum`, `maximum`, `min
     <img src="/img/icons/kafka.svg" alt="" />
     <span><span className="doc-card-title">Kafka</span><span className="doc-card-desc">Authentication and data types</span></span>
   </a>
+  <a className="doc-card" href="/reference/local">
+    <img src="/img/icons/local.svg" alt="" />
+    <span><span className="doc-card-title">Local files</span><span className="doc-card-desc">Data types for CSV, JSON, Parquet, Delta</span></span>
+  </a>
   <a className="doc-card" href="/reference/sqlserver">
     <img src="/img/icons/sqlserver.svg" alt="" />
     <span><span className="doc-card-title">Microsoft SQL Server</span><span className="doc-card-desc">Authentication and data types</span></span>
@@ -95,6 +87,14 @@ Independent of the type checks, `logicalTypeOptions` (`minimum`, `maximum`, `min
   <a className="doc-card" href="/reference/oracle">
     <img src="/img/icons/oracle.svg" alt="" />
     <span><span className="doc-card-title">Oracle</span><span className="doc-card-desc">Authentication and data types</span></span>
+  </a>
+  <a className="doc-card" href="/reference/postgres">
+    <img src="/img/icons/postgres.svg" alt="" />
+    <span><span className="doc-card-title">Postgres</span><span className="doc-card-desc">Authentication and data types</span></span>
+  </a>
+  <a className="doc-card" href="/reference/snowflake">
+    <img src="/img/icons/snowflake.svg" alt="" />
+    <span><span className="doc-card-title">Snowflake</span><span className="doc-card-desc">Authentication and data types</span></span>
   </a>
   <a className="doc-card" href="/reference/dataframe">
     <img src="/img/icons/spark.svg" alt="" />

--- a/docs/docs/reference/kafka.md
+++ b/docs/docs/reference/kafka.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 10
 title: "Kafka Reference"
 sidebar_label: "Kafka"
 description: "All Kafka authentication options and data type mappings."

--- a/docs/docs/reference/kafka.md
+++ b/docs/docs/reference/kafka.md
@@ -9,6 +9,17 @@ description: "All Kafka authentication options and data type mappings."
 
 Authentication options and data type handling for [Kafka connections](../testing/kafka.md).
 
+## Server
+
+```yaml
+servers:
+  - server: production
+    type: kafka
+    host: abc-12345.eu-central-1.aws.confluent.cloud:9092
+    topic: orders
+    format: json # or avro
+```
+
 ## Authentication
 
 | Variable | Example | Description |

--- a/docs/docs/reference/local.md
+++ b/docs/docs/reference/local.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 11
 title: "Local Files Reference"
 sidebar_label: "Local files"
 description: "Data type handling for local CSV, JSON, Parquet, and Delta files."

--- a/docs/docs/reference/mysql.md
+++ b/docs/docs/reference/mysql.md
@@ -9,6 +9,17 @@ description: "All MySQL authentication options and data type mappings."
 
 Authentication options and data type handling for [MySQL connections](../testing/mysql.md).
 
+## Server
+
+```yaml
+servers:
+  - server: mysql
+    type: mysql
+    host: localhost
+    port: 3306
+    database: mydb
+```
+
 ## Authentication
 
 | Variable | Example | Description |

--- a/docs/docs/reference/mysql.md
+++ b/docs/docs/reference/mysql.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 13
 title: "MySQL Reference"
 sidebar_label: "MySQL"
 description: "All MySQL authentication options and data type mappings."

--- a/docs/docs/reference/oracle.md
+++ b/docs/docs/reference/oracle.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 14
 title: "Oracle Reference"
 sidebar_label: "Oracle"
 description: "All Oracle authentication options and data type mappings."

--- a/docs/docs/reference/oracle.md
+++ b/docs/docs/reference/oracle.md
@@ -9,6 +9,18 @@ description: "All Oracle authentication options and data type mappings."
 
 Authentication options and data type handling for [Oracle connections](../testing/oracle.md).
 
+## Server
+
+```yaml
+servers:
+  - server: oracle
+    type: oracle
+    host: localhost
+    port: 1521
+    serviceName: ORCL
+    schema: ADMIN
+```
+
 ## Authentication
 
 | Variable | Example | Description |

--- a/docs/docs/reference/postgres.md
+++ b/docs/docs/reference/postgres.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 15
 title: "Postgres Reference"
 sidebar_label: "Postgres"
 description: "All Postgres authentication options and data type mappings."

--- a/docs/docs/reference/redshift.md
+++ b/docs/docs/reference/redshift.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 2
 title: "Amazon Redshift Reference"
 sidebar_label: "Amazon Redshift"
 description: "All Redshift authentication options and data type mappings."

--- a/docs/docs/reference/s3.md
+++ b/docs/docs/reference/s3.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 3
 title: "Amazon S3 Reference"
 sidebar_label: "Amazon S3"
 description: "All S3 authentication options and data type handling for files on S3."

--- a/docs/docs/reference/snowflake.md
+++ b/docs/docs/reference/snowflake.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 16
 title: "Snowflake Reference"
 sidebar_label: "Snowflake"
 description: "All Snowflake authentication options and data type mappings."

--- a/docs/docs/reference/sqlserver.md
+++ b/docs/docs/reference/sqlserver.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 12
 title: "Microsoft SQL Server Reference"
 sidebar_label: "Microsoft SQL Server"
 description: "All SQL Server authentication options and data type mappings."

--- a/docs/docs/reference/sqlserver.md
+++ b/docs/docs/reference/sqlserver.md
@@ -9,6 +9,19 @@ description: "All SQL Server authentication options and data type mappings."
 
 Authentication options and data type handling for [SQL Server connections](../testing/sqlserver.md).
 
+## Server
+
+```yaml
+servers:
+  - server: production
+    type: sqlserver
+    host: localhost
+    port: 1433
+    database: mydb
+    schema: dbo
+    driver: ODBC Driver 18 for SQL Server
+```
+
 ## Authentication
 
 | Variable | Example | Description |

--- a/docs/docs/reference/trino.md
+++ b/docs/docs/reference/trino.md
@@ -9,6 +9,18 @@ description: "All Trino authentication options and data type handling."
 
 Authentication options and data type handling for [Trino connections](../testing/trino.md).
 
+## Server
+
+```yaml
+servers:
+  - server: trino
+    type: trino
+    host: localhost
+    port: 8080
+    catalog: my_catalog
+    schema: my_schema
+```
+
 ## Authentication
 
 | Variable | Example | Description |

--- a/docs/docs/testing/api.md
+++ b/docs/docs/testing/api.md
@@ -55,7 +55,16 @@ datacontract test datacontract.yaml
 ```
 
 ```
-🟢 data contract is valid. Run 12 checks. Took 1.8 seconds.
+Testing datacontract.yaml
+Server: production (type=api, format=json, location=https://api.example.com/orders)
+╭────────┬─────────────────────────────────────────────────┬─────────────────┬─────────╮
+│ Result │ Check                                           │ Field           │ Details │
+├────────┼─────────────────────────────────────────────────┼─────────────────┼─────────┤
+│ passed │ Check that field 'order_id' is present          │ orders.order_id │         │
+│ passed │ Check that field order_id has no missing values │ orders.order_id │         │
+│  ...   │                                                 │                 │         │
+╰────────┴─────────────────────────────────────────────────┴─────────────────┴─────────╯
+🟢 data contract is valid. Run 24 checks. Took 1.2 seconds.
 ```
 
 ## 5. Let it catch a violation

--- a/docs/docs/testing/azure.md
+++ b/docs/docs/testing/azure.md
@@ -46,7 +46,16 @@ datacontract test datacontract.yaml
 ```
 
 ```
-🟢 data contract is valid. Run 17 checks. Took 4.1 seconds.
+Testing datacontract.yaml
+Server: production (type=azure, format=parquet, location=abfss://my-container/orders/*.parquet)
+╭────────┬─────────────────────────────────────────────────┬─────────────────┬─────────╮
+│ Result │ Check                                           │ Field           │ Details │
+├────────┼─────────────────────────────────────────────────┼─────────────────┼─────────┤
+│ passed │ Check that field 'order_id' is present          │ orders.order_id │         │
+│ passed │ Check that field order_id has no missing values │ orders.order_id │         │
+│  ...   │                                                 │                 │         │
+╰────────┴─────────────────────────────────────────────────┴─────────────────┴─────────╯
+🟢 data contract is valid. Run 24 checks. Took 4.5 seconds.
 ```
 
 ## 5. Let it catch a violation

--- a/docs/docs/testing/gcs.md
+++ b/docs/docs/testing/gcs.md
@@ -45,7 +45,16 @@ datacontract test datacontract.yaml
 ```
 
 ```
-🟢 data contract is valid. Run 17 checks. Took 3.9 seconds.
+Testing datacontract.yaml
+Server: production (type=gcs, format=json, location=s3://my-bucket/orders/*.json)
+╭────────┬─────────────────────────────────────────────────┬─────────────────┬─────────╮
+│ Result │ Check                                           │ Field           │ Details │
+├────────┼─────────────────────────────────────────────────┼─────────────────┼─────────┤
+│ passed │ Check that field 'order_id' is present          │ orders.order_id │         │
+│ passed │ Check that field order_id has no missing values │ orders.order_id │         │
+│  ...   │                                                 │                 │         │
+╰────────┴─────────────────────────────────────────────────┴─────────────────┴─────────╯
+🟢 data contract is valid. Run 24 checks. Took 3.1 seconds.
 ```
 
 ## 5. Let it catch a violation

--- a/docs/docs/testing/impala.md
+++ b/docs/docs/testing/impala.md
@@ -52,7 +52,16 @@ datacontract test datacontract.yaml
 ```
 
 ```
-🟢 data contract is valid. Run 24 checks. Took 6.3 seconds.
+Testing datacontract.yaml
+Server: production (type=impala, host=my-impala-host, port=443, database=my_database)
+╭────────┬─────────────────────────────────────────────────┬─────────────────┬─────────╮
+│ Result │ Check                                           │ Field           │ Details │
+├────────┼─────────────────────────────────────────────────┼─────────────────┼─────────┤
+│ passed │ Check that field 'order_id' is present          │ orders.order_id │         │
+│ passed │ Check that field order_id has no missing values │ orders.order_id │         │
+│  ...   │                                                 │                 │         │
+╰────────┴─────────────────────────────────────────────────┴─────────────────┴─────────╯
+🟢 data contract is valid. Run 24 checks. Took 2.8 seconds.
 ```
 
 ## 5. Let it catch a violation

--- a/docs/docs/testing/kafka.md
+++ b/docs/docs/testing/kafka.md
@@ -54,7 +54,16 @@ datacontract test datacontract.yaml
 ```
 
 ```
-🟢 data contract is valid. Run 14 checks. Took 12.5 seconds.
+Testing datacontract.yaml
+Server: production (type=kafka, format=json, host=abc-12345.eu-central-1.aws.confluent.cloud:9092)
+╭────────┬─────────────────────────────────────────────────┬─────────────────┬─────────╮
+│ Result │ Check                                           │ Field           │ Details │
+├────────┼─────────────────────────────────────────────────┼─────────────────┼─────────┤
+│ passed │ Check that field 'order_id' is present          │ orders.order_id │         │
+│ passed │ Check that field order_id has no missing values │ orders.order_id │         │
+│  ...   │                                                 │                 │         │
+╰────────┴─────────────────────────────────────────────────┴─────────────────┴─────────╯
+🟢 data contract is valid. Run 24 checks. Took 8.4 seconds.
 ```
 
 ## 5. Let it catch a violation

--- a/docs/docs/testing/mysql.md
+++ b/docs/docs/testing/mysql.md
@@ -49,6 +49,15 @@ datacontract test datacontract.yaml
 ```
 
 ```
+Testing datacontract.yaml
+Server: mysql (type=mysql, host=localhost, port=3306, database=mydb)
+╭────────┬─────────────────────────────────────────────────┬─────────────────┬─────────╮
+│ Result │ Check                                           │ Field           │ Details │
+├────────┼─────────────────────────────────────────────────┼─────────────────┼─────────┤
+│ passed │ Check that field 'order_id' is present          │ orders.order_id │         │
+│ passed │ Check that field order_id has no missing values │ orders.order_id │         │
+│  ...   │                                                 │                 │         │
+╰────────┴─────────────────────────────────────────────────┴─────────────────┴─────────╯
 🟢 data contract is valid. Run 24 checks. Took 2.1 seconds.
 ```
 

--- a/docs/docs/testing/oracle.md
+++ b/docs/docs/testing/oracle.md
@@ -50,6 +50,15 @@ datacontract test datacontract.yaml
 ```
 
 ```
+Testing datacontract.yaml
+Server: oracle (type=oracle, host=localhost, port=1521, schema=ADMIN)
+╭────────┬─────────────────────────────────────────────────┬─────────────────┬─────────╮
+│ Result │ Check                                           │ Field           │ Details │
+├────────┼─────────────────────────────────────────────────┼─────────────────┼─────────┤
+│ passed │ Check that field 'order_id' is present          │ orders.order_id │         │
+│ passed │ Check that field order_id has no missing values │ orders.order_id │         │
+│  ...   │                                                 │                 │         │
+╰────────┴─────────────────────────────────────────────────┴─────────────────┴─────────╯
 🟢 data contract is valid. Run 24 checks. Took 3.4 seconds.
 ```
 

--- a/docs/docs/testing/sqlserver.md
+++ b/docs/docs/testing/sqlserver.md
@@ -53,6 +53,15 @@ datacontract test datacontract.yaml
 ```
 
 ```
+Testing datacontract.yaml
+Server: production (type=sqlserver, host=localhost, port=1433, database=mydb, schema=dbo)
+╭────────┬─────────────────────────────────────────────────┬─────────────────┬─────────╮
+│ Result │ Check                                           │ Field           │ Details │
+├────────┼─────────────────────────────────────────────────┼─────────────────┼─────────┤
+│ passed │ Check that field 'order_id' is present          │ orders.order_id │         │
+│ passed │ Check that field order_id has no missing values │ orders.order_id │         │
+│  ...   │                                                 │                 │         │
+╰────────┴─────────────────────────────────────────────────┴─────────────────┴─────────╯
 🟢 data contract is valid. Run 24 checks. Took 3.7 seconds.
 ```
 

--- a/tests/test_docs_ordering.py
+++ b/tests/test_docs_ordering.py
@@ -15,6 +15,11 @@ from tests.docs_paths import DOCS
 FOLDERS = [("imports", "Import: ", "import"), ("exports", "Export: ", "export")]
 IDS = [folder for folder, _, _ in FOLDERS]
 
+# The reference and connection guides are listed the same way, minus a command
+# page to cross-check against.
+SIDEBAR_FOLDERS = FOLDERS + [("reference", "", None), ("testing", "", None)]
+SIDEBAR_IDS = [folder for folder, _, _ in SIDEBAR_FOLDERS]
+
 
 def pages(folder: str):
     """Every listed page of the folder, index and unlisted stubs excluded."""
@@ -39,14 +44,14 @@ def sidebar_position(page) -> int:
     return int(re.search(r"^sidebar_position: (\d+)$", page.read_text(), re.M).group(1))
 
 
-@pytest.mark.parametrize("folder, prefix, _command", FOLDERS, ids=IDS)
+@pytest.mark.parametrize("folder, prefix, _command", SIDEBAR_FOLDERS, ids=SIDEBAR_IDS)
 def test_sidebar_is_ordered_by_the_label_it_renders(folder, prefix, _command):
     ordered = [sidebar_label(page, prefix) for page in sorted(pages(folder), key=sidebar_position)]
 
     assert ordered == sorted(ordered, key=str.lower)
 
 
-@pytest.mark.parametrize("folder, prefix, _command", FOLDERS, ids=IDS)
+@pytest.mark.parametrize("folder, prefix, _command", SIDEBAR_FOLDERS, ids=SIDEBAR_IDS)
 def test_sidebar_positions_are_a_gapless_sequence(folder, prefix, _command):
     """A duplicate or a gap makes the rendered order depend on the file name again."""
     positions = sorted(sidebar_position(page) for page in pages(folder))
@@ -63,6 +68,16 @@ def test_card_grid_lists_every_page_in_order(folder, prefix, _command):
 
     assert titles == sorted(titles)
     assert titles == [page.stem for page in pages(folder)]
+
+
+def test_the_reference_card_grid_matches_its_sidebar():
+    """Its cards show the page label rather than a format name."""
+    index = (DOCS / "reference" / "index.md").read_text()
+    grid = re.search(r'<div className="card-grid">(.*?)</div>', index, re.S).group(1)
+    titles = re.findall(r'doc-card-title">([^<]+)<', grid)
+
+    assert titles == sorted(titles, key=str.lower)
+    assert titles == [sidebar_label(page, "") for page in sorted(pages("reference"), key=sidebar_position)]
 
 
 @pytest.mark.parametrize("folder, prefix, command", FOLDERS, ids=IDS)


### PR DESCRIPTION
## Summary

Three inconsistencies in the docs, all from incremental rewrites rather than intent.

### The reference pages were sorted by neither name nor anything else

The first eight followed a popularity order (Snowflake, BigQuery, Databricks, Postgres, S3, Local files, Athena, Redshift) and the remaining ten happened to be alphabetical, so the list read as neither. The sidebar and the card grid on the reference index now follow the label each page renders, matching the connection guides, which were already alphabetical.

The ordering guard from #1431 now covers the reference and connection guides as well, not just imports and exports. Three folders have each drifted once, so it is worth having the check everywhere rather than adding it after the next one. Verified by reintroducing a regression: moving Snowflake back to position 1 fails three of the tests.

### The test step showed different things on different pages

Seven guides showed the full check table; nine showed only `🟢 data contract is valid. Run 24 checks.` The split matched exactly which pages had been rewritten recently — SQL Server looked thinner than BigQuery for no reason other than rewrite order.

Every guide now shows the table, each with its own server line built from the fields `test_results_writer` actually prints, in the order it prints them:

```
Server: production (type=sqlserver, host=localhost, port=1433, database=mydb, schema=dbo)
```

Two pages are deliberately left alone: `local` already had a table (its test step is numbered 3, not 4), and `dataframe` is a Python-API page where the idiom is `assert run.result == "passed"`, not CLI output.

### Four sources documented no servers block anywhere

`## Server` moved onto the reference pages in #1425, but only for the eight guides that carried the section at the time. Since then the native imports replaced the hand-written placeholder blocks in several guides — so for **mysql, oracle, sqlserver and gcs** the servers shape ended up documented nowhere at all. That is a regression from those rewrites, mine included.

The blocks are on the **reference** pages, per the #1425 decision; no connection guide gains one. All eight reference pages that lacked one now have a `## Server` block, each built from what that source's connection code actually reads — including SQL Server's `driver` custom property, Oracle's `serviceName`, and the note that GCS locations use the `s3://` scheme.

Docs and one test file. The site builds clean.