### PR TITLE
Sign released Docker images with cosign

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -164,6 +164,9 @@ jobs:
     needs:
       - test
       - check_version
+    permissions:
+      contents: read
+      id-token: write  # IMPORTANT: mandatory for keyless signing with cosign
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -195,6 +198,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -207,14 +211,23 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           sbom: true
           provenance: mode=max
+      - name: Install cosign
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: sigstore/cosign-installer@v3
+      - name: Sign the image with cosign (keyless)
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        # Sign the immutable digest of the multi-arch index, not the mutable tags.
+        run: cosign sign --yes "datacontract/cli@${DIGEST}"
 
   push-to-ecr:
     runs-on: ubuntu-latest
     needs:
       - docker
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
 
       - name: Set up AWS CLI
         uses: aws-actions/configure-aws-credentials@v4
@@ -234,10 +247,13 @@ jobs:
           aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/s4e5k7s9
 
       - name: Copy Multi-Arch Image from Docker Hub to AWS ECR
+        # `cosign copy` carries the signature and the SBOM/provenance attestations
+        # along with the image; `docker buildx imagetools create` would copy the
+        # manifest only and leave the signature behind on Docker Hub.
         run: |
           VERSION="${{ github.ref_name }}"
           VERSION="${VERSION#v}"  # Strip 'v' prefix to match Docker Hub tag
-          docker buildx imagetools create \
-            --tag public.ecr.aws/s4e5k7s9/datacontract-cli:latest \
-            --tag public.ecr.aws/s4e5k7s9/datacontract-cli:${VERSION} \
-            docker.io/datacontract/cli:${VERSION}
+          SOURCE="docker.io/datacontract/cli:${VERSION}"
+          TARGET="public.ecr.aws/s4e5k7s9/datacontract-cli"
+          cosign copy --force "${SOURCE}" "${TARGET}:${VERSION}"
+          cosign copy --force "${SOURCE}" "${TARGET}:latest"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -164,6 +164,9 @@ jobs:
     needs:
       - test
       - check_version
+    permissions:
+      contents: read
+      id-token: write  # IMPORTANT: mandatory for keyless signing with cosign
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -195,6 +198,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -207,6 +211,15 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           sbom: true
           provenance: mode=max
+      - name: Install cosign
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: sigstore/cosign-installer@v4.1.2
+      - name: Sign the image with cosign (keyless)
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        # Sign the immutable digest of the multi-arch index, not the mutable tags.
+        run: cosign sign --yes "datacontract/cli@${DIGEST}"
 
   push-to-ecr:
     runs-on: ubuntu-latest
@@ -218,8 +231,8 @@ jobs:
     needs:
       - docker
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.1.2
 
       # Federated rather than a long-lived access key. The role is scoped to
       # this repository's tags and to the datacontract-cli repository alone.
@@ -240,10 +253,13 @@ jobs:
           aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/s4e5k7s9
 
       - name: Copy Multi-Arch Image from Docker Hub to AWS ECR
+        # `cosign copy` carries the signature and the SBOM/provenance attestations
+        # along with the image; `docker buildx imagetools create` would copy the
+        # manifest only and leave the signature behind on Docker Hub.
         run: |
           VERSION="${{ github.ref_name }}"
           VERSION="${VERSION#v}"  # Strip 'v' prefix to match Docker Hub tag
-          docker buildx imagetools create \
-            --tag public.ecr.aws/s4e5k7s9/datacontract-cli:latest \
-            --tag public.ecr.aws/s4e5k7s9/datacontract-cli:${VERSION} \
-            docker.io/datacontract/cli:${VERSION}
+          SOURCE="docker.io/datacontract/cli:${VERSION}"
+          TARGET="public.ecr.aws/s4e5k7s9/datacontract-cli"
+          cosign copy --force "${SOURCE}" "${TARGET}:${VERSION}"
+          cosign copy --force "${SOURCE}" "${TARGET}:latest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This removes the JVM dependency, makes the images much, much smaller (Docker ima
 
 ### Added
 - `DATACONTRACT_KAFKA_MAX_MESSAGES` limits how many messages `datacontract test` reads from a topic, and `DATACONTRACT_KAFKA_TIMEOUT` how long it waits for one
+- Released Docker images are signed with cosign keyless signing, on Docker Hub and the Amazon ECR Public mirror; see [Installation](https://docs.datacontract.com/installation#verifying-the-image) for how to verify them
 
 ### Changed
 - `datacontract test` for Kafka no longer needs PySpark or a Java runtime: `datacontract-cli[kafka]` now installs confluent-kafka, fastavro, and DuckDB instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SQL quality rules support the `${dataset}`, `${project}`, `${catalog}`, and `${database}` placeholders for the server's values
 - `datacontract test --metadata-only` runs only checks that read the schema (field presence and types) and reports checks that read row values as skipped
 - `datacontract test --checks` accepts the ODCS terms `properties` and `slaProperties`, keeping `schema` and `servicelevel` as legacy aliases
+- Released Docker images are signed with cosign keyless signing, on Docker Hub and the Amazon ECR Public mirror; see [Installation](https://docs.datacontract.com/installation#verifying-the-image) for how to verify them
 
 ### Changed
 - `datacontract export excel` uses the ODCS Excel template bundled with the CLI instead of downloading it, so the export works offline; use `--template` for a custom template

--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ alias datacontract='docker run --rm -v "${PWD}:/home/datacontract" datacontract/
 
 _Note:_ The output of Docker command line messages is limited to 80 columns and may include line breaks. Don't pipe docker output to files if you want to export code. Use the `--output` option instead.
 
+Released images are signed with [cosign](https://docs.sigstore.dev/cosign/signing/overview/) keyless signing. See [Verifying the image](https://docs.datacontract.com/installation#verifying-the-image) to check a signature before you run it.
+
 
 
 ## Optional Dependencies (Extras)

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -74,6 +74,43 @@ alias datacontract='docker run --rm -v "${PWD}:/home/datacontract" datacontract/
 The output of Docker command line messages is limited to 80 columns and may include line breaks. Don't pipe Docker output to files if you want to export code — use the `--output` option instead.
 :::
 
+The image is also mirrored to Amazon ECR Public:
+
+```bash
+docker pull public.ecr.aws/s4e5k7s9/datacontract-cli
+```
+
+### Verifying the image
+
+Released images are signed with [cosign](https://docs.sigstore.dev/cosign/signing/overview/) keyless signing, using the GitHub Actions OIDC identity of the release workflow. There is no public key to distribute — verification checks that the image was built and signed by that workflow, in this repository, from a release tag.
+
+Install [cosign](https://docs.sigstore.dev/cosign/system_config/installation/) v2.6.3 or later (v3 or later recommended), then:
+
+```bash
+cosign verify datacontract/cli:latest \
+  --certificate-identity-regexp '^https://github\.com/datacontract/datacontract-cli/\.github/workflows/release\.yaml@refs/tags/v' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+Both `--certificate-identity-regexp` and `--certificate-oidc-issuer` are required. Without them, `cosign verify` accepts any valid Sigstore signature — including one produced by someone else.
+
+The same command works for the ECR mirror, which carries the signature and attestations along with the image:
+
+```bash
+cosign verify public.ecr.aws/s4e5k7s9/datacontract-cli:latest \
+  --certificate-identity-regexp '^https://github\.com/datacontract/datacontract-cli/\.github/workflows/release\.yaml@refs/tags/v' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+Each image also ships an SBOM and SLSA provenance attestation, which you can inspect with:
+
+```bash
+docker buildx imagetools inspect datacontract/cli:latest --format '{{ json .SBOM }}'
+docker buildx imagetools inspect datacontract/cli:latest --format '{{ json .Provenance }}'
+```
+
+Signatures are attached to images released after version 1.1.0. Older tags, 1.1.0 included, are unsigned.
+
 ## Optional dependencies (extras)
 
 The CLI defines several optional dependencies (extras) for specific server types. With `all`, every server dependency is included.

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -74,6 +74,43 @@ alias datacontract='docker run --rm -v "${PWD}:/home/datacontract" datacontract/
 The output of Docker command line messages is limited to 80 columns and may include line breaks. Don't pipe Docker output to files if you want to export code — use the `--output` option instead.
 :::
 
+The image is also mirrored to Amazon ECR Public:
+
+```bash
+docker pull public.ecr.aws/s4e5k7s9/datacontract-cli
+```
+
+### Verifying the image
+
+Released images are signed with [cosign](https://docs.sigstore.dev/cosign/signing/overview/) keyless signing, using the GitHub Actions OIDC identity of the release workflow. There is no public key to distribute — verification checks that the image was built and signed by that workflow, in this repository, from a release tag.
+
+Install [cosign](https://docs.sigstore.dev/cosign/system_config/installation/), then:
+
+```bash
+cosign verify datacontract/cli:latest \
+  --certificate-identity-regexp '^https://github\.com/datacontract/datacontract-cli/\.github/workflows/release\.yaml@refs/tags/v' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+Both `--certificate-identity-regexp` and `--certificate-oidc-issuer` are required. Without them, `cosign verify` accepts any valid Sigstore signature — including one produced by someone else.
+
+The same command works for the ECR mirror, which carries the signature and attestations along with the image:
+
+```bash
+cosign verify public.ecr.aws/s4e5k7s9/datacontract-cli:latest \
+  --certificate-identity-regexp '^https://github\.com/datacontract/datacontract-cli/\.github/workflows/release\.yaml@refs/tags/v' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+Each image also ships an SBOM and SLSA provenance attestation, which you can inspect with:
+
+```bash
+docker buildx imagetools inspect datacontract/cli:latest --format '{{ json .SBOM }}'
+docker buildx imagetools inspect datacontract/cli:latest --format '{{ json .Provenance }}'
+```
+
+Signatures are attached to images released from version 1.1.0 onwards. Older tags are unsigned.
+
 ## Optional dependencies (extras)
 
 The CLI defines several optional dependencies (extras) for specific server types. With `all`, every server dependency is included.

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -24,10 +24,14 @@ marked as such in the entry.
 - Install or upgrade with `uv tool install --upgrade datacontract-cli` or `pip install --upgrade datacontract-cli` — see [Installation](./installation.md).
 - Packages: [PyPI](https://pypi.org/project/datacontract-cli/#history) · [Docker Hub](https://hub.docker.com/r/datacontract/cli/tags) · [GitHub releases](https://github.com/datacontract/datacontract-cli/releases)
 
-## Unreleased {#unreleased}
+## Unreleased - targeting for 1.1.0 {#vUnreleased - targeting for 1-1-0}
+
+This release drops the pyspark compile-time dependency. The server types `dataframe` and `databricks` still work with a provided Spark session.
+This removes the JVM dependency, makes the images much, much smaller (Docker image from 777 MB to 277 MB), and many CVEs are resolved.
 
 ### Added
 - `DATACONTRACT_KAFKA_MAX_MESSAGES` limits how many messages `datacontract test` reads from a topic, and `DATACONTRACT_KAFKA_TIMEOUT` how long it waits for one
+- Released Docker images are signed with cosign keyless signing, on Docker Hub and the Amazon ECR Public mirror; see [Installation](https://docs.datacontract.com/installation#verifying-the-image) for how to verify them
 
 ### Changed
 - `datacontract test` for Kafka no longer needs PySpark or a Java runtime: `datacontract-cli[kafka]` now installs confluent-kafka, fastavro, and DuckDB instead


### PR DESCRIPTION
Adds cosign keyless signing to the released Docker images, on both Docker Hub and the Amazon ECR Public mirror.

The PyPI artifacts are already signed with Sigstore, and the images already carry an SBOM and SLSA provenance (`sbom: true`, `provenance: mode=max`). Signatures were the missing piece: nothing tied the published image to this release workflow in a way a consumer could verify. This also unblocks users running admission policies (Kyverno, Gatekeeper) that require a verifiable signature.

## Changes

**`.github/workflows/release.yaml`**

- `docker` job gets `id-token: write` and signs the image with `cosign sign` after the push. Keyless — the signing identity is the workflow's GitHub OIDC token, so there is no key material to manage or rotate.
- Signs the **digest** (`datacontract/cli@sha256:…`) rather than a tag. Tags are mutable, and the digest covers the whole multi-arch index.
- `push-to-ecr` job switches from `docker buildx imagetools create` to `cosign copy`. `imagetools create` copies the manifest only and would leave the signature (a separate `sha256-<digest>.sig` tag) and the attestations behind on Docker Hub; `cosign copy` carries all three across.

**Docs** — a "Verifying the image" section in `docs/docs/installation.md`, a pointer to it from the README, and a CHANGELOG entry. The section also documents the ECR Public mirror, which was previously published but undocumented.

## Verification

```bash
cosign verify datacontract/cli:latest \
  --certificate-identity-regexp '^https://github\.com/datacontract/datacontract-cli/\.github/workflows/release\.yaml@refs/tags/v' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com
```

Both flags are required and documented as such — without pinning the identity and issuer, `cosign verify` accepts any valid Sigstore signature, including one produced by someone else.

## Notes

- Signing steps are gated on `github.event_name != 'pull_request'`, matching the existing `push:` condition on the build step.
- The signing itself can only be exercised on a real tag push, since it needs the OIDC token and a pushed digest. The workflow YAML parses and the docs site builds.
- The docs claim signatures start at 1.1.0, matching the current `Unreleased` target in the CHANGELOG. Worth a second look if that target moves.