### PR TITLE
fix(import): write GCS as an ODCS s3 server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract test` verifies declared primary keys: each key column must have no missing values, and the key must have no duplicates (a composite key is checked as a tuple) (#1220 @DMZ22)
 
 ### Fixed
+- `datacontract import gcs` wrote `type: gcs`, which is not an ODCS server type, so the imported contract failed `datacontract lint` and `datacontract test`; GCS is now written as an `s3` server on the Google interoperability endpoint
 - A data contract could inject SQL into the duckdb session through `endpointUrl`, which is interpolated into the statement that stores the S3, GCS and Azure credentials; every value is escaped now
 - The `datacontract api` server accepted a local file path as the `schema` query parameter, so a caller could have it read files from the server's filesystem; only `http(s)` URLs are accepted now
 - Trino physical type checks were silently skipped: its `information_schema` has no length or precision columns, so the catalog query failed and a wrong `physicalType` still passed

--- a/datacontract/imports/object_storage_importer.py
+++ b/datacontract/imports/object_storage_importer.py
@@ -30,13 +30,18 @@ FORMATS_BY_SUFFIX = {
 SUPPORTED_FORMATS = {"json", "csv", "parquet", "delta"}
 
 # The import format is the name a user types; the server type is what goes into
-# the contract. They differ for ADLS, which ODCS calls `azure`.
-SERVER_TYPES = {"s3": "s3", "gcs": "gcs", "adls": "azure"}
+# the contract. They differ for ADLS, which ODCS calls `azure`, and for GCS,
+# which ODCS has no server type for at all.
+SERVER_TYPES = {"s3": "s3", "gcs": "s3", "adls": "azure"}
 
-# duckdb reads GCS through the S3-compatible endpoint, hence the s3:// scheme there.
+# GCS speaks the S3 protocol through its interoperability endpoint, so a GCS
+# import writes an ODCS `s3` server pinned to that endpoint. Credentials are the
+# bucket's HMAC key, supplied through the DATACONTRACT_S3_* variables.
+GCS_ENDPOINT_URL = "https://storage.googleapis.com"
+DEFAULT_ENDPOINT_URLS = {"gcs": GCS_ENDPOINT_URL}
+
 _EXAMPLE_LOCATIONS = {
     "s3": "s3://my-bucket/orders/*.json",
-    "gcs": "s3://my-bucket/orders/*.json",
     "azure": "abfss://my-container/orders/*.json",
 }
 
@@ -51,11 +56,11 @@ _READERS = {
 class ObjectStorageImporter(Importer):
     def import_source(self, source: str, import_args: dict) -> OpenDataContractStandard:
         return import_object_storage(
-            location=source,
+            location=normalize_location(source, self.import_format),
             server_type=SERVER_TYPES[self.import_format],
             format=import_args.get("file_format"),
             delimiter=import_args.get("delimiter"),
-            endpoint_url=import_args.get("endpoint_url"),
+            endpoint_url=import_args.get("endpoint_url") or DEFAULT_ENDPOINT_URLS.get(self.import_format),
         )
 
 
@@ -124,6 +129,15 @@ def import_object_storage(
     return odcs
 
 
+def normalize_location(location: Optional[str], import_format: str) -> Optional[str]:
+    """Rewrite a GCS location to the s3:// scheme duckdb's S3 reader expects."""
+    if location and import_format == "gcs":
+        for scheme in ("gs://", "gcs://"):
+            if location.startswith(scheme):
+                return "s3://" + location[len(scheme) :]
+    return location
+
+
 def detect_format(location: str) -> Optional[str]:
     """Derive the format from the object suffix; delta has none, so it needs --format."""
     match = re.search(r"(\.[A-Za-z0-9]+)(?:\?.*)?$", location)
@@ -143,11 +157,10 @@ def _read_columns(server: Server, location: str, format: str):
     from datacontract.engines.ibis.connections.duckdb_connection import (
         _import_duckdb,
         setup_azure_connection,
-        setup_gcs_connection,
         setup_s3_connection,
     )
 
-    setup = {"s3": setup_s3_connection, "gcs": setup_gcs_connection, "azure": setup_azure_connection}[server.type]
+    setup = {"s3": setup_s3_connection, "azure": setup_azure_connection}[server.type]
     duckdb = _import_duckdb()
     con = duckdb.connect(database=":memory:")
     setup(con, server)

--- a/docs/docs/imports/gcs.md
+++ b/docs/docs/imports/gcs.md
@@ -16,7 +16,7 @@ datacontract import gcs \
 
 The format is taken from the file suffix; pass `--format` for Delta tables, which have none, or to override the guess. `--delimiter` pins how a JSON file is laid out (`new_line`, `array`, or `none`) instead of letting it be detected.
 
-duckdb reads Google Cloud Storage through its S3-compatible endpoint, so the location uses the `s3://` scheme rather than `gs://`.
+duckdb reads Google Cloud Storage through its S3-compatible endpoint, so the location uses the `s3://` scheme rather than `gs://`; a `gs://` source is rewritten for you.
 
 The objects are read with duckdb through the same connection the test path uses, so the import authenticates identically and infers the column types from exactly the reader that later verifies them.
 

--- a/docs/docs/reference/gcs.md
+++ b/docs/docs/reference/gcs.md
@@ -11,11 +11,14 @@ Authentication options and data type handling for [GCS connections](../testing/g
 
 ## Server
 
+GCS is an S3-compatible server: ODCS defines no `gcs` server type, so the contract uses `type: s3` pointed at the [interoperability](https://cloud.google.com/storage/docs/interoperability) endpoint.
+
 ```yaml
 servers:
   - server: production
-    type: gcs
-    location: s3://my-bucket/orders/*.json # duckdb reads GCS over the S3-compatible endpoint
+    type: s3
+    endpointUrl: https://storage.googleapis.com
+    location: s3://my-bucket/orders/*.json # the S3 endpoint needs the s3:// scheme, not gs://
     format: json
     delimiter: new_line # new_line, array, or none
 ```

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -45,6 +45,7 @@ marked as such in the entry.
 - `datacontract test` verifies declared primary keys: each key column must have no missing values, and the key must have no duplicates (a composite key is checked as a tuple) ([#1220](https://github.com/datacontract/datacontract-cli/issues/1220) [@DMZ22](https://github.com/DMZ22))
 
 ### Fixed
+- `datacontract import gcs` wrote `type: gcs`, which is not an ODCS server type, so the imported contract failed `datacontract lint` and `datacontract test`; GCS is now written as an `s3` server on the Google interoperability endpoint
 - A data contract could inject SQL into the duckdb session through `endpointUrl`, which is interpolated into the statement that stores the S3, GCS and Azure credentials; every value is escaped now
 - The `datacontract api` server accepted a local file path as the `schema` query parameter, so a caller could have it read files from the server's filesystem; only `http(s)` URLs are accepted now
 - Trino physical type checks were silently skipped: its `information_schema` has no length or precision columns, so the catalog query failed and a wrong `physicalType` still passed

--- a/docs/docs/testing/gcs.md
+++ b/docs/docs/testing/gcs.md
@@ -6,7 +6,7 @@ description: "Create a data contract from files on Google Cloud Storage and test
 
 # <img className="page-icon" src="/img/icons/gcs.svg" alt="" /> Google Cloud Storage (GCS)
 
-The [Amazon S3](./s3.md) integration also works with files on Google Cloud Storage through its [interoperability](https://cloud.google.com/storage/docs/interoperability). Use `https://storage.googleapis.com` as the endpoint URL and the `s3://` scheme for the location.
+The [Amazon S3](./s3.md) integration also works with files on Google Cloud Storage through its [interoperability](https://cloud.google.com/storage/docs/interoperability). ODCS defines no `gcs` server type, so a GCS contract uses `type: s3` with `https://storage.googleapis.com` as the endpoint URL and the `s3://` scheme for the location — `datacontract import gcs` writes exactly that.
 
 ## 1. Install
 
@@ -36,7 +36,7 @@ datacontract import gcs \
   --output datacontract.yaml
 ```
 
-duckdb reads Google Cloud Storage through its S3-compatible endpoint, so the location uses the `s3://` scheme rather than `gs://`. The format is taken from the file suffix; pass `--format` for Delta tables, which have none.
+duckdb reads Google Cloud Storage through its S3-compatible endpoint, so the location uses the `s3://` scheme rather than `gs://`; a `gs://` source is rewritten for you. The format is taken from the file suffix; pass `--format` for Delta tables, which have none.
 
 ## 4. Test the actual data
 
@@ -46,7 +46,7 @@ datacontract test datacontract.yaml
 
 ```
 Testing datacontract.yaml
-Server: production (type=gcs, format=json, location=s3://my-bucket/orders/*.json)
+Server: production (type=s3, format=json, location=s3://my-bucket/orders/*.json)
 ╭────────┬─────────────────────────────────────────────────┬─────────────────┬─────────╮
 │ Result │ Check                                           │ Field           │ Details │
 ├────────┼─────────────────────────────────────────────────┼─────────────────┼─────────┤

--- a/docs/scripts/generate-release-notes.mjs
+++ b/docs/scripts/generate-release-notes.mjs
@@ -24,7 +24,7 @@ const outputPath = path.join(scriptDir, '..', 'docs', 'release-notes.md');
 const REPO = 'https://github.com/datacontract/datacontract-cli';
 
 const FRONT_MATTER = `---
-sidebar_position: 22
+sidebar_position: 25
 title: "Release Notes"
 description: "What changed in every release of the Data Contract CLI — new importers, exporters, data sources, and fixes, newest first."
 slug: /release-notes

--- a/tests/test_import_object_storage.py
+++ b/tests/test_import_object_storage.py
@@ -125,24 +125,46 @@ def test_an_unreadable_object_explains_the_location_and_format(minio, credential
 # which is how the existing gcs/azure suites are gated, so only the dispatch is
 # checked here.
 # ---------------------------------------------------------------------------
-@pytest.mark.parametrize("storage, server_type", [("s3", "s3"), ("gcs", "gcs"), ("adls", "azure")])
+@pytest.mark.parametrize("storage, server_type", [("s3", "s3"), ("gcs", "s3"), ("adls", "azure")])
 def test_each_storage_writes_its_own_server_type(storage, server_type, monkeypatch):
-    from datacontract.imports import object_storage_importer
+    result = _import_with_stubbed_read(monkeypatch, storage, "s3://bucket/orders/orders.csv")
 
-    captured = {}
-
-    def fake_read_columns(server, location, file_format):
-        captured["server"] = server
-        return [("id", "BIGINT")]
-
-    monkeypatch.setattr(object_storage_importer, "_read_columns", fake_read_columns)
-    result = DataContract.import_from_source(storage, "s3://bucket/orders/orders.csv")
-
-    # ODCS calls the Azure server type `azure`, so the format name and the
-    # server type deliberately differ for adls
-    assert captured["server"].type == server_type
+    # ODCS calls the Azure server type `azure` and has no GCS type at all, so
+    # the format name and the server type deliberately differ for adls and gcs
     assert result.servers[0].type == server_type
     assert result.servers[0].format == "csv"
+
+
+def test_gcs_writes_an_odcs_server_the_cli_can_lint_and_test(monkeypatch):
+    """ODCS has no `gcs` server type; GCS is reached as an S3-compatible server."""
+    result = _import_with_stubbed_read(monkeypatch, "gcs", "s3://bucket/orders/orders.csv")
+
+    assert result.servers[0].type == "s3"
+    assert result.servers[0].endpointUrl == "https://storage.googleapis.com"
+    assert DataContract(data_contract_str=result.to_yaml()).lint().result == ResultEnum.passed
+
+
+def test_gcs_accepts_a_gs_location(monkeypatch):
+    """duckdb reads GCS through the S3 endpoint, which needs the s3:// scheme."""
+    result = _import_with_stubbed_read(monkeypatch, "gcs", "gs://bucket/orders/orders.csv")
+
+    assert result.servers[0].location == "s3://bucket/orders/orders.csv"
+
+
+def test_an_explicit_endpoint_url_wins_over_the_gcs_default(monkeypatch):
+    result = _import_with_stubbed_read(
+        monkeypatch, "gcs", "s3://bucket/orders/orders.csv", endpoint_url="https://minio.example.com"
+    )
+
+    assert result.servers[0].endpointUrl == "https://minio.example.com"
+
+
+def _import_with_stubbed_read(monkeypatch, storage, location, **kwargs):
+    """Import without touching object storage — only the server block is of interest."""
+    from datacontract.imports import object_storage_importer
+
+    monkeypatch.setattr(object_storage_importer, "_read_columns", lambda *_: [("id", "BIGINT")])
+    return DataContract.import_from_source(storage, location, **kwargs)
 
 
 @pytest.mark.parametrize("storage", ["s3", "gcs", "adls"])
@@ -158,7 +180,7 @@ def test_adls_uses_the_azure_connection_setup(monkeypatch):
     from datacontract.imports import object_storage_importer
 
     calls = []
-    for name in ("setup_s3_connection", "setup_gcs_connection", "setup_azure_connection"):
+    for name in ("setup_s3_connection", "setup_azure_connection"):
         monkeypatch.setattr(
             "datacontract.engines.ibis.connections.duckdb_connection." + name,
             lambda con, server, _n=name: calls.append(_n),


### PR DESCRIPTION
## Summary

ODCS defines no `gcs` server type, so the contract produced by `datacontract import gcs` failed both `datacontract lint` and `datacontract test` on schema validation:

```
🔴 data.servers[0].type must be one of ['api', 'athena', 'azure', ... 'custom']
```

GCS is now written as an `s3` server pinned to the Google [interoperability](https://cloud.google.com/storage/docs/interoperability) endpoint — a modeling the codebase already treats as valid (`tests/fixtures/gcs-json-remote/datacontract.yaml` has carried an `s3-style` server alongside the `gcs` one), and which `setup_s3_connection` already supports via `endpointUrl`. No connector code was needed.

Also in scope:

- A `gs://` source is rewritten to the `s3://` scheme the duckdb S3 reader expects, so either scheme works on the command line.
- The documented credentials (`DATACONTRACT_S3_ACCESS_KEY_ID` / `DATACONTRACT_S3_SECRET_ACCESS_KEY`) are now the ones the code actually reads. The docs previously named those while the `gcs` code path required `DATACONTRACT_GCS_KEY_ID` / `DATACONTRACT_GCS_SECRET`, so following the docs failed with `missing_env_DATACONTRACT_GCS_KEY_ID`.
- `reference/gcs.md` showed a `servers` block that could not be linted; it now shows `type: s3` + `endpointUrl`.

The parametrized importer test asserted `("gcs", "gcs")` — it encoded the bug as expected behavior. It now asserts `("gcs", "s3")`, joined by cases covering the lint result, the `gs://` rewrite, and an explicit `--endpoint-url` overriding the default. All three fail against the pre-fix code.

**Backwards compatibility:** the legacy `type: gcs` runtime path is untouched — `_FILE_SERVER_TYPES`, `setup_gcs_connection`, the `DATACONTRACT_GCS_*` variables and the credential-gated `test_test_gcs_json_remote_gcs_url` test all keep working, so existing contracts are unaffected. That does leave two GCS routes with different credentials, and the legacy one still skips JSON schema checks (`check_jsonschema.py:274-281`). Whether to deprecate it is worth deciding separately.