### PR TITLE
Escape the MySQL catalog statement for both layers

### DIFF
--- a/datacontract/imports/mysql_importer.py
+++ b/datacontract/imports/mysql_importer.py
@@ -27,14 +27,14 @@ DEFAULT_PORT = 3306
 _TABLES_QUERY = """
     SELECT table_name, table_type, table_comment
     FROM information_schema.tables
-    WHERE table_schema = ''{database}''
+    WHERE table_schema = '{database}'
 """
 
 _COLUMNS_QUERY = """
     SELECT table_name, column_name, column_type, is_nullable, column_key, column_comment,
            character_maximum_length, numeric_precision, numeric_scale
     FROM information_schema.columns
-    WHERE table_schema = ''{database}''
+    WHERE table_schema = '{database}'
     ORDER BY table_name, ordinal_position
 """
 
@@ -134,9 +134,14 @@ def _attach(host: str, port: int, database: str):
 
 
 def _query(con, sql: str) -> List[Dict[str, Any]]:
-    """Run a catalog statement on MySQL itself and return decoded rows."""
+    """Run a catalog statement on MySQL itself and return decoded rows.
+
+    The statement is escaped a second time here: it travels inside a duckdb
+    string literal, which consumes one level of quoting before MySQL sees it.
+    Escaping only once would hand MySQL the raw quotes.
+    """
     try:
-        result = con.sql(f"SELECT * FROM mysql_query('mysqldb', '{sql}')")
+        result = con.sql(f"SELECT * FROM mysql_query('mysqldb', '{_escape(sql)}')")
         # MySQL 8 names its information_schema columns in upper case
         columns = [description[0].lower() for description in result.description]
         return [dict(zip(columns, (_decode(value) for value in row))) for row in result.fetchall()]

--- a/tests/test_import_mysql.py
+++ b/tests/test_import_mysql.py
@@ -173,3 +173,27 @@ def test_import_mysql_requires_credentials(monkeypatch):
         _import()
 
     assert "DATACONTRACT_MYSQL_PASSWORD is not set" in exc_info.value.reason
+
+
+def test_a_quote_in_the_database_name_is_escaped_for_both_layers(monkeypatch):
+    """The statement travels inside a duckdb string literal, which consumes one
+    level of quoting before MySQL sees it — escaping once hands MySQL raw quotes."""
+    from datacontract.imports import mysql_importer
+
+    executed = []
+
+    class FakeResult:
+        description = [("table_name",)]
+
+        def fetchall(self):
+            return []
+
+    class FakeCon:
+        def sql(self, statement):
+            executed.append(statement)
+            return FakeResult()
+
+    mysql_importer._query(FakeCon(), "SELECT 1 WHERE table_schema = 'it''s'")
+
+    # duckdb turns '''' back into '', which is what MySQL needs for one quote
+    assert "'it''''s'" in executed[0]


### PR DESCRIPTION
## Summary

The MySQL importer builds a catalog statement and hands it to duckdb's `mysql_query('mysqldb', '<statement>')`. That statement sits inside a duckdb string literal, so duckdb consumes one level of quoting before MySQL ever sees it. The database name was escaped once, which the duckdb layer then undid:

```
escaped for the template:  WHERE table_schema = ''x'' OR ''1''=''1''
what MySQL actually saw:   WHERE table_schema = 'x' OR '1'='1'
```

**Demonstrated as a plain correctness bug.** A database legitimately named `it's` failed the import outright with a MySQL syntax error, because the apostrophe reached MySQL unescaped:

```
Could not read the MySQL catalog: IO Error: Failed to prepare MySQL query
```

It now imports correctly.

**On the security side, this was not exploitable through the CLI**, and I want to be precise rather than overstate it: the only parameter that reaches the statement is `--database`, and the same value is first used in the `ATTACH`, which fails unless it names a real database. A hostile `--database "x' OR '1'='1"` is rejected before the catalog query runs — verified against a live MySQL with a second database present; nothing leaked. The defect is that the escaping was wrong, not that there is a known path through it. Any future parameter reaching `_query` without that incidental constraint would have been injectable.

The name is now escaped for MySQL, and the whole statement escaped again for duckdb.

## Verified against a real MySQL

| `--database` | before | after |
|---|---|---|
| `shop` | imports | imports |
| `it's` | **fails** with a MySQL syntax error | imports |
| `x' OR '1'='1` | rejected at ATTACH | rejected at ATTACH |

## The other importers were checked too

- **postgres, redshift** — bound parameters (`%s`), nothing interpolated
- **sqlserver, oracle, trino** — single layer, quotes doubled correctly; a hostile schema stays inside the literal
- **trino catalog** — an identifier, quoted with doubled double-quotes rather than escaped as a literal
- **table filters everywhere** — applied in Python after the query, never interpolated

MySQL was the only one with a second layer, and the only one that got it wrong.