### PR TITLE
Fix physicalType checks that fail a column against its own declared type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SQL imports now map `TIME` types with precision or time zone (e.g. `TIME(9)`) to `logicalType: time`; previously the logical type was left unset
 - `datacontract test --checks quality` now runs `rowCount` quality rules, which were wrongly categorized as schema checks
 - `datacontract import dbt` derives the contract `id` from the dbt manifest's `project_name` instead of always emitting the placeholder `my-data-contract` (#1221 @DMZ22)
-- Snowflake `physicalType` checks: a declared `NUMBER(38,0)` failed against its own column (the catalog reconstruction spells it `NUMBER(38)`, and the comparison did not treat `DECIMAL(p)` as `DECIMAL(p,0)`), and structured `OBJECT`/`ARRAY`/`MAP` types never matched because their fields were compared as rendered strings; structured types are now compared field by field (order-insensitive, alias-aware), a catalog that strips the field list (`INFORMATION_SCHEMA` reports bare `OBJECT`) no longer fails the declaration, and Athena's Hive spellings (`array<string>`) match the Trino names it reports back (`array(varchar)`)
+- A `physicalType` declaring a zero scale (`NUMBER(38,0)`, `decimal(18,0)`) failed against its own column on Snowflake, Oracle, SQL Server and Databricks (#1377 @DMZ22)
+- Snowflake `physicalType` checks failed for structured `OBJECT`, `ARRAY` and `MAP` columns, whose fields are now compared field by field instead of as rendered strings (#1377 @DMZ22)
+- `datacontract test` on Athena failed a `physicalType` written in the Hive spelling `datacontract import athena` produces (`array<string>` against the reported `array(varchar)`) (#1377 @DMZ22)
+- A `physicalType` declaring fractional seconds (`TIMESTAMP_NTZ(9)`, `datetime2(7)`, `timestamp(3)`) failed against its own column, so every timestamp column imported from Snowflake failed the first `datacontract test`
+- `datacontract test` and `datacontract import oracle` read Oracle character lengths in bytes, so an `NVARCHAR2(50)` column was reported and checked as `NVARCHAR2(100)`
+- `datacontract test` on Databricks could not check the element types of `ARRAY`, `MAP` and `STRUCT` columns, which the catalog reports as a bare type name
 
 ## [1.0.14] - 2026-07-23
 

--- a/datacontract/engines/ibis/native_type.py
+++ b/datacontract/engines/ibis/native_type.py
@@ -43,7 +43,7 @@ _CATALOG_STRATEGY = {
     "postgres": "information_schema",
     "redshift": "information_schema",
     "snowflake": "information_schema",
-    "databricks": "information_schema",
+    "databricks": "databricks",
     "oracle": "oracle",
     "athena": "full_type",
     "trino": "full_type",
@@ -67,11 +67,50 @@ _DECIMAL_TYPES = {"decimal", "numeric", "number", "dec"}
 _ORACLE_LENGTH_TYPES = {"char", "nchar", "varchar", "varchar2", "nvarchar2", "raw"}
 
 
-def oracle_char_length(data_type: Optional[str], data_length):
-    """Oracle reports DATA_LENGTH for every column, but the length is only part
-    of the declared type for character and raw types; appending it elsewhere
-    would corrupt types such as ROWID or DATE."""
-    return data_length if (data_type or "").strip().lower() in _ORACLE_LENGTH_TYPES else None
+def oracle_char_length(data_type: Optional[str], data_length, char_length=None):
+    """The length Oracle's declared type carries, or ``None``.
+
+    DATA_LENGTH is only part of the declared type for character and raw types;
+    appending it elsewhere would corrupt types such as ROWID or DATE. It is also
+    measured in *bytes*, so ``NVARCHAR2(50)`` reports 100 and ``VARCHAR2(50
+    CHAR)`` reports up to 200 in a multibyte character set — CHAR_LENGTH is the
+    character count the type was declared with. RAW is declared in bytes and
+    reports CHAR_LENGTH 0, so it keeps DATA_LENGTH.
+    """
+    data_type = (data_type or "").strip().lower()
+    if data_type not in _ORACLE_LENGTH_TYPES:
+        return None
+    if data_type != "raw" and char_length:
+        return char_length
+    return data_length
+
+
+# Temporal types whose fractional-seconds precision is part of the declared type.
+# DATE and the legacy SQL Server DATETIME / SMALLDATETIME also report a
+# datetime_precision, but they take no precision argument (``date(0)`` is not a
+# type), so it is only appended for these.
+_DATETIME_PRECISION_TYPES = {
+    "timestamp",
+    "timestamptz",
+    "timestamp_ntz",
+    "timestamp_ltz",
+    "timestamp_tz",
+    "time",
+    "timetz",
+    "datetime2",
+    "datetimeoffset",
+}
+
+# Postgres and Redshift spell the time zone out as part of data_type, and the
+# precision goes on the leading word: ``timestamp(6) without time zone``.
+_TIME_ZONE_SUFFIXES = (" without time zone", " with time zone", " with local time zone")
+
+
+def _split_time_zone_suffix(base: str) -> tuple[str, str]:
+    for suffix in _TIME_ZONE_SUFFIXES:
+        if base.lower().endswith(suffix):
+            return base[: -len(suffix)].strip(), base[-len(suffix) :]
+    return base, ""
 
 
 def reconstruct_native_type(
@@ -79,12 +118,15 @@ def reconstruct_native_type(
     char_len=None,
     num_precision=None,
     num_scale=None,
+    datetime_precision=None,
 ) -> Optional[str]:
     """Rebuild a parameterized native type string from catalog columns.
 
     ``varchar`` + char_len 255 -> ``varchar(255)`` (``-1`` means SQL Server MAX
     -> ``varchar(max)``); ``decimal`` + precision 10 + scale 2 ->
-    ``decimal(10,2)``. Precision is only attached to genuine decimal types.
+    ``decimal(10,2)``; ``timestamp_ntz`` + datetime_precision 9 ->
+    ``timestamp_ntz(9)``. Precision is only attached to the types that declare
+    one.
     """
     if not data_type:
         return None
@@ -107,6 +149,14 @@ def reconstruct_native_type(
         if num_scale:
             return f"{base}({int(num_precision)},{int(num_scale)})"
         return f"{base}({int(num_precision)})"
+
+    if datetime_precision is not None and "(" not in base:
+        head, time_zone = _split_time_zone_suffix(base)
+        if head.lower() in _DATETIME_PRECISION_TYPES:
+            try:
+                return f"{head}({int(datetime_precision)}){time_zone}"
+            except (TypeError, ValueError):
+                return base
 
     return base
 
@@ -157,18 +207,27 @@ def _rows(con, query: str):
 
 
 def _map_reconstructed(con, query: str, oracle_length: bool = False) -> Optional[dict[str, str]]:
-    """Read ``(column_name, data_type, length, precision, scale)`` rows and
-    reconstruct each parameterized native type string."""
+    """Read ``(column_name, data_type, length, precision, scale, …)`` rows and
+    reconstruct each parameterized native type string.
+
+    The sixth column is the catalog's own: ``datetime_precision`` for
+    information_schema, ``char_length`` for Oracle, which has no
+    datetime_precision (it carries the fractional seconds in data_type itself,
+    as ``TIMESTAMP(6)``).
+    """
     rows = _rows(con, query)
     if not rows:
         return None
     result: dict[str, str] = {}
     for row in rows:
         column_name, data_type = row[0], row[1]
-        char_len = row[2]
+        char_len, extra = row[2], row[5] if len(row) > 5 else None
+        datetime_precision = None
         if oracle_length:
-            char_len = oracle_char_length(data_type, char_len)
-        native = reconstruct_native_type(data_type, char_len, row[3], row[4])
+            char_len = oracle_char_length(data_type, char_len, extra)
+        else:
+            datetime_precision = extra
+        native = reconstruct_native_type(data_type, char_len, row[3], row[4], datetime_precision)
         if column_name and native:
             result[str(column_name).lower()] = native
     return result or None
@@ -206,10 +265,15 @@ def _schema_filter(server: Server, column: str = "table_schema") -> str:
 
 
 def _read_information_schema(con, server: Server, model: str) -> Optional[dict[str, str]]:
-    """Standard ``INFORMATION_SCHEMA.COLUMNS`` with separate length/precision."""
+    """Standard ``INFORMATION_SCHEMA.COLUMNS`` with separate length/precision.
+
+    ``datetime_precision`` is part of the declared type of a timestamp or time
+    column (Snowflake's own importer writes ``TIMESTAMP_NTZ(9)``), so it is read
+    alongside the character and numeric parts.
+    """
     query = (
         "SELECT column_name, data_type, character_maximum_length, "
-        "numeric_precision, numeric_scale "
+        "numeric_precision, numeric_scale, datetime_precision "
         f"FROM information_schema.columns WHERE upper(table_name) = upper('{_quote(model)}')"
         f"{_schema_filter(server)}"
     )
@@ -217,13 +281,32 @@ def _read_information_schema(con, server: Server, model: str) -> Optional[dict[s
 
 
 def _read_oracle(con, server: Server, model: str) -> Optional[dict[str, str]]:
-    """Oracle exposes columns via ``ALL_TAB_COLUMNS`` instead of information_schema."""
+    """Oracle exposes columns via ``ALL_TAB_COLUMNS`` instead of information_schema.
+
+    ``CHAR_LENGTH`` is read next to ``DATA_LENGTH`` because the latter is in
+    bytes, which is not the length ``NVARCHAR2(50)`` was declared with.
+    """
     query = (
-        "SELECT column_name, data_type, data_length, data_precision, data_scale "
+        "SELECT column_name, data_type, data_length, data_precision, data_scale, char_length "
         f"FROM all_tab_columns WHERE upper(table_name) = upper('{_quote(model)}')"
         f"{_schema_filter(server, 'owner')}"
     )
     return _map_reconstructed(con, query, oracle_length=True)
+
+
+def _read_databricks(con, server: Server, model: str) -> Optional[dict[str, str]]:
+    """Databricks reports a complex column as the bare token in ``data_type``
+    (``array<string>`` as ``ARRAY``), which cannot be checked against the
+    declared element types; ``full_data_type`` carries the whole spelling.
+
+    It only exists in Unity Catalog, so a workspace whose ``information_schema``
+    lacks the column falls back to the reconstructed parts.
+    """
+    query = (
+        "SELECT column_name, full_data_type FROM information_schema.columns "
+        f"WHERE upper(table_name) = upper('{_quote(model)}'){_schema_filter(server)}"
+    )
+    return _map_full_type(con, query) or _read_information_schema(con, server, model)
 
 
 def _read_full_type_information_schema(con, server: Server, model: str) -> Optional[dict[str, str]]:
@@ -255,6 +338,7 @@ def _read_bigquery(con, server: Server, model: str) -> Optional[dict[str, str]]:
 _READERS = {
     "information_schema": _read_information_schema,
     "oracle": _read_oracle,
+    "databricks": _read_databricks,
     "full_type": _read_full_type_information_schema,
     "bigquery": _read_bigquery,
 }

--- a/datacontract/imports/oracle_importer.py
+++ b/datacontract/imports/oracle_importer.py
@@ -1,10 +1,11 @@
 """Create a data contract from a live Oracle schema.
 
 Reads ``ALL_TAB_COLUMNS``, the same catalog ``datacontract test`` reads back to
-verify physical types, and applies the same rule about which types carry a
-length — Oracle reports ``DATA_LENGTH`` for every column, but it is only part of
-the declared type for character and raw types. An imported contract therefore
-passes on the first run without hand-editing.
+verify physical types, and applies the same length rule — Oracle reports
+``DATA_LENGTH`` for every column, but it is only part of the declared type for
+character and raw types, and it is measured in bytes, so a character type takes
+its length from ``CHAR_LENGTH``. An imported contract therefore passes on the
+first run without hand-editing.
 """
 
 from __future__ import annotations
@@ -30,7 +31,8 @@ _TABLES_QUERY = """
 """
 
 _COLUMNS_QUERY = """
-    SELECT table_name, column_name, data_type, data_length, data_precision, data_scale, nullable
+    SELECT table_name, column_name, data_type, data_length, data_precision, data_scale, nullable,
+           char_length
     FROM all_tab_columns
     WHERE owner = '{schema}'
     ORDER BY table_name, column_id
@@ -226,7 +228,7 @@ def _create_property(row: Dict[str, Any], primary_keys: Dict[str, int]) -> Schem
     precision = _as_int(row.get("data_precision"))
     scale = _as_int(row.get("data_scale"))
     # the same length rule the test path applies when reading this catalog back
-    char_length = _as_int(oracle_char_length(data_type, row.get("data_length")))
+    char_length = _as_int(oracle_char_length(data_type, row.get("data_length"), row.get("char_length")))
     physical_type = reconstruct_native_type(data_type, char_length, precision, scale)
     logical_type, format = map_type_from_sql(physical_type)
     is_decimal = physical_type is not None and physical_type.lower().startswith(("decimal", "numeric", "number"))

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -27,6 +27,7 @@ marked as such in the entry.
 ## Unreleased {#unreleased}
 
 ### Added
+- `datacontract test` treats a server typed `mssql` as SQL Server, so contracts carrying the ODBC/dbt spelling are testable (ODCS itself only defines `sqlserver`)
 - `datacontract test --quality-id` runs a single quality rule by its ODCS `quality.id`, and `--tag` runs every quality rule declaring one of the given `quality.tags` ([#1080](https://github.com/datacontract/datacontract-cli/issues/1080))
 - Test results report the `quality_id` and `tags` of the quality rule a check comes from
 - New `databricks-runtime` extra for installing inside a Databricks Runtime, where the cluster already provides PySpark: `pip install datacontract-cli[databricks-runtime]` ([#1211](https://github.com/datacontract/datacontract-cli/issues/1211) [@chifu1234](https://github.com/chifu1234))
@@ -51,6 +52,8 @@ marked as such in the entry.
 - `datacontract test` verifies declared primary keys: each key column must have no missing values, and the key must have no duplicates (a composite key is checked as a tuple) ([#1220](https://github.com/datacontract/datacontract-cli/issues/1220) [@DMZ22](https://github.com/DMZ22))
 
 ### Fixed
+- `datacontract test` checked `physicalType` against a same-named table in another schema when one existed, because the native column types were read from the catalog without the contract's schema
+- `datacontract test` against SQL Server no longer fails every check with "Could not read model" when `server.schema` differs from the login's default schema
 - `datacontract-cli[s3]` could not run `datacontract test`, and `datacontract-cli[gcs]` was missing the AWS duckdb extension the GCS connection loads; each data source extra now installs everything its guide needs
 - The API testing guide stated that no extra is required, but the response is tested with duckdb; it installs `datacontract-cli[duckdb]` now
 - `datacontract test` told users to install `datacontract-cli[local]`, an extra that does not exist, and `datacontract-cli[api]`, which installs the web server rather than a test backend; both now point at `duckdb`
@@ -70,6 +73,13 @@ marked as such in the entry.
 - CSV and JSON imports now write detected formats (`email`, `uuid`, `date-time`) to `logicalTypeOptions.format` instead of a custom property, so they are validated by `datacontract test`
 - SQL imports now map `TIME` types with precision or time zone (e.g. `TIME(9)`) to `logicalType: time`; previously the logical type was left unset
 - `datacontract test --checks quality` now runs `rowCount` quality rules, which were wrongly categorized as schema checks
+- `datacontract import dbt` derives the contract `id` from the dbt manifest's `project_name` instead of always emitting the placeholder `my-data-contract` ([#1221](https://github.com/datacontract/datacontract-cli/issues/1221) [@DMZ22](https://github.com/DMZ22))
+- A `physicalType` declaring a zero scale (`NUMBER(38,0)`, `decimal(18,0)`) failed against its own column on Snowflake, Oracle, SQL Server and Databricks ([#1377](https://github.com/datacontract/datacontract-cli/issues/1377) [@DMZ22](https://github.com/DMZ22))
+- Snowflake `physicalType` checks failed for structured `OBJECT`, `ARRAY` and `MAP` columns, whose fields are now compared field by field instead of as rendered strings ([#1377](https://github.com/datacontract/datacontract-cli/issues/1377) [@DMZ22](https://github.com/DMZ22))
+- `datacontract test` on Athena failed a `physicalType` written in the Hive spelling `datacontract import athena` produces (`array<string>` against the reported `array(varchar)`) ([#1377](https://github.com/datacontract/datacontract-cli/issues/1377) [@DMZ22](https://github.com/DMZ22))
+- A `physicalType` declaring fractional seconds (`TIMESTAMP_NTZ(9)`, `datetime2(7)`, `timestamp(3)`) failed against its own column, so every timestamp column imported from Snowflake failed the first `datacontract test`
+- `datacontract test` and `datacontract import oracle` read Oracle character lengths in bytes, so an `NVARCHAR2(50)` column was reported and checked as `NVARCHAR2(100)`
+- `datacontract test` on Databricks could not check the element types of `ARRAY`, `MAP` and `STRUCT` columns, which the catalog reports as a bare type name
 
 ## 1.0.14 — 2026-07-23 {#v1-0-14}
 

--- a/tests/test_native_type_schema_scope.py
+++ b/tests/test_native_type_schema_scope.py
@@ -14,14 +14,22 @@ from datacontract.engines.ibis.native_type import fetch_native_types
 
 
 class _RecordingBackend:
-    """Backend that records the catalog query and answers from a fixed catalog."""
+    """Backend that records the catalog query and answers from a fixed catalog.
 
-    def __init__(self, rows):
+    ``unknown_columns`` are column names this catalog does not have; a query
+    naming one fails, as it would on a server whose catalog lacks it.
+    """
+
+    def __init__(self, rows, unknown_columns=()):
         self._rows = rows
+        self._unknown_columns = unknown_columns
         self.queries = []
 
     def raw_sql(self, query):
         self.queries.append(query)
+        for column in self._unknown_columns:
+            if column in query:
+                raise Exception(f"column '{column}' cannot be resolved")
         return _Cursor(self._rows)
 
 
@@ -36,9 +44,9 @@ class _Cursor:
         pass
 
 
-@pytest.mark.parametrize("server_type", ["sqlserver", "postgres", "redshift", "snowflake", "databricks"])
+@pytest.mark.parametrize("server_type", ["sqlserver", "postgres", "redshift", "snowflake"])
 def test_information_schema_query_is_scoped_to_the_contract_schema(server_type):
-    con = _RecordingBackend([("field_one", "varchar", 10, None, None)])
+    con = _RecordingBackend([("field_one", "varchar", 10, None, None, None)])
     server = Server(type=server_type, schema="myschema")
 
     assert fetch_native_types(con, server, "my_table") == {"field_one": "varchar(10)"}
@@ -46,18 +54,37 @@ def test_information_schema_query_is_scoped_to_the_contract_schema(server_type):
 
 
 def test_information_schema_query_is_unfiltered_without_a_schema():
-    con = _RecordingBackend([("field_one", "varchar", 10, None, None)])
+    con = _RecordingBackend([("field_one", "varchar", 10, None, None, None)])
 
     fetch_native_types(con, Server(type="sqlserver"), "my_table")
     assert "table_schema" not in con.queries[0]
 
 
 def test_oracle_query_is_scoped_to_the_contract_owner():
-    con = _RecordingBackend([("FIELD_ONE", "VARCHAR2", 10, None, None)])
+    con = _RecordingBackend([("FIELD_ONE", "VARCHAR2", 10, None, None, 10)])
     server = Server(type="oracle", schema="PSD1_VERBIS")
 
     assert fetch_native_types(con, server, "BERUF") == {"field_one": "VARCHAR2(10)"}
     assert "upper(owner) = upper('PSD1_VERBIS')" in con.queries[0]
+
+
+def test_databricks_reads_the_full_type_and_is_scoped_to_the_contract_schema():
+    # data_type is the bare token for a complex column; full_data_type spells it out.
+    con = _RecordingBackend([("field_one", "array<string>")])
+    server = Server(type="databricks", schema="myschema")
+
+    assert fetch_native_types(con, server, "my_table") == {"field_one": "array<string>"}
+    assert "full_data_type" in con.queries[0]
+    assert "upper(table_schema) = upper('myschema')" in con.queries[0]
+
+
+def test_databricks_falls_back_when_the_catalog_has_no_full_data_type():
+    # full_data_type only exists in Unity Catalog.
+    con = _RecordingBackend([("field_one", "decimal", None, 10, 2, None)], unknown_columns=["full_data_type"])
+    server = Server(type="databricks", schema="myschema")
+
+    assert fetch_native_types(con, server, "my_table") == {"field_one": "decimal(10,2)"}
+    assert "upper(table_schema) = upper('myschema')" in con.queries[-1]
 
 
 def test_full_type_query_is_scoped_to_the_contract_schema():

--- a/tests/test_physical_type_match.py
+++ b/tests/test_physical_type_match.py
@@ -1,6 +1,7 @@
 from datacontract.engines.checks.physical_type_match import physical_type_matches
 from datacontract.engines.ibis.native_type import (
     _rows,
+    oracle_char_length,
     reconstruct_native_type,
     supports_native_type_introspection,
 )
@@ -166,6 +167,68 @@ def test_snowflake_declared_scale_zero_matches_reconstructed_column():
     assert physical_type_matches("NUMBER(38,0)", reconstructed, "snowflake")[0] is True
     assert physical_type_matches("NUMBER(38)", reconstructed, "snowflake")[0] is True
     assert physical_type_matches("NUMBER(12,2)", reconstructed, "snowflake")[0] is False
+
+
+def test_declared_fractional_seconds_precision_matches_its_own_column():
+    # The catalog reports the fractional seconds separately, in
+    # datetime_precision; without it a declared TIMESTAMP_NTZ(9) — which is what
+    # `datacontract import snowflake` writes — failed against its own column.
+    reconstructed = reconstruct_native_type("TIMESTAMP_NTZ", datetime_precision=9)
+    assert reconstructed == "TIMESTAMP_NTZ(9)"
+    assert physical_type_matches("TIMESTAMP_NTZ(9)", reconstructed, "snowflake")[0] is True
+    assert physical_type_matches("TIMESTAMP_NTZ", reconstructed, "snowflake")[0] is True
+    assert physical_type_matches("TIMESTAMP_NTZ(3)", reconstructed, "snowflake")[0] is False
+
+    assert (
+        physical_type_matches("datetime2(7)", reconstruct_native_type("datetime2", datetime_precision=7), "tsql")[0]
+        is True
+    )
+    assert physical_type_matches("time(3)", reconstruct_native_type("time", datetime_precision=3), "tsql")[0] is True
+
+
+def test_postgres_precision_goes_on_the_leading_word():
+    # Postgres spells the time zone out in data_type, and the precision belongs
+    # to the type name: `timestamp(6) without time zone`, not `timestamp
+    # without time zone(6)`, which does not parse.
+    reconstructed = reconstruct_native_type("timestamp without time zone", datetime_precision=6)
+    assert reconstructed == "timestamp(6) without time zone"
+    assert physical_type_matches("timestamp(6)", reconstructed, "postgres")[0] is True
+    assert physical_type_matches("timestamp", reconstructed, "postgres")[0] is True
+    assert physical_type_matches("timestamp(3)", reconstructed, "postgres")[0] is False
+
+    with_tz = reconstruct_native_type("timestamp with time zone", datetime_precision=6)
+    assert with_tz == "timestamp(6) with time zone"
+    assert physical_type_matches("timestamptz", with_tz, "postgres")[0] is True
+
+
+def test_datetime_precision_is_only_added_to_types_that_declare_one():
+    # DATE and the legacy SQL Server DATETIME report a datetime_precision but
+    # take no argument, so `date(0)` must never be reconstructed.
+    assert reconstruct_native_type("date", datetime_precision=0) == "date"
+    assert reconstruct_native_type("datetime", datetime_precision=3) == "datetime"
+    assert reconstruct_native_type("smalldatetime", datetime_precision=0) == "smalldatetime"
+    # Oracle carries the precision inside data_type already
+    assert reconstruct_native_type("TIMESTAMP(6)", datetime_precision=6) == "TIMESTAMP(6)"
+    # a character or decimal type still wins over datetime_precision
+    assert reconstruct_native_type("varchar", char_len=10, datetime_precision=6) == "varchar(10)"
+
+
+def test_oracle_length_is_read_in_characters_not_bytes():
+    # ALL_TAB_COLUMNS.DATA_LENGTH is in bytes: NVARCHAR2(50) reports 100 and
+    # VARCHAR2(50 CHAR) reports 200 in a multibyte character set. CHAR_LENGTH is
+    # the length the type was declared with.
+    assert oracle_char_length("NVARCHAR2", 100, 50) == 50
+    assert oracle_char_length("VARCHAR2", 200, 50) == 50
+    assert oracle_char_length("CHAR", 4, 1) == 1
+    # RAW is declared in bytes and reports CHAR_LENGTH 0
+    assert oracle_char_length("RAW", 2000, 0) == 2000
+    # types that carry no length at all are unchanged
+    assert oracle_char_length("DATE", 7, 0) is None
+    assert oracle_char_length("NUMBER", 22, 0) is None
+    # a catalog that does not report CHAR_LENGTH keeps the old behaviour
+    assert oracle_char_length("VARCHAR2", 50) == 50
+
+    assert physical_type_matches("NVARCHAR2(50)", reconstruct_native_type("NVARCHAR2", 50), "oracle")[0] is True
 
 
 def test_decimal_missing_scale_means_scale_zero():


### PR DESCRIPTION
Rebased onto `main` now that #1449 has merged, so the diff below is this change alone.

#1449 fixes the *comparison* side of #1377. Reviewing it turned up three more `physicalType` checks that fail a column against its own declared type, all on the *catalog-reading* side. Same failure shape, none of them addressed by that PR.

### Fractional-seconds precision was never read

`information_schema` reports it in `datetime_precision`, which `_read_information_schema` did not select, so a declared `TIMESTAMP_NTZ(9)` was compared against a bare `TIMESTAMP_NTZ`:

```
mssql   declared 'datetime2(7)'      catalog 'datetime2'                   -> False
pg      declared 'timestamp(3)'      catalog 'timestamp without time zone' -> False
sf      declared 'TIMESTAMP_NTZ(9)'  catalog 'TIMESTAMP_NTZ'               -> False
```

On Snowflake this breaks end to end, because the importer and the test path disagree: `snowflake_importer.py` appends `DATETIME_PRECISION` to the physicalType, so **every timestamp column imported from Snowflake failed the first `datacontract test`**. SQL Server and Postgres escaped it only because their importers don't select the column either — there, just hand-written contracts that spell the precision (as the DDL does) failed.

Two details in the fix:

- Postgres and Redshift spell the time zone into `data_type`, and the precision goes on the leading word. `timestamp without time zone(6)` does not parse in sqlglot, so appending it would have turned a false failure into a silent skip; the reconstruction produces `timestamp(6) without time zone`.
- `DATE`, `DATETIME` and `SMALLDATETIME` report a `datetime_precision` (0, 3, 0) but take no argument — `date(0)` is not a type. Only types that declare one get it, and a `data_type` that already carries parens (Oracle's `TIMESTAMP(6)`) is left alone.

### Oracle character lengths were read in bytes

`ALL_TAB_COLUMNS.DATA_LENGTH` is documented as a byte count: `NVARCHAR2(50)` reports 100, and `VARCHAR2(50 CHAR)` reports up to 200 in a multibyte character set. `CHAR_LENGTH` is the length the type was declared with. A contract declaring `NVARCHAR2(50)` — matching the DDL — was checked against `NVARCHAR2(100)` and failed.

`datacontract import oracle` shares the rule via `oracle_char_length`, so it was writing both the `physicalType` and `maxLength` in bytes. Import and test agreed with each other, so it round-tripped silently while reporting the wrong number. `RAW` is declared in bytes and reports `CHAR_LENGTH` 0, so it keeps `DATA_LENGTH`.

### Databricks could not check complex element types

`data_type` is the bare `ARRAY` for an `array<string>` column; the full spelling lives in `full_data_type`, which wasn't selected. A declared `array<string>` was compared against bare `ARRAY` and passed regardless of element type — not a false failure, a vacuous check. `full_data_type` exists only in Unity Catalog, so a catalog without it falls back to the reconstructed parts and is no worse off than today.

### Verification

Simulating catalog rows through reconstruction and comparison, all 22 round-trips built from these failures now pass, including the ones that already worked — bare `datetime2` still matches `datetime2(7)`, `date` stays `date`, `varchar(max)` is unchanged.

`tests/test_native_type_schema_scope.py` needed real edits rather than widened tuples: Databricks now issues a different query, so it moved out of the information_schema parametrization into two dedicated tests, one for the `full_data_type` path and one proving the fallback when the column is absent.

Full suite: 1597 passed, 23 skipped. The 4 PySpark failures on this machine are pre-existing — identical on `main` with Java 21.

### Note on #1449's CHANGELOG

#1449 merged with its original entry, so this branch rewrites it to the one-line house style in `AGENTS.md` and adds `(#1377 @DMZ22)`, splitting it into one line per user-visible fix. Worth flagging: the zero-scale fix in #1449 is **not** Snowflake-specific — it also repaired Oracle `NUMBER(10,0)`, SQL Server `decimal(18,0)` and Databricks `decimal(10,0)`, which failed for the same reason. The entry is scoped accordingly.

`docs/docs/release-notes.md` is regenerated here and back in sync with `CHANGELOG.md`.

- [x] Tests pass (`uv run pytest`)
- [x] Code formatted (`uv run ruff check --fix && uv run ruff format`)
- [ ] Docs updated (if relevant)
- [x] CHANGELOG.md entry added
