### PR TITLE
Support programmatic Databricks and Snowflake credentials

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,19 @@ repos:
       args: [ --fix ]
     # Run the formatter.
     - id: ruff-format
+
+# Regenerate the committed generated docs, so CI never fails on stale ones.
+- repo: local
+  hooks:
+    - id: command-docs
+      name: Regenerate docs/docs/commands from the CLI --help output
+      entry: python update_command_docs.py
+      language: system
+      pass_filenames: false
+      files: ^(datacontract/|update_command_docs\.py$)
+    - id: release-notes
+      name: Regenerate docs/docs/release-notes.md from CHANGELOG.md
+      entry: node docs/scripts/generate-release-notes.mjs
+      language: system
+      pass_filenames: false
+      files: ^(CHANGELOG\.md|docs/scripts/generate-release-notes\.mjs)$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- The Python library accepts Databricks and Snowflake credentials programmatically via `source_config=`, so multithreaded callers no longer have to mutate `os.environ` per request (#1250)
+
 ### Fixed
+- `datacontract test` against Snowflake no longer fails with a `TypeError` when `DATACONTRACT_SNOWFLAKE_ACCOUNT`, `..._DATABASE`, or `..._SCHEMA` is set
 - `datacontract dbt sync` does not assume `severity: warn` as default anymore: tests now fail with dbt's default severity unless the contract declares a non-blocking `quality.severity`
 - `datacontract dbt sync` no longer drops or misplaces YAML comments that introduce the next column, test, or key
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `datacontract test` against Snowflake no longer fails with a `TypeError` when `DATACONTRACT_SNOWFLAKE_ACCOUNT`, `..._DATABASE`, or `..._SCHEMA` is set
+- `datacontract import databricks` now names a missing environment variable instead of the generic "Failed to connect to unity catalog schema"
 - `datacontract dbt sync` does not assume `severity: warn` as default anymore: tests now fail with dbt's default severity unless the contract declares a non-blocking `quality.severity`
 - `datacontract dbt sync` no longer drops or misplaces YAML comments that introduce the next column, test, or key
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- The Python library accepts Databricks and Snowflake credentials programmatically via `source_config=`, so multithreaded callers no longer have to mutate `os.environ` per request (#1250)
+- The Python library accepts Databricks and Snowflake credentials programmatically via `source_config=` (#1250)
 
 ### Fixed
 - `datacontract test` against Snowflake no longer fails with a `TypeError` when `DATACONTRACT_SNOWFLAKE_ACCOUNT`, `..._DATABASE`, or `..._SCHEMA` is set

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -18,7 +18,7 @@ from datacontract.lint import resolve
 from datacontract.model.changelog import ChangelogEntry, ChangelogResult, ChangelogType
 from datacontract.model.exceptions import DataContractException, DataContractValidationErrors
 from datacontract.model.run import Check, ResultEnum, Run
-from datacontract.model.source_config import SourceConfigInput, normalize_source_configs
+from datacontract.model.source_config import SourceConfigInput, normalize_source_configs, select_source_config
 
 
 class DataContract:
@@ -271,11 +271,15 @@ class DataContract:
         """
         id = kwargs.get("id")
         owner = kwargs.get("owner")
-        # Importer.import_source(source, import_args) is the registered plugin ABI,
-        # so the configs travel as a reserved import_args key rather than a parameter.
-        kwargs["source_config"] = normalize_source_configs(source_config)
+        # Importer.import_source(source, import_args) is the registered plugin ABI, so the config
+        # travels as a reserved import_args key rather than a parameter. Only the family the
+        # importer declares is handed over, so it never sees another source's credentials.
+        configs = normalize_source_configs(source_config)
+        importer = importer_factory.create(format)
+        if importer.source_config_type is not None:
+            kwargs["source_config"] = select_source_config(configs, importer.source_config_type)
 
-        odcs_imported = importer_factory.create(format).import_source(source=source, import_args=kwargs)
+        odcs_imported = importer.import_source(source=source, import_args=kwargs)
 
         cls._overwrite_id_in_odcs(odcs_imported, id)
         cls._overwrite_owner_in_odcs(odcs_imported, owner)

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -18,6 +18,7 @@ from datacontract.lint import resolve
 from datacontract.model.changelog import ChangelogEntry, ChangelogResult, ChangelogType
 from datacontract.model.exceptions import DataContractException, DataContractValidationErrors
 from datacontract.model.run import Check, ResultEnum, Run
+from datacontract.model.source_config import SourceConfigInput, normalize_source_configs
 
 
 class DataContract:
@@ -42,6 +43,7 @@ class DataContract:
         tags: set[str] | None = None,
         fastapi_url: str = None,
         include_failed_samples: bool = False,
+        source_config: SourceConfigInput = None,
     ):
         self._data_contract_file = data_contract_file
         self._data_contract_str = data_contract_str
@@ -62,6 +64,7 @@ class DataContract:
         self._tags = tags
         self._fastapi_url = fastapi_url
         self._include_failed_samples = include_failed_samples
+        self._source_configs = normalize_source_configs(source_config)
 
     @classmethod
     def init(cls, template: typing.Optional[str], schema: typing.Optional[str] = None) -> OpenDataContractStandard:
@@ -156,6 +159,7 @@ class DataContract:
                 quality_ids=self._quality_ids,
                 tags=self._tags,
                 include_failed_samples=self._include_failed_samples,
+                source_configs=self._source_configs,
             )
 
         except DataContractException as e:
@@ -258,6 +262,7 @@ class DataContract:
         cls,
         format: str,
         source: typing.Optional[str] = None,
+        source_config: SourceConfigInput = None,
         **kwargs,
     ) -> OpenDataContractStandard:
         """Import a data contract from a source in a given format.
@@ -266,6 +271,9 @@ class DataContract:
         """
         id = kwargs.get("id")
         owner = kwargs.get("owner")
+        # Importer.import_source(source, import_args) is the registered plugin ABI,
+        # so the configs travel as a reserved import_args key rather than a parameter.
+        kwargs["source_config"] = normalize_source_configs(source_config)
 
         odcs_imported = importer_factory.create(format).import_source(source=source, import_args=kwargs)
 

--- a/datacontract/engines/data_contract_test.py
+++ b/datacontract/engines/data_contract_test.py
@@ -2,6 +2,7 @@ import atexit
 import os
 import tempfile
 import typing
+from collections.abc import Sequence
 
 import requests
 from open_data_contract_standard.model import OpenDataContractStandard, Server
@@ -21,6 +22,7 @@ from datacontract.engines.fastjsonschema.check_jsonschema import check_jsonschem
 from datacontract.engines.ibis.ibis_check_execute import build_check_stubs, execute_ibis_checks
 from datacontract.model.exceptions import DataContractException
 from datacontract.model.run import ResultEnum, Run
+from datacontract.model.source_config import BaseSourceConfig
 
 
 def execute_data_contract_test(
@@ -35,6 +37,7 @@ def execute_data_contract_test(
     quality_ids: set[str] | None = None,
     tags: set[str] | None = None,
     include_failed_samples: bool = False,
+    source_configs: Sequence[BaseSourceConfig] = (),
 ):
     if data_contract.schema_ is None or len(data_contract.schema_) == 0:
         raise DataContractException(
@@ -129,6 +132,7 @@ def execute_data_contract_test(
         duckdb_connection,
         schema_name=schema_name,
         include_failed_samples=include_failed_samples,
+        source_configs=source_configs,
     )
 
 

--- a/datacontract/engines/ibis/connections/connect.py
+++ b/datacontract/engines/ibis/connections/connect.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import logging
 import os
 import typing
+from collections.abc import Sequence
 
 from open_data_contract_standard.model import OpenDataContractStandard, Server
 
@@ -21,6 +22,12 @@ from datacontract.engines.ibis.connections.duckdb_connection import get_duckdb_c
 from datacontract.model.exceptions import DataContractException, require_env
 from datacontract.model.run import Check, ResultEnum, Run
 from datacontract.model.server import get_server_type
+from datacontract.model.source_config import (
+    BaseSourceConfig,
+    DatabricksSourceConfig,
+    SnowflakeSourceConfig,
+    select_source_config,
+)
 
 if typing.TYPE_CHECKING:
     import ibis
@@ -28,6 +35,7 @@ if typing.TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_DATABRICKS_PREFIX = "DATACONTRACT_DATABRICKS_"
 _FILE_SERVER_TYPES = {"s3", "gcs", "azure", "local"}
 _SUPPORTED_FILE_FORMATS = {"json", "parquet", "csv", "delta"}
 
@@ -51,6 +59,7 @@ def connect_ibis(
     spark: "SparkSession" = None,
     duckdb_connection=None,
     schema_name: str = "all",
+    source_configs: Sequence[BaseSourceConfig] = (),
 ) -> "ibis.BaseBackend | None":
     """Return a connected ibis backend, or ``None`` if the server is unsupported.
 
@@ -92,7 +101,7 @@ def connect_ibis(
             if database_name:
                 spark.sql(f"USE {database_name}")
             return ibis.pyspark.connect(session=spark)
-        return _connect_databricks(ibis, server, run)
+        return _connect_databricks(ibis, server, run, select_source_config(source_configs, DatabricksSourceConfig))
 
     if server_type == "postgres":
         return ibis.postgres.connect(
@@ -134,25 +143,17 @@ def connect_ibis(
         return _connect_mysql_via_duckdb(ibis, data_contract, server, run, schema_name)
 
     if server_type == "snowflake":
-        prefix = "DATACONTRACT_SNOWFLAKE_"
-        extra = {k.replace(prefix, "").lower(): v for k, v in os.environ.items() if k.startswith(prefix)}
-        # ibis passes kwargs straight to snowflake-connector-python, which uses
-        # `user` (not soda's `username`). Keep DATACONTRACT_SNOWFLAKE_USERNAME working.
-        if "username" in extra:
-            extra.setdefault("user", extra.pop("username"))
+        config = select_source_config(source_configs, SnowflakeSourceConfig)
+        extra = config.driver_parameters()
+        # The contract owns the connection's identity; config only fills what it omits.
+        for name, value in (("account", server.account), ("database", server.database), ("schema", server.schema_)):
+            if value is not None:
+                extra[name] = value
         # ibis tries to CREATE DATABASE for helper UDFs on connect (create_object_udfs=True).
         # datacontract only reads, and the read-only roles used for testing lack CREATE DATABASE,
         # so this otherwise emits a noisy "Insufficient privileges" warning. Default it off, but
-        # let users opt back in via DATACONTRACT_SNOWFLAKE_CREATE_OBJECT_UDFS=true (env values are
-        # strings, so coerce it; an unset/blank/non-"true" value keeps UDF creation disabled).
-        create_object_udfs = str(extra.pop("create_object_udfs", "")).strip().lower() == "true"
-        return ibis.snowflake.connect(
-            create_object_udfs=create_object_udfs,
-            account=server.account,
-            database=server.database,
-            schema=server.schema_,
-            **extra,
-        )
+        # let users opt back in via DATACONTRACT_SNOWFLAKE_CREATE_OBJECT_UDFS=true.
+        return ibis.snowflake.connect(create_object_udfs=config.create_object_udfs, **extra)
 
     if server_type == "bigquery":
         credentials_path = os.getenv("DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH")
@@ -222,8 +223,8 @@ def connect_ibis(
     return None
 
 
-def _connect_databricks(ibis, server: Server, run: Run):
-    """Connect to Databricks SQL directly, selecting the auth method from env vars.
+def _connect_databricks(ibis, server: Server, run: Run, config: DatabricksSourceConfig):
+    """Connect to Databricks SQL directly, selecting the auth method from the config.
 
     Auth is resolved in priority order, so an existing token-based setup keeps
     working unchanged:
@@ -240,44 +241,63 @@ def _connect_databricks(ibis, server: Server, run: Run):
     The OAuth credential providers build their SDK ``Config`` lazily, so token
     exchange happens when the connection is opened rather than while reading env.
     """
-    host = server.host or require_env("DATACONTRACT_DATABRICKS_SERVER_HOSTNAME", server_type="databricks")
+    # The contract owns the connection's identity; config only fills what it omits.
+    host = server.host or config.server_hostname
+    if not host:
+        raise _databricks_missing("server_hostname", "DATACONTRACT_DATABRICKS_SERVER_HOSTNAME")
     kwargs = dict(
         server_hostname=host,
-        http_path=os.getenv("DATACONTRACT_DATABRICKS_HTTP_PATH"),
+        http_path=config.http_path,
         catalog=server.catalog,
         schema=server.schema_,
     )
 
-    token = os.getenv("DATACONTRACT_DATABRICKS_TOKEN")
-    client_id = os.getenv("DATACONTRACT_DATABRICKS_CLIENT_ID")
-    client_secret = os.getenv("DATACONTRACT_DATABRICKS_CLIENT_SECRET")
-    profile = os.getenv("DATACONTRACT_DATABRICKS_PROFILE")
-    auth_type = os.getenv("DATACONTRACT_DATABRICKS_AUTH_TYPE")
-
-    if token:
+    if config.token:
         run.log_info("Connecting to databricks with a personal access token")
-        return ibis.databricks.connect(access_token=token, **kwargs)
+        _log_credential_source("token")
+        return ibis.databricks.connect(access_token=config.token.get_secret_value(), **kwargs)
 
-    if client_id and client_secret:
+    if config.client_id and config.client_secret:
         run.log_info("Connecting to databricks with an OAuth service principal (M2M)")
+        _log_credential_source("client_id")
         sdk_host = host if host.startswith("http") else f"https://{host}"
         kwargs["credentials_provider"] = _databricks_credentials_provider(
-            host=sdk_host, client_id=client_id, client_secret=client_secret
+            host=sdk_host, client_id=config.client_id, client_secret=config.client_secret.get_secret_value()
         )
         return ibis.databricks.connect(**kwargs)
 
-    if profile:
-        run.log_info(f"Connecting to databricks with config profile '{profile}'")
-        kwargs["credentials_provider"] = _databricks_credentials_provider(profile=profile)
+    if config.profile:
+        run.log_info(f"Connecting to databricks with config profile '{config.profile}'")
+        _log_credential_source("profile")
+        kwargs["credentials_provider"] = _databricks_credentials_provider(profile=config.profile)
         return ibis.databricks.connect(**kwargs)
 
-    if auth_type:
-        run.log_info(f"Connecting to databricks with auth_type '{auth_type}'")
-        return ibis.databricks.connect(auth_type=auth_type, **kwargs)
+    if config.auth_type:
+        run.log_info(f"Connecting to databricks with auth_type '{config.auth_type}'")
+        _log_credential_source("auth_type")
+        return ibis.databricks.connect(auth_type=config.auth_type, **kwargs)
 
-    # Nothing configured: fail with the same clear message as before.
-    token = require_env("DATACONTRACT_DATABRICKS_TOKEN", server_type="databricks")
-    return ibis.databricks.connect(access_token=token, **kwargs)
+    raise _databricks_missing("token", "DATACONTRACT_DATABRICKS_TOKEN")
+
+
+def _databricks_missing(field: str, env_var: str) -> DataContractException:
+    # Same type/name as require_env produced here before, so existing handlers still match.
+    return DataContractException(
+        type="databricks-connection",
+        name=f"missing_env_{env_var}",
+        reason=f"Set {env_var} (or pass DatabricksSourceConfig({field}=...)) to connect to databricks.",
+        engine="datacontract",
+    )
+
+
+def _log_credential_source(field: str) -> None:
+    """Record which field decided the auth method, and which variables the environment supplied.
+
+    Unset config fields fall back to the environment per field, so an ambient variable can
+    decide the auth method even when the caller passed different credentials. Names only.
+    """
+    present = sorted(name for name, value in os.environ.items() if name.startswith(_DATABRICKS_PREFIX) and value)
+    logger.debug("databricks auth selected on '%s'; environment supplied: %s", field, present or "nothing")
 
 
 def _databricks_credentials_provider(**config_kwargs):

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 import uuid
 from collections import defaultdict
+from collections.abc import Sequence
 from typing import List, Optional
 
 from open_data_contract_standard.model import OpenDataContractStandard, SchemaProperty, Server
@@ -32,6 +33,7 @@ from datacontract.engines.ibis.snowflake_structured_types import fetch_structure
 from datacontract.model.exceptions import DataContractException
 from datacontract.model.run import Check, ResultEnum, Run
 from datacontract.model.server import get_server_type
+from datacontract.model.source_config import BaseSourceConfig
 
 logger = logging.getLogger(__name__)
 
@@ -103,6 +105,7 @@ def execute_ibis_checks(
     duckdb_connection=None,
     schema_name: str = "all",
     include_failed_samples: bool = False,
+    source_configs: Sequence[BaseSourceConfig] = (),
 ):
     if data_contract is None:
         run.log_warn("Cannot run engine ibis, as data contract is invalid")
@@ -121,7 +124,7 @@ def execute_ibis_checks(
 
     run.log_info("Running engine ibis")
     try:
-        con = connect_ibis(run, data_contract, server, spark, duckdb_connection, schema_name)
+        con = connect_ibis(run, data_contract, server, spark, duckdb_connection, schema_name, source_configs)
     except DataContractException:
         raise
     except ImportError:

--- a/datacontract/imports/importer.py
+++ b/datacontract/imports/importer.py
@@ -5,6 +5,10 @@ from open_data_contract_standard.model import OpenDataContractStandard
 
 
 class Importer(ABC):
+    # The source config family this importer accepts. Declaring one makes the caller's config for
+    # that family arrive as import_args["source_config"]; importers never see another family's.
+    source_config_type: type | None = None
+
     def __init__(self, import_format) -> None:
         self.import_format = import_format
 

--- a/datacontract/imports/snowflake_importer.py
+++ b/datacontract/imports/snowflake_importer.py
@@ -18,17 +18,19 @@ from datacontract.imports.importer import Importer
 from datacontract.imports.odcs_helper import create_odcs, create_property, create_schema_object, create_server
 from datacontract.imports.sql_importer import map_type_from_sql
 from datacontract.model.exceptions import DataContractException
-from datacontract.model.source_config import SnowflakeSourceConfig, select_source_config
+from datacontract.model.source_config import SnowflakeSourceConfig
 
 
 class SnowflakeImporter(Importer):
+    source_config_type = SnowflakeSourceConfig
+
     def import_source(self, source: str, import_args: dict) -> OpenDataContractStandard:
         if source is not None:
             return import_snowflake_from_connector(
                 account=source,
                 database=import_args.get("database"),
                 schema=import_args.get("schema"),
-                config=select_source_config(import_args.get("source_config") or (), SnowflakeSourceConfig),
+                config=import_args.get("source_config"),
             )
         else:
             raise DataContractException(

--- a/datacontract/imports/snowflake_importer.py
+++ b/datacontract/imports/snowflake_importer.py
@@ -18,6 +18,7 @@ from datacontract.imports.importer import Importer
 from datacontract.imports.odcs_helper import create_odcs, create_property, create_schema_object, create_server
 from datacontract.imports.sql_importer import map_type_from_sql
 from datacontract.model.exceptions import DataContractException
+from datacontract.model.source_config import SnowflakeSourceConfig, select_source_config
 
 
 class SnowflakeImporter(Importer):
@@ -27,6 +28,7 @@ class SnowflakeImporter(Importer):
                 account=source,
                 database=import_args.get("database"),
                 schema=import_args.get("schema"),
+                config=select_source_config(import_args.get("source_config") or (), SnowflakeSourceConfig),
             )
         else:
             raise DataContractException(
@@ -341,7 +343,9 @@ def property_customs_ordinal_position_sort(col: SchemaProperty) -> Any:
     return (ord_val is None, ord_val or 0, col.name.lower())
 
 
-def import_snowflake_from_connector(account: str, database: str, schema: str) -> OpenDataContractStandard:
+def import_snowflake_from_connector(
+    account: str, database: str, schema: str, config: SnowflakeSourceConfig | None = None
+) -> OpenDataContractStandard:
 
     try:
         # Verify the snowflake extra is fully installed
@@ -357,7 +361,7 @@ def import_snowflake_from_connector(account: str, database: str, schema: str) ->
         )
 
     result_sets = {}
-    cnx = snowflake_cursor(account, database, schema)
+    cnx = snowflake_cursor(account, database, schema, config)
     try:
         with cnx.cursor() as cur:
             # Always use quoted identifiers to prevent SQL injection and handle case-sensitive names
@@ -447,7 +451,7 @@ def import_snowflake_from_connector(account: str, database: str, schema: str) ->
     return odcs
 
 
-def snowflake_cursor(account: str, database: str, schema: str):
+def snowflake_cursor(account: str, database: str, schema: str, config: SnowflakeSourceConfig | None = None):
     try:
         from snowflake.connector import connect
     except ImportError as e:
@@ -464,36 +468,24 @@ def snowflake_cursor(account: str, database: str, schema: str):
     ## Snowflake connection
     ## https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect
     ###
-    # gather connection parameters from environment variables
-    user_connect = os.environ.get("DATACONTRACT_SNOWFLAKE_USERNAME", None)
-    password_connect = os.environ.get("DATACONTRACT_SNOWFLAKE_PASSWORD", None)
+    # gather connection parameters from the config, which falls back to environment variables
+    config = config or SnowflakeSourceConfig()
+    user_connect = config.user
+    password_connect = config.password.get_secret_value() if config.password else None
     account_connect = account
-    role_connect = os.environ.get("DATACONTRACT_SNOWFLAKE_ROLE", None)
-    authenticator_connect = (
-        "externalbrowser"
-        if password_connect is None
-        else os.environ.get("DATACONTRACT_SNOWFLAKE_AUTHENTICATOR", "snowflake")
-    )
-    warehouse_connect = os.environ.get("DATACONTRACT_SNOWFLAKE_WAREHOUSE", None)
+    role_connect = config.role
+    authenticator_connect = "externalbrowser" if password_connect is None else (config.authenticator or "snowflake")
+    warehouse_connect = config.warehouse
     database_connect = database
     schema_connect = schema
-    snowflake_home = os.environ.get("DATACONTRACT_SNOWFLAKE_HOME") or os.environ.get("SNOWFLAKE_HOME")
-    snowflake_connections_file = os.environ.get("DATACONTRACT_SNOWFLAKE_CONNECTIONS_FILE") or os.environ.get(
-        "SNOWFLAKE_CONNECTIONS_FILE"
-    )
-    if not snowflake_connections_file and snowflake_home:
-        snowflake_connections_file = os.path.join(snowflake_home, "connections.toml")
+    snowflake_connections_file = config.connections_file
+    if not snowflake_connections_file and config.home:
+        snowflake_connections_file = os.path.join(config.home, "connections.toml")
 
-    default_connection = os.environ.get("DATACONTRACT_SNOWFLAKE_DEFAULT_CONNECTION_NAME") or os.environ.get(
-        "SNOWFLAKE_DEFAULT_CONNECTION_NAME"
-    )
+    default_connection = config.default_connection_name
 
-    private_key_file = os.environ.get("DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_FILE") or os.environ.get(
-        "SNOWFLAKE_PRIVATE_KEY_FILE"
-    )
-    private_key_file_pwd = os.environ.get("DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_FILE_PWD") or os.environ.get(
-        "SNOWFLAKE_PRIVATE_KEY_FILE_PWD"
-    )
+    private_key_file = config.private_key_file
+    private_key_file_pwd = config.private_key_file_pwd.get_secret_value() if config.private_key_file_pwd else None
 
     # build connection
     if default_connection is not None and password_connect is None:

--- a/datacontract/imports/unity_importer.py
+++ b/datacontract/imports/unity_importer.py
@@ -15,13 +15,15 @@ from datacontract.imports.odcs_helper import (
 )
 from datacontract.imports.sql_importer import map_type_from_sql
 from datacontract.model.exceptions import DataContractException
-from datacontract.model.source_config import DatabricksSourceConfig, select_source_config
+from datacontract.model.source_config import DatabricksSourceConfig
 
 logger = logging.getLogger(__name__)
 
 
 class UnityImporter(Importer):
     """UnityImporter class for importing data contract specifications from Unity Catalog."""
+
+    source_config_type = DatabricksSourceConfig
 
     def import_source(
         self,
@@ -33,8 +35,7 @@ class UnityImporter(Importer):
             return import_unity_from_json(source)
         else:
             unity_table_full_name_list = import_args.get("unity_table_full_name")
-            config = select_source_config(import_args.get("source_config") or (), DatabricksSourceConfig)
-            return import_unity_from_api(unity_table_full_name_list, config)
+            return import_unity_from_api(unity_table_full_name_list, import_args.get("source_config"))
 
 
 def import_unity_from_json(source: str) -> OpenDataContractStandard:

--- a/datacontract/imports/unity_importer.py
+++ b/datacontract/imports/unity_importer.py
@@ -57,6 +57,16 @@ def import_unity_from_json(source: str) -> OpenDataContractStandard:
     return convert_unity_schema(odcs, unity_schema)
 
 
+def _missing_databricks_configuration(reason: str) -> DataContractException:
+    # DataContractException renders its message at construction, so the reason has to be passed in.
+    return DataContractException(
+        type="configuration",
+        name="Databricks configuration",
+        reason=reason,
+        engine="datacontract",
+    )
+
+
 def import_unity_from_api(
     unity_table_full_name_list: List[str] = None,
     config: "DatabricksSourceConfig | None" = None,
@@ -66,27 +76,21 @@ def import_unity_from_api(
     try:
         profile = config.profile
         host, token = config.server_hostname, config.token
-        exception = DataContractException(
-            type="configuration",
-            name="Databricks configuration",
-            reason="",
-            engine="datacontract",
-        )
         if not profile and not host and not token:
-            reason = "Either DATACONTRACT_DATABRICKS_PROFILE or both DATACONTRACT_DATABRICKS_SERVER_HOSTNAME and DATACONTRACT_DATABRICKS_TOKEN environment variables must be set (or pass DatabricksSourceConfig)"
-            exception.reason = reason
-            raise exception
+            raise _missing_databricks_configuration(
+                "Either DATACONTRACT_DATABRICKS_PROFILE or both DATACONTRACT_DATABRICKS_SERVER_HOSTNAME and DATACONTRACT_DATABRICKS_TOKEN environment variables must be set (or pass DatabricksSourceConfig)"
+            )
         if token and not host:
-            reason = "DATACONTRACT_DATABRICKS_SERVER_HOSTNAME environment variable is not set"
-            exception.reason = reason
-            raise exception
+            raise _missing_databricks_configuration(
+                "DATACONTRACT_DATABRICKS_SERVER_HOSTNAME environment variable is not set"
+            )
         if host and not token:
-            reason = "DATACONTRACT_DATABRICKS_TOKEN environment variable is not set"
-            exception.reason = reason
-            raise exception
+            raise _missing_databricks_configuration("DATACONTRACT_DATABRICKS_TOKEN environment variable is not set")
         workspace_client = (
             WorkspaceClient(profile=profile) if profile else WorkspaceClient(host=host, token=token.get_secret_value())
         )
+    except DataContractException:
+        raise
     except Exception as e:
         raise DataContractException(
             type="schema",

--- a/datacontract/imports/unity_importer.py
+++ b/datacontract/imports/unity_importer.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 from typing import List, Optional, Tuple
 
 from databricks.sdk import WorkspaceClient
@@ -16,6 +15,7 @@ from datacontract.imports.odcs_helper import (
 )
 from datacontract.imports.sql_importer import map_type_from_sql
 from datacontract.model.exceptions import DataContractException
+from datacontract.model.source_config import DatabricksSourceConfig, select_source_config
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,8 @@ class UnityImporter(Importer):
             return import_unity_from_json(source)
         else:
             unity_table_full_name_list = import_args.get("unity_table_full_name")
-            return import_unity_from_api(unity_table_full_name_list)
+            config = select_source_config(import_args.get("source_config") or (), DatabricksSourceConfig)
+            return import_unity_from_api(unity_table_full_name_list, config)
 
 
 def import_unity_from_json(source: str) -> OpenDataContractStandard:
@@ -55,11 +56,15 @@ def import_unity_from_json(source: str) -> OpenDataContractStandard:
     return convert_unity_schema(odcs, unity_schema)
 
 
-def import_unity_from_api(unity_table_full_name_list: List[str] = None) -> OpenDataContractStandard:
+def import_unity_from_api(
+    unity_table_full_name_list: List[str] = None,
+    config: "DatabricksSourceConfig | None" = None,
+) -> OpenDataContractStandard:
     """Import data contract specification from Unity Catalog API."""
+    config = config or DatabricksSourceConfig()
     try:
-        profile = os.getenv("DATACONTRACT_DATABRICKS_PROFILE")
-        host, token = os.getenv("DATACONTRACT_DATABRICKS_SERVER_HOSTNAME"), os.getenv("DATACONTRACT_DATABRICKS_TOKEN")
+        profile = config.profile
+        host, token = config.server_hostname, config.token
         exception = DataContractException(
             type="configuration",
             name="Databricks configuration",
@@ -67,7 +72,7 @@ def import_unity_from_api(unity_table_full_name_list: List[str] = None) -> OpenD
             engine="datacontract",
         )
         if not profile and not host and not token:
-            reason = "Either DATACONTRACT_DATABRICKS_PROFILE or both DATACONTRACT_DATABRICKS_SERVER_HOSTNAME and DATACONTRACT_DATABRICKS_TOKEN environment variables must be set"
+            reason = "Either DATACONTRACT_DATABRICKS_PROFILE or both DATACONTRACT_DATABRICKS_SERVER_HOSTNAME and DATACONTRACT_DATABRICKS_TOKEN environment variables must be set (or pass DatabricksSourceConfig)"
             exception.reason = reason
             raise exception
         if token and not host:
@@ -78,7 +83,9 @@ def import_unity_from_api(unity_table_full_name_list: List[str] = None) -> OpenD
             reason = "DATACONTRACT_DATABRICKS_TOKEN environment variable is not set"
             exception.reason = reason
             raise exception
-        workspace_client = WorkspaceClient(profile=profile) if profile else WorkspaceClient(host=host, token=token)
+        workspace_client = (
+            WorkspaceClient(profile=profile) if profile else WorkspaceClient(host=host, token=token.get_secret_value())
+        )
     except Exception as e:
         raise DataContractException(
             type="schema",

--- a/datacontract/model/source_config.py
+++ b/datacontract/model/source_config.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import os
 import typing
 
-from pydantic import AliasChoices, Field, SecretStr
+from pydantic import AliasChoices, Field, SecretStr, ValidationError, field_serializer
 from pydantic_settings import BaseSettings, EnvSettingsSource, SettingsConfigDict
 
 
@@ -18,6 +18,22 @@ class BaseSourceConfig(BaseSettings):
     # populate_by_name is load-bearing: a field with a validation_alias is otherwise
     # settable only by its environment variable name, which breaks the Python API.
     model_config = SettingsConfigDict(extra="forbid", env_ignore_empty=True, populate_by_name=True)
+
+    def __init__(__pydantic_self__, **values):
+        # A rejected value is often a secret under a mistyped field name, and pydantic echoes
+        # the input into the error. Re-raise with locations and messages only.
+        try:
+            super().__init__(**values)
+        except ValidationError as e:
+            details = "; ".join(
+                f"{'.'.join(str(part) for part in error['loc'])}: {error['msg']}"
+                for error in e.errors(include_url=False)
+            )
+        else:
+            return
+        # raised outside the handler so the pydantic error, which still holds the rejected
+        # value, is not attached as this exception's __context__
+        raise ValueError(f"invalid {type(__pydantic_self__).__name__}: {details}")
 
 
 class DatabricksSourceConfig(BaseSourceConfig):
@@ -43,12 +59,18 @@ class _SnowflakeEnvSource(EnvSettingsSource):
 
     def __call__(self) -> dict[str, typing.Any]:
         data = super().__call__()
-        declared = {
-            env_name.lower()
-            for name, field in self.settings_cls.model_fields.items()
-            for _, env_name, _ in self._extract_field_info(field, name)
-        }
         prefix = self.env_prefix
+        # A field's environment variable is its validation_alias if it has one (already a full
+        # name, the prefix is not applied on top), otherwise the prefix plus the field name.
+        declared = set()
+        for name, field in self.settings_cls.model_fields.items():
+            alias = field.validation_alias
+            if alias is None:
+                declared.add(f"{prefix}{name}".lower())
+            elif isinstance(alias, str):
+                declared.add(alias.lower())
+            else:
+                declared.update(choice.lower() for choice in alias.choices if isinstance(choice, str))
         swept = {
             name[len(prefix) :].lower(): value
             for name, value in os.environ.items()
@@ -95,8 +117,18 @@ class SnowflakeSourceConfig(BaseSourceConfig):
     # ibis opens the connection with helper UDF creation enabled; datacontract only reads.
     create_object_udfs: bool = False
 
-    # Connector parameters we do not declare, forwarded verbatim to the driver.
-    connection_parameters: dict[str, str] = Field(default_factory=dict)
+    # Connector parameters we do not declare, forwarded verbatim to the driver. Values can be
+    # secrets the driver accepts without a field here (passcode, oauth_client_secret, ...), so
+    # they are masked everywhere the declared SecretStr fields are: repr, str, and dumps.
+    connection_parameters: dict[str, typing.Any] = Field(default_factory=dict)
+
+    @field_serializer("connection_parameters")
+    def _mask_connection_parameters(self, value: dict[str, typing.Any]) -> dict[str, str]:
+        return dict.fromkeys(value, "**********")
+
+    def __repr_args__(self):
+        for name, value in super().__repr_args__():
+            yield name, self._mask_connection_parameters(value) if name == "connection_parameters" else value
 
     @classmethod
     def settings_customise_sources(

--- a/datacontract/model/source_config.py
+++ b/datacontract/model/source_config.py
@@ -1,0 +1,158 @@
+"""Typed credentials for a source family, passable programmatically.
+
+Each class mirrors one ``DATACONTRACT_<FAMILY>_*`` variable group. Fields passed
+explicitly win per field; anything left unset falls back to the environment, so
+environment-only setups keep working unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+import typing
+
+from pydantic import AliasChoices, Field, SecretStr
+from pydantic_settings import BaseSettings, EnvSettingsSource, SettingsConfigDict
+
+
+class BaseSourceConfig(BaseSettings):
+    # populate_by_name is load-bearing: a field with a validation_alias is otherwise
+    # settable only by its environment variable name, which breaks the Python API.
+    model_config = SettingsConfigDict(extra="forbid", env_ignore_empty=True, populate_by_name=True)
+
+
+class DatabricksSourceConfig(BaseSourceConfig):
+    """Credentials for the ``databricks`` server type and the Unity Catalog importer."""
+
+    model_config = SettingsConfigDict(env_prefix="DATACONTRACT_DATABRICKS_")
+
+    server_hostname: str | None = None
+    http_path: str | None = None
+    token: SecretStr | None = None
+    client_id: str | None = None
+    client_secret: SecretStr | None = None
+    profile: str | None = None
+    auth_type: str | None = None
+
+
+class _SnowflakeEnvSource(EnvSettingsSource):
+    """Sweep undeclared ``DATACONTRACT_SNOWFLAKE_*`` variables into ``connection_parameters``.
+
+    Any prefixed variable is a documented connection parameter for
+    snowflake-connector-python, so the set is open and cannot be fully declared.
+    """
+
+    def __call__(self) -> dict[str, typing.Any]:
+        data = super().__call__()
+        declared = {
+            env_name.lower()
+            for name, field in self.settings_cls.model_fields.items()
+            for _, env_name, _ in self._extract_field_info(field, name)
+        }
+        prefix = self.env_prefix
+        swept = {
+            name[len(prefix) :].lower(): value
+            for name, value in os.environ.items()
+            if value and name.startswith(prefix) and name.lower() not in declared
+        }
+        data["connection_parameters"] = {**swept, **data.get("connection_parameters", {})}
+        return data
+
+
+def _snowflake_alias(name: str) -> AliasChoices:
+    """The prefixed variable, then the bare ``SNOWFLAKE_*`` one the importer accepts."""
+    return AliasChoices(f"DATACONTRACT_SNOWFLAKE_{name.upper()}", f"SNOWFLAKE_{name.upper()}")
+
+
+class SnowflakeSourceConfig(BaseSourceConfig):
+    """Credentials for the ``snowflake`` server type and the Snowflake importer."""
+
+    model_config = SettingsConfigDict(env_prefix="DATACONTRACT_SNOWFLAKE_")
+
+    user: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("DATACONTRACT_SNOWFLAKE_USER", "DATACONTRACT_SNOWFLAKE_USERNAME"),
+    )
+    password: SecretStr | None = None
+    role: str | None = None
+    warehouse: str | None = None
+    authenticator: str | None = None
+    connection_timeout: str | None = None
+    private_key: SecretStr | None = None
+    private_key_passphrase: SecretStr | None = None
+    private_key_path: str | None = None
+    private_key_file: str | None = Field(default=None, validation_alias=_snowflake_alias("private_key_file"))
+    private_key_file_pwd: SecretStr | None = Field(
+        default=None, validation_alias=_snowflake_alias("private_key_file_pwd")
+    )
+
+    # Locate connections.toml. Read by the importer only; not connection parameters.
+    home: str | None = Field(default=None, validation_alias=_snowflake_alias("home"))
+    connections_file: str | None = Field(default=None, validation_alias=_snowflake_alias("connections_file"))
+    default_connection_name: str | None = Field(
+        default=None, validation_alias=_snowflake_alias("default_connection_name")
+    )
+
+    # ibis opens the connection with helper UDF creation enabled; datacontract only reads.
+    create_object_udfs: bool = False
+
+    # Connector parameters we do not declare, forwarded verbatim to the driver.
+    connection_parameters: dict[str, str] = Field(default_factory=dict)
+
+    @classmethod
+    def settings_customise_sources(
+        cls, settings_cls, init_settings, env_settings, dotenv_settings, file_secret_settings
+    ):
+        return init_settings, _SnowflakeEnvSource(settings_cls), dotenv_settings, file_secret_settings
+
+    def driver_parameters(self) -> dict[str, typing.Any]:
+        """The declared fields snowflake-connector-python accepts, plus the undeclared sweep."""
+        declared = {
+            "user": self.user,
+            "password": self.password,
+            "role": self.role,
+            "warehouse": self.warehouse,
+            "authenticator": self.authenticator,
+            "connection_timeout": self.connection_timeout,
+            "private_key": self.private_key,
+            "private_key_passphrase": self.private_key_passphrase,
+            "private_key_path": self.private_key_path,
+            "private_key_file": self.private_key_file,
+            "private_key_file_pwd": self.private_key_file_pwd,
+        }
+        params = {**self.connection_parameters}
+        for name, value in declared.items():
+            if value is not None:
+                params[name] = value.get_secret_value() if isinstance(value, SecretStr) else value
+        return params
+
+
+SourceConfigType = typing.Union[DatabricksSourceConfig, SnowflakeSourceConfig]
+
+SourceConfigInput = typing.Union[SourceConfigType, typing.Sequence[SourceConfigType], None]
+
+
+def normalize_source_configs(source_config: SourceConfigInput) -> tuple[BaseSourceConfig, ...]:
+    """Accept one config or a sequence, rejecting anything ambiguous at construction time."""
+    if source_config is None:
+        return ()
+    configs = (source_config,) if isinstance(source_config, BaseSourceConfig) else tuple(source_config)
+
+    seen = set()
+    for config in configs:
+        if not isinstance(config, BaseSourceConfig):
+            raise ValueError(f"source_config must be a source config object, got {type(config).__name__}")
+        if type(config) in seen:
+            raise ValueError(f"source_config contains more than one {type(config).__name__}")
+        seen.add(type(config))
+    return configs
+
+
+_T = typing.TypeVar("_T", bound=BaseSourceConfig)
+
+
+def select_source_config(configs: typing.Sequence[BaseSourceConfig], config_type: type[_T]) -> _T:
+    """The caller's config for this family, or a bare one reading the environment."""
+    for config in configs:
+        if isinstance(config, config_type):
+            return config
+    return config_type()

--- a/datacontract/model/source_config.py
+++ b/datacontract/model/source_config.py
@@ -119,10 +119,11 @@ class SnowflakeSourceConfig(BaseSourceConfig):
 
     # Connector parameters we do not declare, forwarded verbatim to the driver. Values can be
     # secrets the driver accepts without a field here (passcode, oauth_client_secret, ...), so
-    # they are masked everywhere the declared SecretStr fields are: repr, str, and dumps.
+    # they are masked wherever SecretStr is: repr, str, and JSON dumps. Like SecretStr, a
+    # python-mode model_dump() keeps the real values, so a config survives a dump round-trip.
     connection_parameters: dict[str, typing.Any] = Field(default_factory=dict)
 
-    @field_serializer("connection_parameters")
+    @field_serializer("connection_parameters", when_used="json")
     def _mask_connection_parameters(self, value: dict[str, typing.Any]) -> dict[str, str]:
         return dict.fromkeys(value, "**********")
 

--- a/docs/docs/reference/databricks.md
+++ b/docs/docs/reference/databricks.md
@@ -35,6 +35,28 @@ The authentication method is selected from the variables you set, in this order:
 
 `datacontract import unity` needs only the hostname plus a PAT or profile; `datacontract test` additionally needs `DATACONTRACT_DATABRICKS_HTTP_PATH`. When a `spark` session is passed programmatically (notebook/pipeline), no credentials are needed at all.
 
+### Programmatic configuration
+
+Library users can pass credentials directly instead of setting environment variables, which matters in multithreaded services where mutating `os.environ` per request races between threads:
+
+```python
+from datacontract.data_contract import DataContract
+from datacontract.model.source_config import DatabricksSourceConfig
+
+DataContract(
+    data_contract_file="datacontract.yaml",
+    source_config=DatabricksSourceConfig(token=tenant_token, http_path=tenant_path),
+).test()
+
+DataContract.import_from_source(
+    "unity",
+    unity_table_full_name=["acme.orders.latest"],
+    source_config=DatabricksSourceConfig(server_hostname=host, token=tenant_token),
+)
+```
+
+Fields left unset fall back to their environment variable individually, so you can vary one value per call and leave the rest ambient. Note that this also means an environment variable can decide the authentication method when the matching field is unset — passing only `client_id` and `client_secret` while `DATACONTRACT_DATABRICKS_TOKEN` is set still connects with the token, because the token has priority. Run with `--debug` to see which variables the environment supplied.
+
 ## Data types
 
 ### Importing

--- a/docs/docs/reference/databricks.md
+++ b/docs/docs/reference/databricks.md
@@ -37,25 +37,18 @@ The authentication method is selected from the variables you set, in this order:
 
 ### Programmatic configuration
 
-Library users can pass credentials directly instead of setting environment variables, which matters in multithreaded services where mutating `os.environ` per request races between threads:
+Library users can pass credentials directly instead of setting environment variables.
 
 ```python
-from datacontract.data_contract import DataContract
 from datacontract.model.source_config import DatabricksSourceConfig
 
 DataContract(
     data_contract_file="datacontract.yaml",
     source_config=DatabricksSourceConfig(token=tenant_token, http_path=tenant_path),
 ).test()
-
-DataContract.import_from_source(
-    "unity",
-    unity_table_full_name=["acme.orders.latest"],
-    source_config=DatabricksSourceConfig(server_hostname=host, token=tenant_token),
-)
 ```
 
-Fields left unset fall back to their environment variable individually, so you can vary one value per call and leave the rest ambient. Note that this also means an environment variable can decide the authentication method when the matching field is unset — passing only `client_id` and `client_secret` while `DATACONTRACT_DATABRICKS_TOKEN` is set still connects with the token, because the token has priority. Run with `--debug` to see which variables the environment supplied.
+Unset fields fall back to their environment variable individually.
 
 ## Data types
 

--- a/docs/docs/reference/snowflake.md
+++ b/docs/docs/reference/snowflake.md
@@ -22,11 +22,11 @@ servers:
 
 ## Authentication
 
-Any `DATACONTRACT_SNOWFLAKE_`-prefixed variable is passed (lowercased, prefix stripped) as a connection parameter to the [snowflake-connector-python](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-api#connect) driver. Set the variables required by your workspace's `authenticator` mode.
+Any `DATACONTRACT_SNOWFLAKE_`-prefixed variable is passed (lowercased, prefix stripped) as a connection parameter to the [snowflake-connector-python](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-api#connect) driver, except the import-specific ones listed below and `DATACONTRACT_SNOWFLAKE_CREATE_OBJECT_UDFS`. Set the variables required by your workspace's `authenticator` mode.
 
 | Connection parameter | Environment variable |
 |---|---|
-| `username` | `DATACONTRACT_SNOWFLAKE_USERNAME` |
+| `user` | `DATACONTRACT_SNOWFLAKE_USER` (or `DATACONTRACT_SNOWFLAKE_USERNAME`) |
 | `password` | `DATACONTRACT_SNOWFLAKE_PASSWORD` |
 | `warehouse` | `DATACONTRACT_SNOWFLAKE_WAREHOUSE` |
 | `role` | `DATACONTRACT_SNOWFLAKE_ROLE` |
@@ -37,6 +37,8 @@ Any `DATACONTRACT_SNOWFLAKE_`-prefixed variable is passed (lowercased, prefix st
 | `private_key_path` | `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_PATH` |
 
 `account`, `database`, and `schema` come from the contract's `servers` block.
+
+The driver creates helper UDFs on connect, which needs `CREATE DATABASE` and is not used for reading. It is therefore disabled; set `DATACONTRACT_SNOWFLAKE_CREATE_OBJECT_UDFS=true` to enable it.
 
 ### Import-specific options
 
@@ -54,25 +56,20 @@ The `SNOWFLAKE_`-prefixed equivalents work as fallbacks. If no password is set, 
 
 ### Programmatic configuration
 
-Library users can pass credentials directly instead of setting environment variables, which matters in multithreaded services where mutating `os.environ` per request races between threads:
+Library users can pass credentials directly instead of setting environment variables. Connection parameters without a field of their own go in `connection_parameters`, forwarded to the driver verbatim.
 
 ```python
-from datacontract.data_contract import DataContract
 from datacontract.model.source_config import SnowflakeSourceConfig
 
 DataContract(
     data_contract_file="datacontract.yaml",
-    source_config=SnowflakeSourceConfig(user=tenant_user, password=tenant_password),
+    source_config=SnowflakeSourceConfig(
+        user=tenant_user, password=tenant_password, connection_parameters={"passcode": "123456"}
+    ),
 ).test()
 ```
 
-Fields left unset fall back to their environment variable individually, so you can vary one value per call and leave the rest ambient. Connection parameters that have no field of their own go in `connection_parameters`, which is forwarded to the driver verbatim:
-
-```python
-SnowflakeSourceConfig(user="jakob", connection_parameters={"passcode": "123456"})
-```
-
-`account`, `database`, and `schema` always come from the contract when it declares them; the config only fills what the contract leaves out.
+Unset fields fall back to their environment variable individually.
 
 ## Data types
 

--- a/docs/docs/reference/snowflake.md
+++ b/docs/docs/reference/snowflake.md
@@ -52,6 +52,28 @@ Any `DATACONTRACT_SNOWFLAKE_`-prefixed variable is passed (lowercased, prefix st
 
 The `SNOWFLAKE_`-prefixed equivalents work as fallbacks. If no password is set, the import falls back to browser-based SSO (`externalbrowser`).
 
+### Programmatic configuration
+
+Library users can pass credentials directly instead of setting environment variables, which matters in multithreaded services where mutating `os.environ` per request races between threads:
+
+```python
+from datacontract.data_contract import DataContract
+from datacontract.model.source_config import SnowflakeSourceConfig
+
+DataContract(
+    data_contract_file="datacontract.yaml",
+    source_config=SnowflakeSourceConfig(user=tenant_user, password=tenant_password),
+).test()
+```
+
+Fields left unset fall back to their environment variable individually, so you can vary one value per call and leave the rest ambient. Connection parameters that have no field of their own go in `connection_parameters`, which is forwarded to the driver verbatim:
+
+```python
+SnowflakeSourceConfig(user="jakob", connection_parameters={"passcode": "123456"})
+```
+
+`account`, `database`, and `schema` always come from the contract when it declares them; the config only fills what the contract leaves out.
+
 ## Data types
 
 ### Importing

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -26,6 +26,14 @@ marked as such in the entry.
 
 ## Unreleased {#unreleased}
 
+### Added
+- The Python library accepts Databricks and Snowflake credentials programmatically via `source_config=` ([#1250](https://github.com/datacontract/datacontract-cli/issues/1250))
+
+### Fixed
+- `datacontract test` against Snowflake no longer fails with a `TypeError` when `DATACONTRACT_SNOWFLAKE_ACCOUNT`, `..._DATABASE`, or `..._SCHEMA` is set
+- `datacontract dbt sync` does not assume `severity: warn` as default anymore: tests now fail with dbt's default severity unless the contract declares a non-blocking `quality.severity`
+- `datacontract dbt sync` no longer drops or misplaces YAML comments that introduce the next column, test, or key
+
 ## 1.0.15 — 2026-07-30 {#v1-0-15}
 
 ### Added

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -31,6 +31,7 @@ marked as such in the entry.
 
 ### Fixed
 - `datacontract test` against Snowflake no longer fails with a `TypeError` when `DATACONTRACT_SNOWFLAKE_ACCOUNT`, `..._DATABASE`, or `..._SCHEMA` is set
+- `datacontract import databricks` now names a missing environment variable instead of the generic "Failed to connect to unity catalog schema"
 - `datacontract dbt sync` does not assume `severity: warn` as default anymore: tests now fail with dbt's default severity unless the contract declares a non-blocking `quality.severity`
 - `datacontract dbt sync` no longer drops or misplaces YAML comments that introduce the next column, test, or key
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "typer>=0.18.0,<0.28",
   "click>=8.1.0,<9.0.0",
   "pydantic>=2.8.2,<2.14.0",
+  "pydantic-settings>=2.4.0,<3.0.0",
   "pyyaml~=6.0.1",
   "ruamel.yaml>=0.17,<0.20",
   "requests>=2.31,<2.35",

--- a/tests/test_connect_databricks.py
+++ b/tests/test_connect_databricks.py
@@ -119,15 +119,10 @@ def test_hostname_falls_back_to_env(clean_databricks_env, captured_connect):
 def test_missing_auth_raises(clean_databricks_env, captured_connect):
     from datacontract.model.exceptions import DataContractException
 
-    with pytest.raises(DataContractException):
+    with pytest.raises(DataContractException, match="DATACONTRACT_DATABRICKS_TOKEN") as excinfo:
         _connect()
 
-
-def test_missing_auth_names_the_config_field_too(clean_databricks_env, captured_connect):
-    from datacontract.model.exceptions import DataContractException
-
-    with pytest.raises(DataContractException, match="DatabricksSourceConfig"):
-        _connect()
+    assert "DatabricksSourceConfig" in excinfo.value.reason
 
 
 # --- the same dispatch, driven by a config passed programmatically ------------

--- a/tests/test_connect_databricks.py
+++ b/tests/test_connect_databricks.py
@@ -1,7 +1,8 @@
 """Unit tests for Databricks auth-method selection in connect_ibis.
 
 These do not hit Databricks: ``ibis.databricks.connect`` is patched and we only
-assert which auth kwargs the dispatch passes for a given set of env vars.
+assert which auth kwargs the dispatch passes for a given set of env vars, or for
+a ``DatabricksSourceConfig`` passed programmatically.
 """
 
 import ibis
@@ -10,6 +11,7 @@ from open_data_contract_standard.model import Server
 
 from datacontract.engines.ibis.connections.connect import connect_ibis
 from datacontract.model.run import Run
+from datacontract.model.source_config import DatabricksSourceConfig
 
 DATABRICKS_ENV_VARS = [
     "DATACONTRACT_DATABRICKS_TOKEN",
@@ -46,8 +48,8 @@ def _server():
     return Server(type="databricks", host="dbc-x.cloud.databricks.com", catalog="cat", schema="sch")
 
 
-def _connect(server=None):
-    return connect_ibis(Run.create_run(), data_contract=None, server=server or _server())
+def _connect(server=None, source_configs=()):
+    return connect_ibis(Run.create_run(), data_contract=None, server=server or _server(), source_configs=source_configs)
 
 
 def test_personal_access_token_is_default(clean_databricks_env, captured_connect):
@@ -119,3 +121,64 @@ def test_missing_auth_raises(clean_databricks_env, captured_connect):
 
     with pytest.raises(DataContractException):
         _connect()
+
+
+def test_missing_auth_names_the_config_field_too(clean_databricks_env, captured_connect):
+    from datacontract.model.exceptions import DataContractException
+
+    with pytest.raises(DataContractException, match="DatabricksSourceConfig"):
+        _connect()
+
+
+# --- the same dispatch, driven by a config passed programmatically ------------
+
+
+def test_token_from_config(clean_databricks_env, captured_connect):
+    configs = (DatabricksSourceConfig(token="dapiPASSED", http_path="/sql/1.0/warehouses/abc"),)
+
+    assert _connect(source_configs=configs) == "connection"
+    assert captured_connect["access_token"] == "dapiPASSED"
+    assert captured_connect["http_path"] == "/sql/1.0/warehouses/abc"
+
+
+def test_service_principal_from_config(clean_databricks_env, captured_connect):
+    configs = (DatabricksSourceConfig(client_id="cid", client_secret="csec"),)
+
+    _connect(source_configs=configs)
+
+    assert "access_token" not in captured_connect
+    assert callable(captured_connect["credentials_provider"])
+
+
+def test_config_field_beats_env(clean_databricks_env, captured_connect):
+    clean_databricks_env.setenv("DATACONTRACT_DATABRICKS_TOKEN", "dapiFROM_ENV")
+
+    _connect(source_configs=(DatabricksSourceConfig(token="dapiPASSED"),))
+
+    assert captured_connect["access_token"] == "dapiPASSED"
+
+
+def test_unset_config_field_still_falls_back_to_env(clean_databricks_env, captured_connect):
+    """The per-tenant loop: vary http_path per call, keep the token ambient."""
+    clean_databricks_env.setenv("DATACONTRACT_DATABRICKS_TOKEN", "dapiFROM_ENV")
+
+    _connect(source_configs=(DatabricksSourceConfig(http_path="/sql/1.0/warehouses/tenant-a"),))
+
+    assert captured_connect["access_token"] == "dapiFROM_ENV"
+    assert captured_connect["http_path"] == "/sql/1.0/warehouses/tenant-a"
+
+
+def test_hostname_from_config_when_the_contract_omits_it(clean_databricks_env, captured_connect):
+    configs = (DatabricksSourceConfig(token="dapi", server_hostname="from-config.databricks.com"),)
+
+    _connect(Server(type="databricks", catalog="cat", schema="sch"), source_configs=configs)
+
+    assert captured_connect["server_hostname"] == "from-config.databricks.com"
+
+
+def test_contract_host_wins_over_config(clean_databricks_env, captured_connect):
+    configs = (DatabricksSourceConfig(token="dapi", server_hostname="from-config.databricks.com"),)
+
+    _connect(source_configs=configs)
+
+    assert captured_connect["server_hostname"] == "dbc-x.cloud.databricks.com"

--- a/tests/test_source_config.py
+++ b/tests/test_source_config.py
@@ -78,6 +78,13 @@ def test_undeclared_parameters_are_masked_but_still_reach_the_driver(clean_env):
     assert config.driver_parameters()["oauth_client_secret"] == "sekret"
 
 
+def test_a_config_survives_a_model_dump_round_trip(clean_env):
+    """Masking the dump would silently turn every connection parameter into the mask itself."""
+    config = SnowflakeSourceConfig(user="u", connection_parameters={"passcode": "123456", "login_timeout": 30})
+
+    assert SnowflakeSourceConfig(**config.model_dump()).driver_parameters() == config.driver_parameters()
+
+
 def test_unknown_field_is_rejected_without_echoing_its_value(clean_env):
     """A mistyped field name is usually a secret's; the rejected value must stay out of the error."""
     with pytest.raises(ValueError, match="tokne") as excinfo:

--- a/tests/test_source_config.py
+++ b/tests/test_source_config.py
@@ -14,6 +14,7 @@ from open_data_contract_standard.model import Server
 
 from datacontract.data_contract import DataContract
 from datacontract.engines.ibis.connections.connect import connect_ibis
+from datacontract.imports.importer import Importer
 from datacontract.model.run import Run
 from datacontract.model.source_config import (
     DatabricksSourceConfig,
@@ -68,9 +69,24 @@ def test_secrets_are_not_exposed_by_repr(clean_env):
     assert "dapiSECRET" not in str(config.model_dump())
 
 
-def test_unknown_field_is_rejected(clean_env):
-    with pytest.raises(Exception, match="tokne"):
-        DatabricksSourceConfig(tokne="typo")
+def test_undeclared_parameters_are_masked_but_still_reach_the_driver(clean_env):
+    config = SnowflakeSourceConfig(connection_parameters={"oauth_client_secret": "sekret"})
+
+    assert "sekret" not in repr(config)
+    assert "sekret" not in str(config)
+    assert "sekret" not in config.model_dump_json()
+    assert config.driver_parameters()["oauth_client_secret"] == "sekret"
+
+
+def test_unknown_field_is_rejected_without_echoing_its_value(clean_env):
+    """A mistyped field name is usually a secret's; the rejected value must stay out of the error."""
+    with pytest.raises(ValueError, match="tokne") as excinfo:
+        DatabricksSourceConfig(tokne="dapiSECRET")
+
+    assert "dapiSECRET" not in str(excinfo.value)
+    # the chained pydantic error would carry it back into the traceback
+    assert excinfo.value.__cause__ is None
+    assert excinfo.value.__context__ is None
 
 
 def test_aliased_field_is_settable_by_its_own_name(clean_env):
@@ -101,6 +117,32 @@ def test_undeclared_variables_are_swept_into_connection_parameters(clean_env):
     assert config.connection_parameters == {"passcode": "123456"}
 
 
+def test_no_declared_variable_is_swept(clean_env):
+    """A declared variable swept as well would reach the driver twice, under two spellings."""
+    for name in (
+        "USER",
+        "USERNAME",
+        "PASSWORD",
+        "ROLE",
+        "WAREHOUSE",
+        "AUTHENTICATOR",
+        "CONNECTION_TIMEOUT",
+        "PRIVATE_KEY",
+        "PRIVATE_KEY_PASSPHRASE",
+        "PRIVATE_KEY_PATH",
+        "PRIVATE_KEY_FILE",
+        "PRIVATE_KEY_FILE_PWD",
+        "HOME",
+        "CONNECTIONS_FILE",
+        "DEFAULT_CONNECTION_NAME",
+    ):
+        clean_env.setenv(f"DATACONTRACT_SNOWFLAKE_{name}", "x")
+    clean_env.setenv("DATACONTRACT_SNOWFLAKE_CREATE_OBJECT_UDFS", "true")
+    clean_env.setenv("DATACONTRACT_SNOWFLAKE_CONNECTION_PARAMETERS", "{}")
+
+    assert SnowflakeSourceConfig().connection_parameters == {}
+
+
 def test_importer_only_variables_are_not_driver_parameters(clean_env):
     clean_env.setenv("DATACONTRACT_SNOWFLAKE_HOME", "/home/jakob/.snowflake")
 
@@ -108,6 +150,14 @@ def test_importer_only_variables_are_not_driver_parameters(clean_env):
 
     assert config.home == "/home/jakob/.snowflake"
     assert "home" not in config.driver_parameters()
+
+
+def test_connection_parameters_keep_non_string_values(clean_env):
+    """The driver takes bools and ints for several parameters; forwarding must not stringify them."""
+    config = SnowflakeSourceConfig(connection_parameters={"insecure_mode": True, "login_timeout": 30})
+
+    assert config.driver_parameters()["insecure_mode"] is True
+    assert config.driver_parameters()["login_timeout"] == 30
 
 
 def test_bare_snowflake_home_variable_is_honoured(clean_env):
@@ -221,7 +271,7 @@ def test_test_passes_the_config_down_to_the_connector(clean_env, monkeypatch):
     assert captured["source_configs"] == (config,)
 
 
-def test_import_passes_the_config_to_the_importer(clean_env, monkeypatch):
+def test_import_passes_only_the_importers_own_family_to_it(clean_env, monkeypatch):
     captured = {}
 
     def fake_import(unity_table_full_name_list, config):
@@ -233,6 +283,27 @@ def test_import_passes_the_config_to_the_importer(clean_env, monkeypatch):
     monkeypatch.setattr("datacontract.imports.unity_importer.import_unity_from_api", fake_import)
     config = DatabricksSourceConfig(token="dapiPASSED", server_hostname="h")
 
-    DataContract.import_from_source("unity", unity_table_full_name=["a.b.c"], source_config=config)
+    DataContract.import_from_source(
+        "unity",
+        unity_table_full_name=["a.b.c"],
+        source_config=[config, SnowflakeSourceConfig(password="pw")],
+    )
 
     assert captured["config"] is config
+
+
+def test_import_hands_no_config_to_an_importer_that_declares_no_family(clean_env, monkeypatch):
+    captured = {}
+
+    class FakeImporter(Importer):
+        def import_source(self, source, import_args):
+            captured["import_args"] = import_args
+            from datacontract.imports.odcs_helper import create_odcs
+
+            return create_odcs()
+
+    monkeypatch.setattr("datacontract.data_contract.importer_factory.create", lambda format: FakeImporter(format))
+
+    DataContract.import_from_source("sql", source="some.sql", source_config=SnowflakeSourceConfig(password="pw"))
+
+    assert "source_config" not in captured["import_args"]

--- a/tests/test_source_config.py
+++ b/tests/test_source_config.py
@@ -314,3 +314,14 @@ def test_import_hands_no_config_to_an_importer_that_declares_no_family(clean_env
     DataContract.import_from_source("sql", source="some.sql", source_config=SnowflakeSourceConfig(password="pw"))
 
     assert "source_config" not in captured["import_args"]
+
+
+def test_unity_import_without_credentials_says_what_to_set(clean_env):
+    """The actionable reason has to survive to the message the user sees, not just the attribute."""
+    from datacontract.model.exceptions import DataContractException
+
+    with pytest.raises(DataContractException) as excinfo:
+        DataContract.import_from_source("unity", unity_table_full_name=["a.b.c"])
+
+    assert "DATACONTRACT_DATABRICKS_TOKEN" in str(excinfo.value)
+    assert "DatabricksSourceConfig" in str(excinfo.value)

--- a/tests/test_source_config.py
+++ b/tests/test_source_config.py
@@ -1,0 +1,238 @@
+"""Unit tests for programmatic source configs.
+
+Covers the config objects themselves, the Snowflake dispatch in connect_ibis, and
+that a config passed to ``DataContract`` actually reaches the connector. The
+Databricks dispatch is covered in ``test_connect_databricks.py``, alongside the
+env-driven cases it shares fixtures with.
+"""
+
+import os
+
+import ibis
+import pytest
+from open_data_contract_standard.model import Server
+
+from datacontract.data_contract import DataContract
+from datacontract.engines.ibis.connections.connect import connect_ibis
+from datacontract.model.run import Run
+from datacontract.model.source_config import (
+    DatabricksSourceConfig,
+    SnowflakeSourceConfig,
+    normalize_source_configs,
+    select_source_config,
+)
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    for name in list(os.environ):
+        if name.startswith(("DATACONTRACT_DATABRICKS_", "DATACONTRACT_SNOWFLAKE_", "SNOWFLAKE_")):
+            monkeypatch.delenv(name, raising=False)
+    return monkeypatch
+
+
+@pytest.fixture
+def captured_snowflake(monkeypatch):
+    calls = {}
+    monkeypatch.setattr(ibis.snowflake, "connect", lambda **kwargs: calls.update(kwargs) or "connection")
+    return calls
+
+
+def _connect_snowflake(source_configs=(), **server_kwargs):
+    return connect_ibis(
+        Run.create_run(),
+        data_contract=None,
+        server=Server(type="snowflake", **server_kwargs),
+        source_configs=source_configs,
+    )
+
+
+# --- the config object itself -------------------------------------------------
+
+
+def test_config_falls_back_to_env_field_by_field(clean_env):
+    clean_env.setenv("DATACONTRACT_DATABRICKS_TOKEN", "dapiFROM_ENV")
+    clean_env.setenv("DATACONTRACT_DATABRICKS_SERVER_HOSTNAME", "env-host.databricks.com")
+
+    config = DatabricksSourceConfig(http_path="/sql/1.0/warehouses/passed")
+
+    assert config.http_path == "/sql/1.0/warehouses/passed"
+    assert config.token.get_secret_value() == "dapiFROM_ENV"
+    assert config.server_hostname == "env-host.databricks.com"
+
+
+def test_secrets_are_not_exposed_by_repr(clean_env):
+    config = DatabricksSourceConfig(token="dapiSECRET")
+
+    assert "dapiSECRET" not in repr(config)
+    assert "dapiSECRET" not in str(config.model_dump())
+
+
+def test_unknown_field_is_rejected(clean_env):
+    with pytest.raises(Exception, match="tokne"):
+        DatabricksSourceConfig(tokne="typo")
+
+
+def test_aliased_field_is_settable_by_its_own_name(clean_env):
+    """A validation_alias makes a field alias-only unless populate_by_name is set."""
+    assert SnowflakeSourceConfig(user="jakob").user == "jakob"
+
+
+def test_user_falls_back_to_the_username_variable(clean_env):
+    clean_env.setenv("DATACONTRACT_SNOWFLAKE_USERNAME", "from-username")
+
+    assert SnowflakeSourceConfig().user == "from-username"
+
+
+def test_user_variable_wins_over_username(clean_env):
+    clean_env.setenv("DATACONTRACT_SNOWFLAKE_USERNAME", "from-username")
+    clean_env.setenv("DATACONTRACT_SNOWFLAKE_USER", "from-user")
+
+    assert SnowflakeSourceConfig().user == "from-user"
+
+
+def test_undeclared_variables_are_swept_into_connection_parameters(clean_env):
+    clean_env.setenv("DATACONTRACT_SNOWFLAKE_WAREHOUSE", "COMPUTE_WH")
+    clean_env.setenv("DATACONTRACT_SNOWFLAKE_PASSCODE", "123456")
+
+    config = SnowflakeSourceConfig()
+
+    assert config.warehouse == "COMPUTE_WH"
+    assert config.connection_parameters == {"passcode": "123456"}
+
+
+def test_importer_only_variables_are_not_driver_parameters(clean_env):
+    clean_env.setenv("DATACONTRACT_SNOWFLAKE_HOME", "/home/jakob/.snowflake")
+
+    config = SnowflakeSourceConfig()
+
+    assert config.home == "/home/jakob/.snowflake"
+    assert "home" not in config.driver_parameters()
+
+
+def test_bare_snowflake_home_variable_is_honoured(clean_env):
+    clean_env.setenv("SNOWFLAKE_HOME", "/home/jakob/.snowflake")
+
+    assert SnowflakeSourceConfig().home == "/home/jakob/.snowflake"
+
+
+def test_normalize_accepts_a_single_config(clean_env):
+    config = DatabricksSourceConfig(token="dapi")
+
+    assert normalize_source_configs(config) == (config,)
+
+
+def test_normalize_rejects_two_configs_of_one_family(clean_env):
+    with pytest.raises(ValueError, match="more than one DatabricksSourceConfig"):
+        normalize_source_configs([DatabricksSourceConfig(), DatabricksSourceConfig()])
+
+
+def test_normalize_rejects_a_non_config(clean_env):
+    with pytest.raises(ValueError, match="must be a source config object"):
+        normalize_source_configs(["DATACONTRACT_DATABRICKS_TOKEN=dapi"])
+
+
+def test_select_returns_a_bare_config_when_the_family_is_absent(clean_env):
+    clean_env.setenv("DATACONTRACT_DATABRICKS_TOKEN", "dapiFROM_ENV")
+
+    config = select_source_config((SnowflakeSourceConfig(user="jakob"),), DatabricksSourceConfig)
+
+    assert config.token.get_secret_value() == "dapiFROM_ENV"
+
+
+# --- snowflake, through connect_ibis -----------------------------------------
+
+
+def test_snowflake_credentials_from_config(clean_env, captured_snowflake):
+    configs = (SnowflakeSourceConfig(user="jakob", password="pw", warehouse="COMPUTE_WH"),)
+
+    assert _connect_snowflake(configs, account="acc", database="db", schema="sch") == "connection"
+    assert captured_snowflake["user"] == "jakob"
+    assert captured_snowflake["password"] == "pw"
+    assert captured_snowflake["warehouse"] == "COMPUTE_WH"
+    assert captured_snowflake["account"] == "acc"
+
+
+def test_snowflake_undeclared_parameters_reach_the_driver(clean_env, captured_snowflake):
+    configs = (SnowflakeSourceConfig(user="jakob", connection_parameters={"passcode": "123456"}),)
+
+    _connect_snowflake(configs, account="acc")
+
+    assert captured_snowflake["passcode"] == "123456"
+
+
+def test_snowflake_contract_account_wins_over_the_environment(clean_env, captured_snowflake):
+    """Setting the variable used to collide with the contract's value and raise TypeError."""
+    clean_env.setenv("DATACONTRACT_SNOWFLAKE_ACCOUNT", "from-env")
+
+    _connect_snowflake(account="from-contract")
+
+    assert captured_snowflake["account"] == "from-contract"
+
+
+def test_snowflake_account_from_the_environment_when_the_contract_omits_it(clean_env, captured_snowflake):
+    clean_env.setenv("DATACONTRACT_SNOWFLAKE_ACCOUNT", "from-env")
+
+    _connect_snowflake()
+
+    assert captured_snowflake["account"] == "from-env"
+
+
+def test_snowflake_importer_only_variables_do_not_reach_the_driver(clean_env, captured_snowflake):
+    clean_env.setenv("DATACONTRACT_SNOWFLAKE_HOME", "/home/jakob/.snowflake")
+
+    _connect_snowflake(account="acc")
+
+    assert "home" not in captured_snowflake
+
+
+def test_snowflake_udf_creation_stays_off_by_default(clean_env, captured_snowflake):
+    _connect_snowflake(account="acc")
+
+    assert captured_snowflake["create_object_udfs"] is False
+
+
+def test_snowflake_udf_creation_can_be_enabled(clean_env, captured_snowflake):
+    clean_env.setenv("DATACONTRACT_SNOWFLAKE_CREATE_OBJECT_UDFS", "true")
+
+    _connect_snowflake(account="acc")
+
+    assert captured_snowflake["create_object_udfs"] is True
+
+
+# --- the config reaches the connector from the public entry points ------------
+
+
+def test_test_passes_the_config_down_to_the_connector(clean_env, monkeypatch):
+    captured = {}
+
+    def fake_connect_ibis(run, data_contract, server, *args, **kwargs):
+        captured["source_configs"] = kwargs.get("source_configs", args[3] if len(args) > 3 else ())
+        return None
+
+    monkeypatch.setattr(
+        "datacontract.engines.ibis.ibis_check_execute.connect_ibis",
+        fake_connect_ibis,
+    )
+    config = DatabricksSourceConfig(token="dapiPASSED")
+
+    DataContract(data_contract_file="fixtures/databricks-sql/datacontract.yaml", source_config=config).test()
+
+    assert captured["source_configs"] == (config,)
+
+
+def test_import_passes_the_config_to_the_importer(clean_env, monkeypatch):
+    captured = {}
+
+    def fake_import(unity_table_full_name_list, config):
+        captured["config"] = config
+        from datacontract.imports.odcs_helper import create_odcs
+
+        return create_odcs()
+
+    monkeypatch.setattr("datacontract.imports.unity_importer.import_unity_from_api", fake_import)
+    config = DatabricksSourceConfig(token="dapiPASSED", server_hostname="h")
+
+    DataContract.import_from_source("unity", unity_table_full_name=["a.b.c"], source_config=config)
+
+    assert captured["config"] is config


### PR DESCRIPTION
Adds programmatic credentials for Databricks and Snowflake using Pydantic Settings, so library users embedding the CLI no longer have to mutate `os.environ` per request. Draft for #1250, possible alternative to #1339.

```python
DataContract(
    data_contract_file="datacontract.yaml",
    source_config=DatabricksSourceConfig(token=tenant_token, http_path=tenant_path),
).test()
```

Fields left unset fall back to their environment variable individually, so existing environment-only setups are unchanged. Also fixes a `TypeError` when `DATACONTRACT_SNOWFLAKE_ACCOUNT`, `..._DATABASE`, or `..._SCHEMA` was set alongside the contract's own values.

Adds `pydantic-settings` as a dependency; its own requirements are already in the tree.

- [x] Tests pass (`uv run pytest`)
- [x] Code formatted (`uv run ruff check --fix && uv run ruff format`)
- [x] Docs updated (if relevant)
- [x] CHANGELOG.md entry added