### PR TITLE
Round trip the Pydantic exporter and importer over every example contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `datacontract export pydantic-model` exports the ODCS `timestamp` and `time` logical types as `datetime.datetime` and `datetime.time` instead of guessing from the physical type, which turned a `TIMESTAMPTZ` column into a `str`
+- `datacontract export pydantic-model` exports the ODCS `date` logical type as `datetime.date` instead of `datetime.datetime`
+- `datacontract import pydantic-model` maps `datetime.datetime` to the `timestamp` logical type and `datetime.time` to `time`
+
 ## [1.1.1] - 2026-08-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `datacontract import pydantic-model` reads the contract description from the module docstring
+
 ### Fixed
 - `datacontract export pydantic-model` exports the ODCS `timestamp` and `time` logical types as `datetime.datetime` and `datetime.time` instead of guessing from the physical type, which turned a `TIMESTAMPTZ` column into a `str`
 - `datacontract export pydantic-model` exports the ODCS `date` logical type as `datetime.date` instead of `datetime.datetime`

--- a/datacontract/export/pydantic_exporter.py
+++ b/datacontract/export/pydantic_exporter.py
@@ -102,7 +102,11 @@ def constant_field_annotation(
         case "boolean":
             return (ast.Name("bool", ctx=ast.Load()), None)
         case "date":
+            return (ast.Attribute(value=ast.Name(id="datetime", ctx=ast.Load()), attr="date"), None)
+        case "timestamp":
             return (ast.Attribute(value=ast.Name(id="datetime", ctx=ast.Load()), attr="datetime"), None)
+        case "time":
+            return (ast.Attribute(value=ast.Name(id="datetime", ctx=ast.Load()), attr="time"), None)
         case "array":
             if prop.items:
                 (annotated_type, new_class) = type_annotation(field_name, prop.items)

--- a/datacontract/imports/pydantic_importer.py
+++ b/datacontract/imports/pydantic_importer.py
@@ -27,9 +27,9 @@ _SCALAR_TYPES: Dict[str, Tuple[str, str]] = {
     "bool": ("boolean", "bool"),
     "bytes": ("array", "bytes"),
     "Decimal": ("number", "decimal"),
-    "datetime": ("date", "datetime"),
+    "datetime": ("timestamp", "datetime"),
     "date": ("date", "date"),
-    "time": ("string", "time"),
+    "time": ("time", "time"),
     "timedelta": ("string", "timedelta"),
     "UUID": ("string", "uuid"),
 }

--- a/datacontract/imports/pydantic_importer.py
+++ b/datacontract/imports/pydantic_importer.py
@@ -12,7 +12,12 @@ also what makes the round trip with ``datacontract export pydantic-model`` hold.
 import ast
 from typing import Any, Dict, List, Optional, Tuple
 
-from open_data_contract_standard.model import DataQuality, OpenDataContractStandard, SchemaProperty
+from open_data_contract_standard.model import (
+    DataQuality,
+    Description,
+    OpenDataContractStandard,
+    SchemaProperty,
+)
 
 from datacontract.imports.importer import Importer
 from datacontract.imports.odcs_helper import create_odcs, create_property, create_schema_object
@@ -401,6 +406,24 @@ def _resolve_annotation(annotation: ast.expr, index: _ModuleIndex, depth: int) -
     return {"logical_type": "string", "physical_type": segment or "str"}
 
 
+def _module_description(tree: ast.Module) -> Optional[str]:
+    """The contract description, from the module docstring or a bare string.
+
+    ``datacontract export pydantic-model`` writes it below the imports rather
+    than as a docstring, so both spellings are read back.
+    """
+    docstring = ast.get_docstring(tree)
+    if docstring:
+        return docstring
+    for statement in tree.body:
+        if isinstance(statement, ast.ClassDef):
+            break
+        if isinstance(statement, ast.Expr) and isinstance(statement.value, ast.Constant):
+            if isinstance(statement.value.value, str):
+                return statement.value.value
+    return None
+
+
 def import_pydantic(source: str) -> OpenDataContractStandard:
     """Read a Python module of Pydantic models into an ODCS data contract."""
     try:
@@ -437,6 +460,9 @@ def import_pydantic(source: str) -> OpenDataContractStandard:
     roots = [name for name in index.top_level if name not in nested] or index.top_level
 
     odcs = create_odcs()
+    purpose = _module_description(tree)
+    if purpose:
+        odcs.description = Description(purpose=purpose)
     odcs.schema_ = [
         create_schema_object(
             name=name,

--- a/docs/docs/exports/avro.md
+++ b/docs/docs/exports/avro.md
@@ -31,8 +31,8 @@ Running this against the [example `orders` contract](https://github.com/datacont
       "name": "order_timestamp",
       "doc": "Timestamp when the order was placed.",
       "type": {
-        "type": "int",
-        "logicalType": "date"
+        "type": "long",
+        "logicalType": "timestamp-millis"
       }
     },
     {

--- a/docs/docs/exports/dbml.md
+++ b/docs/docs/exports/dbml.md
@@ -24,7 +24,7 @@ Project "Orders" {
 Table orders {
     note: "One row per customer order."
     order_id string [pk, unique, not null, note: "Unique identifier of the order."]
-    order_timestamp date [not null, note: "Timestamp when the order was placed."]
+    order_timestamp timestamp [not null, note: "Timestamp when the order was placed."]
     customer_id string [not null, note: "Reference to the customer who placed the order."]
     order_total number [not null, note: "Total amount of the order in cents."]
     status string [not null, note: "Current fulfilment status of the order."]

--- a/docs/docs/exports/jsonschema.md
+++ b/docs/docs/exports/jsonschema.md
@@ -29,7 +29,7 @@ Running this against the [example `orders` contract](https://github.com/datacont
     },
     "order_timestamp": {
       "type": "string",
-      "format": "date",
+      "format": "date-time",
       "description": "Timestamp when the order was placed."
     },
     "customer_id": {

--- a/docs/docs/exports/markdown.md
+++ b/docs/docs/exports/markdown.md
@@ -47,7 +47,7 @@ Not suitable for real-time fraud detection; data is loaded in hourly batches.
 | Field | Type | Attributes |
 | ----- | ---- | ---------- |
 |  order_id | string | *Unique identifier of the order.*<br />• `primaryKey`<br />• `required`<br />• `unique`<br />• **examples:** ['ORD-1001', 'ORD-1002'] |
-|  order_timestamp | date | *Timestamp when the order was placed.*<br />• `required` |
+|  order_timestamp | timestamp | *Timestamp when the order was placed.*<br />• `required` |
 |  customer_id | string | *Reference to the customer who placed the order.*<br />• `required` |
 |  order_total | number | *Total amount of the order in cents.*<br />• `required`<br />• **quality:** [{'description': 'Order total is never negative.', 'type': 'sql', 'mustBe': 0, 'query': 'SELECT COUNT(*) FROM orders WHERE order_total < 0'}] |
 |  status | string | *Current fulfilment status of the order.*<br />• `required`<br />• **examples:** ['pending', 'shipped', 'delivered'] |

--- a/docs/docs/exports/mermaid.md
+++ b/docs/docs/exports/mermaid.md
@@ -20,7 +20,7 @@ Running this against the [example `orders` contract](https://github.com/datacont
 erDiagram
         "**orders**" {
         order_id🔑🔒 string
-        order_timestamp date
+        order_timestamp timestamp
         customer_id string
         order_total number
         status string

--- a/docs/docs/exports/sqlalchemy.md
+++ b/docs/docs/exports/sqlalchemy.md
@@ -30,7 +30,7 @@ class Orders(Base):
     __tablename__ = 'orders'
     __table_args__ = {'comment': 'One row per customer order.', 'schema': None}
     order_id = Column(String(None), nullable=False, comment='Unique identifier of the order.', primary_key=True)
-    order_timestamp = Column(Date, nullable=False, comment='Timestamp when the order was placed.', primary_key=None)
+    order_timestamp = Column(TIMESTAMP, nullable=False, comment='Timestamp when the order was placed.', primary_key=None)
     customer_id = Column(String(None), nullable=False, comment='Reference to the customer who placed the order.', primary_key=None)
     order_total = Column(Numeric(None, None), nullable=False, comment='Total amount of the order in cents.', primary_key=None)
     status = Column(String(None), nullable=False, comment='Current fulfilment status of the order.', primary_key=None)

--- a/docs/docs/imports/pydantic-model.md
+++ b/docs/docs/imports/pydantic-model.md
@@ -76,7 +76,7 @@ schema:
     required: true
   - name: order_timestamp
     physicalType: datetime
-    logicalType: date
+    logicalType: timestamp
     required: true
   - name: customer_id
     physicalType: str

--- a/examples/imports/pydantic-model/datacontract.odcs.yaml
+++ b/examples/imports/pydantic-model/datacontract.odcs.yaml
@@ -19,7 +19,7 @@ schema:
     required: true
   - name: order_timestamp
     physicalType: datetime
-    logicalType: date
+    logicalType: timestamp
     required: true
   - name: customer_id
     physicalType: str

--- a/examples/orders/orders.odcs.yaml
+++ b/examples/orders/orders.odcs.yaml
@@ -41,7 +41,7 @@ schema:
           - ORD-1001
           - ORD-1002
       - name: order_timestamp
-        logicalType: date
+        logicalType: timestamp
         physicalType: TIMESTAMP
         required: true
         description: Timestamp when the order was placed.

--- a/tests/fixtures/pydantic-model/expected/models.odcs.yaml
+++ b/tests/fixtures/pydantic-model/expected/models.odcs.yaml
@@ -17,7 +17,7 @@ schema:
     required: true
   - name: order_timestamp
     physicalType: datetime
-    logicalType: date
+    logicalType: timestamp
     required: true
   - name: order_date
     physicalType: date

--- a/tests/test_roundtrip_pydantic_model.py
+++ b/tests/test_roundtrip_pydantic_model.py
@@ -1,0 +1,80 @@
+"""Round trip every example contract through the Pydantic exporter and importer.
+
+`datacontract export pydantic-model` and `datacontract import pydantic-model` are
+each other's inverse, so a contract exported to Pydantic models and imported back
+has to describe the same schema. The example contracts under `examples/` are the
+corpus: they are produced by ten different importers, so they cover far more
+column shapes than a hand-written fixture would.
+
+What a Python annotation cannot carry does not survive, and is not asserted here:
+`physicalType` is database specific, and constraints, quality rules and examples
+have no place in a bare annotation. Name, logical type, requiredness, description
+and nesting do survive, and that is what a round trip has to preserve.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from datacontract.data_contract import DataContract
+from datacontract.lint import resolve
+
+EXAMPLES = sorted((Path(__file__).resolve().parents[1] / "examples").rglob("*.odcs.yaml"))
+
+
+def shape(properties):
+    """The part of a property the Pydantic representation is able to carry."""
+    return [
+        (
+            prop.name,
+            prop.logicalType,
+            bool(prop.required),
+            prop.description,
+            shape(prop.properties or []),
+            shape([prop.items] if prop.items else []),
+        )
+        for prop in properties or []
+    ]
+
+
+def round_trip(contract_file: Path, tmp_path: Path):
+    """Export the contract to Pydantic models and import the result back."""
+    exported = DataContract(data_contract_file=str(contract_file)).export("pydantic-model")
+    generated = tmp_path / "generated_models.py"
+    generated.write_text(exported)
+    return exported, DataContract.import_from_source("pydantic-model", str(generated))
+
+
+@pytest.mark.parametrize("contract_file", EXAMPLES, ids=lambda path: path.parent.name)
+def test_every_example_contract_survives_the_round_trip(contract_file, tmp_path):
+    original = resolve.resolve_data_contract(data_contract_location=str(contract_file))
+    _, reimported = round_trip(contract_file, tmp_path)
+
+    assert [schema.name.lower() for schema in reimported.schema_] == [
+        # The exporter names the class after the schema, capitalized, because a
+        # Python class is CapWords: `orders` is exported as `class Orders`.
+        schema.name.lower()
+        for schema in original.schema_
+    ]
+    for before, after in zip(original.schema_, reimported.schema_):
+        assert shape(after.properties) == shape(before.properties)
+
+
+@pytest.mark.parametrize("contract_file", EXAMPLES, ids=lambda path: path.parent.name)
+def test_the_exported_module_is_valid_python(contract_file, tmp_path):
+    exported, _ = round_trip(contract_file, tmp_path)
+
+    ast.parse(exported)
+
+
+@pytest.mark.parametrize("contract_file", EXAMPLES, ids=lambda path: path.parent.name)
+def test_the_round_trip_reaches_a_fixed_point(contract_file, tmp_path):
+    """A second lap must not drift: whatever the first lap settled on is stable."""
+    first_module, first_contract = round_trip(contract_file, tmp_path)
+
+    contract_file_again = tmp_path / "first_lap.odcs.yaml"
+    contract_file_again.write_text(first_contract.to_yaml())
+    second_module, _ = round_trip(contract_file_again, tmp_path)
+
+    assert second_module == first_module


### PR DESCRIPTION
The round trip you asked for in #1492, over every contract under `examples/` rather than a fixture I write myself — ten different importers produce those, so they cover column shapes I wouldn't have thought to invent.

It found three things, so the fixes are the first two commits and the test is the third.

**`timestamp` and `time` were never handled.** ODCS v3.1.0 allows `string, date, timestamp, time, number, integer, object, array, boolean`, but the exporter's `match` had no case for `timestamp` or `time`. Both fell through to the physical-type guess, so `physicalType: TIMESTAMPTZ` from the SQL importer came out as a plain `str`, and `TIMESTAMP` from dbml and BigQuery only reached `datetime.datetime` by accident.

Fixing that forced a decision on `date`, which exported as `datetime.datetime`. If `timestamp` also exports as `datetime.datetime` the two are indistinguishable coming back, so `date` now exports as `datetime.date`. That is the one judgement call here — happy to revert it and let the test treat `date` and `timestamp` as equivalent, if you'd rather not change what `date` exports today.

`order_timestamp` in `examples/orders/orders.odcs.yaml` was declared `logicalType: date` with `physicalType: TIMESTAMP` and described as "Timestamp when the order was placed", so I corrected it to `timestamp`. That keeps the Pydantic export identical to before, and it also improves the avro (`int`/`date` → `long`/`timestamp-millis`), dbml, jsonschema (`date` → `date-time`), markdown, mermaid and sqlalchemy (`Column(Date)` → `Column(TIMESTAMP)`) examples generated from that contract.

**The contract description was dropped on import.** The exporter writes it as a string below the imports; the importer ignored it, so it didn't survive. Now both that spelling and a real module docstring are read back.

The test asserts name, logical type, requiredness, description and nesting. It deliberately doesn't assert `physicalType`, constraints, quality rules or examples — a bare annotation can't carry those, and pretending otherwise would just encode today's behaviour. Schema names compare case-insensitively because the exporter names the class after the schema, capitalized (`orders` → `class Orders`).

There's also a fixed-point check: a second lap has to produce the same module as the first. That's what caught the dropped description, since the loss only shows on the way back round.

All 12 examples pass on the first assertion and reach a fixed point.
