### PR TITLE
Fix the Snowflake key-pair and timeout variables being silently ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+- `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_PATH`, `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE`, and `DATACONTRACT_SNOWFLAKE_CONNECTION_TIMEOUT`: use `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_FILE`, `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_FILE_PWD`, and `DATACONTRACT_SNOWFLAKE_LOGIN_TIMEOUT` instead
+
 ### Fixed
 - `datacontract test` passes `DATACONTRACT_IMPALA_AUTH_MECHANISM`, `DATACONTRACT_IMPALA_USE_HTTP_TRANSPORT`, and `DATACONTRACT_IMPALA_HTTP_PATH` to Impala again, so Cloudera Virtual Warehouses no longer fail with `TSocket read 0 bytes`; the port now defaults to 443 with HTTP transport and 21050 with the binary protocol
 - `datacontract test` passes the `servers` block `catalog` to Athena again, instead of always querying `awsdatacatalog`
 - `datacontract test` supports `DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT` again to impersonate a service account
+- `datacontract test` applies the documented Snowflake key-pair and timeout variables instead of silently ignoring them: the names they were documented under are not accepted by the Snowflake driver, and now map to the ones that are
 - `datacontract dbt sync` does not assume `severity: warn` as default anymore: tests now fail with dbt's default severity unless the contract declares a non-blocking `quality.severity`
 - `datacontract dbt sync` no longer drops or misplaces YAML comments that introduce the next column, test, or key
 

--- a/datacontract/engines/ibis/connections/connect.py
+++ b/datacontract/engines/ibis/connections/connect.py
@@ -140,6 +140,7 @@ def connect_ibis(
         # `user` (not soda's `username`). Keep DATACONTRACT_SNOWFLAKE_USERNAME working.
         if "username" in extra:
             extra.setdefault("user", extra.pop("username"))
+        _rename_deprecated_snowflake_params(extra, prefix, run)
         # ibis tries to CREATE DATABASE for helper UDFs on connect (create_object_udfs=True).
         # datacontract only reads, and the read-only roles used for testing lack CREATE DATABASE,
         # so this otherwise emits a noisy "Insufficient privileges" warning. Default it off, but
@@ -347,6 +348,31 @@ def _connect_impala(ibis, server: Server):
     if use_http_transport:
         kwargs["http_path"] = os.getenv("DATACONTRACT_IMPALA_HTTP_PATH", "cliservice")
     return ibis.impala.connect(**kwargs)
+
+
+# Names this CLI documented for key-pair auth and timeouts that snowflake-connector-python
+# has never accepted. The driver ignores unknown parameters instead of raising, so setting
+# one of these used to do nothing at all and surfaced as an unrelated authentication error.
+# They are kept as synonyms for the real parameters, with a deprecation warning.
+_SNOWFLAKE_DEPRECATED_PARAMS = {
+    "private_key_path": "private_key_file",
+    "private_key_passphrase": "private_key_file_pwd",
+    "connection_timeout": "login_timeout",
+}
+
+
+def _rename_deprecated_snowflake_params(extra: dict, prefix: str, run: Run):
+    """Map deprecated connection parameter names onto the ones the driver accepts."""
+    for deprecated, replacement in _SNOWFLAKE_DEPRECATED_PARAMS.items():
+        if deprecated not in extra:
+            continue
+        value = extra.pop(deprecated)
+        run.log_warn(
+            f"{prefix}{deprecated.upper()} is deprecated and will be removed in a future release, "
+            f"use {prefix}{replacement.upper()} instead"
+        )
+        # An explicitly set replacement wins over the deprecated synonym.
+        extra.setdefault(replacement, value)
 
 
 def _connect_mysql_via_duckdb(ibis, data_contract, server: Server, run: Run, schema_name: str):

--- a/docs/docs/reference/snowflake.md
+++ b/docs/docs/reference/snowflake.md
@@ -26,17 +26,35 @@ Any `DATACONTRACT_SNOWFLAKE_`-prefixed variable is passed (lowercased, prefix st
 
 | Connection parameter | Environment variable |
 |---|---|
-| `username` | `DATACONTRACT_SNOWFLAKE_USERNAME` |
+| `user` | `DATACONTRACT_SNOWFLAKE_USERNAME` (also `..._USER`) |
 | `password` | `DATACONTRACT_SNOWFLAKE_PASSWORD` |
 | `warehouse` | `DATACONTRACT_SNOWFLAKE_WAREHOUSE` |
 | `role` | `DATACONTRACT_SNOWFLAKE_ROLE` |
-| `connection_timeout` | `DATACONTRACT_SNOWFLAKE_CONNECTION_TIMEOUT` |
 | `authenticator` | `DATACONTRACT_SNOWFLAKE_AUTHENTICATOR` |
+| `private_key_file` | `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_FILE` |
+| `private_key_file_pwd` | `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_FILE_PWD` |
 | `private_key` | `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY` |
-| `private_key_passphrase` | `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE` |
-| `private_key_path` | `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_PATH` |
+| `login_timeout` | `DATACONTRACT_SNOWFLAKE_LOGIN_TIMEOUT` |
+| `network_timeout` | `DATACONTRACT_SNOWFLAKE_NETWORK_TIMEOUT` |
+| `socket_timeout` | `DATACONTRACT_SNOWFLAKE_SOCKET_TIMEOUT` |
 
 `account`, `database`, and `schema` come from the contract's `servers` block.
+
+For key-pair auth, set `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_FILE` to the path of the key file and `..._PRIVATE_KEY_FILE_PWD` to its passphrase, if it has one. `..._PRIVATE_KEY` takes the key itself rather than a path.
+
+:::warning
+The variable name after the prefix must match the driver's parameter name exactly. The driver ignores parameters it does not recognise without raising, so a misspelled variable is silently dropped and the connection then fails for an unrelated-looking reason — a mistyped key-pair variable surfaces as an authentication error, not as a bad-parameter error.
+:::
+
+### Deprecated variables
+
+Earlier versions documented three names the driver has never accepted, so setting them had no effect. They now work as synonyms and log a deprecation warning; set the replacement instead. If both are set, the replacement wins.
+
+| Deprecated | Use instead |
+|---|---|
+| `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_PATH` | `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_FILE` |
+| `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE` | `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_FILE_PWD` |
+| `DATACONTRACT_SNOWFLAKE_CONNECTION_TIMEOUT` | `DATACONTRACT_SNOWFLAKE_LOGIN_TIMEOUT` |
 
 ### Import-specific options
 
@@ -44,8 +62,6 @@ Any `DATACONTRACT_SNOWFLAKE_`-prefixed variable is passed (lowercased, prefix st
 
 | Variable | Description |
 |---|---|
-| `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_FILE` | Path to a private key file (key-pair auth) |
-| `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_FILE_PWD` | Passphrase for the private key file |
 | `DATACONTRACT_SNOWFLAKE_HOME` | Directory containing a [connections.toml](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect#connecting-using-the-connections-toml-file) |
 | `DATACONTRACT_SNOWFLAKE_CONNECTIONS_FILE` | Path to a connections.toml file |
 | `DATACONTRACT_SNOWFLAKE_DEFAULT_CONNECTION_NAME` | Connection name within connections.toml |

--- a/tests/test_connect_snowflake.py
+++ b/tests/test_connect_snowflake.py
@@ -1,0 +1,104 @@
+"""Unit tests for how connect_ibis maps Snowflake connection parameters.
+
+These do not hit Snowflake: ``ibis.snowflake.connect`` is patched and we only assert
+which kwargs the dispatch passes for a given set of env vars.
+"""
+
+import os
+
+import ibis
+import pytest
+from open_data_contract_standard.model import Server
+
+from datacontract.engines.ibis.connections.connect import connect_ibis
+from datacontract.model.run import Run
+
+KEY_FILE = "/keys/rsa_key.p8"
+
+
+@pytest.fixture
+def env(monkeypatch):
+    """Every DATACONTRACT_SNOWFLAKE_ variable is forwarded, so start from a clean slate."""
+    for name in list(os.environ):
+        if name.startswith("DATACONTRACT_SNOWFLAKE_"):
+            monkeypatch.delenv(name, raising=False)
+    return monkeypatch
+
+
+@pytest.fixture
+def captured_connect(monkeypatch):
+    calls = {}
+
+    def fake_connect(**kwargs):
+        calls.update(kwargs)
+        return "connection"
+
+    monkeypatch.setattr(ibis.snowflake, "connect", fake_connect)
+    return calls
+
+
+def _server():
+    return Server(server="snowflake", type="snowflake", account="abc-xy123", database="ORDER_DB", schema="ORDERS")
+
+
+def _connect(run=None):
+    return connect_ibis(run or Run.create_run(), data_contract=None, server=_server())
+
+
+def test_username_maps_to_the_drivers_user_parameter(env, captured_connect):
+    env.setenv("DATACONTRACT_SNOWFLAKE_USERNAME", "analytics_user")
+
+    _connect()
+
+    assert captured_connect["user"] == "analytics_user"
+    assert "username" not in captured_connect
+
+
+def test_deprecated_private_key_path_maps_to_private_key_file(env, captured_connect):
+    env.setenv("DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_PATH", KEY_FILE)
+    run = Run.create_run()
+
+    _connect(run)
+
+    assert captured_connect["private_key_file"] == KEY_FILE
+    assert "private_key_path" not in captured_connect
+    assert any("PRIVATE_KEY_PATH is deprecated" in log.message for log in run.logs)
+
+
+def test_deprecated_private_key_passphrase_maps_to_private_key_file_pwd(env, captured_connect):
+    env.setenv("DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE", "secret")
+
+    _connect()
+
+    assert captured_connect["private_key_file_pwd"] == "secret"
+    assert "private_key_passphrase" not in captured_connect
+
+
+def test_deprecated_connection_timeout_maps_to_login_timeout(env, captured_connect):
+    env.setenv("DATACONTRACT_SNOWFLAKE_CONNECTION_TIMEOUT", "30")
+
+    _connect()
+
+    assert captured_connect["login_timeout"] == "30"
+    assert "connection_timeout" not in captured_connect
+
+
+def test_the_replacement_wins_over_the_deprecated_synonym(env, captured_connect):
+    env.setenv("DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_PATH", "/keys/old.p8")
+    env.setenv("DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_FILE", KEY_FILE)
+
+    _connect()
+
+    assert captured_connect["private_key_file"] == KEY_FILE
+
+
+def test_current_names_are_passed_through_without_a_warning(env, captured_connect):
+    env.setenv("DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_FILE", KEY_FILE)
+    env.setenv("DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_FILE_PWD", "secret")
+    run = Run.create_run()
+
+    _connect(run)
+
+    assert captured_connect["private_key_file"] == KEY_FILE
+    assert captured_connect["private_key_file_pwd"] == "secret"
+    assert not any("deprecated" in log.message for log in run.logs)


### PR DESCRIPTION
Found while auditing every `DATACONTRACT_*` variable in the docs against the ones the code actually reads, after #1458.

The Snowflake branch forwards every `DATACONTRACT_SNOWFLAKE_`-prefixed variable to snowflake-connector-python with the prefix stripped and lowercased. Three of the names the reference page documented are not parameters the driver accepts:

| Documented | Actual driver parameter |
|---|---|
| `private_key_path` | `private_key_file` |
| `private_key_passphrase` | `private_key_file_pwd` |
| `connection_timeout` | `login_timeout` |

The driver ignores unknown parameters rather than raising — it only warns when `validate_default_parameters` is set, which defaults to off. So following the docs silently disabled key-pair auth, and the failure surfaced as an unrelated authentication error with no hint that the variable was the problem.

The `import` path already used the correct `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_FILE` names (`snowflake_importer.py:491`), so `import` and `test` were documented inconsistently for the same credential.

## Approach

The deprecated names are kept as synonyms rather than dropped, so existing configurations start working instead of breaking. Each logs a deprecation warning naming its replacement, and an explicitly set replacement wins over the synonym.

The reference now lists the driver's real parameter names, adds a deprecation table, and warns that a name which does not match the driver exactly is silently dropped. I verified every remaining row against `snowflake.connector.connection.DEFAULT_CONFIGURATION` — that also caught the `username` row, whose driver parameter is `user`; the dispatch already remaps it, so only the docs were wrong there.

## Tests

New `tests/test_connect_snowflake.py` covers each synonym, the precedence rule, the `username` remap, and that current names pass through without a warning. 383 pass across the snowflake, impala, docs, and connect suites; ruff clean.
