### PR TITLE
Run individual quality rules with test --quality-id and --tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `datacontract test --quality-id` runs a single quality rule by its ODCS `quality.id`, and `--tag` runs every quality rule declaring one of the given `quality.tags` (#1080)
+- Test results report the `quality_id` and `tags` of the quality rule a check comes from
 - New `databricks-runtime` extra for installing inside a Databricks Runtime, where the cluster already provides PySpark: `pip install datacontract-cli[databricks-runtime]` (#1211 @chifu1234)
 - The docs Commands reference documents the global options `--version` and `--system-truststore`, and every import and export guide links to its command page and back
 - `datacontract test --dimension` runs only the checks measuring one data quality dimension, e.g. `--dimension uniqueness`; it matches the ODCS `quality.dimension` of a rule and the schema and service level checks that measure the same aspect

--- a/datacontract/command_test.py
+++ b/datacontract/command_test.py
@@ -56,6 +56,17 @@ def _parse_enum_csv(value: str | None, enum_cls: type[Enum], option: str, label:
     return {enum_cls(v).value for v in raw}
 
 
+def _parse_csv(value: str | None, option: str) -> set[str] | None:
+    """Parse a comma-separated option into a set of values, or None if unset."""
+    if value is None:
+        return None
+    values = {v.strip() for v in value.split(",") if v.strip()}
+    if not values:
+        console.print(f"[red]Empty {option} specified.[/red]")
+        raise typer.Exit(code=1)
+    return values
+
+
 @app.command(
     name="test",
     epilog="Example: datacontract test datacontract.yaml --server production",
@@ -112,6 +123,21 @@ def test(
             "and service level checks that measure it. Omit to run everything."
         ),
     ] = None,
+    quality_id: Annotated[
+        str,
+        typer.Option(
+            help="Comma-separated list of quality rule ids to run, as defined in the `id` of the "
+            "quality rule. Runs only those rules, no schema or service level checks. "
+            "Fails if an id is not defined in the data contract. Omit to run everything."
+        ),
+    ] = None,
+    tag: Annotated[
+        str,
+        typer.Option(
+            help="Comma-separated list of tags to run. Runs the quality rules declaring a matching "
+            "tag in their `tags`, no schema or service level checks. Omit to run everything."
+        ),
+    ] = None,
     include_failed_samples: Annotated[
         bool,
         typer.Option(
@@ -141,6 +167,8 @@ def test(
 
     check_categories = _parse_enum_csv(checks, CheckCategory, "--checks", "categories")
     dimensions = _parse_enum_csv(dimension, QualityDimension, "--dimension", "dimensions")
+    quality_ids = _parse_csv(quality_id, "--quality-id")
+    tags = _parse_csv(tag, "--tag")
 
     output_format = resolve_output_format(output_format, output)
 
@@ -157,6 +185,8 @@ def test(
         ssl_verification=ssl_verification,
         check_categories=check_categories,
         dimensions=dimensions,
+        quality_ids=quality_ids,
+        tags=tags,
         inline_references=inline_references,
         include_failed_samples=include_failed_samples,
     ).test()

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -38,6 +38,8 @@ class DataContract:
         all_errors: bool = False,
         check_categories: set[str] | None = None,
         dimensions: set[str] | None = None,
+        quality_ids: set[str] | None = None,
+        tags: set[str] | None = None,
         fastapi_url: str = None,
         include_failed_samples: bool = False,
     ):
@@ -56,6 +58,8 @@ class DataContract:
         self._all_errors = all_errors
         self._check_categories = check_categories
         self._dimensions = dimensions
+        self._quality_ids = quality_ids
+        self._tags = tags
         self._fastapi_url = fastapi_url
         self._include_failed_samples = include_failed_samples
 
@@ -149,6 +153,8 @@ class DataContract:
                 schema_name=self._schema_name,
                 check_categories=self._check_categories,
                 dimensions=self._dimensions,
+                quality_ids=self._quality_ids,
+                tags=self._tags,
                 include_failed_samples=self._include_failed_samples,
             )
 

--- a/datacontract/engines/checks/check_filter.py
+++ b/datacontract/engines/checks/check_filter.py
@@ -1,0 +1,50 @@
+"""The `datacontract test` check selection (`--checks`, `--dimension`, `--quality-id`, `--tag`).
+
+Engines that build their checks from a :class:`~datacontract.engines.checks.check_spec.CheckSpec`
+list filter the specs directly (see ``datacontract/engines/data_contract_test.py``).
+Engines that emit checks as they go — currently the Azure Blob file engine — carry a
+:class:`CheckFilter` instead and ask it about each check before appending it.
+
+An unset (``None``) criterion selects everything; the criteria that are set all apply.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+from datacontract.engines.checks.dimensions import default_dimension
+
+
+@dataclass(frozen=True)
+class CheckFilter:
+    categories: Optional[set[str]] = None
+    dimensions: Optional[set[str]] = None
+    quality_ids: Optional[set[str]] = None
+    tags: Optional[set[str]] = None
+
+    def matches(
+        self,
+        *,
+        category: str,
+        check_type: str,
+        dimension: Optional[str] = None,
+        quality_id: Optional[str] = None,
+        tags: Optional[Iterable[str]] = None,
+    ) -> bool:
+        """Whether a check should run. ``dimension``/``quality_id``/``tags`` come from
+        the ODCS quality rule behind the check, if any."""
+        if self.categories is not None and category not in self.categories:
+            return False
+        if self.dimensions is not None:
+            # A rule's own ODCS dimension wins; otherwise fall back to the one this
+            # built-in check measures. Checks with neither are dropped by the filter.
+            if (dimension if dimension is not None else default_dimension(check_type)) not in self.dimensions:
+                return False
+        # Only quality rules carry an id and tags, so these criteria exclude the
+        # built-in schema and service level checks entirely.
+        if self.quality_ids is not None and quality_id not in self.quality_ids:
+            return False
+        if self.tags is not None and (tags is None or self.tags.isdisjoint(tags)):
+            return False
+        return True

--- a/datacontract/engines/checks/check_spec.py
+++ b/datacontract/engines/checks/check_spec.py
@@ -117,6 +117,15 @@ class CheckSpec:
     # and for quality rules that do not declare one.
     dimension: Optional[str] = None
 
+    # ODCS quality.id: the author-defined identifier of the quality rule this
+    # check comes from. `test --quality-id` selects a single rule by it.
+    # None for schema and service level checks, and for unidentified rules.
+    quality_id: Optional[str] = None
+
+    # ODCS quality.tags: the author-defined labels of the quality rule this
+    # check comes from. `test --tag` selects rules by them.
+    tags: Optional[List[str]] = None
+
     # --- metric arguments -------------------------------------------------
     missing_values: Optional[List[Any]] = None  # MISSING_COUNT / INVALID_COUNT
     valid_values: Optional[List[Any]] = None  # INVALID_COUNT

--- a/datacontract/engines/checks/create_checks.py
+++ b/datacontract/engines/checks/create_checks.py
@@ -577,68 +577,77 @@ def _quality_checks(
     model: str, field: Optional[str], quality_list: List[DataQuality], server: Optional[Server]
 ) -> List[CheckSpec]:
     checks: List[CheckSpec] = []
-    count = 0
-    for quality in quality_list:
-        if quality.type == "custom" and quality.engine == "soda" and quality.implementation:
-            checks.append(
-                CheckSpec(
-                    key=f"{model}__quality_custom_{count}",
-                    category="quality",
-                    type="quality_custom_soda",
-                    name=quality.description or "Custom SodaCL Check",
-                    model=model,
-                    field=field,
-                    metric=MetricType.UNSUPPORTED,
-                    dimension=quality.dimension,
-                    preset_result="warning",
-                    preset_reason=(
-                        "Raw SodaCL custom checks (quality.type: custom, engine: soda) are no longer "
-                        "supported since soda-core was removed. Migrate this check to quality.type: sql."
-                    ),
-                )
-            )
-        elif quality.type == "sql":
-            if field is None:
-                check_key = f"{model}__quality_sql_{count}"
-                check_type = "model_quality_sql"
-            else:
-                check_key = f"{model}__{field}__quality_sql_{count}"
-                check_type = "field_quality_sql"
-            threshold = to_threshold(quality)
-            query = prepare_query(quality, model, field, server)
-            if query is None:
-                logger.warning(f"Quality check {check_key} has no query")
-                count += 1
-                continue
-            if threshold is None:
-                logger.warning(f"Quality check {check_key} has no valid threshold")
-                count += 1
-                continue
-            checks.append(
-                CheckSpec(
-                    key=check_key,
-                    category="quality",
-                    type=check_type,
-                    name=quality.description or "Quality Check",
-                    model=model,
-                    field=field,
-                    metric=MetricType.CUSTOM_SQL,
-                    threshold=threshold,
-                    query=query,
-                    dialect=getattr(quality, "dialect", None),
-                    severity=quality.severity,
-                    dimension=quality.dimension,
-                )
-            )
-        elif quality.metric is not None:
-            threshold = to_threshold(quality)
-            if threshold is None:
-                logger.warning(f"Quality metric {quality.metric} has no valid threshold")
-                count += 1
-                continue
-            checks.extend(_quality_metric_check(model, field, quality, threshold))
-        count += 1
+    for count, quality in enumerate(quality_list):
+        rule_checks = _quality_rule_checks(model, field, quality, count, server)
+        # Every check keeps a link back to the rule that declared it, so that
+        # `test --quality-id` / `test --tag` can select it.
+        for check in rule_checks:
+            check.quality_id = quality.id
+            check.tags = list(quality.tags) if quality.tags else None
+        checks.extend(rule_checks)
     return checks
+
+
+def _quality_rule_checks(
+    model: str, field: Optional[str], quality: DataQuality, count: int, server: Optional[Server]
+) -> List[CheckSpec]:
+    """The checks of a single ODCS quality rule (``count`` is its index in the list)."""
+    if quality.type == "custom" and quality.engine == "soda" and quality.implementation:
+        return [
+            CheckSpec(
+                key=f"{model}__quality_custom_{count}",
+                category="quality",
+                type="quality_custom_soda",
+                name=quality.description or "Custom SodaCL Check",
+                model=model,
+                field=field,
+                metric=MetricType.UNSUPPORTED,
+                dimension=quality.dimension,
+                preset_result="warning",
+                preset_reason=(
+                    "Raw SodaCL custom checks (quality.type: custom, engine: soda) are no longer "
+                    "supported since soda-core was removed. Migrate this check to quality.type: sql."
+                ),
+            )
+        ]
+    if quality.type == "sql":
+        if field is None:
+            check_key = f"{model}__quality_sql_{count}"
+            check_type = "model_quality_sql"
+        else:
+            check_key = f"{model}__{field}__quality_sql_{count}"
+            check_type = "field_quality_sql"
+        threshold = to_threshold(quality)
+        query = prepare_query(quality, model, field, server)
+        if query is None:
+            logger.warning(f"Quality check {check_key} has no query")
+            return []
+        if threshold is None:
+            logger.warning(f"Quality check {check_key} has no valid threshold")
+            return []
+        return [
+            CheckSpec(
+                key=check_key,
+                category="quality",
+                type=check_type,
+                name=quality.description or "Quality Check",
+                model=model,
+                field=field,
+                metric=MetricType.CUSTOM_SQL,
+                threshold=threshold,
+                query=query,
+                dialect=getattr(quality, "dialect", None),
+                severity=quality.severity,
+                dimension=quality.dimension,
+            )
+        ]
+    if quality.metric is not None:
+        threshold = to_threshold(quality)
+        if threshold is None:
+            logger.warning(f"Quality metric {quality.metric} has no valid threshold")
+            return []
+        return _quality_metric_check(model, field, quality, threshold)
+    return []
 
 
 def _quality_metric_check(model, field, quality: DataQuality, threshold: Threshold) -> List[CheckSpec]:

--- a/datacontract/engines/data_contract_test.py
+++ b/datacontract/engines/data_contract_test.py
@@ -32,6 +32,8 @@ def execute_data_contract_test(
     schema_name: str = "all",
     check_categories: set[str] | None = None,
     dimensions: set[str] | None = None,
+    quality_ids: set[str] | None = None,
+    tags: set[str] | None = None,
     include_failed_samples: bool = False,
 ):
     if data_contract.schema_ is None or len(data_contract.schema_) == 0:
@@ -63,6 +65,11 @@ def execute_data_contract_test(
                 engine="datacontract",
             )
 
+    if quality_ids is not None:
+        # A quality rule id is a precise reference, like --schema-name: an id that
+        # matches nothing is a typo, and silently testing nothing would pass.
+        check_that_quality_ids_exist(data_contract, quality_ids, schema_name)
+
     if server.type == "api":
         server = process_api_response(run, server)
 
@@ -77,14 +84,28 @@ def execute_data_contract_test(
         specs = [s for s in specs if s.dimension in dimensions]
         if not specs:
             run.log_warn(f"No checks found for dimensions: {', '.join(sorted(dimensions))}")
+    # Only quality rules carry an id and tags, so these filters exclude the
+    # built-in schema and service level checks entirely.
+    if quality_ids is not None:
+        specs = [s for s in specs if s.quality_id in quality_ids]
+        if not specs:
+            run.log_warn(f"No checks found for quality rule ids: {', '.join(sorted(quality_ids))}")
+    if tags is not None:
+        specs = [s for s in specs if s.tags and not tags.isdisjoint(s.tags)]
+        if not specs:
+            run.log_warn(f"No checks found for tags: {', '.join(sorted(tags))}")
     run.checks.extend(build_check_stubs(specs))
 
     # TODO check server is supported type for nicer error messages
     # TODO check server credentials are complete for nicer error messages
     if server.format == "json" and server.type != "kafka":
-        # The JSON Schema validation emits checks of type "schema" throughout.
-        if (check_categories is None or "schema" in check_categories) and (
-            dimensions is None or default_dimension("schema") in dimensions
+        # The JSON Schema validation emits checks of type "schema" throughout,
+        # so it is out of scope once a quality rule is selected by id or tag.
+        if (
+            (check_categories is None or "schema" in check_categories)
+            and (dimensions is None or default_dimension("schema") in dimensions)
+            and quality_ids is None
+            and tags is None
         ):
             check_jsonschema(run, data_contract, server, schema_name=schema_name)
     # Azure Blob / ADLS Gen2 file-metadata checks (logicalType=blob schemas)
@@ -96,6 +117,8 @@ def execute_data_contract_test(
             schema_name=schema_name,
             check_categories=check_categories,
             dimensions=dimensions,
+            quality_ids=quality_ids,
+            tags=tags,
         )
     execute_ibis_checks(
         run,
@@ -106,6 +129,43 @@ def execute_data_contract_test(
         duckdb_connection,
         schema_name=schema_name,
         include_failed_samples=include_failed_samples,
+    )
+
+
+def quality_rule_ids(data_contract: OpenDataContractStandard, schema_name: str = "all") -> set[str]:
+    """The ids declared by the quality rules of the contract, on schemas and properties."""
+    ids: set[str] = set()
+
+    def collect(quality_list) -> None:
+        for quality in quality_list or []:
+            if quality.id is not None:
+                ids.add(quality.id)
+
+    for schema_object in data_contract.schema_ or []:
+        if schema_name != "all" and schema_object.name != schema_name:
+            continue
+        collect(schema_object.quality)
+        for prop in schema_object.properties or []:
+            collect(prop.quality)
+    return ids
+
+
+def check_that_quality_ids_exist(
+    data_contract: OpenDataContractStandard, quality_ids: set[str], schema_name: str = "all"
+) -> None:
+    available = quality_rule_ids(data_contract, schema_name)
+    unknown = sorted(quality_ids - available)
+    if not unknown:
+        return
+    raise DataContractException(
+        type="lint",
+        name="Check that quality rule id exists",
+        result=ResultEnum.failed,
+        reason=(
+            f"Quality rule id(s) not found in data contract: {', '.join(unknown)}. "
+            f"Available quality rule ids: {sorted(available)}"
+        ),
+        engine="datacontract",
     )
 
 

--- a/datacontract/engines/datacontract/check_azure_blob_file.py
+++ b/datacontract/engines/datacontract/check_azure_blob_file.py
@@ -16,7 +16,7 @@ from open_data_contract_standard.model import (
     Server,
 )
 
-from datacontract.engines.checks.dimensions import default_dimension
+from datacontract.engines.checks.check_filter import CheckFilter
 from datacontract.model.exceptions import DataContractException
 from datacontract.model.run import Check, ResultEnum, Run
 
@@ -73,6 +73,8 @@ def check_azure_blob_file(
     schema_name: str = "all",
     check_categories: set[str] | None = None,
     dimensions: set[str] | None = None,
+    quality_ids: set[str] | None = None,
+    tags: set[str] | None = None,
 ) -> None:
     """Run Azure Blob Storage metadata checks for all blob-logicalType schemas.
 
@@ -81,6 +83,8 @@ def check_azure_blob_file(
     No exception is raised if the server is not Azure or if no blob schemas exist —
     the function simply returns without adding checks.
     """
+    check_filter = CheckFilter(categories=check_categories, dimensions=dimensions, quality_ids=quality_ids, tags=tags)
+
     if data_contract.schema_ is None:
         return
 
@@ -102,8 +106,7 @@ def check_azure_blob_file(
             model=None,
             result=ResultEnum.failed,
             reason="Server block has no 'location' property. Cannot resolve container and prefix.",
-            check_categories=check_categories,
-            dimensions=dimensions,
+            check_filter=check_filter,
         )
         return
 
@@ -118,8 +121,7 @@ def check_azure_blob_file(
             model=None,
             result=ResultEnum.error,
             reason=f"Could not connect to Azure Blob Storage: {exc}",
-            check_categories=check_categories,
-            dimensions=dimensions,
+            check_filter=check_filter,
         )
         return
 
@@ -137,8 +139,7 @@ def check_azure_blob_file(
             "abfss://<container>@<account>.dfs.core.windows.net/<prefix>, "
             "azure://<container>@<account>.blob.core.windows.net/<prefix>, "
             "wasbs://<container>@<account>.blob.core.windows.net/<prefix>.",
-            check_categories=check_categories,
-            dimensions=dimensions,
+            check_filter=check_filter,
         )
         return
 
@@ -147,7 +148,7 @@ def check_azure_blob_file(
     )
 
     for schema in blob_schemas:
-        _check_schema(run, schema, blob_service_client, container_name, prefix, check_categories, dimensions)
+        _check_schema(run, schema, blob_service_client, container_name, prefix, check_filter)
 
 
 # ---------------------------------------------------------------------------
@@ -161,8 +162,7 @@ def _check_schema(
     blob_service_client: "BlobServiceClient",
     container_name: str,
     prefix: str,
-    check_categories: set[str] | None = None,
-    dimensions: set[str] | None = None,
+    check_filter: CheckFilter = CheckFilter(),
 ) -> None:
     schema_name = schema.name or "unknown"
 
@@ -194,8 +194,7 @@ def _check_schema(
             model=schema_name,
             result=ResultEnum.error,
             reason=reason,
-            check_categories=check_categories,
-            dimensions=dimensions,
+            check_filter=check_filter,
         )
         return
 
@@ -208,11 +207,11 @@ def _check_schema(
     # ── Per-property checks (driven by schema.properties) ────────────────────
     if schema.properties:
         for prop in schema.properties:
-            _check_property(run, schema_name, prop, blobs, check_categories, dimensions)
+            _check_property(run, schema_name, prop, blobs, check_filter)
 
     # ── Quality file-count thresholds on the schema object ───────────────────
     if schema.quality:
-        _check_file_count_quality(run, schema_name, schema.quality, file_count, check_categories, dimensions)
+        _check_file_count_quality(run, schema_name, schema.quality, file_count, check_filter)
 
 
 # ---------------------------------------------------------------------------
@@ -225,8 +224,7 @@ def _check_property(
     schema_name: str,
     prop: SchemaProperty,
     blobs: List["BlobProperties"],
-    check_categories: set[str] | None = None,
-    dimensions: set[str] | None = None,
+    check_filter: CheckFilter = CheckFilter(),
 ) -> None:
     """Run required + quality checks for one declared schema property across all blobs."""
     prop_name = prop.name
@@ -250,8 +248,7 @@ def _check_property(
                 result=ResultEnum.failed,
                 reason=f"{len(missing)} blob(s) have no value for '{prop_name}'.",
                 details="; ".join(missing[:5]) + (" …" if len(missing) > 5 else ""),
-                check_categories=check_categories,
-                dimensions=dimensions,
+                check_filter=check_filter,
             )
         else:
             _append_check(
@@ -263,8 +260,7 @@ def _check_property(
                 field=prop_name,
                 result=ResultEnum.passed,
                 reason=f"All {len(blobs)} blob(s) have a value for '{prop_name}'.",
-                check_categories=check_categories,
-                dimensions=dimensions,
+                check_filter=check_filter,
             )
 
     # ── quality constraints ────────────────────────────────────────────────────
@@ -300,9 +296,8 @@ def _check_property(
                 result=ResultEnum.failed,
                 reason=f"{len(violations)} blob(s) violate '{prop_name} {constraint_desc}'.",
                 details=details,
-                check_categories=check_categories,
-                dimensions=dimensions,
-                dimension=quality.dimension,
+                check_filter=check_filter,
+                quality=quality,
             )
         else:
             _append_check(
@@ -314,9 +309,8 @@ def _check_property(
                 field=prop_name,
                 result=ResultEnum.passed,
                 reason=f"All {len(blobs)} blob(s) satisfy '{prop_name} {constraint_desc}'.",
-                check_categories=check_categories,
-                dimensions=dimensions,
-                dimension=quality.dimension,
+                check_filter=check_filter,
+                quality=quality,
             )
 
 
@@ -423,8 +417,7 @@ def _check_file_count_quality(
     schema_name: str,
     quality_list: List[DataQuality],
     file_count: int,
-    check_categories: set[str] | None = None,
-    dimensions: set[str] | None = None,
+    check_filter: CheckFilter = CheckFilter(),
 ) -> None:
     """Evaluate schema-level quality thresholds interpreted as file-count constraints."""
     for quality in quality_list:
@@ -440,9 +433,8 @@ def _check_file_count_quality(
             model=schema_name,
             result=ResultEnum.passed if passed else ResultEnum.failed,
             reason=reason,
-            check_categories=check_categories,
-            dimensions=dimensions,
-            dimension=quality.dimension,
+            check_filter=check_filter,
+            quality=quality,
         )
 
 
@@ -609,17 +601,23 @@ def _append_check(
     reason: str,
     field: Optional[str] = None,
     details: Optional[str] = None,
-    check_categories: set[str] | None = None,
-    dimensions: set[str] | None = None,
-    dimension: Optional[str] = None,
+    check_filter: CheckFilter = CheckFilter(),
+    quality: Optional[DataQuality] = None,
 ) -> None:
-    if check_categories is not None and category not in check_categories:
-        return
-    # A rule's own ODCS dimension wins; otherwise fall back to the one this
-    # built-in check measures. Checks with neither are dropped by the filter.
-    if dimension is None:
-        dimension = default_dimension(check_type)
-    if dimensions is not None and dimension not in dimensions:
+    """Append a check to the run, unless the active `test` filters exclude it.
+
+    ``quality`` is the ODCS rule the check comes from, if any: it supplies the
+    dimension, id and tags that `--dimension`, `--quality-id` and `--tag` match on.
+    """
+    quality_id = quality.id if quality is not None else None
+    tags = list(quality.tags) if quality is not None and quality.tags else None
+    if not check_filter.matches(
+        category=category,
+        check_type=check_type,
+        dimension=quality.dimension if quality is not None else None,
+        quality_id=quality_id,
+        tags=tags,
+    ):
         return
     run.checks.append(
         Check(
@@ -630,6 +628,8 @@ def _append_check(
             name=name,
             model=model,
             field=field,
+            quality_id=quality_id,
+            tags=tags,
             engine="datacontract",
             language="python",
             result=result,

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -55,6 +55,8 @@ def build_check_stubs(specs: List[CheckSpec]) -> List[Check]:
                 name=spec.name,
                 model=spec.model,
                 field=spec.field,
+                quality_id=spec.quality_id,
+                tags=spec.tags,
                 engine="ibis",
                 implementation=_describe(spec),
             )

--- a/datacontract/model/run.py
+++ b/datacontract/model/run.py
@@ -32,6 +32,11 @@ class Check(BaseModel):
     name: str | None = None
     model: str | None = None
     field: str | None = None
+    # The ODCS `quality.id` / `quality.tags` of the rule this check comes from,
+    # so a check can be traced back to (and re-run through `test --quality-id`
+    # / `test --tag`) the rule that declared it. Empty for built-in checks.
+    quality_id: str | None = None
+    tags: list[str] | None = None
 
     engine: str | None = None
     language: str | None = None

--- a/docs/docs/commands/test.md
+++ b/docs/docs/commands/test.md
@@ -29,6 +29,8 @@ datacontract test [OPTIONS] [LOCATION]
 | `--output-format` | — | The target format for the test results. Accepted values: json, junit. |
 | `--checks` | — | Comma-separated list of check categories to run (available: schema, quality, servicelevel, custom). Omit to enable all. |
 | `--dimension` | — | Comma-separated list of quality dimensions to run (available: accuracy, completeness, conformity, consistency, coverage, timeliness, uniqueness). Runs the quality rules declaring a matching `dimension`, plus the schema and service level checks that measure it. Omit to run everything. |
+| `--quality-id` | — | Comma-separated list of quality rule ids to run, as defined in the `id` of the quality rule. Runs only those rules, no schema or service level checks. Fails if an id is not defined in the data contract. Omit to run everything. |
+| `--tag` | — | Comma-separated list of tags to run. Runs the quality rules declaring a matching tag in their `tags`, no schema or service level checks. Omit to run everything. |
 | `--include-failed-samples` / `--no-include-failed-samples` | `--no-include-failed-samples` | Collect a small sample of rows that failed each missing/invalid/duplicate check (identifier + offending columns; sensitive columns omitted). Off by default. |
 | `--logs` / `--no-logs` | `--no-logs` | Print logs |
 | `--ssl-verification` / `--no-ssl-verification` | `--ssl-verification` | SSL verification when publishing the data contract. |

--- a/docs/docs/quality-rules/index.md
+++ b/docs/docs/quality-rules/index.md
@@ -84,6 +84,31 @@ ODCS defines seven dimensions. `datacontract lint` rejects any other value:
 
 The [HTML export](../exports/html.md) renders the dimension as a badge next to schema-level rules.
 
+## Identifying rules
+
+Any rule can carry an `id` and a list of `tags`. Both are optional and work with every rule type. They name a rule so that a pipeline can run it on its own: an `id` addresses exactly one rule, `tags` group rules that belong together — by cost, criticality, or the pipeline step they guard.
+
+```yaml
+schema:
+  - name: orders
+    quality:
+      - id: orders_not_empty
+        type: library
+        metric: rowCount
+        mustBeGreaterThan: 0
+        tags: ["critical", "cheap"]
+    properties:
+      - name: order_id
+        quality:
+          - id: order_id_is_unique
+            type: library
+            metric: duplicateValues
+            mustBe: 0
+            tags: ["critical", "expensive"]
+```
+
+An `id` must be unique within the contract, so that `--quality-id` selects a single rule. Test results report the `id` and `tags` of the rule each check comes from.
+
 ## Running only quality checks
 
 Use `--checks` to restrict a run to quality rules:
@@ -102,6 +127,18 @@ datacontract test --dimension completeness,accuracy datacontract.yaml
 This selects quality rules by their declared `dimension` **and** the built-in checks that measure the same thing — `--dimension uniqueness` runs your `duplicateValues` rules alongside the `unique` and primary-key checks derived from the schema.
 
 Quality rules that declare no `dimension` are never selected: only the author can say what a custom rule measures. If nothing matches, the run executes nothing and reports no checks.
+
+Use `--quality-id` to run a single rule, and `--tag` to run a group of them:
+
+```bash
+datacontract test --quality-id order_id_is_unique datacontract.yaml
+datacontract test --tag critical datacontract.yaml
+datacontract test --tag critical,cheap datacontract.yaml
+```
+
+Both select quality rules only — no schema or service level checks run alongside them. This makes it possible to spread the rules of one contract over a data pipeline: run the cheap rules on ingest, the expensive ones after the nightly load, without splitting the contract into several files.
+
+`--quality-id` matches the `id` of the rule, and fails the run if no rule in the contract declares it — a mistyped id must not pass by testing nothing. `--tag` matches the `tags` of the rule (not the `tags` of a schema or property), and reports no checks when nothing matches. Options combine: `--tag critical --checks quality --server production` runs the critical rules on production.
 
 ### Dimensions of the built-in checks
 

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -27,6 +27,8 @@ marked as such in the entry.
 ## Unreleased {#unreleased}
 
 ### Added
+- `datacontract test --quality-id` runs a single quality rule by its ODCS `quality.id`, and `--tag` runs every quality rule declaring one of the given `quality.tags` ([#1080](https://github.com/datacontract/datacontract-cli/issues/1080))
+- Test results report the `quality_id` and `tags` of the quality rule a check comes from
 - New `databricks-runtime` extra for installing inside a Databricks Runtime, where the cluster already provides PySpark: `pip install datacontract-cli[databricks-runtime]` ([#1211](https://github.com/datacontract/datacontract-cli/issues/1211) [@chifu1234](https://github.com/chifu1234))
 - The docs Commands reference documents the global options `--version` and `--system-truststore`, and every import and export guide links to its command page and back
 - `datacontract test --dimension` runs only the checks measuring one data quality dimension, e.g. `--dimension uniqueness`; it matches the ODCS `quality.dimension` of a rule and the schema and service level checks that measure the same aspect

--- a/docs/docs/testing/index.md
+++ b/docs/docs/testing/index.md
@@ -111,6 +111,8 @@ Omit `--checks` to run all of them.
 
 `--dimension` cuts across those categories instead: it selects every check that measures one aspect of data quality — the [quality rules](../quality-rules/index.md#quality-dimensions) tagged with that `dimension` plus the schema and service level checks that measure the same thing.
 
+`--quality-id` and `--tag` go the other way and narrow the run to individual [quality rules](../quality-rules/index.md#identifying-rules): `--quality-id` runs the one rule declaring that `id`, `--tag` runs every rule declaring that tag, and neither runs any schema or service level check.
+
 ## Configuring the connection
 
 The connection details (host, catalog, location, …) live in the contract's `servers` block; **credentials are provided as environment variables**.
@@ -137,7 +139,7 @@ The page for each source above lists its `servers` fields and the environment va
 
 ## Options
 
-`--server`, `--schema-name`, `--checks`, and `--dimension` narrow down what runs. `--output` with `--output-format` writes the results to a file as `json` or `junit`, `--publish` sends them to a URL, and `--include-failed-samples` collects a small sample of the offending rows. See the full [`test` command reference](../commands/test.md).
+`--server`, `--schema-name`, `--checks`, `--dimension`, `--quality-id`, and `--tag` narrow down what runs. `--output` with `--output-format` writes the results to a file as `json` or `junit`, `--publish` sends them to a URL, and `--include-failed-samples` collects a small sample of the offending rows. See the full [`test` command reference](../commands/test.md).
 
 For CI/CD pipelines, use the [`ci`](../commands/ci.md) command, which wraps `test` with annotations, summaries, and exit-code control.
 

--- a/tests/fixtures/quality-id/datacontract.yaml
+++ b/tests/fixtures/quality-id/datacontract.yaml
@@ -1,0 +1,24 @@
+apiVersion: v3.0.2
+kind: DataContract
+id: quality-id
+version: 1.0.0
+status: active
+servers:
+  - server: local
+    type: local
+    path: ./fixtures/diagnostics/data/orders.csv
+    format: csv
+schema:
+  - name: orders
+    quality:
+      # Passes: the fixture has 5 rows.
+      - id: orders_not_empty
+        type: library
+        metric: rowCount
+        mustBeGreaterThan: 1
+        tags: ["critical", "cheap"]
+    properties:
+      - name: order_id
+        logicalType: integer
+      - name: email
+        logicalType: string

--- a/tests/test_test_azure_blob_file.py
+++ b/tests/test_test_azure_blob_file.py
@@ -391,3 +391,41 @@ class TestDimensionFilter:
         run = self._run_with_dimensions(None)
         assert _checks_by_type(run, "azure_file_property_required")
         assert _checks_by_type(run, "azure_file_count_quality")
+
+
+class TestQualityIdAndTagFilter:
+    """`--quality-id` and `--tag` also select the Azure blob quality checks."""
+
+    def _run(self, **kwargs) -> Run:
+        data_contract = _load_contract()
+        schema = data_contract.schema_[0]
+        # The fixture identifies no rules; identify two so the filters have
+        # something to select on.
+        schema.quality[0].id = "enough_files"
+        schema.quality[0].tags = ["critical"]
+        size_prop = next(p for p in schema.properties if p.name == "size")
+        size_prop.quality[0].id = "file_size"
+        size_prop.quality[0].tags = ["critical", "cheap"]
+
+        run = _make_run()
+        with patch(
+            "datacontract.engines.datacontract.check_azure_blob_file._build_blob_service_client",
+            return_value=_patched_client([_make_blob("raw/orders/a.json", size=1024)]),
+        ):
+            check_azure_blob_file(run, data_contract, data_contract.servers[0], **kwargs)
+        return run
+
+    def test_quality_id_selects_a_single_rule(self):
+        run = self._run(quality_ids={"enough_files"})
+        assert [c.type for c in run.checks] == ["azure_file_count_quality"]
+        assert run.checks[0].quality_id == "enough_files"
+
+    def test_tag_selects_every_rule_carrying_it(self):
+        run = self._run(tags={"critical"})
+        assert sorted(c.type for c in run.checks) == ["azure_file_count_quality", "azure_file_property_quality"]
+
+    def test_tag_excludes_the_rules_without_it(self):
+        run = self._run(tags={"cheap"})
+        assert [c.type for c in run.checks] == ["azure_file_property_quality"]
+        assert run.checks[0].field == "size"
+        assert run.checks[0].tags == ["critical", "cheap"]

--- a/tests/test_test_quality_id_and_tag_filter.py
+++ b/tests/test_test_quality_id_and_tag_filter.py
@@ -1,0 +1,164 @@
+from typer.testing import CliRunner
+
+from datacontract.cli import app
+from datacontract.data_contract import DataContract
+
+runner = CliRunner()
+
+CONTRACT = """
+apiVersion: v3.0.2
+kind: DataContract
+id: quality_id_filter_test
+version: 1.0.0
+status: active
+servers:
+  - server: local
+    type: local
+    path: ./fixtures/diagnostics/data/orders.csv
+    format: csv
+schema:
+  - name: orders
+    quality:
+      # Passes: the fixture has 5 rows.
+      - id: orders_not_empty
+        type: library
+        metric: rowCount
+        mustBeGreaterThan: 1
+        tags: ["critical", "cheap"]
+      # Fails: the fixture has an amount of -5.
+      - id: amounts_are_positive
+        type: sql
+        description: amounts are positive
+        query: SELECT MIN(amount) FROM orders
+        mustBeGreaterThan: 0
+        tags: ["expensive"]
+    properties:
+      # Fails: the fixture repeats order_id 2.
+      - name: order_id
+        logicalType: integer
+        quality:
+          - id: order_id_is_unique
+            type: library
+            metric: duplicateValues
+            mustBe: 0
+            tags: ["critical"]
+      - name: email
+        logicalType: string
+        quality:
+          # No id, no tags: only reachable without a filter.
+          - type: library
+            metric: nullValues
+            mustBe: 0
+"""
+
+
+def test_quality_id_runs_only_that_rule():
+    run = DataContract(data_contract_str=CONTRACT, quality_ids={"order_id_is_unique"}).test()
+    print(run.pretty())
+    assert [check.type for check in run.checks] == ["field_duplicate_values"]
+    assert run.result == "failed"
+
+
+def test_quality_id_skips_schema_checks():
+    run = DataContract(data_contract_str=CONTRACT, quality_ids={"orders_not_empty"}).test()
+    print(run.pretty())
+    assert [check.type for check in run.checks] == ["row_count"]
+    assert run.result == "passed"
+
+
+def test_quality_id_accepts_multiple_ids():
+    run = DataContract(
+        data_contract_str=CONTRACT,
+        quality_ids={"orders_not_empty", "amounts_are_positive"},
+    ).test()
+    print(run.pretty())
+    assert sorted(check.type for check in run.checks) == ["model_quality_sql", "row_count"]
+
+
+def test_unknown_quality_id_fails_the_run():
+    """An id that matches nothing is a typo — testing nothing must not pass."""
+    run = DataContract(data_contract_str=CONTRACT, quality_ids={"does_not_exist"}).test()
+    print(run.pretty())
+    assert run.result == "failed"
+    assert "does_not_exist" in run.checks[0].reason
+    assert "orders_not_empty" in run.checks[0].reason
+
+
+def test_tag_runs_every_rule_carrying_it():
+    run = DataContract(data_contract_str=CONTRACT, tags={"critical"}).test()
+    print(run.pretty())
+    assert sorted(check.type for check in run.checks) == ["field_duplicate_values", "row_count"]
+
+
+def test_tag_accepts_multiple_tags():
+    run = DataContract(data_contract_str=CONTRACT, tags={"cheap", "expensive"}).test()
+    print(run.pretty())
+    assert sorted(check.type for check in run.checks) == ["model_quality_sql", "row_count"]
+
+
+def test_unknown_tag_runs_nothing():
+    run = DataContract(data_contract_str=CONTRACT, tags={"nightly"}).test()
+    print(run.pretty())
+    assert len(run.checks) == 0
+
+
+def test_rules_without_id_or_tags_are_never_matched():
+    run = DataContract(data_contract_str=CONTRACT, tags={"critical"}).test()
+    assert not [check for check in run.checks if check.type == "field_null_values"]
+
+
+def test_quality_id_and_tag_combine():
+    """Both filters apply; here they select disjoint rules."""
+    run = DataContract(
+        data_contract_str=CONTRACT,
+        quality_ids={"amounts_are_positive"},
+        tags={"critical"},
+    ).test()
+    print(run.pretty())
+    assert len(run.checks) == 0
+
+
+def test_checks_report_the_id_and_tags_of_their_rule():
+    """The results say which rule produced them, so it can be re-run by id."""
+    run = DataContract(data_contract_str=CONTRACT).test()
+    print(run.pretty())
+    by_type = {check.type: check for check in run.checks}
+    assert by_type["row_count"].quality_id == "orders_not_empty"
+    assert by_type["row_count"].tags == ["critical", "cheap"]
+    assert by_type["field_null_values"].quality_id is None
+    assert by_type["field_null_values"].tags is None
+    assert by_type["field_is_present"].quality_id is None
+
+
+def test_quality_id_cli_option():
+    result = runner.invoke(
+        app,
+        ["test", "--quality-id", "orders_not_empty", "./fixtures/quality-id/datacontract.yaml"],
+    )
+    assert result.exit_code == 0
+
+
+def test_quality_id_cli_unknown_id_exits_non_zero():
+    result = runner.invoke(
+        app,
+        ["test", "--quality-id", "typo", "./fixtures/quality-id/datacontract.yaml"],
+    )
+    assert result.exit_code == 1
+    assert "typo" in result.stdout
+
+
+def test_tag_cli_option():
+    result = runner.invoke(
+        app,
+        ["test", "--tag", "critical, cheap", "./fixtures/quality-id/datacontract.yaml"],
+    )
+    assert result.exit_code == 0
+
+
+def test_quality_id_cli_empty_value():
+    result = runner.invoke(
+        app,
+        ["test", "--quality-id", "", "./fixtures/quality-id/datacontract.yaml"],
+    )
+    assert result.exit_code == 1
+    assert "Empty --quality-id specified" in result.stdout


### PR DESCRIPTION
Closes #1080.

## Problem

`datacontract test` selects checks by category (`--checks`) or by dimension (`--dimension`). Neither addresses an individual rule, so running some of a table's rules on ingest and the rest after the nightly load meant splitting the contract into several files — which is exactly what the reporter did not want to do.

## Solution

ODCS quality rules already have an `id` and `tags`. Both were parsed and then dropped on the floor. They now travel with the check from the contract through the check IR into the run, and `test` can filter on them:

```bash
datacontract test --quality-id order_id_is_unique datacontract.yaml
datacontract test --tag critical datacontract.yaml
datacontract test --tag critical,cheap --server production datacontract.yaml
```

```yaml
schema:
  - name: orders
    quality:
      - id: orders_not_empty
        type: library
        metric: rowCount
        mustBeGreaterThan: 0
        tags: ["critical", "cheap"]
```

Behaviour worth reviewing:

- **Quality only.** Both options select quality rules and nothing else — no schema or service level checks, and the JSON Schema validation is skipped for the same reason. Only a rule carries an id or a tag, so anything else would be arbitrary.
- **An unknown `--quality-id` fails the run**, listing the ids the contract does declare. An id is a precise reference like `--schema-name`, and a typo that silently tests nothing would report green in a pipeline.
- **An unmatched `--tag` reports no checks**, the way `--checks` and `--dimension` already behave for a selector that matches nothing.
- **`--tag` matches the rule's own `tags`**, not the tags of a schema or property. Selecting every check of a `pii`-tagged column is a plausible next step, but it is a different feature and would make `--tag` mean two things.
- Filters combine: `--tag critical --checks quality` is an AND, consistent with `--checks` + `--dimension` today.
- Test results now report the `quality_id` and `tags` of the rule each check came from, so a failing check names the rule to re-run.

## Notes

The Azure blob engine emits checks as it goes instead of building a `CheckSpec` list, so it filters per check. Rather than thread a fourth pair of parameters through six helpers, its criteria are bundled into a `CheckFilter` (`datacontract/engines/checks/check_filter.py`). The public `check_azure_blob_file(...)` keyword arguments are unchanged.

## Tests

- `tests/test_test_quality_id_and_tag_filter.py` — 14 new tests: selection by id and tag, multiple values, combination with each other, unknown id failing the run, rules without an id/tags never being matched, ids and tags reported on the results, and the CLI options end to end.
- `tests/test_test_azure_blob_file.py` — 3 new tests covering the same filters on the Azure blob path.
- Full suite green locally (1242 passed, 7 skipped; excludes the container-backed backends).

## Docs

- `docs/docs/quality-rules/index.md` — new "Identifying rules" section and the two new options under "Running only quality checks".
- `docs/docs/testing/index.md` — the options overview.
- `docs/docs/commands/test.md` — regenerated with `update_command_docs.py`.