### PR TITLE
Add dataset, project, catalog, and database placeholders to SQL quality rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- SQL quality rules support the `${dataset}`, `${project}`, `${catalog}`, and `${database}` placeholders for the server's values
+
 ### Changed
 - Test results name the check fields `qualityId` and `failedSamples` instead of `quality_id` and `failed_samples`; the old names are deprecated, but still accepted as input and still written next to the new ones
 - `datacontract import unity` no longer writes the `databricksType` custom property, which duplicated `physicalType`

--- a/datacontract/engines/checks/create_checks.py
+++ b/datacontract/engines/checks/create_checks.py
@@ -141,10 +141,6 @@ def to_threshold(quality: DataQuality) -> Optional[Threshold]:
     return None
 
 
-def _server_value(server: Optional[Server], attribute: str) -> Optional[str]:
-    return getattr(server, attribute, None) if server else None
-
-
 def prepare_query(
     quality: DataQuality, model_name: str, field_name: Optional[str], server: Optional[Server]
 ) -> Optional[str]:
@@ -162,12 +158,12 @@ def prepare_query(
     query = re.sub(r'["\']?\$?\{table}["\']?', model_name, query)
     query = re.sub(r'["\']?\$?\{object}["\']?', model_name, query)
 
-    schema_replacement = _server_value(server, "schema_") or model_name
+    schema_replacement = server.schema_ if server and server.schema_ else model_name
     query = re.sub(r'["\']?\$?\{schema}["\']?', schema_replacement, query)
 
     for placeholder in ("dataset", "project", "catalog", "database"):
-        replacement = _server_value(server, placeholder) or model_name
-        query = re.sub(rf'["\']?\$?\{{{placeholder}}}["\']?', replacement, query)
+        replacement = getattr(server, placeholder, None) if server else None
+        query = re.sub(rf'["\']?\$?\{{{placeholder}}}["\']?', replacement or model_name, query)
 
     if field_name is not None:
         query = re.sub(r'["\']?\$?\{field}["\']?', field_name, query)

--- a/datacontract/engines/checks/create_checks.py
+++ b/datacontract/engines/checks/create_checks.py
@@ -141,6 +141,10 @@ def to_threshold(quality: DataQuality) -> Optional[Threshold]:
     return None
 
 
+def _server_value(server: Optional[Server], attribute: str) -> Optional[str]:
+    return getattr(server, attribute, None) if server else None
+
+
 def prepare_query(
     quality: DataQuality, model_name: str, field_name: Optional[str], server: Optional[Server]
 ) -> Optional[str]:
@@ -158,8 +162,12 @@ def prepare_query(
     query = re.sub(r'["\']?\$?\{table}["\']?', model_name, query)
     query = re.sub(r'["\']?\$?\{object}["\']?', model_name, query)
 
-    schema_replacement = server.schema_ if server and server.schema_ else model_name
+    schema_replacement = _server_value(server, "schema_") or model_name
     query = re.sub(r'["\']?\$?\{schema}["\']?', schema_replacement, query)
+
+    for placeholder in ("dataset", "project", "catalog", "database"):
+        replacement = _server_value(server, placeholder) or model_name
+        query = re.sub(rf'["\']?\$?\{{{placeholder}}}["\']?', replacement, query)
 
     if field_name is not None:
         query = re.sub(r'["\']?\$?\{field}["\']?', field_name, query)

--- a/datacontract/export/sodacl_check_builder.py
+++ b/datacontract/export/sodacl_check_builder.py
@@ -59,6 +59,15 @@ def _quote_field_name(field_name: str, quoting_config: QuotingConfig) -> str:
     return field_name
 
 
+def _quote_model_name(model_name: str, quoting_config: QuotingConfig) -> str:
+    """Quote a model, schema, or other identifier according to the quoting configuration."""
+    if quoting_config.quote_model_name:
+        return f'"{model_name}"'
+    elif quoting_config.quote_model_name_with_backticks:
+        return f"`{model_name}`"
+    return model_name
+
+
 _BACKTICK_DIALECTS = {"databricks", "bigquery", "mysql", "impala", "dataframe", "kafka"}
 _ANSI_QUOTING_DIALECTS = {"postgres", "redshift", "sqlserver", "mssql", "snowflake", "azure", "s3", "gcs", "local"}
 
@@ -939,27 +948,20 @@ def prepare_query(
 
     field_name_for_soda = _quote_field_name(field_name, quoting_config)
 
-    def quote_identifier(name: str) -> str:
-        if quoting_config.quote_model_name:
-            return f'"{name}"'
-        if quoting_config.quote_model_name_with_backticks:
-            return f"`{name}`"
-        return name
-
-    model_name_for_soda = quote_identifier(model_name)
+    model_name_for_soda = _quote_model_name(model_name, quoting_config)
 
     query = re.sub(r'["\']?\$?\{model}["\']?', model_name_for_soda, query)
     query = re.sub(r'["\']?\$?\{table}["\']?', model_name_for_soda, query)
     query = re.sub(r'["\']?\$?\{object}["\']?', model_name_for_soda, query)
 
     if server and server.schema_:
-        query = re.sub(r'["\']?\$?\{schema}["\']?', quote_identifier(server.schema_), query)
+        query = re.sub(r'["\']?\$?\{schema}["\']?', _quote_model_name(server.schema_, quoting_config), query)
     else:
         query = re.sub(r'["\']?\$?\{schema}["\']?', model_name_for_soda, query)
 
     for placeholder in ("dataset", "project", "catalog", "database"):
         value = getattr(server, placeholder, None) if server else None
-        replacement = quote_identifier(value) if value else model_name_for_soda
+        replacement = _quote_model_name(value, quoting_config) if value else model_name_for_soda
         query = re.sub(rf'["\']?\$?\{{{placeholder}}}["\']?', replacement, query)
 
     if field_name is not None:

--- a/datacontract/export/sodacl_check_builder.py
+++ b/datacontract/export/sodacl_check_builder.py
@@ -939,27 +939,30 @@ def prepare_query(
 
     field_name_for_soda = _quote_field_name(field_name, quoting_config)
 
-    if quoting_config.quote_model_name:
-        model_name_for_soda = f'"{model_name}"'
-    elif quoting_config.quote_model_name_with_backticks:
-        model_name_for_soda = f"`{model_name}`"
-    else:
-        model_name_for_soda = model_name
+    def quote_identifier(name: str) -> str:
+        if quoting_config.quote_model_name:
+            return f'"{name}"'
+        if quoting_config.quote_model_name_with_backticks:
+            return f"`{name}`"
+        return name
+
+    def server_value(attribute: str) -> str | None:
+        return getattr(server, attribute, None) if server else None
+
+    model_name_for_soda = quote_identifier(model_name)
 
     query = re.sub(r'["\']?\$?\{model}["\']?', model_name_for_soda, query)
     query = re.sub(r'["\']?\$?\{table}["\']?', model_name_for_soda, query)
     query = re.sub(r'["\']?\$?\{object}["\']?', model_name_for_soda, query)
 
-    if server and server.schema_:
-        if quoting_config.quote_model_name:
-            schema_name_for_soda = f'"{server.schema_}"'
-        elif quoting_config.quote_model_name_with_backticks:
-            schema_name_for_soda = f"`{server.schema_}`"
-        else:
-            schema_name_for_soda = server.schema_
-        query = re.sub(r'["\']?\$?\{schema}["\']?', schema_name_for_soda, query)
-    else:
-        query = re.sub(r'["\']?\$?\{schema}["\']?', model_name_for_soda, query)
+    schema_value = server_value("schema_")
+    schema_name_for_soda = quote_identifier(schema_value) if schema_value else model_name_for_soda
+    query = re.sub(r'["\']?\$?\{schema}["\']?', schema_name_for_soda, query)
+
+    for placeholder in ("dataset", "project", "catalog", "database"):
+        value = server_value(placeholder)
+        replacement = quote_identifier(value) if value else model_name_for_soda
+        query = re.sub(rf'["\']?\$?\{{{placeholder}}}["\']?', replacement, query)
 
     if field_name is not None:
         query = re.sub(r'["\']?\$?\{field}["\']?', field_name_for_soda, query)

--- a/datacontract/export/sodacl_check_builder.py
+++ b/datacontract/export/sodacl_check_builder.py
@@ -946,21 +946,19 @@ def prepare_query(
             return f"`{name}`"
         return name
 
-    def server_value(attribute: str) -> str | None:
-        return getattr(server, attribute, None) if server else None
-
     model_name_for_soda = quote_identifier(model_name)
 
     query = re.sub(r'["\']?\$?\{model}["\']?', model_name_for_soda, query)
     query = re.sub(r'["\']?\$?\{table}["\']?', model_name_for_soda, query)
     query = re.sub(r'["\']?\$?\{object}["\']?', model_name_for_soda, query)
 
-    schema_value = server_value("schema_")
-    schema_name_for_soda = quote_identifier(schema_value) if schema_value else model_name_for_soda
-    query = re.sub(r'["\']?\$?\{schema}["\']?', schema_name_for_soda, query)
+    if server and server.schema_:
+        query = re.sub(r'["\']?\$?\{schema}["\']?', quote_identifier(server.schema_), query)
+    else:
+        query = re.sub(r'["\']?\$?\{schema}["\']?', model_name_for_soda, query)
 
     for placeholder in ("dataset", "project", "catalog", "database"):
-        value = server_value(placeholder)
+        value = getattr(server, placeholder, None) if server else None
         replacement = quote_identifier(value) if value else model_name_for_soda
         query = re.sub(rf'["\']?\$?\{{{placeholder}}}["\']?', replacement, query)
 

--- a/docs/docs/quality-rules/sql.md
+++ b/docs/docs/quality-rules/sql.md
@@ -47,6 +47,31 @@ schema:
         mustBeLessThan: 3600
 ```
 
+## Placeholders
+
+Instead of hard-coding names, the query can reference the schema, the property, and the location the server names:
+
+| Placeholder | Replaced with |
+|---|---|
+| `${model}` / `${table}` / `${object}` | the name of the schema object the rule belongs to |
+| `${field}` / `${column}` / `${property}` | the name of the property the rule belongs to (property-level rules only) |
+| `${schema}` | the server's `schema` |
+| `${dataset}` | the server's `dataset` (BigQuery) |
+| `${project}` | the server's `project` (BigQuery) |
+| `${catalog}` | the server's `catalog` (Databricks, Trino) |
+| `${database}` | the server's `database` (Postgres, SQL Server, Snowflake) |
+
+The `$` is optional: `{schema}` works the same as `${schema}`. A placeholder the server has no value for falls back to the name of the schema object.
+
+```yaml
+quality:
+  - type: sql
+    description: The orders table is not empty.
+    query: |
+      SELECT COUNT(*) FROM ${project}.${dataset}.${table}
+    mustBeGreaterThan: 0
+```
+
 ## Comparators
 
 The query must return a single value, which is compared using exactly one of:

--- a/tests/test_create_checks_sql_placeholders.py
+++ b/tests/test_create_checks_sql_placeholders.py
@@ -1,0 +1,44 @@
+from open_data_contract_standard.model import DataQuality, Server
+
+from datacontract.engines.checks.create_checks import prepare_query
+
+
+def test_schema_placeholder():
+    quality = DataQuality(type="sql", query="SELECT * FROM {schema}.{model}")
+    server = Server(**{"type": "postgres", "schema": "my_schema"})
+
+    assert prepare_query(quality, "my_table", None, server) == "SELECT * FROM my_schema.my_table"
+
+
+def test_schema_placeholder_falls_back_to_model_name():
+    quality = DataQuality(type="sql", query="SELECT * FROM {schema}")
+    server = Server(type="postgres")
+
+    assert prepare_query(quality, "my_table", None, server) == "SELECT * FROM my_table"
+
+
+def test_dataset_and_project_placeholders():
+    quality = DataQuality(type="sql", query="SELECT COUNT(*) FROM ${project}.${dataset}.${table}")
+    server = Server(type="bigquery", project="my_project", dataset="my_dataset")
+
+    assert prepare_query(quality, "my_table", None, server) == "SELECT COUNT(*) FROM my_project.my_dataset.my_table"
+
+
+def test_catalog_and_database_placeholders():
+    quality = DataQuality(type="sql", query="SELECT * FROM {catalog}.{database}.{model}")
+    server = Server(**{"type": "databricks", "catalog": "my_catalog", "database": "my_database"})
+
+    assert prepare_query(quality, "my_table", None, server) == "SELECT * FROM my_catalog.my_database.my_table"
+
+
+def test_dataset_placeholder_falls_back_to_model_name():
+    quality = DataQuality(type="sql", query="SELECT * FROM {dataset}")
+    server = Server(**{"type": "postgres", "schema": "my_schema"})
+
+    assert prepare_query(quality, "my_table", None, server) == "SELECT * FROM my_table"
+
+
+def test_placeholders_without_server():
+    quality = DataQuality(type="sql", query="SELECT {column} FROM {dataset}.{table}")
+
+    assert prepare_query(quality, "my_table", "my_field", None) == "SELECT my_field FROM my_table.my_table"

--- a/tests/test_data_contract_checks.py
+++ b/tests/test_data_contract_checks.py
@@ -78,6 +78,47 @@ def test_prepare_query_schema_placeholder_no_schema():
     assert result == "SELECT * FROM my_table"
 
 
+def test_prepare_query_dataset_and_project_placeholders():
+    """Test that {dataset} and {project} are replaced with the BigQuery server values."""
+    quality = DataQuality(type="sql", query="SELECT COUNT(*) FROM ${project}.${dataset}.${table}")
+    server = Server(type="bigquery", project="my_project", dataset="my_dataset")
+
+    result = prepare_query(quality, "my_table", None, QuotingConfig(), server)
+
+    assert result == "SELECT COUNT(*) FROM my_project.my_dataset.my_table"
+
+
+def test_prepare_query_dataset_placeholder_backticks():
+    """Test that {dataset} and {project} are backtick-quoted for bigquery."""
+    quality = DataQuality(type="sql", query="SELECT * FROM {project}.{dataset}.{model}")
+    server = Server(type="bigquery", project="my_project", dataset="my_dataset")
+    quoting_config = QuotingConfig(quote_model_name_with_backticks=True)
+
+    result = prepare_query(quality, "my_table", None, quoting_config, server)
+
+    assert result == "SELECT * FROM `my_project`.`my_dataset`.`my_table`"
+
+
+def test_prepare_query_catalog_and_database_placeholders():
+    """Test that {catalog} and {database} are replaced with the server values."""
+    quality = DataQuality(type="sql", query="SELECT * FROM {catalog}.{database}.{model}")
+    server = Server(**{"type": "databricks", "catalog": "my_catalog", "database": "my_database"})
+
+    result = prepare_query(quality, "my_table", None, QuotingConfig(), server)
+
+    assert result == "SELECT * FROM my_catalog.my_database.my_table"
+
+
+def test_prepare_query_dataset_placeholder_falls_back_to_model_name():
+    """Test that {dataset} falls back to the model name when the server has no dataset."""
+    quality = DataQuality(type="sql", query="SELECT * FROM {dataset}")
+    server = Server(**{"type": "postgres", "schema": "my_schema"})
+
+    result = prepare_query(quality, "my_table", None, QuotingConfig(), server)
+
+    assert result == "SELECT * FROM my_table"
+
+
 def test_prepare_query_schema_placeholder_with_dollar():
     """Test that ${schema} placeholder (with $) is replaced with server schema."""
     quality = DataQuality(type="sql", query="SELECT * FROM ${schema}.${model}")


### PR DESCRIPTION
Follows up on the [Slack thread in #datacontract](https://datacontract.slack.com/archives/C06L4GBKJC8/p1786378830588679) about `type: sql` quality rules against BigQuery.

## The gap

`prepare_query()` can substitute the model name (`${model}` / `${table}` / `${object}`) and the server's schema (`${schema}`), and nothing else. BigQuery has no schema concept - an ODCS BigQuery server sets `project` and `dataset` - so `schema` is never set there and:

- `SELECT COUNT(*) FROM ${table}` fails with `400 Table "my_table" must be qualified with a dataset (e.g. dataset.table)`
- `${schema}.${table}` resolves to `my_table.my_table`, because `${schema}` falls back to the model name

That leaves no way to write a rule against BigQuery without hardcoding `project.dataset.table` into every query, which defeats the point of naming the location once in the server block.

## The change

`${dataset}`, `${project}`, `${catalog}`, and `${database}` now resolve to the matching value on the selected server, so a rule can be written as:

```yaml
quality:
  - type: sql
    query: SELECT COUNT(*) FROM ${project}.${dataset}.${table}
    mustBeGreaterThan: 0
```

Applied in both query preparation paths - `datacontract/engines/checks/create_checks.py` (ibis) and `datacontract/export/sodacl_check_builder.py` (sodacl, where the new placeholders get the same identifier quoting as `${model}` and `${schema}`). Like `${schema}`, a placeholder the server has no value for falls back to the model name.

The `if/elif/else` quoting blocks in the sodacl path were folded into one local helper so the new placeholders reuse them rather than repeating the branches a third time.

## One deviation from the thread

The thread also suggested making `${schema}` fall back `schema_ -> dataset -> model_name`. That is not in this PR: with `${dataset}` available, the fallback is a second, implicit path to the same value, and `${schema}` meaning "dataset" on some servers but "schema" on others is harder to document than two distinct placeholders. Happy to add it if you'd rather have both - it's a two-line change.

## Docs and tests

- `docs/docs/quality-rules/sql.md` gains a Placeholders section; the existing placeholders were undocumented, so the table covers all of them, not just the new ones.
- `tests/test_create_checks_sql_placeholders.py` (new) covers the ibis path, and `tests/test_data_contract_checks.py` the sodacl path including backtick quoting.
