### PR TITLE
Require the API schema parameter to be a URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract test` verifies declared primary keys: each key column must have no missing values, and the key must have no duplicates (a composite key is checked as a tuple) (#1220 @DMZ22)
 
 ### Fixed
+- The `datacontract api` server accepted a local file path as the `schema` query parameter, so a caller could have it read files from the server's filesystem; only `http(s)` URLs are accepted now
 - Trino physical type checks were silently skipped: its `information_schema` has no length or precision columns, so the catalog query failed and a wrong `physicalType` still passed
 - `datacontract import athena` and `datacontract import glue` now honour `DATACONTRACT_S3_ACCESS_KEY_ID` and `DATACONTRACT_S3_SECRET_ACCESS_KEY`; the Glue catalog was read with ambient AWS credentials only
 - S3 now uses an existing AWS session (`aws sso login`, `AWS_PROFILE`, instance roles) when no access key is configured; previously such a setup failed with `403 Forbidden`

--- a/datacontract/api.py
+++ b/datacontract/api.py
@@ -204,6 +204,25 @@ customProperties:
 contractCreatedTs: "2025-01-15T10:00:00Z"
 """
 
+
+def _require_schema_url(schema: str | None) -> str | None:
+    """Reject anything that is not an http(s) URL.
+
+    The parameter is documented as a URL, but `fetch_schema` falls through to the
+    filesystem for anything else — so without this an unauthenticated caller could
+    have the server open its own files, and tell existing paths from missing ones
+    by the error it got back.
+    """
+    if schema is None:
+        return None
+    if not schema.startswith(("http://", "https://")):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="The schema parameter must be an http:// or https:// URL.",
+        )
+    return schema
+
+
 app = FastAPI(
     docs_url="/",
     title="Data Contract CLI API",
@@ -365,7 +384,9 @@ async def lint(
         Query(description="Report all JSON Schema validation errors instead of only the first one."),
     ] = False,
 ):
-    data_contract = DataContract(data_contract_str=body, schema_location=schema, all_errors=all_errors)
+    data_contract = DataContract(
+        data_contract_str=body, schema_location=_require_schema_url(schema), all_errors=all_errors
+    )
     lint_result = data_contract.lint()
     return {"result": lint_result.result, "checks": lint_result.checks}
 

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -45,6 +45,7 @@ marked as such in the entry.
 - `datacontract test` verifies declared primary keys: each key column must have no missing values, and the key must have no duplicates (a composite key is checked as a tuple) ([#1220](https://github.com/datacontract/datacontract-cli/issues/1220) [@DMZ22](https://github.com/DMZ22))
 
 ### Fixed
+- The `datacontract api` server accepted a local file path as the `schema` query parameter, so a caller could have it read files from the server's filesystem; only `http(s)` URLs are accepted now
 - Trino physical type checks were silently skipped: its `information_schema` has no length or precision columns, so the catalog query failed and a wrong `physicalType` still passed
 - `datacontract import athena` and `datacontract import glue` now honour `DATACONTRACT_S3_ACCESS_KEY_ID` and `DATACONTRACT_S3_SECRET_ACCESS_KEY`; the Glue catalog was read with ambient AWS credentials only
 - S3 now uses an existing AWS session (`aws sso login`, `AWS_PROFILE`, instance roles) when no access key is configured; previously such a setup failed with `403 Forbidden`

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -122,3 +122,43 @@ def test_changelog_data_contract_exception_returns_422():
     detail = response.json()["detail"]
     assert detail.startswith("Data Contract Validation Failure:")
     assert "something went wrong" in detail
+
+
+# ---------------------------------------------------------------------------
+# The schema parameter is documented as a URL. Without that being enforced,
+# fetch_schema falls through to the filesystem, so an unauthenticated caller
+# could have the server open its own files and tell existing paths from missing
+# ones by the error returned.
+# ---------------------------------------------------------------------------
+def _lint_with_schema(schema: str):
+    with open("fixtures/lint/valid_datacontract.yaml") as f:
+        return client.post(url="/lint", params={"schema": schema}, json=f.read())
+
+
+def test_a_local_path_as_schema_is_rejected():
+    response = _lint_with_schema("/etc/passwd")
+
+    assert response.status_code == 422
+    assert "http://" in response.json()["detail"]
+
+
+def test_a_missing_path_is_rejected_the_same_way():
+    """Identical responses, so nothing can be learned about the filesystem."""
+    existing = _lint_with_schema("/etc/passwd")
+    missing = _lint_with_schema("/nonexistent/path")
+
+    assert existing.status_code == missing.status_code == 422
+    assert existing.json() == missing.json()
+
+
+def test_a_relative_path_is_rejected():
+    assert _lint_with_schema("fixtures/lint/valid_datacontract.yaml").status_code == 422
+
+
+def test_an_http_url_is_still_accepted():
+    """Only the filesystem fallback is closed; URLs keep working."""
+    with patch("datacontract.lint.schema.requests.get") as get:
+        get.return_value.json.return_value = {"type": "object"}
+        response = _lint_with_schema("https://example.com/schema.json")
+
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary

The `/lint` endpoint of the `datacontract api` server documents its `schema` query parameter as *"This must be a URL"*, but nothing enforced it. `fetch_schema` treats anything that is not `http(s)://` as a filesystem path, so an unauthenticated caller could make the server read its own files.

Verified against a running server before the fix:

| request | before |
|---|---|
| `?schema=/tmp/local-schema.json` | server **read the local file** and validated against it — `"result":"passed"` |
| `?schema=/etc/passwd` | server **opened it**, failing at JSON parse (`Expecting value: line 1`) — proof the read happened |
| `?schema=/nonexistent/path` | distinct `The file ... does not exist` — a **file-existence oracle** |

Only `http://` and `https://` are accepted now, and every rejection returns the same 422, so nothing can be learned about the filesystem from the response.

After the fix, same three requests:

```
/tmp/local-schema.json   -> {"detail":"The schema parameter must be an http:// or https:// URL."}
/etc/passwd              -> {"detail":"The schema parameter must be an http:// or https:// URL."}
/nonexistent/path        -> {"detail":"The schema parameter must be an http:// or https:// URL."}
```

A real URL and the no-schema case both still work.

## How it was found

Two of the three open CodeQL alerts — `py/path-injection` at `lint/schema.py:50` and `:60`. They read as false positives at first, since the same function is reached from the CLI's `--json-schema`, where the operator supplies the path deliberately. Following the call graph to `api.py` showed a second caller where the value is remote and unauthenticated, which is what makes them real.

## The third alert is a false positive

`py/unsafe-deserialization` at `lint/resolve.py:405` flags `yaml.load(data_contract_str, Loader=_SafeLoaderNoTimestamp)`. That loader is a `yaml.SafeLoader` subclass which only drops the timestamp implicit resolver so dates stay strings. CodeQL does not track the subclass. No code change; it should be dismissed as a false positive rather than worked around.

## Still open, deliberately not in this PR

The URL branch calls `requests.get` on a caller-supplied URL with no restriction, so the server can be made to fetch arbitrary hosts, including link-local metadata endpoints. Closing that needs a policy decision — an allowlist, or blocking private ranges — rather than a one-line validation, so it is worth deciding separately.

## Testing

Four tests: a local path rejected, a missing path rejected identically to an existing one, a relative path rejected, and an `http` URL still accepted.