### PR TITLE
Add S3 data contract location support across CLI, docs, and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Credentials and connection options can be provided in a YAML config file, via `--config-file` (defaults to `./datacontract-config.yaml` or `~/.datacontract/config.yaml`) or `Config.from_yaml()`, with `${VAR}` references resolved from the environment
 - New Snowflake connection options: `DATACONTRACT_SNOWFLAKE_TOKEN`, `DATACONTRACT_SNOWFLAKE_PASSCODE`, `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY`, `DATACONTRACT_SNOWFLAKE_NETWORK_TIMEOUT`, `DATACONTRACT_SNOWFLAKE_SOCKET_TIMEOUT`, `DATACONTRACT_SNOWFLAKE_HOST`, `DATACONTRACT_SNOWFLAKE_PORT`
 - Config options to override the server details from the data contract (host, port, database, schema, catalog, project, dataset, account, service name, staging directory) for Postgres, MySQL, SQL Server, Oracle, Redshift, Snowflake, BigQuery, Databricks, Trino, Athena, and Impala, e.g. `DATACONTRACT_POSTGRES_HOST` (#1076)
+- Data contract locations now support `s3://` URLs for commands that read contracts, including `lint`, `test`, `export`, `publish`, `changelog`, and `ci`
 
 ### Changed
 - `datacontract test` against Snowflake only forwards the documented `DATACONTRACT_SNOWFLAKE_*` options to the connector; unknown variables are ignored with a warning

--- a/datacontract/command_changelog.py
+++ b/datacontract/command_changelog.py
@@ -12,8 +12,14 @@ from datacontract.output.text_changelog_results import write_text_changelog_resu
     epilog="Example: datacontract changelog datacontract-v1.yaml datacontract-v2.yaml",
 )
 def changelog(
-    v1: Annotated[str, typer.Argument(help="The location (url or path) of the source (before) data contract YAML.")],
-    v2: Annotated[str, typer.Argument(help="The location (url or path) of the target (after) data contract YAML.")],
+    v1: Annotated[
+        str,
+        typer.Argument(help="The location (url, s3 url, or local path) of the source (before) data contract YAML."),
+    ],
+    v2: Annotated[
+        str,
+        typer.Argument(help="The location (url, s3 url, or local path) of the target (after) data contract YAML."),
+    ],
     inline_references: Annotated[
         bool,
         typer.Option(

--- a/datacontract/command_ci.py
+++ b/datacontract/command_ci.py
@@ -35,7 +35,7 @@ class FailOn(str, Enum):
 def ci(
     locations: Annotated[
         Optional[list[str]],
-        typer.Argument(help="The location(s) (url or path) of the data contract yaml file(s)."),
+        typer.Argument(help="The location(s) (url, s3 url, or local path) of the data contract yaml file(s)."),
     ] = None,
     schema: Annotated[
         str,

--- a/datacontract/command_export.py
+++ b/datacontract/command_export.py
@@ -18,7 +18,10 @@ export_app = typer.Typer(cls=OrderedCommandsWithMigrationHints, no_args_is_help=
 # ---------------------------------------------------------------------------
 # Shared option type aliases
 # ---------------------------------------------------------------------------
-location_arg = Annotated[str, typer.Argument(help="The location (url or path) of the data contract yaml.")]
+location_arg = Annotated[
+    str,
+    typer.Argument(help="The location (url, s3 url, or local path) of the data contract yaml."),
+]
 output_option = Annotated[
     Optional[Path],
     typer.Option(

--- a/datacontract/command_lint.py
+++ b/datacontract/command_lint.py
@@ -17,7 +17,7 @@ from datacontract.output.test_results_writer import write_test_result
 def lint(
     location: Annotated[
         str,
-        typer.Argument(help="The location (url or path) of the data contract yaml."),
+        typer.Argument(help="The location (url, s3 url, or local path) of the data contract yaml."),
     ] = "datacontract.yaml",
     schema: Annotated[
         str,

--- a/datacontract/command_publish.py
+++ b/datacontract/command_publish.py
@@ -16,7 +16,7 @@ from datacontract.lint.resolve import resolve_data_contract_dict
 def publish(
     location: Annotated[
         str,
-        typer.Argument(help="The location (url or path) of the data contract yaml."),
+        typer.Argument(help="The location (url, s3 url, or local path) of the data contract yaml."),
     ] = "datacontract.yaml",
     schema: Annotated[
         str,

--- a/datacontract/command_test.py
+++ b/datacontract/command_test.py
@@ -98,7 +98,7 @@ def _parse_csv(value: str | None, option: str) -> set[str] | None:
 def test(
     location: Annotated[
         str,
-        typer.Argument(help="The location (url or path) of the data contract yaml."),
+        typer.Argument(help="The location (url, s3 url, or local path) of the data contract yaml."),
     ] = "datacontract.yaml",
     schema: Annotated[
         str,

--- a/datacontract/lint/files.py
+++ b/datacontract/lint/files.py
@@ -1,6 +1,7 @@
 import os
 
 from datacontract.model.exceptions import DataContractException
+from datacontract.model.run import ResultEnum
 
 
 def read_file(path):
@@ -10,7 +11,7 @@ def read_file(path):
             name=f"Reading data contract from {path}",
             reason=f"The file '{path}' does not exist.",
             engine="datacontract",
-            result="error",
+            result=ResultEnum.error,
         )
     with open(path, "r") as file:
         file_content = file.read()

--- a/datacontract/lint/resources.py
+++ b/datacontract/lint/resources.py
@@ -1,23 +1,26 @@
 from datacontract.config import Config
-from datacontract.lint.files import read_file
-from datacontract.lint.urls import fetch_resource
+from datacontract.lint import files, s3, urls
 
 
 def read_resource(location: str, config: Config | None = None) -> str:
     """
     Read a resource from a given location.
 
-    If the location is a URL, fetch the resource from the web. API-Keys are supported.
-    Otherwise, read the resource from a local file.
+    Supported locations:
+    - ``http://`` and ``https://`` URLs (API keys are supported)
+    - ``s3://`` URLs
+    - local file paths
 
     Args:
-        location (str): The location of the resource, either a URL or a file path.
+        location (str): The resource location.
         config: Optional credentials for authenticated URLs.
 
     Returns:
         str: The content of the resource.
     """
     if location.startswith("http://") or location.startswith("https://"):
-        return fetch_resource(location, config)
+        return urls.fetch_resource(location, config)
+    elif location.startswith("s3://"):
+        return s3.fetch_resource(location)
     else:
-        return read_file(location)
+        return files.read_file(location)

--- a/datacontract/lint/resources.py
+++ b/datacontract/lint/resources.py
@@ -13,7 +13,7 @@ def read_resource(location: str, config: Config | None = None) -> str:
 
     Args:
         location (str): The resource location.
-        config: Optional credentials for authenticated URLs.
+        config: Optional credentials for authenticated URLs and ``s3://`` locations.
 
     Returns:
         str: The content of the resource.
@@ -21,6 +21,6 @@ def read_resource(location: str, config: Config | None = None) -> str:
     if location.startswith("http://") or location.startswith("https://"):
         return urls.fetch_resource(location, config)
     elif location.startswith("s3://"):
-        return s3.fetch_resource(location)
+        return s3.fetch_resource(location, config)
     else:
         return files.read_file(location)

--- a/datacontract/lint/s3.py
+++ b/datacontract/lint/s3.py
@@ -1,0 +1,25 @@
+from urllib.parse import urlparse
+
+import boto3
+
+from datacontract.model.exceptions import DataContractException
+from datacontract.model.run import ResultEnum
+
+
+def fetch_resource(url: str) -> str:
+    parsed_url = urlparse(url)
+    bucket = parsed_url.netloc
+    key = parsed_url.path.lstrip("/")
+    try:
+        response = boto3.client("s3").get_object(Bucket=bucket, Key=key)
+        body = response["Body"].read()
+        return body.decode("utf-8")
+    except Exception as e:
+        raise DataContractException(
+            type="lint",
+            name=f"Reading data contract from {url}",
+            reason=f"Cannot read resource from {url}. Error: {e}",
+            engine="datacontract",
+            result=ResultEnum.error,
+            original_exception=e,
+        )

--- a/datacontract/lint/s3.py
+++ b/datacontract/lint/s3.py
@@ -1,17 +1,18 @@
 from urllib.parse import urlparse
 
-import boto3
-
+from datacontract.config import Config
+from datacontract.engines.ibis.connections import aws_credentials
 from datacontract.model.exceptions import DataContractException
 from datacontract.model.run import ResultEnum
 
 
-def fetch_resource(url: str) -> str:
+def fetch_resource(url: str, config: Config | None = None) -> str:
     parsed_url = urlparse(url)
     bucket = parsed_url.netloc
     key = parsed_url.path.lstrip("/")
     try:
-        response = boto3.client("s3").get_object(Bucket=bucket, Key=key)
+        s3_client = aws_credentials.client("s3", config=config)
+        response = s3_client.get_object(Bucket=bucket, Key=key)
         body = response["Body"].read()
         return body.decode("utf-8")
     except Exception as e:

--- a/datacontract/lint/urls.py
+++ b/datacontract/lint/urls.py
@@ -4,6 +4,7 @@ import requests
 
 from datacontract.config import Config
 from datacontract.model.exceptions import DataContractException
+from datacontract.model.run import ResultEnum
 
 
 def fetch_resource(url: str, config: Config | None = None):
@@ -22,7 +23,7 @@ def fetch_resource(url: str, config: Config | None = None):
             name=f"Reading data contract from {url}",
             reason=f"Cannot read resource from URL {url}. Response status is {response.status_code}",
             engine="datacontract",
-            result="error",
+            result=ResultEnum.error,
         )
 
 
@@ -41,7 +42,7 @@ def _set_api_key(headers, url, config: Config):
                 name=f"Reading data contract from {url}",
                 reason="Error: Entropy Data API key is not set. Set env variable ENTROPY_DATA_API_KEY.",
                 engine="datacontract",
-                result="error",
+                result=ResultEnum.error,
             )
         headers["x-api-key"] = entropy_data_api_key
     elif hostname == "datamesh-manager.com" or hostname.endswith(".datamesh-manager.com"):
@@ -52,7 +53,7 @@ def _set_api_key(headers, url, config: Config):
                 name=f"Reading data contract from {url}",
                 reason="Error: Data Mesh Manager API key is not set. Set env variable DATAMESH_MANAGER_API_KEY.",
                 engine="datacontract",
-                result="error",
+                result=ResultEnum.error,
             )
         headers["x-api-key"] = datamesh_manager_api_key
     elif hostname == "datacontract-manager.com" or hostname.endswith(".datacontract-manager.com"):
@@ -63,7 +64,7 @@ def _set_api_key(headers, url, config: Config):
                 name=f"Reading data contract from {url}",
                 reason="Error: Data Contract Manager API key is not set. Set env variable DATACONTRACT_MANAGER_API_KEY.",
                 engine="datacontract",
-                result="error",
+                result=ResultEnum.error,
             )
         headers["x-api-key"] = datacontract_manager_api_key
 

--- a/docs/docs/commands/changelog.md
+++ b/docs/docs/commands/changelog.md
@@ -16,8 +16,8 @@ datacontract changelog [OPTIONS] V1 V2
 
 | Argument | Default | Description |
 |---|---|---|
-| `V1` | required | The location (url or path) of the source (before) data contract YAML. |
-| `V2` | required | The location (url or path) of the target (after) data contract YAML. |
+| `V1` | required | The location (url, s3 url, or local path) of the source (before) data contract YAML. |
+| `V2` | required | The location (url, s3 url, or local path) of the target (after) data contract YAML. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/ci.md
+++ b/docs/docs/commands/ci.md
@@ -16,7 +16,7 @@ datacontract ci [OPTIONS] [LOCATIONS]...
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATIONS]...` | — | The location(s) (url or path) of the data contract yaml file(s). |
+| `[LOCATIONS]...` | — | The location(s) (url, s3 url, or local path) of the data contract yaml file(s). |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/avro-idl.md
+++ b/docs/docs/commands/export/avro-idl.md
@@ -16,7 +16,7 @@ datacontract export avro-idl [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/avro.md
+++ b/docs/docs/commands/export/avro.md
@@ -16,7 +16,7 @@ datacontract export avro [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/bigquery.md
+++ b/docs/docs/commands/export/bigquery.md
@@ -16,7 +16,7 @@ datacontract export bigquery [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/custom.md
+++ b/docs/docs/commands/export/custom.md
@@ -16,7 +16,7 @@ datacontract export custom [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/data-caterer.md
+++ b/docs/docs/commands/export/data-caterer.md
@@ -16,7 +16,7 @@ datacontract export data-caterer [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/dbml.md
+++ b/docs/docs/commands/export/dbml.md
@@ -16,7 +16,7 @@ datacontract export dbml [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/dbt-models.md
+++ b/docs/docs/commands/export/dbt-models.md
@@ -16,7 +16,7 @@ datacontract export dbt-models [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/dbt-sources.md
+++ b/docs/docs/commands/export/dbt-sources.md
@@ -16,7 +16,7 @@ datacontract export dbt-sources [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/dbt-staging-sql.md
+++ b/docs/docs/commands/export/dbt-staging-sql.md
@@ -16,7 +16,7 @@ datacontract export dbt-staging-sql [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/dcs.md
+++ b/docs/docs/commands/export/dcs.md
@@ -16,7 +16,7 @@ datacontract export dcs [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/dqx.md
+++ b/docs/docs/commands/export/dqx.md
@@ -16,7 +16,7 @@ datacontract export dqx [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/excel.md
+++ b/docs/docs/commands/export/excel.md
@@ -16,7 +16,7 @@ datacontract export excel [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/go.md
+++ b/docs/docs/commands/export/go.md
@@ -16,7 +16,7 @@ datacontract export go [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/great-expectations.md
+++ b/docs/docs/commands/export/great-expectations.md
@@ -16,7 +16,7 @@ datacontract export great-expectations [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/html.md
+++ b/docs/docs/commands/export/html.md
@@ -16,7 +16,7 @@ datacontract export html [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/iceberg.md
+++ b/docs/docs/commands/export/iceberg.md
@@ -16,7 +16,7 @@ datacontract export iceberg [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/jsonschema.md
+++ b/docs/docs/commands/export/jsonschema.md
@@ -16,7 +16,7 @@ datacontract export jsonschema [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/markdown.md
+++ b/docs/docs/commands/export/markdown.md
@@ -16,7 +16,7 @@ datacontract export markdown [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/mermaid.md
+++ b/docs/docs/commands/export/mermaid.md
@@ -16,7 +16,7 @@ datacontract export mermaid [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/odcs.md
+++ b/docs/docs/commands/export/odcs.md
@@ -16,7 +16,7 @@ datacontract export odcs [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/protobuf.md
+++ b/docs/docs/commands/export/protobuf.md
@@ -16,7 +16,7 @@ datacontract export protobuf [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/pydantic-model.md
+++ b/docs/docs/commands/export/pydantic-model.md
@@ -16,7 +16,7 @@ datacontract export pydantic-model [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/rdf.md
+++ b/docs/docs/commands/export/rdf.md
@@ -16,7 +16,7 @@ datacontract export rdf [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/sodacl.md
+++ b/docs/docs/commands/export/sodacl.md
@@ -16,7 +16,7 @@ datacontract export sodacl [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/spark.md
+++ b/docs/docs/commands/export/spark.md
@@ -16,7 +16,7 @@ datacontract export spark [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/sql-query.md
+++ b/docs/docs/commands/export/sql-query.md
@@ -16,7 +16,7 @@ datacontract export sql-query [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/sql.md
+++ b/docs/docs/commands/export/sql.md
@@ -16,7 +16,7 @@ datacontract export sql [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/export/sqlalchemy.md
+++ b/docs/docs/commands/export/sqlalchemy.md
@@ -16,7 +16,7 @@ datacontract export sqlalchemy [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/lint.md
+++ b/docs/docs/commands/lint.md
@@ -16,7 +16,7 @@ datacontract lint [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/publish.md
+++ b/docs/docs/commands/publish.md
@@ -16,7 +16,7 @@ datacontract publish [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/commands/test.md
+++ b/docs/docs/commands/test.md
@@ -16,7 +16,7 @@ datacontract test [OPTIONS] [LOCATION]
 
 | Argument | Default | Description |
 |---|---|---|
-| `[LOCATION]` | `datacontract.yaml` | The location (url or path) of the data contract yaml. |
+| `[LOCATION]` | `datacontract.yaml` | The location (url, s3 url, or local path) of the data contract yaml. |
 
 | Option | Default | Description |
 |---|---|---|

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -329,4 +329,4 @@ So a committed team config file can hold defaults, CI can override single values
 ## Notes for specific sources
 
 - **Snowflake**: only the documented `DATACONTRACT_SNOWFLAKE_*` options are passed to the connector. Unknown names are ignored with a warning; use a [connections.toml](./testing/snowflake.md) for connector parameters the CLI does not support directly.
-- **AWS sources (S3, Athena, Redshift IAM, Glue)**: when no `DATACONTRACT_S3_*` options are set, boto3's own credential chain applies (`aws sso login`, `AWS_PROFILE`, instance roles, GitHub OIDC).
+- **AWS sources (S3, Athena, Redshift IAM, Glue)**: when no `DATACONTRACT_S3_*` options are set, boto3's own credential chain applies (`aws sso login`, `AWS_PROFILE`, instance roles, GitHub OIDC). The same credential set is used to read data contracts from `s3://` locations.

--- a/docs/docs/python-library.md
+++ b/docs/docs/python-library.md
@@ -59,7 +59,7 @@ DataContract(
 
 | Argument | Description |
 |---|---|
-| `data_contract_file` | Path or URL to the contract. |
+| `data_contract_file` | Path, URL, or S3 URL (`s3://bucket/key`) to the contract. |
 | `data_contract_str` | The contract as a YAML string. |
 | `data_contract` | An in-memory `OpenDataContractStandard` object. |
 | `server` | Server to test against (the key in `servers`). |

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -4,6 +4,7 @@ from open_data_contract_standard.model import OpenDataContractStandard
 from typer.testing import CliRunner
 
 from datacontract.cli import app
+from datacontract.config import Config
 from datacontract.data_contract import DataContract
 
 # logging.basicConfig(level=logging.INFO, force=True)
@@ -135,18 +136,46 @@ def test_lint_with_references():
     assert run.result == "passed"
 
 
-def test_lint_reads_data_contract_from_s3():
-    with open("fixtures/lint/valid_datacontract.yaml", "rb") as f:
-        yaml_bytes = f.read()
-
+def _mock_s3_client_returning(yaml_bytes: bytes) -> MagicMock:
     mock_body = MagicMock()
     mock_body.read.return_value = yaml_bytes
     mock_s3 = MagicMock()
     mock_s3.get_object.return_value = {"Body": mock_body}
+    return mock_s3
 
-    with patch("datacontract.lint.s3.boto3.client", return_value=mock_s3):
+
+def test_lint_reads_data_contract_from_s3():
+    with open("fixtures/lint/valid_datacontract.yaml", "rb") as f:
+        yaml_bytes = f.read()
+    mock_s3 = _mock_s3_client_returning(yaml_bytes)
+
+    with patch("boto3.client", return_value=mock_s3):
         data_contract = DataContract(data_contract_file="s3://my-bucket/contracts/datacontract.yaml")
         run = data_contract.lint()
 
     assert run.result == "passed"
     mock_s3.get_object.assert_called_once_with(Bucket="my-bucket", Key="contracts/datacontract.yaml")
+
+
+def test_lint_reads_data_contract_from_s3_with_configured_credentials():
+    with open("fixtures/lint/valid_datacontract.yaml", "rb") as f:
+        yaml_bytes = f.read()
+    mock_s3 = _mock_s3_client_returning(yaml_bytes)
+    config = Config(
+        s3_access_key_id="my-access-key",
+        s3_secret_access_key="my-secret-key",
+        s3_region="eu-central-1",
+    )
+
+    with patch("boto3.client", return_value=mock_s3) as mock_client:
+        data_contract = DataContract(data_contract_file="s3://my-bucket/contracts/datacontract.yaml", config=config)
+        run = data_contract.lint()
+
+    assert run.result == "passed"
+    mock_client.assert_called_once_with(
+        "s3",
+        region_name="eu-central-1",
+        aws_access_key_id="my-access-key",
+        aws_secret_access_key="my-secret-key",
+        aws_session_token=None,
+    )

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 from open_data_contract_standard.model import OpenDataContractStandard
 from typer.testing import CliRunner
 
@@ -131,3 +133,20 @@ def test_lint_with_references():
     run = data_contract.lint()
 
     assert run.result == "passed"
+
+
+def test_lint_reads_data_contract_from_s3():
+    with open("fixtures/lint/valid_datacontract.yaml", "rb") as f:
+        yaml_bytes = f.read()
+
+    mock_body = MagicMock()
+    mock_body.read.return_value = yaml_bytes
+    mock_s3 = MagicMock()
+    mock_s3.get_object.return_value = {"Body": mock_body}
+
+    with patch("datacontract.lint.s3.boto3.client", return_value=mock_s3):
+        data_contract = DataContract(data_contract_file="s3://my-bucket/contracts/datacontract.yaml")
+        run = data_contract.lint()
+
+    assert run.result == "passed"
+    mock_s3.get_object.assert_called_once_with(Bucket="my-bucket", Key="contracts/datacontract.yaml")


### PR DESCRIPTION
## Summary

This PR adds support for reading data contracts from **S3 locations** (`s3://...`) in addition to HTTP(S) URLs and local files.

## Changes

- Added a new S3 resource reader: `datacontract/lint/s3.py`
- Updated resource dispatching:
  - `datacontract/lint/resources.py`
  - now routes `s3://` locations to the S3 reader
- Added test coverage:
  - new test `test_lint_reads_data_contract_from_s3` in `tests/test_lint.py`
- Updated CLI help strings to mention S3 contract locations:
  - `command_test.py`
  - `command_lint.py`
  - `command_export.py`
  - `command_publish.py`
  - `command_changelog.py`
  - `command_ci.py`
- Updated documentation to reflect S3 support for contract locations:
  - command docs (`lint`, `test`, `export`, `publish`, `changelog`, `ci`)
  - python library docs


## Why

Users can now store contracts in S3 and use them directly with CLI workflows (lint/test/export/publish/changelog/ci) without downloading files manually first.

## Verification

- [X] Tests pass (`uv run pytest`)
- [x] Code formatted (`uv run ruff check --fix && uv run ruff format`)
- [X] Docs updated (if relevant)
- [X] CHANGELOG.md entry added
