### PR TITLE
Deprecate the DATAMESH_MANAGER_* and DATACONTRACT_MANAGER_* options in favor of ENTROPY_DATA_*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+- `DATAMESH_MANAGER_API_KEY`, `DATAMESH_MANAGER_HOST`, `DATACONTRACT_MANAGER_API_KEY`, and `DATACONTRACT_MANAGER_HOST` (and the matching `Config` fields): use `ENTROPY_DATA_API_KEY` and `ENTROPY_DATA_HOST` instead
+
 ### Added
 - Credentials and connection options can be passed programmatically via `DataContract(config=...)` and `DataContract.import_from_source(..., config=...)`, using the typed `datacontract.Config` class or a dict keyed by the environment variable names
 - The API server accepts per-request credentials on `POST /test` via `datacontract-*` headers (e.g. `datacontract-snowflake-password`)

--- a/datacontract/config/settings.py
+++ b/datacontract/config/settings.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 from pathlib import Path
 
 from pydantic import Field, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
 
 _ENV_PREFIX = "DATACONTRACT_"
 _TRUTHY = ("1", "true", "yes", "y", "on")
@@ -31,6 +34,8 @@ class Config(BaseSettings):
     # Entropy Data / Data Mesh Manager / Data Contract Manager (publishing, contract URLs)
     entropy_data_api_key: SecretStr | None = Field(None, validation_alias="ENTROPY_DATA_API_KEY")
     entropy_data_host: str | None = Field(None, validation_alias="ENTROPY_DATA_HOST")
+    # deprecated synonyms for the entropy_data_* options (pre-rebrand product names);
+    # a warning is emitted when one of them supplies a value
     datamesh_manager_api_key: SecretStr | None = Field(None, validation_alias="DATAMESH_MANAGER_API_KEY")
     datamesh_manager_host: str | None = Field(None, validation_alias="DATAMESH_MANAGER_HOST")
     datacontract_manager_api_key: SecretStr | None = Field(None, validation_alias="DATACONTRACT_MANAGER_API_KEY")
@@ -256,6 +261,19 @@ class Config(BaseSettings):
             )
         return value
 
+    def _deprecated_str_option(self, field_name: str, replacement: str, required: bool = False) -> str | None:
+        """A str option kept as a deprecated synonym: warns when it supplies a value."""
+        value = self._str_option(field_name, required)
+        if value:
+            deprecated_env = env_name(field_name, type(self).model_fields[field_name])
+            replacement_env = env_name(replacement, type(self).model_fields[replacement])
+            logger.warning(
+                "%s is deprecated and will be removed in a future release, use %s instead.",
+                deprecated_env,
+                replacement_env,
+            )
+        return value
+
     def _int_option(self, field_name: str) -> int | None:
         value = self._raw_option(field_name)
         if value is None or value == "":
@@ -290,17 +308,17 @@ class Config(BaseSettings):
 
     # --- datamesh ---
     def get_datamesh_manager_api_key(self, required: bool = False) -> str | None:
-        return self._str_option("datamesh_manager_api_key", required)
+        return self._deprecated_str_option("datamesh_manager_api_key", "entropy_data_api_key", required)
 
     def get_datamesh_manager_host(self, required: bool = False) -> str | None:
-        return self._str_option("datamesh_manager_host", required)
+        return self._deprecated_str_option("datamesh_manager_host", "entropy_data_host", required)
 
     # --- datacontract ---
     def get_datacontract_manager_api_key(self, required: bool = False) -> str | None:
-        return self._str_option("datacontract_manager_api_key", required)
+        return self._deprecated_str_option("datacontract_manager_api_key", "entropy_data_api_key", required)
 
     def get_datacontract_manager_host(self, required: bool = False) -> str | None:
-        return self._str_option("datacontract_manager_host", required)
+        return self._deprecated_str_option("datacontract_manager_host", "entropy_data_host", required)
 
     # --- api ---
     def get_api_header_authorization(self, required: bool = False) -> str | None:

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -26,6 +26,9 @@ marked as such in the entry.
 
 ## Unreleased {#unreleased}
 
+### Deprecated
+- `DATAMESH_MANAGER_API_KEY`, `DATAMESH_MANAGER_HOST`, `DATACONTRACT_MANAGER_API_KEY`, and `DATACONTRACT_MANAGER_HOST` (and the matching `Config` fields): use `ENTROPY_DATA_API_KEY` and `ENTROPY_DATA_HOST` instead
+
 ### Added
 - Credentials and connection options can be passed programmatically via `DataContract(config=...)` and `DataContract.import_from_source(..., config=...)`, using the typed `datacontract.Config` class or a dict keyed by the environment variable names
 - The API server accepts per-request credentials on `POST /test` via `datacontract-*` headers (e.g. `datacontract-snowflake-password`)

--- a/docs/docs/semantics.md
+++ b/docs/docs/semantics.md
@@ -68,8 +68,8 @@ Resolution recurses into nested `properties` and array `items`, so a link on a d
 
 | Environment variable | Purpose |
 |---|---|
-| `ENTROPY_DATA_HOST` | The host that resolves references. Defaults to `https://api.entropy-data.com`. Falls back to `DATAMESH_MANAGER_HOST`, then `DATACONTRACT_MANAGER_HOST`. |
-| `ENTROPY_DATA_API_KEY` | Sent as `x-api-key`, and **only** to the configured host. Falls back to `DATAMESH_MANAGER_API_KEY`, then `DATACONTRACT_MANAGER_API_KEY`. |
+| `ENTROPY_DATA_HOST` | The host that resolves references. Defaults to `https://api.entropy-data.com`. Falls back to the deprecated `DATAMESH_MANAGER_HOST`, then `DATACONTRACT_MANAGER_HOST`. |
+| `ENTROPY_DATA_API_KEY` | Sent as `x-api-key`, and **only** to the configured host. Falls back to the deprecated `DATAMESH_MANAGER_API_KEY`, then `DATACONTRACT_MANAGER_API_KEY`. |
 
 An IRI lookup always requires an API key — `/api/semantics` is API-key only. A REST URL on the configured host uses the key when one is set.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -198,3 +198,32 @@ def test_every_env_var_the_code_reads_is_a_config_field():
         f"Env vars read in code but not declared as Config fields: {sorted(unknown)}. "
         "Add a field to datacontract.config.Config or list the name in _NON_CONFIG_ENV_VARS."
     )
+
+
+def test_deprecated_manager_options_warn_when_they_supply_a_value(caplog):
+    config = Config(datamesh_manager_api_key="legacy-key")
+
+    with caplog.at_level("WARNING"):
+        value = config.get_datamesh_manager_api_key()
+
+    assert value == "legacy-key"
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("DATAMESH_MANAGER_API_KEY is deprecated" in m and "ENTROPY_DATA_API_KEY" in m for m in messages)
+
+
+def test_deprecated_manager_options_stay_silent_when_unset(caplog, monkeypatch):
+    for name in ("DATAMESH_MANAGER_API_KEY", "DATACONTRACT_MANAGER_API_KEY"):
+        monkeypatch.delenv(name, raising=False)
+
+    with caplog.at_level("WARNING"):
+        assert Config.model_construct().get_datamesh_manager_api_key() is None
+        assert Config.model_construct().get_datacontract_manager_api_key() is None
+
+    assert not caplog.records
+
+
+def test_entropy_data_options_do_not_warn(caplog):
+    with caplog.at_level("WARNING"):
+        assert Config(entropy_data_api_key="key").get_entropy_data_api_key() == "key"
+
+    assert not caplog.records


### PR DESCRIPTION
## Summary

`DATAMESH_MANAGER_API_KEY`, `DATAMESH_MANAGER_HOST`, `DATACONTRACT_MANAGER_API_KEY`, and `DATACONTRACT_MANAGER_HOST` are the pre-rebrand synonyms for `ENTROPY_DATA_API_KEY` and `ENTROPY_DATA_HOST`. They keep working as fallbacks, but every time one of them actually supplies a value (via environment variable, `Config` field, or config file section), a deprecation warning names the variable and its replacement.

## Changes

- The four `Config` accessors route through a `_deprecated_str_option` helper that logs the warning when a value is present; unset options stay silent.
- The fields are marked as deprecated synonyms in `Config`, following the same pattern as the deprecated Snowflake options.
- CHANGELOG gains a Deprecated section; the semantics docs note the fallbacks as deprecated; release notes regenerated.

## Test plan

- Three new tests in `tests/test_config.py`: the warning fires with the correct names when a deprecated option supplies a value, stays silent when unset, and `entropy_data_*` options never warn.
- Affected suites (config, config file, entropy data integration, API, docs ordering): 68 passed.