### PR TITLE
fix: make each data source extra install what its guide needs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract test` verifies declared primary keys: each key column must have no missing values, and the key must have no duplicates (a composite key is checked as a tuple) (#1220 @DMZ22)
 
 ### Fixed
+- `datacontract-cli[s3]` could not run `datacontract test`, and `datacontract-cli[gcs]` was missing the AWS duckdb extension the GCS connection loads; each data source extra now installs everything its guide needs
+- The API testing guide stated that no extra is required, but the response is tested with duckdb; it installs `datacontract-cli[duckdb]` now
+- `datacontract test` told users to install `datacontract-cli[local]`, an extra that does not exist, and `datacontract-cli[api]`, which installs the web server rather than a test backend; both now point at `duckdb`
 - `datacontract import gcs` wrote `type: gcs`, which is not an ODCS server type, so the imported contract failed `datacontract lint` and `datacontract test`; GCS is now written as an `s3` server on the Google interoperability endpoint
 - A data contract could inject SQL into the duckdb session through `endpointUrl`, which is interpolated into the statement that stores the S3, GCS and Azure credentials; every value is escaped now
 - The `datacontract api` server accepted a local file path as the `schema` query parameter, so a caller could have it read files from the server's filesystem; only `http(s)` URLs are accepted now

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -35,6 +35,16 @@ from datacontract.model.server import get_server_type
 
 logger = logging.getLogger(__name__)
 
+# Most server types have an install extra of the same name. These do not: they
+# are read with duckdb, so naming the server type would send users to an extra
+# that does not exist (`local`) or to an unrelated one (`api` installs the web
+# server dependencies, not a test backend).
+_INSTALL_EXTRAS = {"local": "duckdb", "api": "duckdb"}
+
+
+def install_extra_for(server_type: Optional[str]) -> str:
+    return _INSTALL_EXTRAS.get(server_type, server_type)
+
 
 class _ColumnNotFound(Exception):
     pass
@@ -116,7 +126,7 @@ def execute_ibis_checks(
         server_type = get_server_type(server)
         reason = (
             f"The '{server_type}' backend is not installed. "
-            f"Install it with: pip install 'datacontract-cli[{server_type}]'"
+            f"Install it with: pip install 'datacontract-cli[{install_extra_for(server_type)}]'"
         )
         logger.exception("ibis backend import failed")
         run.log_error(reason)

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -95,7 +95,7 @@ Available extras:
 | Databricks Runtime | `pip install datacontract-cli[databricks-runtime]` (inside Databricks, where the cluster provides PySpark — see [Databricks Notebooks and Jobs](./databricks.md)) |
 | DataFrame (Spark) | `pip install datacontract-cli[dataframe]` |
 | DBML | `pip install datacontract-cli[dbml]` |
-| DuckDB (local/S3/GCS/Azure file testing) | `pip install datacontract-cli[duckdb]` |
+| DuckDB (local file and API response testing) | `pip install datacontract-cli[duckdb]` |
 | Excel | `pip install datacontract-cli[excel]` |
 | GCS integration | `pip install datacontract-cli[gcs]` |
 | Iceberg | `pip install datacontract-cli[iceberg]` |

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -49,6 +49,9 @@ marked as such in the entry.
 - `datacontract test` verifies declared primary keys: each key column must have no missing values, and the key must have no duplicates (a composite key is checked as a tuple) ([#1220](https://github.com/datacontract/datacontract-cli/issues/1220) [@DMZ22](https://github.com/DMZ22))
 
 ### Fixed
+- `datacontract-cli[s3]` could not run `datacontract test`, and `datacontract-cli[gcs]` was missing the AWS duckdb extension the GCS connection loads; each data source extra now installs everything its guide needs
+- The API testing guide stated that no extra is required, but the response is tested with duckdb; it installs `datacontract-cli[duckdb]` now
+- `datacontract test` told users to install `datacontract-cli[local]`, an extra that does not exist, and `datacontract-cli[api]`, which installs the web server rather than a test backend; both now point at `duckdb`
 - `datacontract import gcs` wrote `type: gcs`, which is not an ODCS server type, so the imported contract failed `datacontract lint` and `datacontract test`; GCS is now written as an `s3` server on the Google interoperability endpoint
 - A data contract could inject SQL into the duckdb session through `endpointUrl`, which is interpolated into the statement that stores the S3, GCS and Azure credentials; every value is escaped now
 - The `datacontract api` server accepted a local file path as the `schema` query parameter, so a caller could have it read files from the server's filesystem; only `http(s)` URLs are accepted now

--- a/docs/docs/testing/api.md
+++ b/docs/docs/testing/api.md
@@ -10,10 +10,10 @@ Test APIs that return data in JSON format. Currently, only GET requests are supp
 
 ## 1. Install
 
-No extra is required for API connections:
+The response is tested with duckdb, so the `duckdb` extra is required:
 
 ```bash
-uv tool install --python python3.11 --upgrade datacontract-cli
+uv tool install --python python3.11 --upgrade 'datacontract-cli[duckdb]'
 ```
 
 See [Installation](../installation.md) for pip, pipx, and Docker.

--- a/docs/docs/testing/azure.md
+++ b/docs/docs/testing/azure.md
@@ -11,7 +11,7 @@ Test data stored in Azure Blob storage or Azure Data Lake Storage Gen2 (ADLS) in
 ## 1. Install
 
 ```bash
-uv tool install --python python3.11 --upgrade 'datacontract-cli[azure,duckdb]'
+uv tool install --python python3.11 --upgrade 'datacontract-cli[azure]'
 ```
 
 See [Installation](../installation.md) for pip, pipx, and Docker.

--- a/docs/docs/testing/s3.md
+++ b/docs/docs/testing/s3.md
@@ -11,7 +11,7 @@ Go from files in a bucket to a tested data contract in about five minutes. Works
 ## 1. Install
 
 ```bash
-uv tool install --python python3.11 --upgrade 'datacontract-cli[s3,duckdb]'
+uv tool install --python python3.11 --upgrade 'datacontract-cli[s3]'
 ```
 
 See [Installation](../installation.md) for pip, pipx, and Docker.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,14 +138,15 @@ redshift = [
 # publishes wheels for all platforms including manylinux2014_aarch64, so no
 # platform markers are needed.
 s3 = [
+  "datacontract-cli[duckdb]",
   "s3fs>=2025.2.0,<2027.0.0",
   "duckdb-extension-httpfs>=1.5.0,<1.6.0",
   "duckdb-extension-aws>=1.5.0,<1.6.0",
 ]
 
+# GCS is an S3-compatible server, tested through the same connection setup.
 gcs = [
-  "datacontract-cli[duckdb]",
-  "duckdb-extension-httpfs>=1.5.0,<1.6.0",
+  "datacontract-cli[s3]",
 ]
 
 azure = [

--- a/tests/test_install_extras.py
+++ b/tests/test_install_extras.py
@@ -1,0 +1,72 @@
+"""The install hints the CLI prints must name extras that actually exist.
+
+`datacontract test` tells the user which extra to install when a backend is
+missing. Most server types share their name with the extra, but not all, and a
+hint naming a non-existent extra leaves the user with a `pip install` that
+silently changes nothing.
+"""
+
+import re
+from importlib.metadata import metadata
+from pathlib import Path
+
+import pytest
+
+from datacontract.engines.ibis.connections.connect import _FILE_SERVER_TYPES
+from datacontract.engines.ibis.ibis_check_execute import install_extra_for
+
+
+def declared_extras() -> set[str]:
+    """Read the extras from the installed distribution, which is what pip resolves."""
+    return set(metadata("datacontract-cli").get_all("Provides-Extra") or [])
+
+
+# Every server type `datacontract test` can dispatch on, so a new backend that
+# forgets its extra is caught here rather than by the first user to hit it.
+SERVER_TYPES = sorted(
+    _FILE_SERVER_TYPES
+    | {
+        "api",
+        "athena",
+        "bigquery",
+        "databricks",
+        "dataframe",
+        "impala",
+        "kafka",
+        "mysql",
+        "oracle",
+        "postgres",
+        "redshift",
+        "snowflake",
+        "sqlserver",
+        "trino",
+    }
+)
+
+
+@pytest.mark.parametrize("server_type", SERVER_TYPES)
+def test_every_server_type_points_at_a_declared_extra(server_type):
+    assert install_extra_for(server_type) in declared_extras()
+
+
+@pytest.mark.parametrize(
+    "server_type, expected",
+    [
+        ("local", "duckdb"),  # there is no `local` extra
+        ("api", "duckdb"),  # `api` installs the web server, not a test backend
+        ("postgres", "postgres"),
+    ],
+)
+def test_server_types_without_a_matching_extra_are_redirected(server_type, expected):
+    assert install_extra_for(server_type) == expected
+
+
+def test_every_extra_a_data_source_guide_installs_exists():
+    """A guide that names a typo'd extra installs nothing and fails at test time."""
+    extras = declared_extras()
+    guides = (Path(__file__).parent.parent / "docs" / "docs" / "testing").glob("*.md")
+
+    for guide in guides:
+        for match in re.finditer(r"datacontract-cli\[([a-z0-9,_-]+)\]", guide.read_text()):
+            for extra in match.group(1).split(","):
+                assert extra in extras, f"{guide.name} installs unknown extra '{extra}'"


### PR DESCRIPTION
## Summary

Each data source guide installs a single extra rather than `[all]`, which is the right pattern — but for some sources that extra could not actually run the example. Verified in clean venvs per extra:

| Extra | `duckdb` | `ibis` | `ext:httpfs` | `ext:aws` | `datacontract test` |
|---|---|---|---|---|---|
| `[s3]` (before) | ✅ | ❌ | ✅ | ✅ | 🔴 fails |
| `[gcs]` (before) | ✅ | ✅ | ✅ | ❌ | ⚠️ needs network |
| `[s3]`, `[gcs]` (after) | ✅ | ✅ | ✅ | ✅ | 🟢 |

- **`[s3]` did not pull the test engine.** It has no ibis, so `datacontract test` failed with `The 'local' backend is not installed`. The S3 guide worked around it with `[s3,duckdb]`, but the extras table in `installation.md` listed the bare `[s3]`, which does not work.
- **`[gcs]` was missing the AWS duckdb extension.** GCS is tested as an S3-compatible server, and that connection setup loads the `aws` extension. `_load_extension` falls back to a network download, so this worked online but failed air-gapped — pointing at `[s3]` from a GCS guide.

Both are self-contained now, matching `azure`, so `testing/s3.md` and `testing/azure.md` install the bare extra and the `installation.md` table is correct for every row.

- **The API guide stated "No extra is required for API connections".** The `api` server type fetches the response and then tests it with duckdb, so a bare install cannot run the example at all. Confirmed: bare → 🔴, `[duckdb]` → 🟢.
- **The install hint named extras that do not exist.** It interpolated the server type into the extra name, producing `pip install 'datacontract-cli[local]'` — there is no `local` extra, so pip installs nothing and the user loops. For `api` it is worse: `[api]` exists but installs the web server dependencies, so the hint looks right and still fails. Both map to `duckdb` now.

`tests/test_install_extras.py` asserts every server type resolves to a declared extra (read from the installed distribution metadata, which is what pip resolves) and that no testing guide names an unknown extra, so a new backend that forgets its extra is caught here rather than by the first user to hit it.