### PR TITLE
Fix config threading gaps and behavior regressions found by code review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New Snowflake connection options: `DATACONTRACT_SNOWFLAKE_TOKEN`, `DATACONTRACT_SNOWFLAKE_PASSCODE`, `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY`, `DATACONTRACT_SNOWFLAKE_NETWORK_TIMEOUT`, `DATACONTRACT_SNOWFLAKE_SOCKET_TIMEOUT`, `DATACONTRACT_SNOWFLAKE_HOST`, `DATACONTRACT_SNOWFLAKE_PORT`
 
 ### Changed
-- `datacontract test` against Snowflake only forwards the documented `DATACONTRACT_SNOWFLAKE_*` options to the connector; unknown variables are ignored with a warning instead of being passed through (use a connections.toml for connector parameters the CLI does not support directly)
+- `datacontract test` against Snowflake only forwards the documented `DATACONTRACT_SNOWFLAKE_*` options to the connector; unknown variables are ignored with a warning
 
 ### Fixed
 - `datacontract dbt sync` writes a description on all dbt tests, not only newly-generated ones

--- a/datacontract/api.py
+++ b/datacontract/api.py
@@ -12,7 +12,7 @@ from fastapi.responses import PlainTextResponse
 from fastapi.security.api_key import APIKeyHeader
 from pydantic import BaseModel, ValidationError
 
-from datacontract.config import Config
+from datacontract.config import Config, known_env_names
 from datacontract.data_contract import DataContract, ExportFormat
 from datacontract.model.exceptions import DataContractException
 from datacontract.model.run import Run
@@ -275,19 +275,22 @@ _CONFIG_HEADER_PREFIX = "datacontract-"
 
 
 def config_from_headers(headers) -> "Config | None":
-    """Build a per-request Config from ``datacontract-*`` headers.
+    """Build a per-request Config from configuration option headers.
 
     Header names are matched case-insensitively and map mechanically to the env
     var names: uppercase, dashes to underscores — ``datacontract-snowflake-password``
-    → ``DATACONTRACT_SNOWFLAKE_PASSWORD``. Returns None when no config headers
-    are present, so env-var-configured deployments behave exactly as before.
-    Unknown option names are rejected with a 400.
+    → ``DATACONTRACT_SNOWFLAKE_PASSWORD``, ``entropy-data-api-key`` →
+    ``ENTROPY_DATA_API_KEY``. Returns None when no config headers are present,
+    so env-var-configured deployments behave exactly as before. Unknown
+    ``datacontract-*`` option names are rejected with a 400.
     """
+    known = known_env_names()
     values = {}
     for name, value in headers.items():
         lowered = name.lower()
-        if lowered.startswith(_CONFIG_HEADER_PREFIX):
-            values[lowered.upper().replace("-", "_")] = value
+        env = lowered.upper().replace("-", "_")
+        if lowered.startswith(_CONFIG_HEADER_PREFIX) or env in known:
+            values[env] = value
     if not values:
         return None
     try:

--- a/datacontract/catalog/catalog.py
+++ b/datacontract/catalog/catalog.py
@@ -8,6 +8,7 @@ import pytz
 from jinja2 import Environment, PackageLoader, select_autoescape
 from open_data_contract_standard.model import OpenDataContractStandard
 
+from datacontract.config import cli_config
 from datacontract.data_contract import DataContract
 from datacontract.export.html_exporter import get_version
 
@@ -26,7 +27,7 @@ def _get_owner(odcs: OpenDataContractStandard) -> Optional[str]:
 def create_data_contract_html(contracts, file: Path, path: Path, schema: str):
     logging.debug(f"Creating data contract html for file {file} and schema {schema}")
     data_contract = DataContract(
-        data_contract_file=f"{file.absolute()}", inline_references=True, schema_location=schema
+        data_contract_file=f"{file.absolute()}", inline_references=True, schema_location=schema, config=cli_config()
     )
     html = data_contract.export(export_format="html")
     odcs = data_contract.get_data_contract()

--- a/datacontract/command_test.py
+++ b/datacontract/command_test.py
@@ -195,7 +195,7 @@ def test(
     if logs:
         _print_logs(run)
     try:
-        data_contract = resolve_data_contract(location, schema_location=schema)
+        data_contract = resolve_data_contract(location, schema_location=schema, config=cli_config())
     except Exception:
         data_contract = None
     write_test_result(run, console, output_format, output, data_contract)

--- a/datacontract/config/__init__.py
+++ b/datacontract/config/__init__.py
@@ -11,9 +11,16 @@ values the config does not set.
 """
 
 from datacontract.config.cli_context import cli_config, set_cli_config
-from datacontract.config.settings import Config, env_name, known_env_names, unknown_snowflake_env_names
+from datacontract.config.settings import (
+    DEPRECATED_OPTIONS,
+    Config,
+    env_name,
+    known_env_names,
+    unknown_snowflake_env_names,
+)
 
 __all__ = [
+    "DEPRECATED_OPTIONS",
     "Config",
     "cli_config",
     "set_cli_config",

--- a/datacontract/config/settings.py
+++ b/datacontract/config/settings.py
@@ -13,6 +13,18 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 logger = logging.getLogger(__name__)
 
 _ENV_PREFIX = "DATACONTRACT_"
+
+# Deprecated option (field name) -> replacement (field name). Single source for
+# the accessor warnings, the Snowflake connect synonyms, and the generated docs.
+DEPRECATED_OPTIONS = {
+    "datamesh_manager_api_key": "entropy_data_api_key",
+    "datamesh_manager_host": "entropy_data_host",
+    "datacontract_manager_api_key": "entropy_data_api_key",
+    "datacontract_manager_host": "entropy_data_host",
+    "snowflake_private_key_path": "snowflake_private_key_file",
+    "snowflake_private_key_passphrase": "snowflake_private_key_file_pwd",
+    "snowflake_connection_timeout": "snowflake_login_timeout",
+}
 _TRUTHY = ("1", "true", "yes", "y", "on")
 
 
@@ -191,7 +203,7 @@ class Config(BaseSettings):
                     unknown.append(key)
             if unknown:
                 raise ValueError(f"Unknown config option(s): {', '.join(sorted(unknown))}. See datacontract.Config.")
-            return cls(**fields)
+            return _ExplicitConfig(**fields)
         raise TypeError(f"config must be a Config, dict, or None, got {type(config).__name__}")
 
     @classmethod
@@ -207,7 +219,10 @@ class Config(BaseSettings):
         import yaml
 
         path = Path(path)
-        data = yaml.safe_load(path.read_text())
+        try:
+            data = yaml.safe_load(path.read_text())
+        except yaml.YAMLError as e:
+            raise ValueError(f"Config file {path} is not valid YAML: {e}")
         if data is None:
             data = {}
         if not isinstance(data, dict):
@@ -227,7 +242,7 @@ class Config(BaseSettings):
         unknown = sorted(set(flat) - set(cls.model_fields))
         if unknown:
             raise ValueError(f"Unknown config option(s) in {path}: {', '.join(unknown)}. See datacontract.Config.")
-        return cls(**flat)
+        return _ExplicitConfig(**flat)
 
     # ------------------------------------------------------------------
     # Value resolution: one typed accessor per option (get_<field>()).
@@ -261,8 +276,11 @@ class Config(BaseSettings):
             )
         return value
 
-    def _deprecated_str_option(self, field_name: str, replacement: str, required: bool = False) -> str | None:
+    def _deprecated_str_option(
+        self, field_name: str, replacement: str | None = None, required: bool = False
+    ) -> str | None:
         """A str option kept as a deprecated synonym: warns when it supplies a value."""
+        replacement = replacement or DEPRECATED_OPTIONS[field_name]
         value = self._str_option(field_name, required)
         if value:
             deprecated_env = env_name(field_name, type(self).model_fields[field_name])
@@ -293,10 +311,11 @@ class Config(BaseSettings):
 
     def _bool_option(self, field_name: str, default: bool) -> bool:
         value = self._raw_option(field_name)
-        if value is None or value == "":
+        if value is None:
             return default
         if isinstance(value, bool):
             return value
+        # A set-but-empty variable counts as false, matching pre-Config parsing.
         return str(value).strip().lower() in _TRUTHY
 
     # --- entropy ---
@@ -609,6 +628,23 @@ class Config(BaseSettings):
                 continue
             values[env_name(name, field)] = _as_env_value(value)
         return values
+
+
+class _ExplicitConfig(Config):
+    """Config built only from explicitly provided values.
+
+    Skips the environment settings source, so an unrelated malformed
+    DATACONTRACT_* variable in the process cannot fail construction of a config
+    file, dict, or per-request header config. Unset options still fall back to
+    the environment lazily through the accessors, which parse each value at the
+    point of use.
+    """
+
+    @classmethod
+    def settings_customise_sources(
+        cls, settings_cls, init_settings, env_settings, dotenv_settings, file_secret_settings
+    ):
+        return (init_settings,)
 
 
 def env_name(field_name: str, field) -> str:

--- a/datacontract/engines/fastjsonschema/check_jsonschema.py
+++ b/datacontract/engines/fastjsonschema/check_jsonschema.py
@@ -56,7 +56,8 @@ def process_exceptions(run, exceptions: List[DataContractException], config: Con
 
     # Define the maximum number of errors to process (can be adjusted via configuration).
     try:
-        error_limit = Config.resolve(config).get_max_errors() or 500
+        configured_limit = Config.resolve(config).get_max_errors()
+        error_limit = 500 if configured_limit is None else configured_limit
     except DataContractException:
         # Fallback to default if the configured value is invalid.
         error_limit = 500

--- a/datacontract/engines/ibis/connections/connect.py
+++ b/datacontract/engines/ibis/connections/connect.py
@@ -15,7 +15,7 @@ import typing
 
 from open_data_contract_standard.model import OpenDataContractStandard, Server
 
-from datacontract.config import Config, unknown_snowflake_env_names
+from datacontract.config import DEPRECATED_OPTIONS, Config, unknown_snowflake_env_names
 from datacontract.engines.ibis.connections import aws_credentials
 from datacontract.engines.ibis.connections.duckdb_connection import get_duckdb_connection
 from datacontract.model.exceptions import DataContractException
@@ -345,6 +345,48 @@ def _connect_impala(ibis, server: Server, config: Config):
     )
 
 
+def _snowflake_private_key(value: str | None):
+    """Normalize DATACONTRACT_SNOWFLAKE_PRIVATE_KEY to DER bytes.
+
+    The connector accepts the private key as DER bytes on every supported
+    version; the base64-DER string form only works from connector 3.13 on, and
+    PEM text never does. Accept both PEM (converted) and base64-DER (decoded),
+    so the option works regardless of the pinned connector version.
+    """
+    if not value:
+        return None
+    if "-----BEGIN" in value:
+        try:
+            from cryptography.hazmat.primitives import serialization
+
+            key = serialization.load_pem_private_key(value.encode(), password=None)
+            return key.private_bytes(
+                encoding=serialization.Encoding.DER,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+        except Exception as e:
+            raise DataContractException(
+                type="snowflake-connection",
+                name="invalid_private_key",
+                reason=f"DATACONTRACT_SNOWFLAKE_PRIVATE_KEY could not be read as an unencrypted PEM private key: {e}. "
+                f"For encrypted keys, use DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_FILE with "
+                f"DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_FILE_PWD.",
+                engine="datacontract",
+            )
+    import base64
+
+    try:
+        return base64.b64decode(value, validate=True)
+    except Exception:
+        raise DataContractException(
+            type="snowflake-connection",
+            name="invalid_private_key",
+            reason="DATACONTRACT_SNOWFLAKE_PRIVATE_KEY must be a PEM private key or base64-encoded DER.",
+            engine="datacontract",
+        )
+
+
 def _snowflake_connection_kwargs(server: Server, run: Run, config: Config) -> dict:
     """Build the ``ibis.snowflake.connect`` kwargs, one line per supported option.
 
@@ -373,7 +415,7 @@ def _snowflake_connection_kwargs(server: Server, run: Run, config: Config) -> di
     put("role", config.get_snowflake_role())
     put("token", config.get_snowflake_token())
     put("passcode", config.get_snowflake_passcode())
-    put("private_key", config.get_snowflake_private_key())
+    put("private_key", _snowflake_private_key(config.get_snowflake_private_key()))
     put("private_key_file", config.get_snowflake_private_key_file())
     put("private_key_file_pwd", config.get_snowflake_private_key_file_pwd())
     put("warehouse", config.get_snowflake_warehouse())
@@ -387,14 +429,16 @@ def _snowflake_connection_kwargs(server: Server, run: Run, config: Config) -> di
     # has never accepted. The driver ignores unknown parameters instead of raising, so setting
     # one of these used to do nothing at all and surfaced as an unrelated authentication error.
     # They are kept as synonyms for the real parameters, with a deprecation warning; an
-    # explicitly set replacement wins over the deprecated synonym.
-    for value, deprecated, replacement in (
-        (config.get_snowflake_private_key_path(), "PRIVATE_KEY_PATH", "private_key_file"),
-        (config.get_snowflake_private_key_passphrase(), "PRIVATE_KEY_PASSPHRASE", "private_key_file_pwd"),
-        (config.get_snowflake_connection_timeout(), "CONNECTION_TIMEOUT", "login_timeout"),
-    ):
+    # explicitly set replacement wins over the deprecated synonym. The mapping lives in
+    # DEPRECATED_OPTIONS, shared with the accessor warnings and the generated docs.
+    for deprecated_field, replacement_field in DEPRECATED_OPTIONS.items():
+        if not deprecated_field.startswith("snowflake_"):
+            continue
+        value = getattr(config, f"get_{deprecated_field}")()
         if not value:
             continue
+        deprecated = deprecated_field.removeprefix("snowflake_").upper()
+        replacement = replacement_field.removeprefix("snowflake_")
         run.log_warn(
             f"DATACONTRACT_SNOWFLAKE_{deprecated} is deprecated and will be removed in a future release, "
             f"use DATACONTRACT_SNOWFLAKE_{replacement.upper()} instead"

--- a/datacontract/engines/ibis/connections/duckdb_connection.py
+++ b/datacontract/engines/ibis/connections/duckdb_connection.py
@@ -46,7 +46,7 @@ def get_duckdb_connection(
         path = server.path
     if server.type == "s3":
         path = server.location
-        setup_s3_connection(con, server)
+        setup_s3_connection(con, server, config)
     if server.type == "gcs":
         path = server.location
         setup_gcs_connection(con, server, config)
@@ -250,10 +250,10 @@ def _sql_literal(value) -> str:
     return str(value).replace("'", "''") if value is not None else ""
 
 
-def setup_s3_connection(con, server: Server):
+def setup_s3_connection(con, server: Server, config: Config | None = None):
     _load_extension(con, "httpfs", "s3")
     _load_extension(con, "aws", "s3")
-    configured = aws_credentials.client_kwargs()
+    configured = aws_credentials.client_kwargs(config=config)
     s3_region = configured["region_name"]
     s3_access_key_id = configured["aws_access_key_id"]
     s3_secret_access_key = configured["aws_secret_access_key"]

--- a/datacontract/engines/ibis/connections/kafka.py
+++ b/datacontract/engines/ibis/connections/kafka.py
@@ -94,8 +94,8 @@ def create_spark_session():
 
 
 def read_kafka_topic(spark, data_contract: OpenDataContractStandard, server: Server, config: Config | None = None):
-    config = Config.resolve(config)
     """Read and process data from a Kafka topic based on the server configuration."""
+    config = Config.resolve(config)
 
     if not data_contract.schema_ or len(data_contract.schema_) == 0:
         raise DataContractException(

--- a/datacontract/imports/athena_importer.py
+++ b/datacontract/imports/athena_importer.py
@@ -34,13 +34,14 @@ HIVE_TO_ATHENA_TYPES = {
 
 
 class AthenaImporter(Importer):
-    def import_source(self, source: str, import_args: dict) -> OpenDataContractStandard:
+    def import_source(self, source: str, import_args: dict, config=None) -> OpenDataContractStandard:
         return import_athena(
             schema=import_args.get("schema"),
             staging_dir=import_args.get("staging_dir"),
             region=import_args.get("region"),
             catalog=import_args.get("catalog"),
             tables=import_args.get("athena_table"),
+            config=config,
         )
 
 
@@ -50,6 +51,7 @@ def import_athena(
     region: Optional[str] = None,
     catalog: Optional[str] = None,
     tables: Optional[List[str]] = None,
+    config=None,
 ) -> OpenDataContractStandard:
     if not schema:
         raise DataContractException(
@@ -69,7 +71,7 @@ def import_athena(
             engine="datacontract",
         )
 
-    selected = _select_tables(get_glue_tables(schema, region), tables)
+    selected = _select_tables(get_glue_tables(schema, region, config), tables)
     if not selected:
         raise DataContractException(
             type="schema",
@@ -90,7 +92,7 @@ def import_athena(
             staging_dir=staging_dir,
         )
     ]
-    odcs.schema_ = create_schema_objects(schema, selected, region)
+    odcs.schema_ = create_schema_objects(schema, selected, region, config)
     for schema_object in odcs.schema_:
         for prop in schema_object.properties or []:
             _to_athena_types(prop)

--- a/datacontract/imports/dcs_importer.py
+++ b/datacontract/imports/dcs_importer.py
@@ -30,12 +30,12 @@ logger = logging.getLogger(__name__)
 class DcsImporter(Importer):
     """Importer for Data Contract Specification (DCS) format."""
 
-    def import_source(self, source: str, import_args: dict) -> OpenDataContractStandard:
+    def import_source(self, source: str, import_args: dict, config=None) -> OpenDataContractStandard:
         import yaml
 
         from datacontract.lint.resources import read_resource
 
-        source_str = read_resource(source)
+        source_str = read_resource(source, config)
         dcs_dict = yaml.safe_load(source_str)
         dcs = parse_dcs_from_dict(dcs_dict)
         return convert_dcs_to_odcs(dcs)

--- a/datacontract/imports/mysql_importer.py
+++ b/datacontract/imports/mysql_importer.py
@@ -100,8 +100,8 @@ def import_mysql(
 
 
 def _attach(host: str, port: int, database: str, config: Optional[Config] = None):
-    config = Config.resolve(config)
     """ATTACH the database exactly as the test path does."""
+    config = Config.resolve(config)
     try:
         import duckdb
     except ImportError as e:

--- a/datacontract/imports/object_storage_importer.py
+++ b/datacontract/imports/object_storage_importer.py
@@ -54,13 +54,14 @@ _READERS = {
 
 
 class ObjectStorageImporter(Importer):
-    def import_source(self, source: str, import_args: dict) -> OpenDataContractStandard:
+    def import_source(self, source: str, import_args: dict, config=None) -> OpenDataContractStandard:
         return import_object_storage(
             location=normalize_location(source, self.import_format),
             server_type=SERVER_TYPES[self.import_format],
             format=import_args.get("file_format"),
             delimiter=import_args.get("delimiter"),
             endpoint_url=import_args.get("endpoint_url") or DEFAULT_ENDPOINT_URLS.get(self.import_format),
+            config=config,
         )
 
 
@@ -70,6 +71,7 @@ def import_object_storage(
     format: Optional[str] = None,
     delimiter: Optional[str] = None,
     endpoint_url: Optional[str] = None,
+    config=None,
 ) -> OpenDataContractStandard:
     if not location:
         raise DataContractException(
@@ -105,7 +107,7 @@ def import_object_storage(
     if endpoint_url:
         server.endpointUrl = endpoint_url
 
-    columns = _read_columns(server, location, format)
+    columns = _read_columns(server, location, format, config)
     if not columns:
         raise DataContractException(
             type="schema",
@@ -153,7 +155,7 @@ def schema_name(location: str) -> str:
     return re.sub(r"[^0-9A-Za-z_]+", "_", segment).strip("_") or "data"
 
 
-def _read_columns(server: Server, location: str, format: str):
+def _read_columns(server: Server, location: str, format: str, config=None):
     from datacontract.engines.ibis.connections.duckdb_connection import (
         _import_duckdb,
         setup_azure_connection,
@@ -163,7 +165,7 @@ def _read_columns(server: Server, location: str, format: str):
     setup = {"s3": setup_s3_connection, "azure": setup_azure_connection}[server.type]
     duckdb = _import_duckdb()
     con = duckdb.connect(database=":memory:")
-    setup(con, server)
+    setup(con, server, config)
     if format == "delta":
         con.sql("update extensions;")
     reader = _READERS[format].format(location=location)

--- a/datacontract/imports/odcs_importer.py
+++ b/datacontract/imports/odcs_importer.py
@@ -7,14 +7,14 @@ from datacontract.model.exceptions import DataContractException
 
 
 class OdcsImporter(Importer):
-    def import_source(self, source: str, import_args: dict) -> OpenDataContractStandard:
-        return import_odcs(source)
+    def import_source(self, source: str, import_args: dict, config=None) -> OpenDataContractStandard:
+        return import_odcs(source, config)
 
 
-def import_odcs(source: str) -> OpenDataContractStandard:
+def import_odcs(source: str, config=None) -> OpenDataContractStandard:
     """Import an ODCS file directly - since ODCS is now the internal format, this is simpler."""
     try:
-        odcs_yaml = yaml.safe_load(read_resource(source))
+        odcs_yaml = yaml.safe_load(read_resource(source, config))
     except Exception as e:
         raise DataContractException(
             type="schema",

--- a/datacontract/imports/postgres_importer.py
+++ b/datacontract/imports/postgres_importer.py
@@ -148,8 +148,8 @@ def import_postgres_from_connector(
 
 
 def postgres_connection(host: str, port: int, database: str, config: Optional[Config] = None):
-    config = Config.resolve(config)
     """Open a psycopg connection using the same DATACONTRACT_POSTGRES_* env vars as `datacontract test`."""
+    config = Config.resolve(config)
     try:
         import psycopg
     except ImportError as e:

--- a/datacontract/lint/resolve.py
+++ b/datacontract/lint/resolve.py
@@ -112,7 +112,9 @@ def resolve_data_contract(
             data_contract_location, schema_location, inline_references, all_errors, config
         )
     elif data_contract_str is not None:
-        return _resolve_data_contract_from_str(data_contract_str, schema_location, inline_references, all_errors)
+        return _resolve_data_contract_from_str(
+            data_contract_str, schema_location, inline_references, all_errors, config
+        )
     elif data_contract is not None:
         return data_contract
     else:
@@ -133,7 +135,7 @@ def resolve_data_contract_from_location(
     config: "Config | None" = None,
 ) -> OpenDataContractStandard:
     data_contract_str = read_resource(location, config)
-    return _resolve_data_contract_from_str(data_contract_str, schema_location, inline_references, all_errors)
+    return _resolve_data_contract_from_str(data_contract_str, schema_location, inline_references, all_errors, config)
 
 
 # Precedence-ordered: a property with both semantics and definition references
@@ -156,7 +158,7 @@ def clear_definition_cache() -> None:
     _definition_cache.clear()
 
 
-def inline_definitions_into_data_contract(data_contract: OpenDataContractStandard):
+def inline_definitions_into_data_contract(data_contract: OpenDataContractStandard, config: "Config | None" = None):
     """Resolve `authoritativeDefinitions[type in {semantics, definition}]` on
     every property.
 
@@ -169,23 +171,23 @@ def inline_definitions_into_data_contract(data_contract: OpenDataContractStandar
     for schema_obj in data_contract.schema_:
         if schema_obj.properties:
             for prop in schema_obj.properties:
-                inline_definition_into_property(prop)
+                inline_definition_into_property(prop, config)
 
 
-def inline_definition_into_property(prop: SchemaProperty):
+def inline_definition_into_property(prop: SchemaProperty, config: "Config | None" = None):
     """Resolve and inline; recurse into nested properties and array items."""
     if prop.items is not None:
-        inline_definition_into_property(prop.items)
+        inline_definition_into_property(prop.items, config)
     if prop.properties is not None:
         for nested_prop in prop.properties:
-            inline_definition_into_property(nested_prop)
+            inline_definition_into_property(nested_prop, config)
 
     resolved = _resolvable_reference(prop)
     if resolved is None:
         return
 
     type_, url = resolved
-    definition = _resolve_definition(url, type_)
+    definition = _resolve_definition(url, type_, config)
     _apply_definition_to_property(prop, definition)
 
 
@@ -199,7 +201,7 @@ def _resolvable_reference(prop: SchemaProperty) -> tuple[str, str] | None:
     return None
 
 
-def _resolve_definition(url: str, type_: str) -> SchemaProperty:
+def _resolve_definition(url: str, type_: str, config: "Config | None" = None) -> SchemaProperty:
     """Fetch and parse the definition or semantic concept at `url`.
 
     `type_` controls how an absolute URL on a different host is handled:
@@ -214,7 +216,7 @@ def _resolve_definition(url: str, type_: str) -> SchemaProperty:
     if url in _definition_cache:
         return _definition_cache[url]
 
-    target_url, headers, host_hint = _build_request(url, type_)
+    target_url, headers, host_hint = _build_request(url, type_, config)
 
     try:
         response = requests.get(target_url, headers=headers, timeout=10)
@@ -238,7 +240,7 @@ def _resolve_definition(url: str, type_: str) -> SchemaProperty:
     return definition
 
 
-def _build_request(url: str, type_: str) -> tuple[str, dict[str, str], str | None]:
+def _build_request(url: str, type_: str, config: "Config | None" = None) -> tuple[str, dict[str, str], str | None]:
     """Return the URL to fetch, the headers to use, and an optional host hint.
 
     The third element is a copy-pasteable ENTROPY_DATA_HOST suggestion that
@@ -258,14 +260,14 @@ def _build_request(url: str, type_: str) -> tuple[str, dict[str, str], str | Non
     """
     from datacontract.integration.entropy_data import _get_api_key_or_none, _get_host
 
-    configured_host = _get_host()
+    configured_host = _get_host(config)
     # urljoin keeps absolute URLs as-is and joins leading-slash paths onto
     # the host -- covers both shapes ODCS allows for `url`.
     direct_url = urljoin(configured_host, url)
     headers = {"Accept": "application/vnd.entropydata.odcs+json"}
 
     if _hosts_match(direct_url, configured_host):
-        api_key = _get_api_key_or_none()
+        api_key = _get_api_key_or_none(config)
         if api_key is not None:
             headers["x-api-key"] = api_key
         return direct_url, headers, None
@@ -276,7 +278,7 @@ def _build_request(url: str, type_: str) -> tuple[str, dict[str, str], str | Non
 
     # Off-host semantics reference: IRI lookup against the configured host.
     host_hint = _host_mismatch_hint(url, configured_host)
-    api_key = _get_api_key_or_none()
+    api_key = _get_api_key_or_none(config)
     if api_key is None:
         raise _definition_resolution_error(
             url,
@@ -343,7 +345,11 @@ def _definition_resolution_error(
 
 
 def _resolve_data_contract_from_str(
-    data_contract_str, schema_location: str = None, inline_references: bool = False, all_errors: bool = False
+    data_contract_str,
+    schema_location: str = None,
+    inline_references: bool = False,
+    all_errors: bool = False,
+    config: "Config | None" = None,
 ) -> OpenDataContractStandard:
     yaml_dict = _to_yaml(data_contract_str)
 
@@ -378,7 +384,7 @@ def _resolve_data_contract_from_str(
 
         odcs = _parse_odcs_from_dict(yaml_dict, lax=custom_schema)
         if inline_references:
-            inline_definitions_into_data_contract(odcs)
+            inline_definitions_into_data_contract(odcs, config)
         return odcs
 
     # For DCS format, we need to convert it to ODCS
@@ -388,7 +394,7 @@ def _resolve_data_contract_from_str(
     dcs = parse_dcs_from_dict(yaml_dict)
     odcs = convert_dcs_to_odcs(dcs)
     if inline_references:
-        inline_definitions_into_data_contract(odcs)
+        inline_definitions_into_data_contract(odcs, config)
     return odcs
 
 

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -36,7 +36,7 @@ marked as such in the entry.
 - New Snowflake connection options: `DATACONTRACT_SNOWFLAKE_TOKEN`, `DATACONTRACT_SNOWFLAKE_PASSCODE`, `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY`, `DATACONTRACT_SNOWFLAKE_NETWORK_TIMEOUT`, `DATACONTRACT_SNOWFLAKE_SOCKET_TIMEOUT`, `DATACONTRACT_SNOWFLAKE_HOST`, `DATACONTRACT_SNOWFLAKE_PORT`
 
 ### Changed
-- `datacontract test` against Snowflake only forwards the documented `DATACONTRACT_SNOWFLAKE_*` options to the connector; unknown variables are ignored with a warning instead of being passed through (use a connections.toml for connector parameters the CLI does not support directly)
+- `datacontract test` against Snowflake only forwards the documented `DATACONTRACT_SNOWFLAKE_*` options to the connector; unknown variables are ignored with a warning
 
 ### Fixed
 - `datacontract dbt sync` writes a description on all dbt tests, not only newly-generated ones

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -219,3 +219,21 @@ def test_test_endpoint_uses_config_from_headers():
 
     config = mock.call_args.kwargs["config"]
     assert config.get_postgres_password() == "pw"
+
+
+def test_entropy_data_api_key_header_is_accepted():
+    from datacontract.api import config_from_headers
+
+    config = config_from_headers({"entropy-data-api-key": "key", "entropy-data-host": "https://dc.example.com"})
+
+    assert config.get_entropy_data_api_key() == "key"
+    assert config.get_entropy_data_host() == "https://dc.example.com"
+
+
+def test_config_headers_work_despite_unrelated_malformed_env_var(monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_SNOWFLAKE_LOGIN_TIMEOUT", "not-a-number")
+    from datacontract.api import config_from_headers
+
+    config = config_from_headers({"datacontract-postgres-username": "u"})
+
+    assert config.get_postgres_username() == "u"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -227,3 +227,17 @@ def test_entropy_data_options_do_not_warn(caplog):
         assert Config(entropy_data_api_key="key").get_entropy_data_api_key() == "key"
 
     assert not caplog.records
+
+
+def test_explicit_config_is_immune_to_unrelated_malformed_env_vars(monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_SNOWFLAKE_LOGIN_TIMEOUT", "not-a-number")
+
+    config = Config.resolve({"DATACONTRACT_POSTGRES_USERNAME": "u"})
+
+    assert config.get_postgres_username() == "u"
+
+
+def test_bool_accessor_treats_set_but_empty_env_var_as_false(monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_IMPALA_USE_SSL", "")
+
+    assert Config.model_construct().get_impala_use_ssl(default=True) is False

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -121,3 +121,20 @@ def test_missing_config_file_fails_with_a_clear_message(tmp_path):
 
     assert result.exit_code != 0
     assert "does not exist" in result.output
+
+
+def test_from_yaml_names_the_file_on_invalid_yaml(tmp_path):
+    path = _write_config(tmp_path, "snowflake: [unclosed\n")
+
+    with pytest.raises(ValueError, match="datacontract-config.yaml"):
+        Config.from_yaml(path)
+
+
+def test_config_file_works_despite_unrelated_malformed_env_var(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_SNOWFLAKE_LOGIN_TIMEOUT", "not-a-number")
+    path = _write_config(tmp_path, "postgres:\n  username: reader\n")
+
+    result = runner.invoke(app, ["--config-file", str(path), "lint", "fixtures/lint/valid_datacontract.yaml"])
+
+    assert result.exit_code == 0, result.output
+    assert cli_config().get_postgres_username() == "reader"

--- a/tests/test_config_threading.py
+++ b/tests/test_config_threading.py
@@ -1,0 +1,96 @@
+"""Regression tests: the config object must actually arrive everywhere it is accepted.
+
+The explicit-passing refactor left paths where config was accepted but not
+forwarded (silently falling back to the process environment); these tests pin
+the repaired paths and guard against new importers reopening the gap.
+"""
+
+import inspect
+
+import pytest
+
+from datacontract import Config
+from datacontract.imports.importer_factory import importer_factory
+
+
+def test_every_registered_importer_declares_the_config_parameter():
+    """import_from_source only passes config to importers that declare it, so a
+    first-party importer without the parameter silently loses credentials."""
+    missing = []
+    for format_name in list(importer_factory.dict_importer.keys()):
+        importer = importer_factory.create(format_name)
+        if "config" not in inspect.signature(importer.import_source).parameters:
+            missing.append(format_name)
+    assert missing == [], f"Importers silently dropping config: {missing}"
+
+
+def test_definition_lookup_uses_the_passed_config(monkeypatch):
+    from datacontract.lint.resolve import _build_request
+
+    monkeypatch.delenv("ENTROPY_DATA_API_KEY", raising=False)
+    monkeypatch.delenv("ENTROPY_DATA_HOST", raising=False)
+    config = Config.resolve({"ENTROPY_DATA_API_KEY": "key-from-config", "ENTROPY_DATA_HOST": "https://dc.example.com"})
+
+    url, headers, _ = _build_request("/api/definitions/orders", "definition", config)
+
+    assert url == "https://dc.example.com/api/definitions/orders"
+    assert headers["x-api-key"] == "key-from-config"
+
+
+def test_s3_duckdb_setup_uses_the_passed_config(monkeypatch):
+    from datacontract.engines.ibis.connections import aws_credentials, duckdb_connection
+
+    seen = {}
+    real = aws_credentials.client_kwargs
+
+    def capture(region=None, config=None):
+        seen["config"] = config
+        return real(region, config)
+
+    monkeypatch.setattr(aws_credentials, "client_kwargs", capture)
+    duckdb = pytest.importorskip("duckdb")
+    con = duckdb.connect()
+    from open_data_contract_standard.model import Server
+
+    config = Config.resolve({"DATACONTRACT_S3_ACCESS_KEY_ID": "AK", "DATACONTRACT_S3_SECRET_ACCESS_KEY": "SK"})
+    try:
+        duckdb_connection.setup_s3_connection(con, Server(server="s3", type="s3", location="s3://bucket/x"), config)
+    except Exception:
+        pass  # only the credential resolution is under test, not the duckdb secret
+
+    assert seen.get("config") is config
+
+
+def test_snowflake_private_key_accepts_pem():
+    serialization = pytest.importorskip("cryptography.hazmat.primitives.serialization")
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    from datacontract.engines.ibis.connections.connect import _snowflake_private_key
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+
+    der = _snowflake_private_key(pem)
+
+    assert isinstance(der, bytes)
+    assert serialization.load_der_private_key(der, password=None) is not None
+
+
+def test_snowflake_private_key_accepts_base64_der():
+    import base64
+
+    from datacontract.engines.ibis.connections.connect import _snowflake_private_key
+
+    assert _snowflake_private_key(base64.b64encode(b"\x30\x82\x01\x00").decode()) == b"\x30\x82\x01\x00"
+
+
+def test_snowflake_private_key_rejects_garbage():
+    from datacontract.engines.ibis.connections.connect import _snowflake_private_key
+    from datacontract.model.exceptions import DataContractException
+
+    with pytest.raises(DataContractException, match="DATACONTRACT_SNOWFLAKE_PRIVATE_KEY"):
+        _snowflake_private_key("not a key !!!")

--- a/tests/test_import_object_storage.py
+++ b/tests/test_import_object_storage.py
@@ -181,9 +181,11 @@ def test_adls_uses_the_azure_connection_setup(monkeypatch):
 
     calls = []
     for name in ("setup_s3_connection", "setup_azure_connection"):
+        # The fake must match the real signature, so a call-shape regression in
+        # _read_columns fails here instead of only in the real command.
         monkeypatch.setattr(
             "datacontract.engines.ibis.connections.duckdb_connection." + name,
-            lambda con, server, _n=name: calls.append(_n),
+            lambda con, server, config, _n=name: calls.append(_n),
         )
     monkeypatch.setattr(object_storage_importer, "_READERS", {"csv": "(SELECT 1 AS id)"})
 

--- a/update_config_options.py
+++ b/update_config_options.py
@@ -9,7 +9,7 @@ committed page is stale.
 
 from pathlib import Path
 
-from datacontract.config import Config, env_name
+from datacontract.config import DEPRECATED_OPTIONS, Config, env_name
 
 DOCS_PAGE = Path(__file__).parent / "docs" / "docs" / "configuration.md"
 
@@ -40,17 +40,6 @@ GROUPS = {
     "trino": "Trino",
 }
 
-# deprecated option -> replacement, mirrored from the accessor/connect warnings
-DEPRECATED = {
-    "datamesh_manager_api_key": "entropy_data_api_key",
-    "datamesh_manager_host": "entropy_data_host",
-    "datacontract_manager_api_key": "entropy_data_api_key",
-    "datacontract_manager_host": "entropy_data_host",
-    "snowflake_private_key_path": "snowflake_private_key_file",
-    "snowflake_private_key_passphrase": "snowflake_private_key_file_pwd",
-    "snowflake_connection_timeout": "snowflake_login_timeout",
-}
-
 
 def _group(field_name: str) -> str:
     for prefix, heading in GROUPS.items():
@@ -75,8 +64,8 @@ def render_options_block() -> str:
     for name, field in Config.model_fields.items():
         heading = _group(name)
         notes = ""
-        if name in DEPRECATED:
-            replacement = DEPRECATED[name]
+        if name in DEPRECATED_OPTIONS:
+            replacement = DEPRECATED_OPTIONS[name]
             replacement_env = env_name(replacement, Config.model_fields[replacement])
             notes = f"Deprecated, use `{replacement_env}`"
         row = f"| `{env_name(name, field)}` | `{name}` | {_type_label(field.annotation)} | {notes} |"


### PR DESCRIPTION
## Summary

A post-merge review of the programmatic-config work (#1467, #1469) found paths where the config object was accepted but never arrived, plus a few behavior regressions against pre-Config parsing. This PR fixes all 15 findings with a regression test for each class of problem.

## Threading gaps fixed (config silently fell back to process env)

- **ADLS import crashed**: `_read_columns` called `setup_azure_connection(con, server)` without the now-required config argument; the test fake masked it with a two-arg lambda, which now matches the real signature so this cannot regress silently.
- **Reference/semantics inlining**: `resolve.py` dropped config on the `data_contract_str` branch and `_build_request` resolved the Entropy Data host/API key from env only; config is now threaded through the whole inlining chain.
- **S3 duckdb test path**: `setup_s3_connection` now receives config, so programmatic S3 credentials reach the duckdb secret.
- **athena, odcs, dcs, object-storage importers** now declare `config`, and a new test asserts every registered importer does, so the `inspect.signature` gate can never silently drop credentials for a first-party importer again.
- **`command_test`'s post-run re-resolution and `datacontract catalog`** pass `cli_config()`.

## Behavior regressions fixed

- **One malformed env var no longer breaks explicit configs**: dict/config-file/header configs are built via an internal `_ExplicitConfig` that skips the env settings source; unset options fall back to the environment lazily through the accessors, which parse each value at point of use (the pre-Config behavior). Direct `Config()` keeps its documented validate-the-snapshot semantics.
- **Set-but-empty boolean variables read as false again** (`DATACONTRACT_IMPALA_USE_SSL=""` used to disable SSL, briefly meant "default").
- **Invalid YAML in a config file names the file** instead of surfacing a raw parse error with no context.
- **`ENTROPY_DATA_API_KEY` / `ENTROPY_DATA_HOST` now work as API headers** (`entropy-data-api-key`); previously only their deprecated aliases were reachable per request.
- **`DATACONTRACT_SNOWFLAKE_PRIVATE_KEY` is normalized to DER bytes**: PEM is converted, base64-DER is decoded, anything else errors clearly — the raw string previously could not work on any pinned connector version.

## Cleanups

- The deprecated-option mapping lives once in `DEPRECATED_OPTIONS` (accessors, Snowflake connect synonyms, and the generated docs all derive from it).
- Docstrings displaced below the inserted `Config.resolve` lines restored.
- An explicit `DATACONTRACT_MAX_ERRORS=0` is honored instead of falling back to 500.
- CHANGELOG entry trimmed to the one-line convention.

## Test plan

- New `tests/test_config_threading.py` (6 tests): importer signature guard, `_build_request` config usage, S3 setup config usage, and the three private-key normalization cases.
- Extended `test_config.py`, `test_config_file.py`, `test_api.py` with the malformed-env immunity, empty-bool, YAML-error, and entropy-header regressions.
- Full local suite: 1613 passed, 0 failed.