### PR TITLE
Add config options to override the contract's server details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The API server accepts per-request credentials on `POST /test` via `datacontract-*` headers (e.g. `datacontract-snowflake-password`)
 - Credentials and connection options can be provided in a YAML config file, via `--config-file` (defaults to `./datacontract-config.yaml` or `~/.datacontract/config.yaml`) or `Config.from_yaml()`, with `${VAR}` references resolved from the environment
 - New Snowflake connection options: `DATACONTRACT_SNOWFLAKE_TOKEN`, `DATACONTRACT_SNOWFLAKE_PASSCODE`, `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY`, `DATACONTRACT_SNOWFLAKE_NETWORK_TIMEOUT`, `DATACONTRACT_SNOWFLAKE_SOCKET_TIMEOUT`, `DATACONTRACT_SNOWFLAKE_HOST`, `DATACONTRACT_SNOWFLAKE_PORT`
+- `DATACONTRACT_POSTGRES_HOST`, `DATACONTRACT_POSTGRES_PORT`, `DATACONTRACT_POSTGRES_DATABASE`, and `DATACONTRACT_POSTGRES_SCHEMA` override the Postgres server details from the data contract (#1076)
 
 ### Changed
 - `datacontract test` against Snowflake only forwards the documented `DATACONTRACT_SNOWFLAKE_*` options to the connector; unknown variables are ignored with a warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The API server accepts per-request credentials on `POST /test` via `datacontract-*` headers (e.g. `datacontract-snowflake-password`)
 - Credentials and connection options can be provided in a YAML config file, via `--config-file` (defaults to `./datacontract-config.yaml` or `~/.datacontract/config.yaml`) or `Config.from_yaml()`, with `${VAR}` references resolved from the environment
 - New Snowflake connection options: `DATACONTRACT_SNOWFLAKE_TOKEN`, `DATACONTRACT_SNOWFLAKE_PASSCODE`, `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY`, `DATACONTRACT_SNOWFLAKE_NETWORK_TIMEOUT`, `DATACONTRACT_SNOWFLAKE_SOCKET_TIMEOUT`, `DATACONTRACT_SNOWFLAKE_HOST`, `DATACONTRACT_SNOWFLAKE_PORT`
-- `DATACONTRACT_POSTGRES_HOST`, `DATACONTRACT_POSTGRES_PORT`, `DATACONTRACT_POSTGRES_DATABASE`, and `DATACONTRACT_POSTGRES_SCHEMA` override the Postgres server details from the data contract (#1076)
+- Config options to override the server details from the data contract (host, port, database, schema, catalog, project, dataset, account, service name, staging directory) for Postgres, MySQL, SQL Server, Oracle, Redshift, Snowflake, BigQuery, Databricks, Trino, Athena, and Impala, e.g. `DATACONTRACT_POSTGRES_HOST` (#1076)
 
 ### Changed
 - `datacontract test` against Snowflake only forwards the documented `DATACONTRACT_SNOWFLAKE_*` options to the connector; unknown variables are ignored with a warning
+- `DATACONTRACT_SNOWFLAKE_ACCOUNT` overrides the contract's `account` instead of being ignored with a warning
+- `DATACONTRACT_DATABRICKS_SERVER_HOSTNAME` overrides the contract's `host`; previously the contract value won when both were set
 
 ### Fixed
 - `datacontract dbt sync` writes a description on all dbt tests, not only newly-generated ones

--- a/datacontract/config/__init__.py
+++ b/datacontract/config/__init__.py
@@ -13,6 +13,7 @@ values the config does not set.
 from datacontract.config.cli_context import cli_config, set_cli_config
 from datacontract.config.settings import (
     DEPRECATED_OPTIONS,
+    SERVER_OVERRIDE_OPTIONS,
     Config,
     env_name,
     known_env_names,
@@ -21,6 +22,7 @@ from datacontract.config.settings import (
 
 __all__ = [
     "DEPRECATED_OPTIONS",
+    "SERVER_OVERRIDE_OPTIONS",
     "Config",
     "cli_config",
     "set_cli_config",

--- a/datacontract/config/settings.py
+++ b/datacontract/config/settings.py
@@ -110,6 +110,11 @@ class Config(BaseSettings):
     # postgres
     postgres_username: str | None = None
     postgres_password: SecretStr | None = None
+    # overrides for the contract's servers block
+    postgres_host: str | None = None
+    postgres_port: int | None = None
+    postgres_database: str | None = None
+    postgres_schema: str | None = None
 
     # redshift
     redshift_authentication: str | None = None
@@ -463,6 +468,18 @@ class Config(BaseSettings):
 
     def get_postgres_password(self, required: bool = False) -> str | None:
         return self._str_option("postgres_password", required)
+
+    def get_postgres_host(self, required: bool = False) -> str | None:
+        return self._str_option("postgres_host", required)
+
+    def get_postgres_port(self) -> int | None:
+        return self._int_option("postgres_port")
+
+    def get_postgres_database(self, required: bool = False) -> str | None:
+        return self._str_option("postgres_database", required)
+
+    def get_postgres_schema(self, required: bool = False) -> str | None:
+        return self._str_option("postgres_schema", required)
 
     # --- redshift ---
     def get_redshift_authentication(self, required: bool = False) -> str | None:

--- a/datacontract/config/settings.py
+++ b/datacontract/config/settings.py
@@ -27,6 +27,46 @@ DEPRECATED_OPTIONS = {
 }
 _TRUTHY = ("1", "true", "yes", "y", "on")
 
+# Config option (field name) -> the property in the contract's ``servers`` block
+# it overrides when set. Single source for the generated docs notes.
+SERVER_OVERRIDE_OPTIONS = {
+    "athena_catalog": "catalog",
+    "athena_schema": "schema",
+    "athena_staging_dir": "stagingDir",
+    "bigquery_project": "project",
+    "bigquery_dataset": "dataset",
+    "databricks_server_hostname": "host",
+    "databricks_catalog": "catalog",
+    "databricks_schema": "schema",
+    "impala_host": "host",
+    "impala_port": "port",
+    "impala_database": "database",
+    "mysql_host": "host",
+    "mysql_port": "port",
+    "mysql_database": "database",
+    "oracle_host": "host",
+    "oracle_port": "port",
+    "oracle_service_name": "serviceName",
+    "postgres_host": "host",
+    "postgres_port": "port",
+    "postgres_database": "database",
+    "postgres_schema": "schema",
+    "redshift_host": "host",
+    "redshift_port": "port",
+    "redshift_database": "database",
+    "redshift_schema": "schema",
+    "snowflake_account": "account",
+    "snowflake_database": "database",
+    "snowflake_schema": "schema",
+    "sqlserver_host": "host",
+    "sqlserver_port": "port",
+    "sqlserver_database": "database",
+    "trino_host": "host",
+    "trino_port": "port",
+    "trino_catalog": "catalog",
+    "trino_schema": "schema",
+}
+
 
 class Config(BaseSettings):
     """All defined config options, one typed field per ``DATACONTRACT_*`` env var.
@@ -57,6 +97,12 @@ class Config(BaseSettings):
     api_header_authorization: SecretStr | None = None
     max_errors: int | None = None
 
+    # athena (credentials come from the s3_* options)
+    # overrides for the contract's servers block
+    athena_catalog: str | None = None
+    athena_schema: str | None = None
+    athena_staging_dir: str | None = None
+
     # azure
     azure_connection_string: SecretStr | None = None
     azure_storage_account_key: SecretStr | None = None
@@ -68,6 +114,9 @@ class Config(BaseSettings):
     bigquery_account_info_json_path: str | None = None
     bigquery_billing_project: str | None = None
     bigquery_impersonation_account: str | None = None
+    # overrides for the contract's servers block
+    bigquery_project: str | None = None
+    bigquery_dataset: str | None = None
 
     # databricks
     databricks_server_hostname: str | None = None
@@ -77,6 +126,9 @@ class Config(BaseSettings):
     databricks_client_secret: SecretStr | None = None
     databricks_profile: str | None = None
     databricks_auth_type: str | None = None
+    # overrides for the contract's servers block
+    databricks_catalog: str | None = None
+    databricks_schema: str | None = None
 
     # gcs
     gcs_key_id: str | None = None
@@ -89,6 +141,10 @@ class Config(BaseSettings):
     impala_http_path: str | None = None
     impala_use_ssl: bool | None = None
     impala_use_http_transport: bool | None = None
+    # overrides for the contract's servers block
+    impala_host: str | None = None
+    impala_port: int | None = None
+    impala_database: str | None = None
 
     # kafka
     kafka_sasl_username: str | None = None
@@ -101,11 +157,19 @@ class Config(BaseSettings):
     # mysql
     mysql_username: str | None = None
     mysql_password: SecretStr | None = None
+    # overrides for the contract's servers block
+    mysql_host: str | None = None
+    mysql_port: int | None = None
+    mysql_database: str | None = None
 
     # oracle
     oracle_username: str | None = None
     oracle_password: SecretStr | None = None
     oracle_client_dir: str | None = None
+    # overrides for the contract's servers block
+    oracle_host: str | None = None
+    oracle_port: int | None = None
+    oracle_service_name: str | None = None
 
     # postgres
     postgres_username: str | None = None
@@ -128,6 +192,11 @@ class Config(BaseSettings):
     redshift_cluster_identifier: str | None = None
     redshift_region: str | None = None
     redshift_duration_seconds: int | None = None
+    # overrides for the contract's servers block
+    redshift_host: str | None = None
+    redshift_port: int | None = None
+    redshift_database: str | None = None
+    redshift_schema: str | None = None
 
     # s3 (also used for Athena and Redshift IAM as the AWS credential set)
     s3_access_key_id: str | None = None
@@ -159,6 +228,10 @@ class Config(BaseSettings):
     snowflake_private_key_path: str | None = None
     snowflake_private_key_passphrase: SecretStr | None = None
     snowflake_connection_timeout: int | None = None
+    # overrides for the contract's servers block
+    snowflake_account: str | None = None
+    snowflake_database: str | None = None
+    snowflake_schema: str | None = None
 
     # sqlserver
     sqlserver_authentication: str | None = None
@@ -170,12 +243,21 @@ class Config(BaseSettings):
     sqlserver_encrypted_connection: bool | None = None
     sqlserver_trust_server_certificate: bool | None = None
     sqlserver_trusted_connection: bool | None = None
+    # overrides for the contract's servers block
+    sqlserver_host: str | None = None
+    sqlserver_port: int | None = None
+    sqlserver_database: str | None = None
 
     # trino
     trino_authentication: str | None = None
     trino_username: str | None = None
     trino_password: SecretStr | None = None
     trino_jwt_token: SecretStr | None = None
+    # overrides for the contract's servers block
+    trino_host: str | None = None
+    trino_port: int | None = None
+    trino_catalog: str | None = None
+    trino_schema: str | None = None
 
     def __init__(self, **data):
         # extra="ignore" keeps unrelated env vars from breaking instantiation, but
@@ -352,6 +434,16 @@ class Config(BaseSettings):
     def get_max_errors(self) -> int | None:
         return self._int_option("max_errors")
 
+    # --- athena ---
+    def get_athena_catalog(self, required: bool = False) -> str | None:
+        return self._str_option("athena_catalog", required)
+
+    def get_athena_schema(self, required: bool = False) -> str | None:
+        return self._str_option("athena_schema", required)
+
+    def get_athena_staging_dir(self, required: bool = False) -> str | None:
+        return self._str_option("athena_staging_dir", required)
+
     # --- azure ---
     def get_azure_connection_string(self, required: bool = False) -> str | None:
         return self._str_option("azure_connection_string", required)
@@ -378,6 +470,12 @@ class Config(BaseSettings):
     def get_bigquery_impersonation_account(self, required: bool = False) -> str | None:
         return self._str_option("bigquery_impersonation_account", required)
 
+    def get_bigquery_project(self, required: bool = False) -> str | None:
+        return self._str_option("bigquery_project", required)
+
+    def get_bigquery_dataset(self, required: bool = False) -> str | None:
+        return self._str_option("bigquery_dataset", required)
+
     # --- databricks ---
     def get_databricks_server_hostname(self, required: bool = False) -> str | None:
         return self._str_option("databricks_server_hostname", required)
@@ -399,6 +497,12 @@ class Config(BaseSettings):
 
     def get_databricks_auth_type(self, required: bool = False) -> str | None:
         return self._str_option("databricks_auth_type", required)
+
+    def get_databricks_catalog(self, required: bool = False) -> str | None:
+        return self._str_option("databricks_catalog", required)
+
+    def get_databricks_schema(self, required: bool = False) -> str | None:
+        return self._str_option("databricks_schema", required)
 
     # --- gcs ---
     def get_gcs_key_id(self, required: bool = False) -> str | None:
@@ -426,6 +530,15 @@ class Config(BaseSettings):
     def get_impala_use_http_transport(self, default: bool = False) -> bool:
         return self._bool_option("impala_use_http_transport", default)
 
+    def get_impala_host(self, required: bool = False) -> str | None:
+        return self._str_option("impala_host", required)
+
+    def get_impala_port(self) -> int | None:
+        return self._int_option("impala_port")
+
+    def get_impala_database(self, required: bool = False) -> str | None:
+        return self._str_option("impala_database", required)
+
     # --- kafka ---
     def get_kafka_sasl_username(self, required: bool = False) -> str | None:
         return self._str_option("kafka_sasl_username", required)
@@ -452,6 +565,15 @@ class Config(BaseSettings):
     def get_mysql_password(self, required: bool = False) -> str | None:
         return self._str_option("mysql_password", required)
 
+    def get_mysql_host(self, required: bool = False) -> str | None:
+        return self._str_option("mysql_host", required)
+
+    def get_mysql_port(self) -> int | None:
+        return self._int_option("mysql_port")
+
+    def get_mysql_database(self, required: bool = False) -> str | None:
+        return self._str_option("mysql_database", required)
+
     # --- oracle ---
     def get_oracle_username(self, required: bool = False) -> str | None:
         return self._str_option("oracle_username", required)
@@ -461,6 +583,15 @@ class Config(BaseSettings):
 
     def get_oracle_client_dir(self, required: bool = False) -> str | None:
         return self._str_option("oracle_client_dir", required)
+
+    def get_oracle_host(self, required: bool = False) -> str | None:
+        return self._str_option("oracle_host", required)
+
+    def get_oracle_port(self) -> int | None:
+        return self._int_option("oracle_port")
+
+    def get_oracle_service_name(self, required: bool = False) -> str | None:
+        return self._str_option("oracle_service_name", required)
 
     # --- postgres ---
     def get_postgres_username(self, required: bool = False) -> str | None:
@@ -514,6 +645,18 @@ class Config(BaseSettings):
 
     def get_redshift_duration_seconds(self) -> int | None:
         return self._int_option("redshift_duration_seconds")
+
+    def get_redshift_host(self, required: bool = False) -> str | None:
+        return self._str_option("redshift_host", required)
+
+    def get_redshift_port(self) -> int | None:
+        return self._int_option("redshift_port")
+
+    def get_redshift_database(self, required: bool = False) -> str | None:
+        return self._str_option("redshift_database", required)
+
+    def get_redshift_schema(self, required: bool = False) -> str | None:
+        return self._str_option("redshift_schema", required)
 
     # --- s3 ---
     def get_s3_access_key_id(self, required: bool = False) -> str | None:
@@ -595,6 +738,15 @@ class Config(BaseSettings):
     def get_snowflake_connection_timeout(self) -> int | None:
         return self._int_option("snowflake_connection_timeout")
 
+    def get_snowflake_account(self, required: bool = False) -> str | None:
+        return self._str_option("snowflake_account", required)
+
+    def get_snowflake_database(self, required: bool = False) -> str | None:
+        return self._str_option("snowflake_database", required)
+
+    def get_snowflake_schema(self, required: bool = False) -> str | None:
+        return self._str_option("snowflake_schema", required)
+
     # --- sqlserver ---
     def get_sqlserver_authentication(self, required: bool = False) -> str | None:
         return self._str_option("sqlserver_authentication", required)
@@ -623,6 +775,15 @@ class Config(BaseSettings):
     def get_sqlserver_trusted_connection(self, default: bool = False) -> bool:
         return self._bool_option("sqlserver_trusted_connection", default)
 
+    def get_sqlserver_host(self, required: bool = False) -> str | None:
+        return self._str_option("sqlserver_host", required)
+
+    def get_sqlserver_port(self) -> int | None:
+        return self._int_option("sqlserver_port")
+
+    def get_sqlserver_database(self, required: bool = False) -> str | None:
+        return self._str_option("sqlserver_database", required)
+
     # --- trino ---
     def get_trino_authentication(self, required: bool = False) -> str | None:
         return self._str_option("trino_authentication", required)
@@ -635,6 +796,18 @@ class Config(BaseSettings):
 
     def get_trino_jwt_token(self, required: bool = False) -> str | None:
         return self._str_option("trino_jwt_token", required)
+
+    def get_trino_host(self, required: bool = False) -> str | None:
+        return self._str_option("trino_host", required)
+
+    def get_trino_port(self) -> int | None:
+        return self._int_option("trino_port")
+
+    def get_trino_catalog(self, required: bool = False) -> str | None:
+        return self._str_option("trino_catalog", required)
+
+    def get_trino_schema(self, required: bool = False) -> str | None:
+        return self._str_option("trino_schema", required)
 
     def to_env_dict(self) -> dict[str, str]:
         """Flatten to a dict keyed by the env var names."""

--- a/datacontract/engines/ibis/connections/connect.py
+++ b/datacontract/engines/ibis/connections/connect.py
@@ -112,13 +112,15 @@ def connect_ibis(
         from datacontract.engines.ibis.connections.redshift_credentials import resolve_redshift_login
         from datacontract.engines.ibis.connections.redshift_patch import CLIENT_ENCODING
 
-        login = resolve_redshift_login(server.host, server.database, config)
+        host = config.get_redshift_host() or server.host
+        database = config.get_redshift_database() or server.database
+        login = resolve_redshift_login(host, database, config)
         kwargs = dict(
-            host=server.host,
-            port=int(server.port) if server.port else 5439,
+            host=host,
+            port=config.get_redshift_port() or (int(server.port) if server.port else 5439),
             user=login.user,
-            database=server.database,
-            schema=server.schema_,
+            database=database,
+            schema=config.get_redshift_schema() or server.schema_,
             client_encoding=CLIENT_ENCODING,
         )
         if login.password:
@@ -143,18 +145,20 @@ def connect_ibis(
     if server_type == "bigquery":
         credentials = _bigquery_credentials(config)
         billing_project = config.get_bigquery_billing_project()
+        project = config.get_bigquery_project() or server.project
+        dataset = config.get_bigquery_dataset() or server.dataset
 
-        if billing_project and billing_project != server.project:
+        if billing_project and billing_project != project:
             from google.cloud import bigquery as bq_client_lib
 
             client = bq_client_lib.Client(project=billing_project, credentials=credentials)
             return ibis.bigquery.connect(
-                project_id=server.project,
-                dataset_id=server.dataset,
+                project_id=project,
+                dataset_id=dataset,
                 client=client,
             )
 
-        kwargs = dict(project_id=server.project, dataset_id=server.dataset)
+        kwargs = dict(project_id=project, dataset_id=dataset)
         if credentials:
             kwargs["credentials"] = credentials
         return ibis.bigquery.connect(**kwargs)
@@ -166,15 +170,15 @@ def connect_ibis(
     if server_type == "oracle":
         from datacontract.engines.ibis.connections.oracle_patch import apply_oracle_compatibility_patch
 
-        service_name = server.serviceName or server.database
+        service_name = config.get_oracle_service_name() or server.serviceName or server.database
         oracle_client_dir = config.get_oracle_client_dir()
         if oracle_client_dir:
             import oracledb
 
             oracledb.init_oracle_client(lib_dir=oracle_client_dir)
         con = ibis.oracle.connect(
-            host=server.host,
-            port=int(server.port) if server.port else 1521,
+            host=config.get_oracle_host() or server.host,
+            port=config.get_oracle_port() or (int(server.port) if server.port else 1521),
             user=config.get_oracle_username(required=True),
             password=config.get_oracle_password(required=True),
             service_name=service_name,
@@ -213,12 +217,15 @@ def _connect_databricks(ibis, server: Server, run: Run, config: Config):
     The OAuth credential providers build their SDK ``Config`` lazily, so token
     exchange happens when the connection is opened rather than while reading env.
     """
-    host = server.host or config.get_databricks_server_hostname(required=True)
+    # the config option wins over the contract, like the other server-detail overrides
+    host = (
+        config.get_databricks_server_hostname() or server.host or config.get_databricks_server_hostname(required=True)
+    )
     kwargs = dict(
         server_hostname=host,
         http_path=config.get_databricks_http_path(),
-        catalog=server.catalog,
-        schema=server.schema_,
+        catalog=config.get_databricks_catalog() or server.catalog,
+        schema=config.get_databricks_schema() or server.schema_,
     )
 
     token = config.get_databricks_token()
@@ -333,11 +340,11 @@ def _connect_impala(ibis, server: Server, config: Config):
     true since Impala support landed and stays that way.
     """
     return ibis.impala.connect(
-        host=server.host,
-        port=int(server.port) if server.port else 21050,
+        host=config.get_impala_host() or server.host,
+        port=config.get_impala_port() or (int(server.port) if server.port else 21050),
         user=config.get_impala_username(),
         password=config.get_impala_password(),
-        database=getattr(server, "database", None),
+        database=config.get_impala_database() or getattr(server, "database", None),
         use_ssl=config.get_impala_use_ssl(default=True),
         auth_mechanism=(config.get_impala_auth_mechanism() or "NOSASL"),
         use_http_transport=config.get_impala_use_http_transport(default=False),
@@ -393,8 +400,9 @@ def _snowflake_connection_kwargs(server: Server, run: Run, config: Config) -> di
     Every option is enumerated; the old behavior of forwarding any
     DATACONTRACT_SNOWFLAKE_* variable verbatim is gone (unknown names are warned
     about instead — see unknown_snowflake_env_names). ``account``, ``database``
-    and ``schema`` always come from the ODCS server object; the driver's ``user``
-    parameter keeps its DATACONTRACT_SNOWFLAKE_USERNAME spelling.
+    and ``schema`` come from the ODCS server object unless the matching config
+    option overrides them; the driver's ``user`` parameter keeps its
+    DATACONTRACT_SNOWFLAKE_USERNAME spelling.
     """
     for name in unknown_snowflake_env_names():
         run.log_warn(
@@ -451,9 +459,9 @@ def _snowflake_connection_kwargs(server: Server, run: Run, config: Config) -> di
     # let users opt back in via DATACONTRACT_SNOWFLAKE_CREATE_OBJECT_UDFS=true.
     return dict(
         create_object_udfs=config.get_snowflake_create_object_udfs(default=False),
-        account=server.account,
-        database=server.database,
-        schema=server.schema_,
+        account=config.get_snowflake_account() or server.account,
+        database=config.get_snowflake_database() or server.database,
+        schema=config.get_snowflake_schema() or server.schema_,
         **kwargs,
     )
 
@@ -473,9 +481,9 @@ def _connect_mysql_via_duckdb(ibis, data_contract, server: Server, run: Run, sch
 
     user = config.get_mysql_username(required=True)
     password = config.get_mysql_password(required=True)
-    host = server.host or "localhost"
-    port = int(server.port) if server.port else 3306
-    database = server.database
+    host = config.get_mysql_host() or server.host or "localhost"
+    port = config.get_mysql_port() or (int(server.port) if server.port else 3306)
+    database = config.get_mysql_database() or server.database
 
     con = duckdb.connect()
     _load_extension(con, "mysql", "mysql")
@@ -567,9 +575,9 @@ def _sqlserver_connection_kwargs(server: Server, config: Config) -> dict:
             )
 
     kwargs = dict(
-        host=server.host,
-        port=int(server.port) if server.port else 1433,
-        database=server.database,
+        host=config.get_sqlserver_host() or server.host,
+        port=config.get_sqlserver_port() or (int(server.port) if server.port else 1433),
+        database=config.get_sqlserver_database() or server.database,
         driver=driver,
         user=None,
         password=None,
@@ -611,14 +619,17 @@ def _sqlserver_connection_kwargs(server: Server, config: Config) -> dict:
 def _connect_athena(ibis, server: Server, config: Config):
     # regionName is a contract value, so the variable still wins over it
     credentials = aws_credentials.client_kwargs(aws_credentials.configured_region(server.regionName, config), config)
-    if not server.schema_:
+    schema = config.get_athena_schema() or server.schema_
+    staging_dir = config.get_athena_staging_dir() or getattr(server, "stagingDir", None)
+    catalog = config.get_athena_catalog() or server.catalog
+    if not schema:
         raise DataContractException(
             type="athena-connection",
             name="missing_schema",
             reason="Schema is required for Athena connection.",
             engine="datacontract",
         )
-    if not getattr(server, "stagingDir", None):
+    if not staging_dir:
         raise DataContractException(
             type="athena-connection",
             name="missing_s3_staging_dir",
@@ -626,16 +637,16 @@ def _connect_athena(ibis, server: Server, config: Config):
             engine="datacontract",
         )
     kwargs = dict(
-        s3_staging_dir=server.stagingDir,
+        s3_staging_dir=staging_dir,
         aws_access_key_id=credentials["aws_access_key_id"],
         aws_secret_access_key=credentials["aws_secret_access_key"],
         aws_session_token=credentials["aws_session_token"],
         region_name=credentials["region_name"],
-        schema_name=server.schema_,
+        schema_name=schema,
     )
     # Optional data source / catalog; pyathena defaults it to `awsdatacatalog`.
-    if server.catalog:
-        kwargs["catalog_name"] = server.catalog
+    if catalog:
+        kwargs["catalog_name"] = catalog
     return ibis.athena.connect(**kwargs)
 
 
@@ -643,11 +654,11 @@ def _connect_trino(ibis, server: Server, config: Config):
     authentication = (config.get_trino_authentication() or "basic").strip().lower()
 
     kwargs = dict(
-        host=server.host,
-        port=int(server.port) if server.port else 8080,
+        host=config.get_trino_host() or server.host,
+        port=config.get_trino_port() or (int(server.port) if server.port else 8080),
         user=None,
-        database=server.catalog,
-        schema=server.schema_,
+        database=config.get_trino_catalog() or server.catalog,
+        schema=config.get_trino_schema() or server.schema_,
     )
 
     if authentication == "basic":

--- a/datacontract/engines/ibis/connections/connect.py
+++ b/datacontract/engines/ibis/connections/connect.py
@@ -100,12 +100,12 @@ def connect_ibis(
 
     if server_type == "postgres":
         return ibis.postgres.connect(
-            host=server.host,
-            port=int(server.port) if server.port else 5432,
+            host=config.get_postgres_host() or server.host,
+            port=config.get_postgres_port() or (int(server.port) if server.port else 5432),
             user=config.get_postgres_username(required=True),
             password=config.get_postgres_password(required=True),
-            database=server.database,
-            schema=server.schema_,
+            database=config.get_postgres_database() or server.database,
+            schema=config.get_postgres_schema() or server.schema_,
         )
 
     if server_type == "redshift":

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -197,6 +197,10 @@ Every option, by its environment variable name and the matching `Config` field. 
 |---|---|---|---|
 | `DATACONTRACT_POSTGRES_USERNAME` | `postgres_username` | string |  |
 | `DATACONTRACT_POSTGRES_PASSWORD` | `postgres_password` | string (secret) |  |
+| `DATACONTRACT_POSTGRES_HOST` | `postgres_host` | string |  |
+| `DATACONTRACT_POSTGRES_PORT` | `postgres_port` | integer |  |
+| `DATACONTRACT_POSTGRES_DATABASE` | `postgres_database` | string |  |
+| `DATACONTRACT_POSTGRES_SCHEMA` | `postgres_schema` | string |  |
 
 ### Redshift
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -117,6 +117,14 @@ Every option, by its environment variable name and the matching `Config` field. 
 | `DATACONTRACT_API_HEADER_AUTHORIZATION` | `api_header_authorization` | string (secret) |  |
 | `DATACONTRACT_MAX_ERRORS` | `max_errors` | integer |  |
 
+### Athena
+
+| Environment variable | `Config` field | Type | Notes |
+|---|---|---|---|
+| `DATACONTRACT_ATHENA_CATALOG` | `athena_catalog` | string | Overrides `catalog` from the contract's `servers` block |
+| `DATACONTRACT_ATHENA_SCHEMA` | `athena_schema` | string | Overrides `schema` from the contract's `servers` block |
+| `DATACONTRACT_ATHENA_STAGING_DIR` | `athena_staging_dir` | string | Overrides `stagingDir` from the contract's `servers` block |
+
 ### Azure
 
 | Environment variable | `Config` field | Type | Notes |
@@ -134,18 +142,22 @@ Every option, by its environment variable name and the matching `Config` field. 
 | `DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH` | `bigquery_account_info_json_path` | string |  |
 | `DATACONTRACT_BIGQUERY_BILLING_PROJECT` | `bigquery_billing_project` | string |  |
 | `DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT` | `bigquery_impersonation_account` | string |  |
+| `DATACONTRACT_BIGQUERY_PROJECT` | `bigquery_project` | string | Overrides `project` from the contract's `servers` block |
+| `DATACONTRACT_BIGQUERY_DATASET` | `bigquery_dataset` | string | Overrides `dataset` from the contract's `servers` block |
 
 ### Databricks
 
 | Environment variable | `Config` field | Type | Notes |
 |---|---|---|---|
-| `DATACONTRACT_DATABRICKS_SERVER_HOSTNAME` | `databricks_server_hostname` | string |  |
+| `DATACONTRACT_DATABRICKS_SERVER_HOSTNAME` | `databricks_server_hostname` | string | Overrides `host` from the contract's `servers` block |
 | `DATACONTRACT_DATABRICKS_HTTP_PATH` | `databricks_http_path` | string |  |
 | `DATACONTRACT_DATABRICKS_TOKEN` | `databricks_token` | string (secret) |  |
 | `DATACONTRACT_DATABRICKS_CLIENT_ID` | `databricks_client_id` | string |  |
 | `DATACONTRACT_DATABRICKS_CLIENT_SECRET` | `databricks_client_secret` | string (secret) |  |
 | `DATACONTRACT_DATABRICKS_PROFILE` | `databricks_profile` | string |  |
 | `DATACONTRACT_DATABRICKS_AUTH_TYPE` | `databricks_auth_type` | string |  |
+| `DATACONTRACT_DATABRICKS_CATALOG` | `databricks_catalog` | string | Overrides `catalog` from the contract's `servers` block |
+| `DATACONTRACT_DATABRICKS_SCHEMA` | `databricks_schema` | string | Overrides `schema` from the contract's `servers` block |
 
 ### GCS
 
@@ -164,6 +176,9 @@ Every option, by its environment variable name and the matching `Config` field. 
 | `DATACONTRACT_IMPALA_HTTP_PATH` | `impala_http_path` | string |  |
 | `DATACONTRACT_IMPALA_USE_SSL` | `impala_use_ssl` | boolean |  |
 | `DATACONTRACT_IMPALA_USE_HTTP_TRANSPORT` | `impala_use_http_transport` | boolean |  |
+| `DATACONTRACT_IMPALA_HOST` | `impala_host` | string | Overrides `host` from the contract's `servers` block |
+| `DATACONTRACT_IMPALA_PORT` | `impala_port` | integer | Overrides `port` from the contract's `servers` block |
+| `DATACONTRACT_IMPALA_DATABASE` | `impala_database` | string | Overrides `database` from the contract's `servers` block |
 
 ### Kafka
 
@@ -182,6 +197,9 @@ Every option, by its environment variable name and the matching `Config` field. 
 |---|---|---|---|
 | `DATACONTRACT_MYSQL_USERNAME` | `mysql_username` | string |  |
 | `DATACONTRACT_MYSQL_PASSWORD` | `mysql_password` | string (secret) |  |
+| `DATACONTRACT_MYSQL_HOST` | `mysql_host` | string | Overrides `host` from the contract's `servers` block |
+| `DATACONTRACT_MYSQL_PORT` | `mysql_port` | integer | Overrides `port` from the contract's `servers` block |
+| `DATACONTRACT_MYSQL_DATABASE` | `mysql_database` | string | Overrides `database` from the contract's `servers` block |
 
 ### Oracle
 
@@ -190,6 +208,9 @@ Every option, by its environment variable name and the matching `Config` field. 
 | `DATACONTRACT_ORACLE_USERNAME` | `oracle_username` | string |  |
 | `DATACONTRACT_ORACLE_PASSWORD` | `oracle_password` | string (secret) |  |
 | `DATACONTRACT_ORACLE_CLIENT_DIR` | `oracle_client_dir` | string |  |
+| `DATACONTRACT_ORACLE_HOST` | `oracle_host` | string | Overrides `host` from the contract's `servers` block |
+| `DATACONTRACT_ORACLE_PORT` | `oracle_port` | integer | Overrides `port` from the contract's `servers` block |
+| `DATACONTRACT_ORACLE_SERVICE_NAME` | `oracle_service_name` | string | Overrides `serviceName` from the contract's `servers` block |
 
 ### Postgres
 
@@ -197,10 +218,10 @@ Every option, by its environment variable name and the matching `Config` field. 
 |---|---|---|---|
 | `DATACONTRACT_POSTGRES_USERNAME` | `postgres_username` | string |  |
 | `DATACONTRACT_POSTGRES_PASSWORD` | `postgres_password` | string (secret) |  |
-| `DATACONTRACT_POSTGRES_HOST` | `postgres_host` | string |  |
-| `DATACONTRACT_POSTGRES_PORT` | `postgres_port` | integer |  |
-| `DATACONTRACT_POSTGRES_DATABASE` | `postgres_database` | string |  |
-| `DATACONTRACT_POSTGRES_SCHEMA` | `postgres_schema` | string |  |
+| `DATACONTRACT_POSTGRES_HOST` | `postgres_host` | string | Overrides `host` from the contract's `servers` block |
+| `DATACONTRACT_POSTGRES_PORT` | `postgres_port` | integer | Overrides `port` from the contract's `servers` block |
+| `DATACONTRACT_POSTGRES_DATABASE` | `postgres_database` | string | Overrides `database` from the contract's `servers` block |
+| `DATACONTRACT_POSTGRES_SCHEMA` | `postgres_schema` | string | Overrides `schema` from the contract's `servers` block |
 
 ### Redshift
 
@@ -217,6 +238,10 @@ Every option, by its environment variable name and the matching `Config` field. 
 | `DATACONTRACT_REDSHIFT_CLUSTER_IDENTIFIER` | `redshift_cluster_identifier` | string |  |
 | `DATACONTRACT_REDSHIFT_REGION` | `redshift_region` | string |  |
 | `DATACONTRACT_REDSHIFT_DURATION_SECONDS` | `redshift_duration_seconds` | integer |  |
+| `DATACONTRACT_REDSHIFT_HOST` | `redshift_host` | string | Overrides `host` from the contract's `servers` block |
+| `DATACONTRACT_REDSHIFT_PORT` | `redshift_port` | integer | Overrides `port` from the contract's `servers` block |
+| `DATACONTRACT_REDSHIFT_DATABASE` | `redshift_database` | string | Overrides `database` from the contract's `servers` block |
+| `DATACONTRACT_REDSHIFT_SCHEMA` | `redshift_schema` | string | Overrides `schema` from the contract's `servers` block |
 
 ### S3 / AWS (also Athena, Redshift IAM, Glue)
 
@@ -253,6 +278,9 @@ Every option, by its environment variable name and the matching `Config` field. 
 | `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_PATH` | `snowflake_private_key_path` | string | Deprecated, use `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_FILE` |
 | `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE` | `snowflake_private_key_passphrase` | string (secret) | Deprecated, use `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_FILE_PWD` |
 | `DATACONTRACT_SNOWFLAKE_CONNECTION_TIMEOUT` | `snowflake_connection_timeout` | integer | Deprecated, use `DATACONTRACT_SNOWFLAKE_LOGIN_TIMEOUT` |
+| `DATACONTRACT_SNOWFLAKE_ACCOUNT` | `snowflake_account` | string | Overrides `account` from the contract's `servers` block |
+| `DATACONTRACT_SNOWFLAKE_DATABASE` | `snowflake_database` | string | Overrides `database` from the contract's `servers` block |
+| `DATACONTRACT_SNOWFLAKE_SCHEMA` | `snowflake_schema` | string | Overrides `schema` from the contract's `servers` block |
 
 ### SQL Server
 
@@ -267,6 +295,9 @@ Every option, by its environment variable name and the matching `Config` field. 
 | `DATACONTRACT_SQLSERVER_ENCRYPTED_CONNECTION` | `sqlserver_encrypted_connection` | boolean |  |
 | `DATACONTRACT_SQLSERVER_TRUST_SERVER_CERTIFICATE` | `sqlserver_trust_server_certificate` | boolean |  |
 | `DATACONTRACT_SQLSERVER_TRUSTED_CONNECTION` | `sqlserver_trusted_connection` | boolean |  |
+| `DATACONTRACT_SQLSERVER_HOST` | `sqlserver_host` | string | Overrides `host` from the contract's `servers` block |
+| `DATACONTRACT_SQLSERVER_PORT` | `sqlserver_port` | integer | Overrides `port` from the contract's `servers` block |
+| `DATACONTRACT_SQLSERVER_DATABASE` | `sqlserver_database` | string | Overrides `database` from the contract's `servers` block |
 
 ### Trino
 
@@ -276,6 +307,10 @@ Every option, by its environment variable name and the matching `Config` field. 
 | `DATACONTRACT_TRINO_USERNAME` | `trino_username` | string |  |
 | `DATACONTRACT_TRINO_PASSWORD` | `trino_password` | string (secret) |  |
 | `DATACONTRACT_TRINO_JWT_TOKEN` | `trino_jwt_token` | string (secret) |  |
+| `DATACONTRACT_TRINO_HOST` | `trino_host` | string | Overrides `host` from the contract's `servers` block |
+| `DATACONTRACT_TRINO_PORT` | `trino_port` | integer | Overrides `port` from the contract's `servers` block |
+| `DATACONTRACT_TRINO_CATALOG` | `trino_catalog` | string | Overrides `catalog` from the contract's `servers` block |
+| `DATACONTRACT_TRINO_SCHEMA` | `trino_schema` | string | Overrides `schema` from the contract's `servers` block |
 
 {/* END AUTOGENERATED CONFIG OPTIONS */}
 

--- a/docs/docs/reference/athena.md
+++ b/docs/docs/reference/athena.md
@@ -34,7 +34,7 @@ Set the variables below only to override that with static keys:
 | `DATACONTRACT_S3_SECRET_ACCESS_KEY` | `93S7LRrJ...` | AWS Secret Access Key |
 | `DATACONTRACT_S3_SESSION_TOKEN` | `AQoDYXdzEJr...` | AWS temporary session token (optional) |
 
-`catalog`, `schema` (the Athena database), `regionName`, and `stagingDir` (required, for query results) come from the contract's `servers` block; `DATACONTRACT_S3_REGION` takes precedence over `regionName` when both are set. The credentials need `athena:StartQueryExecution` plus read access to the data and write access to `stagingDir`, and `glue:GetTables` to import.
+`catalog`, `schema` (the Athena database), `regionName`, and `stagingDir` (required, for query results) come from the contract's `servers` block; they can be overridden with `DATACONTRACT_ATHENA_CATALOG`, `DATACONTRACT_ATHENA_SCHEMA`, `DATACONTRACT_S3_REGION` (takes precedence over `regionName`), and `DATACONTRACT_ATHENA_STAGING_DIR`. The credentials need `athena:StartQueryExecution` plus read access to the data and write access to `stagingDir`, and `glue:GetTables` to import.
 
 ## Data types
 

--- a/docs/docs/reference/bigquery.md
+++ b/docs/docs/reference/bigquery.md
@@ -29,7 +29,7 @@ Authentication uses a Service Account Key or Application Default Credentials (AD
 | `DATACONTRACT_BIGQUERY_BILLING_PROJECT` | `my-compute-project` | Optional. Project to bill query jobs to. Requires `bigquery.jobUser` on the billing project and `bigquery.dataViewer` on the data project. |
 | `DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT` | `runner@my-project.iam.gserviceaccount.com` | Optional. Service account to impersonate, using the key file above (or ADC) as the source principal. Requires `roles/iam.serviceAccountTokenCreator` on the target. |
 
-`project` and `dataset` come from the contract's `servers` block. `datacontract import bigquery` always uses ADC — set `GOOGLE_APPLICATION_CREDENTIALS` to point it at a key file.
+`project` and `dataset` come from the contract's `servers` block, and can be overridden with `DATACONTRACT_BIGQUERY_PROJECT` and `DATACONTRACT_BIGQUERY_DATASET`. `datacontract import bigquery` always uses ADC — set `GOOGLE_APPLICATION_CREDENTIALS` to point it at a key file.
 
 ## Data types
 

--- a/docs/docs/reference/databricks.md
+++ b/docs/docs/reference/databricks.md
@@ -31,7 +31,7 @@ servers:
 | `DATACONTRACT_DATABRICKS_PROFILE` | `my-profile` | A profile from `~/.databrickscfg` (Databricks SDK unified auth) |
 | `DATACONTRACT_DATABRICKS_AUTH_TYPE` | `databricks-oauth` | Explicit connector auth type, e.g. for interactive U2M browser login |
 
-The authentication method is selected from the variables you set, in this order: PAT → OAuth service principal (`CLIENT_ID` + `CLIENT_SECRET`) → config profile → explicit `AUTH_TYPE`. `catalog` and `schema` come from the contract's `servers` block.
+The authentication method is selected from the variables you set, in this order: PAT → OAuth service principal (`CLIENT_ID` + `CLIENT_SECRET`) → config profile → explicit `AUTH_TYPE`. `catalog` and `schema` come from the contract's `servers` block, and can be overridden with `DATACONTRACT_DATABRICKS_CATALOG` and `DATACONTRACT_DATABRICKS_SCHEMA`; `DATACONTRACT_DATABRICKS_SERVER_HOSTNAME` overrides the contract's `host`.
 
 `datacontract import unity` needs only the hostname plus a PAT or profile; `datacontract test` additionally needs `DATACONTRACT_DATABRICKS_HTTP_PATH`. When a `spark` session is passed programmatically (notebook/pipeline), no credentials are needed at all.
 

--- a/docs/docs/reference/impala.md
+++ b/docs/docs/reference/impala.md
@@ -33,7 +33,7 @@ servers:
 
 Apart from `use_ssl`, these default to the same values as the underlying [impyla](https://github.com/cloudera/impyla) driver.
 
-`host`, `port`, and `database` come from the contract's `servers` block. `port` defaults to `21050`, Impala's binary thrift port.
+`host`, `port`, and `database` come from the contract's `servers` block, and can be overridden with `DATACONTRACT_IMPALA_HOST`, `DATACONTRACT_IMPALA_PORT`, and `DATACONTRACT_IMPALA_DATABASE`. `port` defaults to `21050`, Impala's binary thrift port.
 
 ### Cloudera Virtual Warehouse
 

--- a/docs/docs/reference/mysql.md
+++ b/docs/docs/reference/mysql.md
@@ -27,7 +27,7 @@ servers:
 | `DATACONTRACT_MYSQL_USERNAME` | `root` | Username |
 | `DATACONTRACT_MYSQL_PASSWORD` | `mysecretpassword` | Password |
 
-`host`, `port` (default 3306), and `database` come from the contract's `servers` block.
+`host`, `port` (default 3306), and `database` come from the contract's `servers` block, and can be overridden with `DATACONTRACT_MYSQL_HOST`, `DATACONTRACT_MYSQL_PORT`, and `DATACONTRACT_MYSQL_DATABASE`.
 
 ## Data types
 

--- a/docs/docs/reference/oracle.md
+++ b/docs/docs/reference/oracle.md
@@ -29,7 +29,7 @@ servers:
 | `DATACONTRACT_ORACLE_PASSWORD` | `0x162e53` | Password |
 | `DATACONTRACT_ORACLE_CLIENT_DIR` | `C:\oracle\client` | Path to an Oracle Instant Client installation (required for thick mode) |
 
-`host`, `port` (default 1521), `service_name`, and `schema` come from the contract's `servers` block.
+`host`, `port` (default 1521), `service_name`, and `schema` come from the contract's `servers` block; `host`, `port`, and `service_name` can be overridden with `DATACONTRACT_ORACLE_HOST`, `DATACONTRACT_ORACLE_PORT`, and `DATACONTRACT_ORACLE_SERVICE_NAME`.
 
 ## Data types
 

--- a/docs/docs/reference/postgres.md
+++ b/docs/docs/reference/postgres.md
@@ -27,12 +27,8 @@ servers:
 |---|---|---|
 | `DATACONTRACT_POSTGRES_USERNAME` | `postgres` | Username |
 | `DATACONTRACT_POSTGRES_PASSWORD` | `mysecretpassword` | Password |
-| `DATACONTRACT_POSTGRES_HOST` | `localhost` | Overrides `host` from the `servers` block |
-| `DATACONTRACT_POSTGRES_PORT` | `5432` | Overrides `port` from the `servers` block |
-| `DATACONTRACT_POSTGRES_DATABASE` | `postgres` | Overrides `database` from the `servers` block |
-| `DATACONTRACT_POSTGRES_SCHEMA` | `public` | Overrides `schema` from the `servers` block |
 
-`host`, `port` (default 5432), `database`, and `schema` come from the contract's `servers` block, unless overridden with the variables above. For `datacontract import postgres`, they come from `--source`, `--port`, `--database`, and `--schema`.
+`host`, `port` (default 5432), `database`, and `schema` come from the contract's `servers` block, and can be overridden with `DATACONTRACT_POSTGRES_HOST`, `DATACONTRACT_POSTGRES_PORT`, `DATACONTRACT_POSTGRES_DATABASE`, and `DATACONTRACT_POSTGRES_SCHEMA`. For `datacontract import postgres`, they come from `--source`, `--port`, `--database`, and `--schema`.
 
 ## Data types
 

--- a/docs/docs/reference/postgres.md
+++ b/docs/docs/reference/postgres.md
@@ -27,8 +27,12 @@ servers:
 |---|---|---|
 | `DATACONTRACT_POSTGRES_USERNAME` | `postgres` | Username |
 | `DATACONTRACT_POSTGRES_PASSWORD` | `mysecretpassword` | Password |
+| `DATACONTRACT_POSTGRES_HOST` | `localhost` | Overrides `host` from the `servers` block |
+| `DATACONTRACT_POSTGRES_PORT` | `5432` | Overrides `port` from the `servers` block |
+| `DATACONTRACT_POSTGRES_DATABASE` | `postgres` | Overrides `database` from the `servers` block |
+| `DATACONTRACT_POSTGRES_SCHEMA` | `public` | Overrides `schema` from the `servers` block |
 
-`host`, `port` (default 5432), `database`, and `schema` come from the contract's `servers` block — or, for `datacontract import postgres`, from `--source`, `--port`, `--database`, and `--schema`.
+`host`, `port` (default 5432), `database`, and `schema` come from the contract's `servers` block, unless overridden with the variables above. For `datacontract import postgres`, they come from `--source`, `--port`, `--database`, and `--schema`.
 
 ## Data types
 

--- a/docs/docs/reference/redshift.md
+++ b/docs/docs/reference/redshift.md
@@ -23,7 +23,7 @@ servers:
 
 ## Authentication
 
-`datacontract test` and `datacontract import redshift` authenticate identically. `host`, `port` (default 5439), `database`, and `schema` come from the contract's `servers` block; for the import they are passed as `--source`, `--port`, `--database`, and `--schema`.
+`datacontract test` and `datacontract import redshift` authenticate identically. `host`, `port` (default 5439), `database`, and `schema` come from the contract's `servers` block, and can be overridden with `DATACONTRACT_REDSHIFT_HOST`, `DATACONTRACT_REDSHIFT_PORT`, `DATACONTRACT_REDSHIFT_DATABASE`, and `DATACONTRACT_REDSHIFT_SCHEMA`; for the import they are passed as `--source`, `--port`, `--database`, and `--schema`.
 
 | Variable | Example | Description |
 |---|---|---|

--- a/docs/docs/reference/snowflake.md
+++ b/docs/docs/reference/snowflake.md
@@ -38,7 +38,7 @@ Any `DATACONTRACT_SNOWFLAKE_`-prefixed variable is passed (lowercased, prefix st
 | `network_timeout` | `DATACONTRACT_SNOWFLAKE_NETWORK_TIMEOUT` |
 | `socket_timeout` | `DATACONTRACT_SNOWFLAKE_SOCKET_TIMEOUT` |
 
-`account`, `database`, and `schema` come from the contract's `servers` block.
+`account`, `database`, and `schema` come from the contract's `servers` block, and can be overridden with `DATACONTRACT_SNOWFLAKE_ACCOUNT`, `DATACONTRACT_SNOWFLAKE_DATABASE`, and `DATACONTRACT_SNOWFLAKE_SCHEMA`.
 
 For key-pair auth, set `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY_FILE` to the path of the key file and `..._PRIVATE_KEY_FILE_PWD` to its passphrase, if it has one. `..._PRIVATE_KEY` takes the key itself rather than a path.
 

--- a/docs/docs/reference/sqlserver.md
+++ b/docs/docs/reference/sqlserver.md
@@ -35,7 +35,7 @@ servers:
 | `DATACONTRACT_SQLSERVER_ENCRYPTED_CONNECTION` | `True` | Use SSL |
 | `DATACONTRACT_SQLSERVER_DRIVER` | `ODBC Driver 18 for SQL Server` | ODBC driver name |
 
-The `cli` mode reuses an `az login` session through the Azure default credential chain and requires ODBC Driver 18.1 or newer. `host`, `port`, `database`, `schema`, and `driver` come from the contract's `servers` block.
+The `cli` mode reuses an `az login` session through the Azure default credential chain and requires ODBC Driver 18.1 or newer. `host`, `port`, `database`, `schema`, and `driver` come from the contract's `servers` block; `host`, `port`, and `database` can be overridden with `DATACONTRACT_SQLSERVER_HOST`, `DATACONTRACT_SQLSERVER_PORT`, and `DATACONTRACT_SQLSERVER_DATABASE`.
 
 ### Deprecated variables
 

--- a/docs/docs/reference/trino.md
+++ b/docs/docs/reference/trino.md
@@ -30,7 +30,7 @@ servers:
 | `DATACONTRACT_TRINO_AUTHENTICATION` | `oauth2` | `basic` (default), `jwt`, or `oauth2` |
 | `DATACONTRACT_TRINO_JWT_TOKEN` | `eyJhbGciOi...` | JWT bearer token for `jwt` auth |
 
-`host`, `port`, `catalog`, and `schema` come from the contract's `servers` block.
+`host`, `port`, `catalog`, and `schema` come from the contract's `servers` block, and can be overridden with `DATACONTRACT_TRINO_HOST`, `DATACONTRACT_TRINO_PORT`, `DATACONTRACT_TRINO_CATALOG`, and `DATACONTRACT_TRINO_SCHEMA`.
 
 ## Data types
 

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -35,10 +35,12 @@ marked as such in the entry.
 - The API server accepts per-request credentials on `POST /test` via `datacontract-*` headers (e.g. `datacontract-snowflake-password`)
 - Credentials and connection options can be provided in a YAML config file, via `--config-file` (defaults to `./datacontract-config.yaml` or `~/.datacontract/config.yaml`) or `Config.from_yaml()`, with `${VAR}` references resolved from the environment
 - New Snowflake connection options: `DATACONTRACT_SNOWFLAKE_TOKEN`, `DATACONTRACT_SNOWFLAKE_PASSCODE`, `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY`, `DATACONTRACT_SNOWFLAKE_NETWORK_TIMEOUT`, `DATACONTRACT_SNOWFLAKE_SOCKET_TIMEOUT`, `DATACONTRACT_SNOWFLAKE_HOST`, `DATACONTRACT_SNOWFLAKE_PORT`
-- `DATACONTRACT_POSTGRES_HOST`, `DATACONTRACT_POSTGRES_PORT`, `DATACONTRACT_POSTGRES_DATABASE`, and `DATACONTRACT_POSTGRES_SCHEMA` override the Postgres server details from the data contract ([#1076](https://github.com/datacontract/datacontract-cli/issues/1076))
+- Config options to override the server details from the data contract (host, port, database, schema, catalog, project, dataset, account, service name, staging directory) for Postgres, MySQL, SQL Server, Oracle, Redshift, Snowflake, BigQuery, Databricks, Trino, Athena, and Impala, e.g. `DATACONTRACT_POSTGRES_HOST` ([#1076](https://github.com/datacontract/datacontract-cli/issues/1076))
 
 ### Changed
 - `datacontract test` against Snowflake only forwards the documented `DATACONTRACT_SNOWFLAKE_*` options to the connector; unknown variables are ignored with a warning
+- `DATACONTRACT_SNOWFLAKE_ACCOUNT` overrides the contract's `account` instead of being ignored with a warning
+- `DATACONTRACT_DATABRICKS_SERVER_HOSTNAME` overrides the contract's `host`; previously the contract value won when both were set
 
 ### Fixed
 - `datacontract dbt sync` writes a description on all dbt tests, not only newly-generated ones

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -35,6 +35,7 @@ marked as such in the entry.
 - The API server accepts per-request credentials on `POST /test` via `datacontract-*` headers (e.g. `datacontract-snowflake-password`)
 - Credentials and connection options can be provided in a YAML config file, via `--config-file` (defaults to `./datacontract-config.yaml` or `~/.datacontract/config.yaml`) or `Config.from_yaml()`, with `${VAR}` references resolved from the environment
 - New Snowflake connection options: `DATACONTRACT_SNOWFLAKE_TOKEN`, `DATACONTRACT_SNOWFLAKE_PASSCODE`, `DATACONTRACT_SNOWFLAKE_PRIVATE_KEY`, `DATACONTRACT_SNOWFLAKE_NETWORK_TIMEOUT`, `DATACONTRACT_SNOWFLAKE_SOCKET_TIMEOUT`, `DATACONTRACT_SNOWFLAKE_HOST`, `DATACONTRACT_SNOWFLAKE_PORT`
+- `DATACONTRACT_POSTGRES_HOST`, `DATACONTRACT_POSTGRES_PORT`, `DATACONTRACT_POSTGRES_DATABASE`, and `DATACONTRACT_POSTGRES_SCHEMA` override the Postgres server details from the data contract ([#1076](https://github.com/datacontract/datacontract-cli/issues/1076))
 
 ### Changed
 - `datacontract test` against Snowflake only forwards the documented `DATACONTRACT_SNOWFLAKE_*` options to the connector; unknown variables are ignored with a warning

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,12 @@ import pytest
 from pydantic import ValidationError
 
 from datacontract import Config
-from datacontract.config import known_env_names, unknown_snowflake_env_names
+from datacontract.config import SERVER_OVERRIDE_OPTIONS, known_env_names, unknown_snowflake_env_names
+
+
+def test_server_override_options_name_real_config_fields():
+    unknown = set(SERVER_OVERRIDE_OPTIONS) - set(Config.model_fields)
+    assert not unknown, f"SERVER_OVERRIDE_OPTIONS names undeclared Config fields: {sorted(unknown)}"
 
 
 def test_field_names_map_to_env_var_names():

--- a/tests/test_connect_athena.py
+++ b/tests/test_connect_athena.py
@@ -19,6 +19,9 @@ ATHENA_ENV_VARS = [
     "DATACONTRACT_S3_ACCESS_KEY_ID",
     "DATACONTRACT_S3_SECRET_ACCESS_KEY",
     "DATACONTRACT_S3_SESSION_TOKEN",
+    "DATACONTRACT_ATHENA_CATALOG",
+    "DATACONTRACT_ATHENA_SCHEMA",
+    "DATACONTRACT_ATHENA_STAGING_DIR",
 ]
 
 STAGING_DIR = "s3://my-bucket/athena-results/"
@@ -105,3 +108,15 @@ def test_missing_schema_is_rejected(env):
         _connect(server)
 
     assert "Schema is required" in exc_info.value.reason
+
+
+def test_env_variables_override_the_contract_server_details(env, monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_ATHENA_CATALOG", "env_catalog")
+    monkeypatch.setenv("DATACONTRACT_ATHENA_SCHEMA", "env_schema")
+    monkeypatch.setenv("DATACONTRACT_ATHENA_STAGING_DIR", "s3://env-bucket/results/")
+
+    kwargs = _connect(_server(regionName="eu-central-1", catalog="contract_catalog"))
+
+    assert kwargs["catalog_name"] == "env_catalog"
+    assert kwargs["schema_name"] == "env_schema"
+    assert kwargs["s3_staging_dir"] == "s3://env-bucket/results/"

--- a/tests/test_connect_bigquery.py
+++ b/tests/test_connect_bigquery.py
@@ -16,6 +16,8 @@ BIGQUERY_ENV_VARS = [
     "DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH",
     "DATACONTRACT_BIGQUERY_BILLING_PROJECT",
     "DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT",
+    "DATACONTRACT_BIGQUERY_PROJECT",
+    "DATACONTRACT_BIGQUERY_DATASET",
 ]
 
 SERVICE_ACCOUNT = "runner@my-project.iam.gserviceaccount.com"
@@ -93,3 +95,13 @@ def test_billing_project_client_uses_the_impersonated_credentials(env):
     assert client.call_args.kwargs["project"] == "my-billing-project"
     assert client.call_args.kwargs["credentials"] is impersonated.return_value
     assert kwargs["client"] is client.return_value
+
+
+def test_env_variables_override_the_contract_project_and_dataset(env):
+    env.setenv("DATACONTRACT_BIGQUERY_PROJECT", "env-project")
+    env.setenv("DATACONTRACT_BIGQUERY_DATASET", "env_dataset")
+
+    kwargs = _connect()
+
+    assert kwargs["project_id"] == "env-project"
+    assert kwargs["dataset_id"] == "env_dataset"

--- a/tests/test_connect_databricks.py
+++ b/tests/test_connect_databricks.py
@@ -19,6 +19,8 @@ DATABRICKS_ENV_VARS = [
     "DATACONTRACT_DATABRICKS_CLIENT_SECRET",
     "DATACONTRACT_DATABRICKS_PROFILE",
     "DATACONTRACT_DATABRICKS_AUTH_TYPE",
+    "DATACONTRACT_DATABRICKS_CATALOG",
+    "DATACONTRACT_DATABRICKS_SCHEMA",
 ]
 
 
@@ -186,3 +188,16 @@ def test_missing_auth_raises(clean_databricks_env, captured_connect):
 
     with pytest.raises(DataContractException):
         _connect()
+
+
+def test_env_variables_override_the_contract_server_details(clean_databricks_env, captured_connect):
+    clean_databricks_env.setenv("DATACONTRACT_DATABRICKS_TOKEN", "dapi-token")
+    clean_databricks_env.setenv("DATACONTRACT_DATABRICKS_SERVER_HOSTNAME", "from-env.cloud.databricks.com")
+    clean_databricks_env.setenv("DATACONTRACT_DATABRICKS_CATALOG", "env_catalog")
+    clean_databricks_env.setenv("DATACONTRACT_DATABRICKS_SCHEMA", "env_schema")
+
+    _connect()
+
+    assert captured_connect["server_hostname"] == "from-env.cloud.databricks.com"
+    assert captured_connect["catalog"] == "env_catalog"
+    assert captured_connect["schema"] == "env_schema"

--- a/tests/test_connect_impala.py
+++ b/tests/test_connect_impala.py
@@ -18,6 +18,9 @@ IMPALA_ENV_VARS = [
     "DATACONTRACT_IMPALA_AUTH_MECHANISM",
     "DATACONTRACT_IMPALA_USE_HTTP_TRANSPORT",
     "DATACONTRACT_IMPALA_HTTP_PATH",
+    "DATACONTRACT_IMPALA_HOST",
+    "DATACONTRACT_IMPALA_PORT",
+    "DATACONTRACT_IMPALA_DATABASE",
 ]
 
 
@@ -101,3 +104,15 @@ def test_options_are_overridable(env, captured_connect):
     assert captured_connect["use_ssl"] is False
     assert captured_connect["auth_mechanism"] == "GSSAPI"
     assert captured_connect["http_path"] == "impala/cliservice"
+
+
+def test_env_variables_override_the_contract_server_details(env, captured_connect):
+    env.setenv("DATACONTRACT_IMPALA_HOST", "env-host")
+    env.setenv("DATACONTRACT_IMPALA_PORT", "28000")
+    env.setenv("DATACONTRACT_IMPALA_DATABASE", "env_db")
+
+    _connect()
+
+    assert captured_connect["host"] == "env-host"
+    assert captured_connect["port"] == 28000
+    assert captured_connect["database"] == "env_db"

--- a/tests/test_connect_mysql.py
+++ b/tests/test_connect_mysql.py
@@ -1,0 +1,78 @@
+"""Unit tests for how connect_ibis attaches MySQL through DuckDB.
+
+These do not hit MySQL: ``duckdb.connect``, the extension loader, and the ibis
+wrapper are patched, and we only assert the ATTACH connection string built for
+a given set of env vars.
+"""
+
+import os
+
+import duckdb
+import ibis
+import pytest
+from open_data_contract_standard.model import OpenDataContractStandard, Server
+
+from datacontract.engines.ibis.connections.connect import connect_ibis
+from datacontract.model.run import Run
+
+
+@pytest.fixture
+def env(monkeypatch):
+    """The tests assert the exact connection string, so start from a clean slate."""
+    for name in list(os.environ):
+        if name.startswith("DATACONTRACT_MYSQL_"):
+            monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("DATACONTRACT_MYSQL_USERNAME", "reader")
+    monkeypatch.setenv("DATACONTRACT_MYSQL_PASSWORD", "secret")
+    return monkeypatch
+
+
+@pytest.fixture
+def captured_statements(monkeypatch):
+    statements = []
+
+    class FakeConnection:
+        def execute(self, sql):
+            statements.append(sql)
+
+    monkeypatch.setattr(duckdb, "connect", lambda: FakeConnection())
+    monkeypatch.setattr(
+        "datacontract.engines.ibis.connections.duckdb_connection._load_extension", lambda con, ext, name: None
+    )
+    monkeypatch.setattr(ibis.duckdb, "from_connection", lambda con: con)
+    return statements
+
+
+def _server():
+    return Server(server="mysql", type="mysql", host="contract-host", port=3307, database="contract_db")
+
+
+def _connect():
+    data_contract = OpenDataContractStandard(apiVersion="v3.0.2", kind="DataContract", id="test", version="1.0.0")
+    return connect_ibis(Run.create_run(), data_contract=data_contract, server=_server())
+
+
+def _attach_statement(statements):
+    return next(sql for sql in statements if sql.startswith("ATTACH"))
+
+
+def test_server_details_come_from_the_contract_by_default(env, captured_statements):
+    _connect()
+
+    attach = _attach_statement(captured_statements)
+    assert "host=contract-host" in attach
+    assert "port=3307" in attach
+    assert "database=contract_db" in attach
+
+
+def test_env_variables_override_the_contract_server_details(env, captured_statements):
+    env.setenv("DATACONTRACT_MYSQL_HOST", "env-host")
+    env.setenv("DATACONTRACT_MYSQL_PORT", "3308")
+    env.setenv("DATACONTRACT_MYSQL_DATABASE", "env_db")
+
+    _connect()
+
+    attach = _attach_statement(captured_statements)
+    assert "host=env-host" in attach
+    assert "port=3308" in attach
+    assert "database=env_db" in attach

--- a/tests/test_connect_oracle.py
+++ b/tests/test_connect_oracle.py
@@ -1,0 +1,73 @@
+"""Unit tests for how connect_ibis maps Oracle connection parameters.
+
+These do not hit Oracle: ``ibis.oracle.connect`` and the compatibility patch are
+patched, and we only assert which kwargs the dispatch passes for a given set of
+env vars.
+"""
+
+import os
+
+import ibis
+import pytest
+from open_data_contract_standard.model import Server
+
+from datacontract.engines.ibis.connections.connect import connect_ibis
+from datacontract.model.run import Run
+
+
+@pytest.fixture
+def env(monkeypatch):
+    """The tests assert the exact kwargs, so start from a clean slate."""
+    for name in list(os.environ):
+        if name.startswith("DATACONTRACT_ORACLE_"):
+            monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("DATACONTRACT_ORACLE_USERNAME", "reader")
+    monkeypatch.setenv("DATACONTRACT_ORACLE_PASSWORD", "secret")
+    return monkeypatch
+
+
+@pytest.fixture
+def captured_connect(monkeypatch):
+    calls = {}
+
+    def fake_connect(**kwargs):
+        calls.update(kwargs)
+        return "connection"
+
+    monkeypatch.setattr(ibis.oracle, "connect", fake_connect)
+    monkeypatch.setattr(
+        "datacontract.engines.ibis.connections.oracle_patch.apply_oracle_compatibility_patch", lambda con: None
+    )
+    return calls
+
+
+def _server():
+    return Server(server="oracle", type="oracle", host="contract-host", port=1522, serviceName="CONTRACT_SVC")
+
+
+def _connect(server=None):
+    return connect_ibis(Run.create_run(), data_contract=None, server=server or _server())
+
+
+def test_server_details_come_from_the_contract_by_default(env, captured_connect):
+    _connect()
+
+    assert captured_connect == {
+        "host": "contract-host",
+        "port": 1522,
+        "user": "reader",
+        "password": "secret",
+        "service_name": "CONTRACT_SVC",
+    }
+
+
+def test_env_variables_override_the_contract_server_details(env, captured_connect):
+    env.setenv("DATACONTRACT_ORACLE_HOST", "env-host")
+    env.setenv("DATACONTRACT_ORACLE_PORT", "1523")
+    env.setenv("DATACONTRACT_ORACLE_SERVICE_NAME", "ENV_SVC")
+
+    _connect()
+
+    assert captured_connect["host"] == "env-host"
+    assert captured_connect["port"] == 1523
+    assert captured_connect["service_name"] == "ENV_SVC"

--- a/tests/test_connect_postgres.py
+++ b/tests/test_connect_postgres.py
@@ -1,0 +1,87 @@
+"""Unit tests for how connect_ibis maps Postgres connection parameters.
+
+These do not hit Postgres: ``ibis.postgres.connect`` is patched and we only assert
+which kwargs the dispatch passes for a given set of env vars.
+"""
+
+import os
+
+import ibis
+import pytest
+from open_data_contract_standard.model import Server
+
+from datacontract.engines.ibis.connections.connect import connect_ibis
+from datacontract.model.run import Run
+
+
+@pytest.fixture
+def env(monkeypatch):
+    """The tests assert the exact kwargs, so start from a clean slate."""
+    for name in list(os.environ):
+        if name.startswith("DATACONTRACT_POSTGRES_"):
+            monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("DATACONTRACT_POSTGRES_USERNAME", "reader")
+    monkeypatch.setenv("DATACONTRACT_POSTGRES_PASSWORD", "secret")
+    return monkeypatch
+
+
+@pytest.fixture
+def captured_connect(monkeypatch):
+    calls = {}
+
+    def fake_connect(**kwargs):
+        calls.update(kwargs)
+        return "connection"
+
+    monkeypatch.setattr(ibis.postgres, "connect", fake_connect)
+    return calls
+
+
+def _server():
+    return Server(
+        server="postgres",
+        type="postgres",
+        host="contract-host",
+        port=5433,
+        database="contract_db",
+        schema="contract_schema",
+    )
+
+
+def _connect(server=None):
+    return connect_ibis(Run.create_run(), data_contract=None, server=server or _server(), config=None)
+
+
+def test_server_details_come_from_the_contract_by_default(env, captured_connect):
+    _connect()
+
+    assert captured_connect == {
+        "host": "contract-host",
+        "port": 5433,
+        "user": "reader",
+        "password": "secret",
+        "database": "contract_db",
+        "schema": "contract_schema",
+    }
+
+
+def test_env_variables_override_the_contract_server_details(env, captured_connect):
+    env.setenv("DATACONTRACT_POSTGRES_HOST", "env-host")
+    env.setenv("DATACONTRACT_POSTGRES_PORT", "6543")
+    env.setenv("DATACONTRACT_POSTGRES_DATABASE", "env_db")
+    env.setenv("DATACONTRACT_POSTGRES_SCHEMA", "env_schema")
+
+    _connect()
+
+    assert captured_connect["host"] == "env-host"
+    assert captured_connect["port"] == 6543
+    assert captured_connect["database"] == "env_db"
+    assert captured_connect["schema"] == "env_schema"
+
+
+def test_port_defaults_to_5432_when_the_contract_has_none(env, captured_connect):
+    server = Server(server="postgres", type="postgres", host="contract-host", database="db", schema="public")
+
+    _connect(server)
+
+    assert captured_connect["port"] == 5432

--- a/tests/test_connect_redshift.py
+++ b/tests/test_connect_redshift.py
@@ -23,6 +23,10 @@ REDSHIFT_ENV_VARS = [
     "DATACONTRACT_REDSHIFT_PASSWORD",
     "DATACONTRACT_REDSHIFT_SSLMODE",
     "DATACONTRACT_S3_REGION",
+    "DATACONTRACT_REDSHIFT_HOST",
+    "DATACONTRACT_REDSHIFT_PORT",
+    "DATACONTRACT_REDSHIFT_DATABASE",
+    "DATACONTRACT_REDSHIFT_SCHEMA",
 ]
 
 
@@ -78,3 +82,20 @@ def test_iam_authentication_uses_temporary_credentials(env, captured_connect):
     assert captured_connect["password"] == "temporary"
     assert captured_connect["sslmode"] == "require"
     client.get_credentials.assert_called_once_with(workgroupName="my-workgroup", dbName="dev")
+
+
+def test_env_variables_override_the_contract_server_details(env, captured_connect):
+    other_host = "other-workgroup.123456789012.us-east-1.redshift-serverless.amazonaws.com"
+    env.setenv("DATACONTRACT_REDSHIFT_USERNAME", "awsuser")
+    env.setenv("DATACONTRACT_REDSHIFT_PASSWORD", "mysecret")
+    env.setenv("DATACONTRACT_REDSHIFT_HOST", other_host)
+    env.setenv("DATACONTRACT_REDSHIFT_PORT", "5440")
+    env.setenv("DATACONTRACT_REDSHIFT_DATABASE", "env_db")
+    env.setenv("DATACONTRACT_REDSHIFT_SCHEMA", "env_schema")
+
+    connect_ibis(Run.create_run(), None, _server())
+
+    assert captured_connect["host"] == other_host
+    assert captured_connect["port"] == 5440
+    assert captured_connect["database"] == "env_db"
+    assert captured_connect["schema"] == "env_schema"

--- a/tests/test_connect_snowflake.py
+++ b/tests/test_connect_snowflake.py
@@ -134,17 +134,6 @@ def test_unknown_snowflake_variables_are_ignored_with_a_warning(env, captured_co
     assert any("DATACONTRACT_SNOWFLAKE_SESSION_PARAMETERS" in log.message for log in run.logs)
 
 
-def test_account_env_var_no_longer_collides_with_the_server_account(env, captured_connect):
-    """Used to raise ``TypeError: got multiple values for keyword argument 'account'``."""
-    env.setenv("DATACONTRACT_SNOWFLAKE_ACCOUNT", "other-account")
-    run = Run.create_run()
-
-    _connect(run)
-
-    assert captured_connect["account"] == "abc-xy123"
-    assert any("DATACONTRACT_SNOWFLAKE_ACCOUNT" in log.message for log in run.logs)
-
-
 def test_programmatic_config_reaches_the_connector(env, captured_connect):
     config = Config(
         snowflake_username="svc_test",
@@ -167,3 +156,18 @@ def test_programmatic_config_wins_over_the_environment(env, captured_connect):
     _connect(config=Config(snowflake_username="from_config"))
 
     assert captured_connect["user"] == "from_config"
+
+
+def test_env_variables_override_the_contract_server_details(env, captured_connect):
+    """Setting DATACONTRACT_SNOWFLAKE_ACCOUNT alongside a server account used to raise
+    ``TypeError: got multiple values for keyword argument 'account'``, then warn-and-ignore;
+    it is a supported override now."""
+    env.setenv("DATACONTRACT_SNOWFLAKE_ACCOUNT", "env-account")
+    env.setenv("DATACONTRACT_SNOWFLAKE_DATABASE", "ENV_DB")
+    env.setenv("DATACONTRACT_SNOWFLAKE_SCHEMA", "ENV_SCHEMA")
+
+    _connect()
+
+    assert captured_connect["account"] == "env-account"
+    assert captured_connect["database"] == "ENV_DB"
+    assert captured_connect["schema"] == "ENV_SCHEMA"

--- a/tests/test_connect_sqlserver.py
+++ b/tests/test_connect_sqlserver.py
@@ -31,6 +31,9 @@ SQLSERVER_ENV_VARS = [
     "DATACONTRACT_SQLSERVER_ENCRYPTED_CONNECTION",
     "DATACONTRACT_SQLSERVER_DRIVER",
     "DATACONTRACT_SQLSERVER_TRUSTED_CONNECTION",
+    "DATACONTRACT_SQLSERVER_HOST",
+    "DATACONTRACT_SQLSERVER_PORT",
+    "DATACONTRACT_SQLSERVER_DATABASE",
 ]
 
 
@@ -207,3 +210,17 @@ def test_server_fields_and_driver(env):
     assert kwargs["port"] == 1433
     assert kwargs["database"] == "mydb"
     assert kwargs["driver"] == "ODBC Driver 18 for SQL Server"
+
+
+def test_env_variables_override_the_contract_server_details(env):
+    env.setenv("DATACONTRACT_SQLSERVER_USERNAME", "sa")
+    env.setenv("DATACONTRACT_SQLSERVER_PASSWORD", "secret")
+    env.setenv("DATACONTRACT_SQLSERVER_HOST", "env-host")
+    env.setenv("DATACONTRACT_SQLSERVER_PORT", "1444")
+    env.setenv("DATACONTRACT_SQLSERVER_DATABASE", "env_db")
+
+    kwargs = _sqlserver_connection_kwargs(_server())
+
+    assert kwargs["host"] == "env-host"
+    assert kwargs["port"] == 1444
+    assert kwargs["database"] == "env_db"

--- a/tests/test_connect_trino.py
+++ b/tests/test_connect_trino.py
@@ -17,6 +17,10 @@ TRINO_ENV_VARS = [
     "DATACONTRACT_TRINO_USERNAME",
     "DATACONTRACT_TRINO_PASSWORD",
     "DATACONTRACT_TRINO_JWT_TOKEN",
+    "DATACONTRACT_TRINO_HOST",
+    "DATACONTRACT_TRINO_PORT",
+    "DATACONTRACT_TRINO_CATALOG",
+    "DATACONTRACT_TRINO_SCHEMA",
 ]
 
 
@@ -121,3 +125,18 @@ def test_basic_auth_requires_username(env, captured_connect):
         _connect()
 
     assert "DATACONTRACT_TRINO_USERNAME" in exc.value.reason
+
+
+def test_env_variables_override_the_contract_server_details(env, captured_connect):
+    env.setenv("DATACONTRACT_TRINO_USERNAME", "my_user")
+    env.setenv("DATACONTRACT_TRINO_HOST", "env-host")
+    env.setenv("DATACONTRACT_TRINO_PORT", "8443")
+    env.setenv("DATACONTRACT_TRINO_CATALOG", "env_catalog")
+    env.setenv("DATACONTRACT_TRINO_SCHEMA", "env_schema")
+
+    _connect()
+
+    assert captured_connect["host"] == "env-host"
+    assert captured_connect["port"] == 8443
+    assert captured_connect["database"] == "env_catalog"
+    assert captured_connect["schema"] == "env_schema"

--- a/update_config_options.py
+++ b/update_config_options.py
@@ -9,7 +9,7 @@ committed page is stale.
 
 from pathlib import Path
 
-from datacontract.config import DEPRECATED_OPTIONS, Config, env_name
+from datacontract.config import DEPRECATED_OPTIONS, SERVER_OVERRIDE_OPTIONS, Config, env_name
 
 DOCS_PAGE = Path(__file__).parent / "docs" / "docs" / "configuration.md"
 
@@ -24,6 +24,7 @@ GROUPS = {
     "datacontract_manager": "Entropy Data (publishing, remote contracts)",
     "api_header": "General",
     "max_errors": "General",
+    "athena": "Athena",
     "azure": "Azure",
     "bigquery": "BigQuery",
     "databricks": "Databricks",
@@ -68,6 +69,8 @@ def render_options_block() -> str:
             replacement = DEPRECATED_OPTIONS[name]
             replacement_env = env_name(replacement, Config.model_fields[replacement])
             notes = f"Deprecated, use `{replacement_env}`"
+        elif name in SERVER_OVERRIDE_OPTIONS:
+            notes = f"Overrides `{SERVER_OVERRIDE_OPTIONS[name]}` from the contract's `servers` block"
         row = f"| `{env_name(name, field)}` | `{name}` | {_type_label(field.annotation)} | {notes} |"
         sections.setdefault(heading, []).append(row)
 


### PR DESCRIPTION
Adds config options that override the corresponding values from the contract's `servers` block for `datacontract test`, for every SQL server type. When unset, the contract values (and the usual port defaults) are used.

| Server type | Overridable properties |
|---|---|
| Postgres | host, port, database, schema |
| Redshift | host, port, database, schema |
| MySQL | host, port, database |
| SQL Server | host, port, database |
| Oracle | host, port, serviceName |
| Trino | host, port, catalog, schema |
| Snowflake | account, database, schema |
| BigQuery | project, dataset |
| Databricks | host (via `SERVER_HOSTNAME`), catalog, schema |
| Athena | catalog, schema, stagingDir |
| Impala | host, port, database |

All options follow the `DATACONTRACT_<TYPE>_<PROPERTY>` naming and are implemented on the typed `Config` system, so they also work via the YAML config file, per-request API headers, and programmatic `Config` usage. `SERVER_OVERRIDE_OPTIONS` in `settings.py` records which option overrides which server property, and the generated Configuration docs page notes it per option; the per-server reference pages mention the override variables too.

Behavior changes:
- `DATACONTRACT_SNOWFLAKE_ACCOUNT` now overrides the contract's `account` instead of being ignored with a warning.
- `DATACONTRACT_DATABRICKS_SERVER_HOSTNAME` now wins over the contract's `host`; previously the contract value won when both were set.

Replaces #1076, which targeted the removed Soda engine.

Tests: kwargs-capture unit tests for every backend (new `tests/test_connect_mysql.py` and `tests/test_connect_oracle.py`, override tests added to the existing `test_connect_*` files), plus a guard that `SERVER_OVERRIDE_OPTIONS` only names declared `Config` fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)