### PR TITLE
Restore the connection options dropped in the Soda to ibis migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `datacontract test` passes `DATACONTRACT_IMPALA_AUTH_MECHANISM`, `DATACONTRACT_IMPALA_USE_HTTP_TRANSPORT`, and `DATACONTRACT_IMPALA_HTTP_PATH` to Impala again, so Cloudera Virtual Warehouses no longer fail with `TSocket read 0 bytes`; the port now defaults to 443 with HTTP transport and 21050 with the binary protocol
+- `datacontract test` passes the `servers` block `catalog` to Athena again, instead of always querying `awsdatacatalog`
+- `datacontract test` supports `DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT` again to impersonate a service account
 - `datacontract dbt sync` does not assume `severity: warn` as default anymore: tests now fail with dbt's default severity unless the contract declares a non-blocking `quality.severity`
 - `datacontract dbt sync` no longer drops or misplaces YAML comments that introduce the next column, test, or key
 

--- a/datacontract/engines/ibis/connections/connect.py
+++ b/datacontract/engines/ibis/connections/connect.py
@@ -155,13 +155,7 @@ def connect_ibis(
         )
 
     if server_type == "bigquery":
-        credentials_path = os.getenv("DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH")
-        credentials = None
-        if credentials_path:
-            from google.oauth2 import service_account
-
-            credentials = service_account.Credentials.from_service_account_file(credentials_path)
-
+        credentials = _bigquery_credentials()
         billing_project = os.getenv("DATACONTRACT_BIGQUERY_BILLING_PROJECT")
 
         if billing_project and billing_project != server.project:
@@ -209,14 +203,7 @@ def connect_ibis(
         return _connect_athena(ibis, server)
 
     if server_type == "impala":
-        return ibis.impala.connect(
-            host=server.host,
-            port=int(server.port) if server.port else 21050,
-            user=os.getenv("DATACONTRACT_IMPALA_USERNAME"),
-            password=os.getenv("DATACONTRACT_IMPALA_PASSWORD"),
-            database=getattr(server, "database", None),
-            use_ssl=_get_bool_env("DATACONTRACT_IMPALA_USE_SSL", True),
-        )
+        return _connect_impala(ibis, server)
 
     _unsupported(run, f"Server type {server_type} not yet supported by datacontract CLI")
     return None
@@ -295,6 +282,71 @@ def _databricks_credentials_provider(**config_kwargs):
         return Config(**config_kwargs).authenticate
 
     return credentials_provider
+
+
+_BIGQUERY_SCOPES = ["https://www.googleapis.com/auth/bigquery"]
+
+
+def _bigquery_credentials():
+    """Resolve the BigQuery credentials, or ``None`` to let ibis use ADC/WIF.
+
+    ``DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH`` selects a service account key
+    file. ``DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT`` then impersonates that
+    service account, using the key file (or the ambient default credentials) as the
+    source principal — the caller needs ``roles/iam.serviceAccountTokenCreator`` on
+    the target.
+    """
+    credentials_path = os.getenv("DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH")
+    credentials = None
+    if credentials_path:
+        from google.oauth2 import service_account
+
+        credentials = service_account.Credentials.from_service_account_file(credentials_path)
+
+    impersonation_account = os.getenv("DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT")
+    if impersonation_account:
+        import google.auth
+        from google.auth import impersonated_credentials
+
+        source_credentials = credentials
+        if source_credentials is None:
+            source_credentials, _ = google.auth.default(scopes=_BIGQUERY_SCOPES)
+        credentials = impersonated_credentials.Credentials(
+            source_credentials=source_credentials,
+            target_principal=impersonation_account,
+            target_scopes=_BIGQUERY_SCOPES,
+        )
+
+    return credentials
+
+
+def _connect_impala(ibis, server: Server):
+    """Connect to Impala, defaulting to LDAP over HTTPS (the Cloudera setup).
+
+    ``auth_mechanism`` is a native ``ibis.impala.connect`` argument; ``use_http_transport``
+    and ``http_path`` are forwarded verbatim by ibis to ``impyla.connect``. Without them a
+    Cloudera Virtual Warehouse (HTTPS on 443) fails the thrift handshake with
+    ``TSocket read 0 bytes``. impyla's own defaults (``NOSASL``, binary transport, no SSL)
+    are the opposite, so every option has to be passed explicitly.
+
+    The port default follows the transport: 443 for HTTP(S), 21050 — Impala's binary
+    thrift port — otherwise. The pre-ibis soda connection defaulted to 443 for both,
+    which could never work for a binary-protocol cluster.
+    """
+    use_http_transport = _get_bool_env("DATACONTRACT_IMPALA_USE_HTTP_TRANSPORT", True)
+    kwargs = dict(
+        host=server.host,
+        port=int(server.port) if server.port else (443 if use_http_transport else 21050),
+        user=os.getenv("DATACONTRACT_IMPALA_USERNAME"),
+        password=os.getenv("DATACONTRACT_IMPALA_PASSWORD"),
+        database=getattr(server, "database", None),
+        use_ssl=_get_bool_env("DATACONTRACT_IMPALA_USE_SSL", True),
+        auth_mechanism=os.getenv("DATACONTRACT_IMPALA_AUTH_MECHANISM", "LDAP"),
+        use_http_transport=use_http_transport,
+    )
+    if use_http_transport:
+        kwargs["http_path"] = os.getenv("DATACONTRACT_IMPALA_HTTP_PATH", "cliservice")
+    return ibis.impala.connect(**kwargs)
 
 
 def _connect_mysql_via_duckdb(ibis, data_contract, server: Server, run: Run, schema_name: str):
@@ -446,7 +498,7 @@ def _connect_athena(ibis, server: Server):
             reason="S3 staging directory is required for Athena connection.",
             engine="datacontract",
         )
-    return ibis.athena.connect(
+    kwargs = dict(
         s3_staging_dir=server.stagingDir,
         aws_access_key_id=credentials["aws_access_key_id"],
         aws_secret_access_key=credentials["aws_secret_access_key"],
@@ -454,6 +506,10 @@ def _connect_athena(ibis, server: Server):
         region_name=credentials["region_name"],
         schema_name=server.schema_,
     )
+    # Optional data source / catalog; pyathena defaults it to `awsdatacatalog`.
+    if server.catalog:
+        kwargs["catalog_name"] = server.catalog
+    return ibis.athena.connect(**kwargs)
 
 
 def _connect_trino(ibis, server: Server):

--- a/docs/docs/reference/bigquery.md
+++ b/docs/docs/reference/bigquery.md
@@ -27,6 +27,7 @@ Authentication uses a Service Account Key or Application Default Credentials (AD
 |---|---|---|
 | `DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH` | `~/service-access-key.json` | Service Account key JSON file used by `test`. If unset, ADC/WIF is used. |
 | `DATACONTRACT_BIGQUERY_BILLING_PROJECT` | `my-compute-project` | Optional. Project to bill query jobs to. Requires `bigquery.jobUser` on the billing project and `bigquery.dataViewer` on the data project. |
+| `DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT` | `runner@my-project.iam.gserviceaccount.com` | Optional. Service account to impersonate, using the key file above (or ADC) as the source principal. Requires `roles/iam.serviceAccountTokenCreator` on the target. |
 
 `project` and `dataset` come from the contract's `servers` block. `datacontract import bigquery` always uses ADC — set `GOOGLE_APPLICATION_CREDENTIALS` to point it at a key file.
 

--- a/docs/docs/reference/impala.md
+++ b/docs/docs/reference/impala.md
@@ -31,7 +31,7 @@ servers:
 | `DATACONTRACT_IMPALA_USE_HTTP_TRANSPORT` | `true` | Whether to use HTTP transport (defaults to true) |
 | `DATACONTRACT_IMPALA_HTTP_PATH` | `cliservice` | HTTP path for the Impala service (defaults to cliservice) |
 
-`host`, `port`, and `database` come from the contract's `servers` block.
+`host`, `port`, and `database` come from the contract's `servers` block. Without an explicit `port`, the default follows the transport: `443` with HTTP transport (the default), `21050` with the binary thrift protocol.
 
 ## Data types
 

--- a/tests/test_connect_athena.py
+++ b/tests/test_connect_athena.py
@@ -63,6 +63,20 @@ def test_staging_dir_and_schema_are_passed(env):
     assert kwargs["schema_name"] == "my_database"
 
 
+def test_catalog_comes_from_the_server_block(env):
+    """catalog is documented as part of the servers block, so it must be used."""
+    kwargs = _connect(_server(catalog="my_catalog"))
+
+    assert kwargs["catalog_name"] == "my_catalog"
+
+
+def test_catalog_is_omitted_when_not_set(env):
+    """Without a catalog, pyathena's own `awsdatacatalog` default applies."""
+    kwargs = _connect(_server())
+
+    assert "catalog_name" not in kwargs
+
+
 def test_credentials_come_from_the_s3_variables(env):
     env.setenv("DATACONTRACT_S3_ACCESS_KEY_ID", "AKIA_TEST")
     env.setenv("DATACONTRACT_S3_SECRET_ACCESS_KEY", "secret")

--- a/tests/test_connect_bigquery.py
+++ b/tests/test_connect_bigquery.py
@@ -1,0 +1,95 @@
+"""Unit tests for how connect_ibis resolves BigQuery credentials.
+
+These do not hit BigQuery: ``ibis.bigquery.connect`` and the google-auth calls are
+patched, and we only assert which credentials the dispatch passes along.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from open_data_contract_standard.model import Server
+
+from datacontract.engines.ibis.connections.connect import connect_ibis
+from datacontract.model.run import Run
+
+BIGQUERY_ENV_VARS = [
+    "DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH",
+    "DATACONTRACT_BIGQUERY_BILLING_PROJECT",
+    "DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT",
+]
+
+SERVICE_ACCOUNT = "runner@my-project.iam.gserviceaccount.com"
+
+
+@pytest.fixture
+def env(monkeypatch):
+    for name in BIGQUERY_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    return monkeypatch
+
+
+def _server():
+    return Server(server="bigquery", type="bigquery", project="my-project", dataset="my_dataset")
+
+
+def _connect():
+    with patch("ibis.bigquery.connect") as connect:
+        connect_ibis(Run.create_run(), None, _server())
+    return connect.call_args.kwargs
+
+
+def test_no_credentials_without_env_vars(env):
+    """Nothing configured means ibis falls back to application default credentials."""
+    kwargs = _connect()
+
+    assert kwargs["project_id"] == "my-project"
+    assert kwargs["dataset_id"] == "my_dataset"
+    assert "credentials" not in kwargs
+
+
+def test_impersonation_uses_the_ambient_credentials_as_source(env):
+    env.setenv("DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT", SERVICE_ACCOUNT)
+    source = MagicMock(name="adc")
+
+    with patch("google.auth.default", return_value=(source, "my-project")) as default:
+        with patch("google.auth.impersonated_credentials.Credentials") as impersonated:
+            kwargs = _connect()
+
+    default.assert_called_once()
+    assert impersonated.call_args.kwargs["source_credentials"] is source
+    assert impersonated.call_args.kwargs["target_principal"] == SERVICE_ACCOUNT
+    assert kwargs["credentials"] is impersonated.return_value
+
+
+def test_impersonation_uses_the_key_file_as_source_when_set(env, tmp_path):
+    key_file = tmp_path / "key.json"
+    key_file.write_text("{}")
+    env.setenv("DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH", str(key_file))
+    env.setenv("DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT", SERVICE_ACCOUNT)
+    key_credentials = MagicMock(name="key")
+
+    with patch(
+        "google.oauth2.service_account.Credentials.from_service_account_file",
+        return_value=key_credentials,
+    ):
+        with patch("google.auth.default") as default:
+            with patch("google.auth.impersonated_credentials.Credentials") as impersonated:
+                kwargs = _connect()
+
+    default.assert_not_called()
+    assert impersonated.call_args.kwargs["source_credentials"] is key_credentials
+    assert kwargs["credentials"] is impersonated.return_value
+
+
+def test_billing_project_client_uses_the_impersonated_credentials(env):
+    env.setenv("DATACONTRACT_BIGQUERY_BILLING_PROJECT", "my-billing-project")
+    env.setenv("DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT", SERVICE_ACCOUNT)
+
+    with patch("google.auth.default", return_value=(MagicMock(), "my-project")):
+        with patch("google.auth.impersonated_credentials.Credentials") as impersonated:
+            with patch("google.cloud.bigquery.Client") as client:
+                kwargs = _connect()
+
+    assert client.call_args.kwargs["project"] == "my-billing-project"
+    assert client.call_args.kwargs["credentials"] is impersonated.return_value
+    assert kwargs["client"] is client.return_value

--- a/tests/test_connect_impala.py
+++ b/tests/test_connect_impala.py
@@ -1,0 +1,96 @@
+"""Unit tests for the Impala connection options in connect_ibis.
+
+These do not hit Impala: ``ibis.impala.connect`` is patched and we only assert
+which kwargs the dispatch passes for a given set of env vars.
+"""
+
+import ibis
+import pytest
+from open_data_contract_standard.model import Server
+
+from datacontract.engines.ibis.connections.connect import connect_ibis
+from datacontract.model.run import Run
+
+IMPALA_ENV_VARS = [
+    "DATACONTRACT_IMPALA_USERNAME",
+    "DATACONTRACT_IMPALA_PASSWORD",
+    "DATACONTRACT_IMPALA_USE_SSL",
+    "DATACONTRACT_IMPALA_AUTH_MECHANISM",
+    "DATACONTRACT_IMPALA_USE_HTTP_TRANSPORT",
+    "DATACONTRACT_IMPALA_HTTP_PATH",
+]
+
+
+@pytest.fixture
+def env(monkeypatch):
+    for name in IMPALA_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    return monkeypatch
+
+
+@pytest.fixture
+def captured_connect(monkeypatch):
+    calls = {}
+
+    def fake_connect(**kwargs):
+        calls.update(kwargs)
+        return "connection"
+
+    monkeypatch.setattr(ibis.impala, "connect", fake_connect)
+    return calls
+
+
+def _server(**kwargs):
+    defaults = dict(type="impala", host="my-impala-host", database="my_database")
+    defaults.update(kwargs)
+    return Server(**defaults)
+
+
+def _connect(server=None):
+    return connect_ibis(Run.create_run(), data_contract=None, server=server or _server())
+
+
+def test_ldap_over_https_is_default(env, captured_connect):
+    env.setenv("DATACONTRACT_IMPALA_USERNAME", "analytics_user")
+    env.setenv("DATACONTRACT_IMPALA_PASSWORD", "secret")
+
+    result = _connect()
+
+    assert result == "connection"
+    assert captured_connect["host"] == "my-impala-host"
+    assert captured_connect["port"] == 443
+    assert captured_connect["user"] == "analytics_user"
+    assert captured_connect["password"] == "secret"
+    assert captured_connect["database"] == "my_database"
+    assert captured_connect["use_ssl"] is True
+    assert captured_connect["auth_mechanism"] == "LDAP"
+    assert captured_connect["use_http_transport"] is True
+    assert captured_connect["http_path"] == "cliservice"
+
+
+def test_server_port_wins_over_the_default(env, captured_connect):
+    _connect(_server(port=28000))
+
+    assert captured_connect["port"] == 28000
+
+
+def test_binary_transport_defaults_to_the_impala_port(env, captured_connect):
+    env.setenv("DATACONTRACT_IMPALA_USE_HTTP_TRANSPORT", "false")
+
+    _connect()
+
+    assert captured_connect["port"] == 21050
+    assert captured_connect["use_http_transport"] is False
+    assert "http_path" not in captured_connect
+
+
+def test_options_are_overridable(env, captured_connect):
+    env.setenv("DATACONTRACT_IMPALA_USE_SSL", "false")
+    env.setenv("DATACONTRACT_IMPALA_AUTH_MECHANISM", "GSSAPI")
+    env.setenv("DATACONTRACT_IMPALA_HTTP_PATH", "impala/cliservice")
+
+    _connect()
+
+    assert captured_connect["use_ssl"] is False
+    assert captured_connect["auth_mechanism"] == "GSSAPI"
+    assert captured_connect["http_path"] == "impala/cliservice"


### PR DESCRIPTION
Reported by a user testing 1.0.15 against an Impala Virtual Warehouse in Cloudera, whose connection failed with `TSocket read 0 bytes`.

Three connection settings stopped reaching the backend when the test engine moved from Soda Core to ibis in #1279. All three failed silently — the options were still documented, just no longer passed.

## Impala

`connect_ibis` passed only host, port, user, password, database, and `use_ssl`. Dropped:

| Setting | Soda (pre-1.0) | impyla native | This PR |
|---|---|---|---|
| `auth_mechanism` | `LDAP` | `NOSASL` | `LDAP` |
| `use_http_transport` | `true` | `False` | `true` |
| `http_path` | `cliservice` | `''` | `cliservice` |

Because impyla's own defaults are the opposite of the Cloudera setup, every option has to be passed explicitly. Without them the client speaks binary thrift to an HTTPS endpoint and the handshake dies as `TSocket read 0 bytes`. `auth_mechanism` is a native `ibis.impala.connect` argument; `use_http_transport` and `http_path` ride ibis's `**params` into `impyla.connect`.

One deliberate deviation from the old behaviour: the port default now follows the transport — 443 for HTTP, 21050 for binary. Soda defaulted to 443 for both, which could never reach a binary-protocol cluster and contradicted our own troubleshooting docs.

## Athena

`server.catalog` was never passed, so every query hit `awsdatacatalog` regardless of the contract. `docs/docs/reference/athena.md` explicitly promises the field comes from the `servers` block. Now mapped to pyathena's `catalog_name`, and omitted when unset so pyathena's own default still applies.

## BigQuery

`DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT` disappeared entirely. Restored via `google.auth.impersonated_credentials`, using the key file as source principal when `..._ACCOUNT_INFO_JSON_PATH` is set and ADC otherwise. The impersonated credentials also flow into the billing-project client. It was undocumented before, so it is now in the BigQuery reference.

## Audit

Since these were silent, I checked the rest of the migration the same way:

- **Server types** — the old Soda dispatch handled 17; the ibis dispatch covers all 17 plus the `mssql` alias. None lost.
- **Env vars** — diffed every `DATACONTRACT_*` string across all 13 pre-ibis Soda connection modules. Only the Impala four and the BigQuery one were missing.
- **`servers` fields** — enumerated all 26 fields on the ODCS `Server` model and traced each through the engine; every connection-relevant one is used. Verified at the signature level that `schema` is a real parameter on ibis's postgres, trino, and databricks backends rather than something swallowed by `**kwargs`. Oracle and SQL Server have no `schema` connect parameter in ibis and apply it at table resolution instead, which is deliberate and covered.
- **File servers** — the DuckDB path carries `path`, `location`, `format`, `delimiter`, and `endpointUrl` over unchanged.

Four ODCS fields are read by neither engine, so they are pre-existing gaps rather than regressions: `warehouse` (Snowflake's comes from `DATACONTRACT_SNOWFLAKE_WAREHOUSE`, documented that way), `stream` (the Kafka topic is derived from the schema's `physicalName`), `region` (only the more specific `regionName` is read), and the `roles`/`environment`/`description` metadata. Happy to wire up `server.warehouse` separately if wanted.

## Tests

New `tests/test_connect_impala.py` and `tests/test_connect_bigquery.py`, plus two cases in `tests/test_connect_athena.py`. All patch the ibis backend and assert the kwargs the dispatch builds, so nothing hits a real cluster. 60 pass across the bigquery/athena/impala suites and 354 across connect/docs/lint; ruff clean.
