### PR TITLE
Escape the values in the duckdb secret statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract test` verifies declared primary keys: each key column must have no missing values, and the key must have no duplicates (a composite key is checked as a tuple) (#1220 @DMZ22)
 
 ### Fixed
+- A data contract could inject SQL into the duckdb session through `endpointUrl`, which is interpolated into the statement that stores the S3, GCS and Azure credentials; every value is escaped now
 - The `datacontract api` server accepted a local file path as the `schema` query parameter, so a caller could have it read files from the server's filesystem; only `http(s)` URLs are accepted now
 - Trino physical type checks were silently skipped: its `information_schema` has no length or precision columns, so the catalog query failed and a wrong `physicalType` still passed
 - `datacontract import athena` and `datacontract import glue` now honour `DATACONTRACT_S3_ACCESS_KEY_ID` and `DATACONTRACT_S3_SECRET_ACCESS_KEY`; the Glue catalog was read with ambient AWS credentials only

--- a/datacontract/engines/ibis/connections/duckdb_connection.py
+++ b/datacontract/engines/ibis/connections/duckdb_connection.py
@@ -237,6 +237,17 @@ def _load_extension(con, name: str, extra: str) -> None:
         ) from e
 
 
+def _sql_literal(value) -> str:
+    """Escape a value for a single-quoted duckdb string literal.
+
+    Several of these come from the contract rather than the environment —
+    `endpointUrl` and the storage account derived from `location` — and a
+    contract can be a URL someone else published. A quote in one of those
+    would otherwise end the literal and let the rest be parsed as SQL.
+    """
+    return str(value).replace("'", "''") if value is not None else ""
+
+
 def setup_s3_connection(con, server: Server):
     _load_extension(con, "httpfs", "s3")
     _load_extension(con, "aws", "s3")
@@ -262,25 +273,25 @@ def setup_s3_connection(con, server: Server):
             con.sql(f"""
                 CREATE OR REPLACE SECRET s3_secret (
                     TYPE S3,
-                    REGION '{s3_region}',
-                    KEY_ID '{s3_access_key_id}',
-                    SECRET '{s3_secret_access_key}',
-                    SESSION_TOKEN '{s3_session_token}',
-                    ENDPOINT '{s3_endpoint}',
-                    USE_SSL '{use_ssl}',
-                    URL_STYLE '{url_style}'
+                    REGION '{_sql_literal(s3_region)}',
+                    KEY_ID '{_sql_literal(s3_access_key_id)}',
+                    SECRET '{_sql_literal(s3_secret_access_key)}',
+                    SESSION_TOKEN '{_sql_literal(s3_session_token)}',
+                    ENDPOINT '{_sql_literal(s3_endpoint)}',
+                    USE_SSL '{_sql_literal(use_ssl)}',
+                    URL_STYLE '{_sql_literal(url_style)}'
                 );
             """)
         else:
             con.sql(f"""
                 CREATE OR REPLACE SECRET s3_secret (
                     TYPE S3,
-                    REGION '{s3_region}',
-                    KEY_ID '{s3_access_key_id}',
-                    SECRET '{s3_secret_access_key}',
-                    ENDPOINT '{s3_endpoint}',
-                    USE_SSL '{use_ssl}',
-                    URL_STYLE '{url_style}'
+                    REGION '{_sql_literal(s3_region)}',
+                    KEY_ID '{_sql_literal(s3_access_key_id)}',
+                    SECRET '{_sql_literal(s3_secret_access_key)}',
+                    ENDPOINT '{_sql_literal(s3_endpoint)}',
+                    USE_SSL '{_sql_literal(use_ssl)}',
+                    URL_STYLE '{_sql_literal(url_style)}'
                 );
             """)
     else:
@@ -301,7 +312,7 @@ def _create_s3_secret_from_aws_session(con, region, endpoint, use_ssl, url_style
 
     region = region or credentials.region
     token_clause = f"SESSION_TOKEN '{credentials.session_token}'," if credentials.session_token else ""
-    region_clause = f"REGION '{region}'," if region else ""
+    region_clause = f"REGION '{_sql_literal(region)}'," if region else ""
     con.sql(f"""
         CREATE OR REPLACE SECRET s3_secret (
             TYPE S3,
@@ -309,9 +320,9 @@ def _create_s3_secret_from_aws_session(con, region, endpoint, use_ssl, url_style
             KEY_ID '{credentials.access_key_id}',
             SECRET '{credentials.secret_access_key}',
             {token_clause}
-            ENDPOINT '{endpoint}',
-            USE_SSL '{use_ssl}',
-            URL_STYLE '{url_style}'
+            ENDPOINT '{_sql_literal(endpoint)}',
+            USE_SSL '{_sql_literal(use_ssl)}',
+            URL_STYLE '{_sql_literal(url_style)}'
         );
     """)
 
@@ -324,8 +335,8 @@ def setup_gcs_connection(con, server: Server):
     con.sql(f"""
     CREATE SECRET gcs_secret (
         TYPE GCS,
-        KEY_ID '{key_id}',
-        SECRET '{secret}'
+        KEY_ID '{_sql_literal(key_id)}',
+        SECRET '{_sql_literal(secret)}'
     );
     """)
 
@@ -345,10 +356,10 @@ def setup_azure_connection(con, server: Server):
         CREATE SECRET azure_spn (
             TYPE AZURE,
             PROVIDER SERVICE_PRINCIPAL,
-            TENANT_ID '{tenant_id}',
-            CLIENT_ID '{client_id}',
-            CLIENT_SECRET '{client_secret}',
-            ACCOUNT_NAME '{storage_account}'
+            TENANT_ID '{_sql_literal(tenant_id)}',
+            CLIENT_ID '{_sql_literal(client_id)}',
+            CLIENT_SECRET '{_sql_literal(client_secret)}',
+            ACCOUNT_NAME '{_sql_literal(storage_account)}'
         );
         """)
     else:
@@ -356,9 +367,9 @@ def setup_azure_connection(con, server: Server):
         CREATE SECRET azure_spn (
             TYPE AZURE,
             PROVIDER SERVICE_PRINCIPAL,
-            TENANT_ID '{tenant_id}',
-            CLIENT_ID '{client_id}',
-            CLIENT_SECRET '{client_secret}'
+            TENANT_ID '{_sql_literal(tenant_id)}',
+            CLIENT_ID '{_sql_literal(client_id)}',
+            CLIENT_SECRET '{_sql_literal(client_secret)}'
         );
         """)
 

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -45,6 +45,7 @@ marked as such in the entry.
 - `datacontract test` verifies declared primary keys: each key column must have no missing values, and the key must have no duplicates (a composite key is checked as a tuple) ([#1220](https://github.com/datacontract/datacontract-cli/issues/1220) [@DMZ22](https://github.com/DMZ22))
 
 ### Fixed
+- A data contract could inject SQL into the duckdb session through `endpointUrl`, which is interpolated into the statement that stores the S3, GCS and Azure credentials; every value is escaped now
 - The `datacontract api` server accepted a local file path as the `schema` query parameter, so a caller could have it read files from the server's filesystem; only `http(s)` URLs are accepted now
 - Trino physical type checks were silently skipped: its `information_schema` has no length or precision columns, so the catalog query failed and a wrong `physicalType` still passed
 - `datacontract import athena` and `datacontract import glue` now honour `DATACONTRACT_S3_ACCESS_KEY_ID` and `DATACONTRACT_S3_SECRET_ACCESS_KEY`; the Glue catalog was read with ambient AWS credentials only

--- a/tests/test_connect_s3_credentials.py
+++ b/tests/test_connect_s3_credentials.py
@@ -151,3 +151,37 @@ def test_an_expired_session_falls_back_to_no_credentials():
 
     with patch("boto3.Session", return_value=session):
         assert resolve_aws_credentials() is None
+
+
+def test_a_quote_in_the_endpoint_cannot_end_the_sql_literal(env):
+    """endpointUrl comes from the contract, and a contract can be someone else's URL.
+
+    A single quote is a legal URI sub-delimiter, so the schema's `format: uri`
+    check lets it through; without escaping it ended the literal and the rest
+    was parsed as SQL.
+    """
+    env.setenv("DATACONTRACT_S3_ACCESS_KEY_ID", "AKIA_TEST")
+    env.setenv("DATACONTRACT_S3_SECRET_ACCESS_KEY", "secret")
+    server = Server(
+        server="production",
+        type="s3",
+        location="s3://bucket/orders/*.csv",
+        format="csv",
+        endpointUrl="http://a',SCOPE,'b",
+    )
+
+    sql = _setup(server=server)
+
+    # the quotes are doubled, so the whole thing stays one literal
+    assert "a'',SCOPE,''b" in sql
+    assert "SCOPE," not in sql.replace("a'',SCOPE,''b", "")
+
+
+def test_a_quote_in_a_credential_is_escaped(env):
+    env.setenv("DATACONTRACT_S3_ACCESS_KEY_ID", "AKIA'X")
+    env.setenv("DATACONTRACT_S3_SECRET_ACCESS_KEY", "se'cret")
+
+    sql = _setup()
+
+    assert "AKIA''X" in sql
+    assert "se''cret" in sql


### PR DESCRIPTION
## Summary

The S3, GCS and Azure credentials are handed to duckdb with `CREATE SECRET`, built by string interpolation. Two of the interpolated values come from the **contract** rather than the environment:

- `server.endpointUrl` — used for MinIO and other S3-compatible stores
- the storage account derived from `server.location` for Azure

A data contract can be a URL someone else published, and testing one is a documented workflow — the quickstart does exactly that.

## The schema check does not stop it

`endpointUrl` is validated as `format: uri`, which rejects an obvious payload containing a space. But a single quote is a legal sub-delimiter in RFC 3986, so a valid URI can carry one. With this contract:

```yaml
servers:
  - server: production
    type: s3
    location: s3://bucket/orders/*.csv
    format: csv
    endpointUrl: "http://a',SCOPE,'b"
```

`datacontract test` reported:

```
Data Contract Tests: Parser Error: syntax error at or near ","
```

The quote ended the string literal and duckdb parsed the remainder as SQL. I stopped at establishing that — no exploit chain was built — but duckdb can read and write local files and install extensions, so the ceiling is high for something reachable by testing a third-party contract.

After the fix the same contract yields:

```
IO Error: URL using bad/illegal format or missing URL error for HTTP GET to
'http://a',SCOPE,'b/bucket/?encoding-type=url&list-type=2&prefix=orders%2F'
```

— the payload is now a literal endpoint string, rejected by the HTTP layer, with the SQL intact.

## The fix

One helper escaping single quotes, applied to all 26 interpolations across the three `setup_*_connection` functions — credentials, region, endpoint, URL style, tenant and client ids, and the derived storage account. Credentials are escaped too: an access key containing a quote would previously have broken the statement.

## Testing

Two new tests: a quote in `endpointUrl` stays inside the literal, and a quote in a credential is escaped. The existing test that a custom endpoint still uses path-style addressing continues to pass, so the MinIO feature is unaffected.

The MinIO-backed suites could not run locally (no Docker daemon at the time); CI covers them.