### PR TITLE
Default the Impala options to impyla's own defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- `datacontract test` passes `DATACONTRACT_IMPALA_AUTH_MECHANISM`, `DATACONTRACT_IMPALA_USE_HTTP_TRANSPORT`, and `DATACONTRACT_IMPALA_HTTP_PATH` to Impala again, so Cloudera Virtual Warehouses no longer fail with `TSocket read 0 bytes`; the port now defaults to 443 with HTTP transport and 21050 with the binary protocol
+- `datacontract test` passes `DATACONTRACT_IMPALA_AUTH_MECHANISM`, `DATACONTRACT_IMPALA_USE_HTTP_TRANSPORT`, and `DATACONTRACT_IMPALA_HTTP_PATH` to Impala again, so a Cloudera Virtual Warehouse can be reached instead of failing with `TSocket read 0 bytes`
 - `datacontract test` passes the `servers` block `catalog` to Athena again, instead of always querying `awsdatacatalog`
 - `datacontract test` supports `DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT` again to impersonate a service account
 - `datacontract dbt sync` does not assume `severity: warn` as default anymore: tests now fail with dbt's default severity unless the contract declares a non-blocking `quality.severity`

--- a/datacontract/engines/ibis/connections/connect.py
+++ b/datacontract/engines/ibis/connections/connect.py
@@ -321,32 +321,29 @@ def _bigquery_credentials():
 
 
 def _connect_impala(ibis, server: Server):
-    """Connect to Impala, defaulting to LDAP over HTTPS (the Cloudera setup).
+    """Connect to Impala, making the transport and auth options configurable.
 
     ``auth_mechanism`` is a native ``ibis.impala.connect`` argument; ``use_http_transport``
-    and ``http_path`` are forwarded verbatim by ibis to ``impyla.connect``. Without them a
-    Cloudera Virtual Warehouse (HTTPS on 443) fails the thrift handshake with
-    ``TSocket read 0 bytes``. impyla's own defaults (``NOSASL``, binary transport, no SSL)
-    are the opposite, so every option has to be passed explicitly.
+    and ``http_path`` are forwarded verbatim by ibis to ``impyla.connect``. None of the
+    three used to be passed at all, so a Cloudera Virtual Warehouse (LDAP over HTTPS on
+    443) fell back to impyla's binary NOSASL defaults and failed the thrift handshake with
+    ``TSocket read 0 bytes``.
 
-    The port default follows the transport: 443 for HTTP(S), 21050 — Impala's binary
-    thrift port — otherwise. The pre-ibis soda connection defaulted to 443 for both,
-    which could never work for a binary-protocol cluster.
+    Each option defaults to impyla's own default, so an unconfigured connection behaves
+    exactly as it did before. The one exception is ``use_ssl``, which has defaulted to
+    true since Impala support landed and stays that way.
     """
-    use_http_transport = _get_bool_env("DATACONTRACT_IMPALA_USE_HTTP_TRANSPORT", True)
-    kwargs = dict(
+    return ibis.impala.connect(
         host=server.host,
-        port=int(server.port) if server.port else (443 if use_http_transport else 21050),
+        port=int(server.port) if server.port else 21050,
         user=os.getenv("DATACONTRACT_IMPALA_USERNAME"),
         password=os.getenv("DATACONTRACT_IMPALA_PASSWORD"),
         database=getattr(server, "database", None),
         use_ssl=_get_bool_env("DATACONTRACT_IMPALA_USE_SSL", True),
-        auth_mechanism=os.getenv("DATACONTRACT_IMPALA_AUTH_MECHANISM", "LDAP"),
-        use_http_transport=use_http_transport,
+        auth_mechanism=os.getenv("DATACONTRACT_IMPALA_AUTH_MECHANISM", "NOSASL"),
+        use_http_transport=_get_bool_env("DATACONTRACT_IMPALA_USE_HTTP_TRANSPORT", False),
+        http_path=os.getenv("DATACONTRACT_IMPALA_HTTP_PATH", ""),
     )
-    if use_http_transport:
-        kwargs["http_path"] = os.getenv("DATACONTRACT_IMPALA_HTTP_PATH", "cliservice")
-    return ibis.impala.connect(**kwargs)
 
 
 def _connect_mysql_via_duckdb(ibis, data_contract, server: Server, run: Run, schema_name: str):

--- a/docs/docs/reference/impala.md
+++ b/docs/docs/reference/impala.md
@@ -16,7 +16,7 @@ servers:
   - server: production
     type: impala
     host: my-impala-host
-    port: 443
+    port: 21050 # 443 for a Cloudera Virtual Warehouse
     database: my_database # optional default database
 ```
 
@@ -26,12 +26,29 @@ servers:
 |---|---|---|
 | `DATACONTRACT_IMPALA_USERNAME` | `analytics_user` | Username |
 | `DATACONTRACT_IMPALA_PASSWORD` | `mysecretpassword` | Password |
-| `DATACONTRACT_IMPALA_USE_SSL` | `true` | Whether to use SSL (defaults to true) |
-| `DATACONTRACT_IMPALA_AUTH_MECHANISM` | `LDAP` | Authentication mechanism (defaults to LDAP) |
-| `DATACONTRACT_IMPALA_USE_HTTP_TRANSPORT` | `true` | Whether to use HTTP transport (defaults to true) |
-| `DATACONTRACT_IMPALA_HTTP_PATH` | `cliservice` | HTTP path for the Impala service (defaults to cliservice) |
+| `DATACONTRACT_IMPALA_USE_SSL` | `true` | Whether to use SSL. Defaults to `true` |
+| `DATACONTRACT_IMPALA_AUTH_MECHANISM` | `LDAP` | `NOSASL` (default), `PLAIN`, `GSSAPI`, or `LDAP` |
+| `DATACONTRACT_IMPALA_USE_HTTP_TRANSPORT` | `true` | Whether to use HTTP transport instead of binary thrift. Defaults to `false` |
+| `DATACONTRACT_IMPALA_HTTP_PATH` | `cliservice` | HTTP path for the Impala service. Defaults to empty |
 
-`host`, `port`, and `database` come from the contract's `servers` block. Without an explicit `port`, the default follows the transport: `443` with HTTP transport (the default), `21050` with the binary thrift protocol.
+Apart from `use_ssl`, these default to the same values as the underlying [impyla](https://github.com/cloudera/impyla) driver.
+
+`host`, `port`, and `database` come from the contract's `servers` block. `port` defaults to `21050`, Impala's binary thrift port.
+
+### Cloudera Virtual Warehouse
+
+A Cloudera Virtual Warehouse terminates LDAP over HTTPS on port 443, so all three transport options need setting — otherwise the client speaks binary thrift to an HTTPS endpoint and the handshake fails with `TSocket read 0 bytes`:
+
+```bash
+# .env
+DATACONTRACT_IMPALA_USERNAME=analytics_user
+DATACONTRACT_IMPALA_PASSWORD=mysecretpassword
+DATACONTRACT_IMPALA_AUTH_MECHANISM=LDAP
+DATACONTRACT_IMPALA_USE_HTTP_TRANSPORT=true
+DATACONTRACT_IMPALA_HTTP_PATH=cliservice
+```
+
+with `port: 443` in the contract's `servers` block.
 
 ## Data types
 

--- a/docs/docs/testing/impala.md
+++ b/docs/docs/testing/impala.md
@@ -26,6 +26,8 @@ DATACONTRACT_IMPALA_USERNAME=analytics_user
 DATACONTRACT_IMPALA_PASSWORD=mysecretpassword
 ```
 
+On a Cloudera Virtual Warehouse, or any cluster reached over HTTPS, also set the transport options listed in the [reference](../reference/impala.md#cloudera-virtual-warehouse).
+
 ## 3. Create a contract from your tables
 
 Get the DDL of a table (`SHOW CREATE TABLE orders;` in impala-shell or Hue), save it to a file, and import it. Impala DDL is Hive-compatible, so use the `spark` dialect:
@@ -41,7 +43,7 @@ servers:
   - server: impala
     type: impala
     host: my-impala-host
-    port: 443
+    port: 21050 # 443 for a Cloudera Virtual Warehouse
     database: my_database # optional default database
 ```
 
@@ -87,5 +89,5 @@ All authentication options (SSL, transport, auth mechanism) and the data type ma
 
 ## Troubleshooting
 
-- **Connection errors** — the defaults assume LDAP auth over SSL and HTTP transport (port 443, e.g. behind a load balancer). For a plain binary-protocol cluster, set `DATACONTRACT_IMPALA_USE_HTTP_TRANSPORT=false` and use port `21050`.
+- **`TSocket read 0 bytes`** — the client is speaking binary thrift to an HTTPS endpoint. On a Cloudera Virtual Warehouse (or anything else behind an HTTPS load balancer) set `DATACONTRACT_IMPALA_AUTH_MECHANISM=LDAP`, `DATACONTRACT_IMPALA_USE_HTTP_TRANSPORT=true`, and `DATACONTRACT_IMPALA_HTTP_PATH=cliservice`, with `port: 443` in the `servers` block. See the [reference](../reference/impala.md#cloudera-virtual-warehouse).
 - **`AuthorizationException`** — the user lacks `SELECT` on the table or the Ranger/Sentry policy doesn't cover the database in the `servers` block.

--- a/tests/test_connect_impala.py
+++ b/tests/test_connect_impala.py
@@ -50,7 +50,8 @@ def _connect(server=None):
     return connect_ibis(Run.create_run(), data_contract=None, server=server or _server())
 
 
-def test_ldap_over_https_is_default(env, captured_connect):
+def test_unconfigured_connection_uses_the_impyla_defaults(env, captured_connect):
+    """Nothing configured must behave exactly as before these options were passed."""
     env.setenv("DATACONTRACT_IMPALA_USERNAME", "analytics_user")
     env.setenv("DATACONTRACT_IMPALA_PASSWORD", "secret")
 
@@ -58,14 +59,15 @@ def test_ldap_over_https_is_default(env, captured_connect):
 
     assert result == "connection"
     assert captured_connect["host"] == "my-impala-host"
-    assert captured_connect["port"] == 443
+    assert captured_connect["port"] == 21050
     assert captured_connect["user"] == "analytics_user"
     assert captured_connect["password"] == "secret"
     assert captured_connect["database"] == "my_database"
+    assert captured_connect["auth_mechanism"] == "NOSASL"
+    assert captured_connect["use_http_transport"] is False
+    assert captured_connect["http_path"] == ""
+    # The one option that has never followed impyla, whose default is False.
     assert captured_connect["use_ssl"] is True
-    assert captured_connect["auth_mechanism"] == "LDAP"
-    assert captured_connect["use_http_transport"] is True
-    assert captured_connect["http_path"] == "cliservice"
 
 
 def test_server_port_wins_over_the_default(env, captured_connect):
@@ -74,14 +76,19 @@ def test_server_port_wins_over_the_default(env, captured_connect):
     assert captured_connect["port"] == 28000
 
 
-def test_binary_transport_defaults_to_the_impala_port(env, captured_connect):
-    env.setenv("DATACONTRACT_IMPALA_USE_HTTP_TRANSPORT", "false")
+def test_cloudera_virtual_warehouse_setup(env, captured_connect):
+    """LDAP over HTTPS, the setup that failed with `TSocket read 0 bytes`."""
+    env.setenv("DATACONTRACT_IMPALA_AUTH_MECHANISM", "LDAP")
+    env.setenv("DATACONTRACT_IMPALA_USE_HTTP_TRANSPORT", "true")
+    env.setenv("DATACONTRACT_IMPALA_HTTP_PATH", "cliservice")
 
-    _connect()
+    _connect(_server(port=443))
 
-    assert captured_connect["port"] == 21050
-    assert captured_connect["use_http_transport"] is False
-    assert "http_path" not in captured_connect
+    assert captured_connect["port"] == 443
+    assert captured_connect["auth_mechanism"] == "LDAP"
+    assert captured_connect["use_http_transport"] is True
+    assert captured_connect["http_path"] == "cliservice"
+    assert captured_connect["use_ssl"] is True
 
 
 def test_options_are_overridable(env, captured_connect):


### PR DESCRIPTION
Follow-up to #1458, which made `auth_mechanism`, `use_http_transport`, and `http_path` configurable for Impala but defaulted them to the Cloudera-flavoured values the pre-ibis Soda connection used (`LDAP`, HTTP transport, `cliservice`).

Those defaults were the wrong call. Because the three options were not passed to the driver at all, every 1.0.x release has effectively been running on impyla's defaults — `NOSASL`, binary transport, empty path, port 21050. Shipping the Soda values as defaults would therefore have *changed* behaviour for every existing Impala user in the name of restoring it.

Defaulting to impyla's own values instead makes the change purely additive: an unconfigured connection behaves exactly as it does today, and the options simply become configurable.

| Setting | 1.0.15 (effective) | #1458 | This PR |
|---|---|---|---|
| `auth_mechanism` | `NOSASL` | `LDAP` | `NOSASL` |
| `use_http_transport` | `False` | `true` | `False` |
| `http_path` | `''` | `cliservice` | `''` |
| `port` | `21050` | 443 / 21050 by transport | `21050` |
| `use_ssl` | `true` | `true` | `true` |

`use_ssl` is the one option that has never followed impyla, whose default is `False`. It has defaulted to true since Impala support landed in #965, so changing it would break working setups — it stays as it is, and the reference notes it as the exception.

A Cloudera Virtual Warehouse now sets the three variables explicitly. Both the reference and the testing guide document that with a worked example, and the `TSocket read 0 bytes` troubleshooting entry points at it — previously that entry described the inverse situation.

## Tests

`tests/test_connect_impala.py` gains a test asserting that an unconfigured connection produces exactly impyla's defaults, which is the property this PR is about, plus one covering the full Cloudera setup. 278 pass across the impala and docs suites; ruff clean.
