### PR TITLE
Fix S3 JSON validation for multiple files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract export pydantic-model` exports the ODCS `timestamp` and `time` logical types as `datetime.datetime` and `datetime.time` instead of guessing from the physical type, which turned a `TIMESTAMPTZ` column into a `str`
 - `datacontract export pydantic-model` exports the ODCS `date` logical type as `datetime.date` instead of `datetime.datetime`
 - `datacontract import pydantic-model` maps `datetime.datetime` to the `timestamp` logical type and `datetime.time` to `time`
+- S3 JSON schema validation checks every file matched by a location instead of only the last file (#1511)
 - `datacontract test --publish` no longer fails for runs with skipped checks (skipped checks are omitted from the published test results)
 
 

--- a/datacontract/engines/fastjsonschema/check_jsonschema.py
+++ b/datacontract/engines/fastjsonschema/check_jsonschema.py
@@ -207,17 +207,20 @@ def process_s3_file(run, server, schema, model_name, validate, config: Config | 
     s3_location = server.location
     if "{model}" in s3_location:
         s3_location = s3_location.format(model=model_name)
-    json_stream = None
+    exceptions: List[DataContractException] = []
+    found_file = False
 
     for file_content in yield_s3_files(s3_endpoint_url, s3_location, config):
+        found_file = True
         if server.delimiter == "new_line":
             json_stream = read_json_lines_content(file_content)
         elif server.delimiter == "array":
             json_stream = read_json_array_content(file_content)
         else:
             json_stream = read_json_file_content(file_content)
+        exceptions.extend(validate_json_stream(schema, model_name, validate, json_stream))
 
-    if json_stream is None:
+    if not found_file:
         raise DataContractException(
             type="schema",
             name="Check that JSON has valid schema",
@@ -225,9 +228,6 @@ def process_s3_file(run, server, schema, model_name, validate, config: Config | 
             reason=f"Cannot find any file in {s3_location}",
             engine="datacontract",
         )
-
-    # Validate the JSON stream and collect exceptions.
-    exceptions = validate_json_stream(schema, model_name, validate, json_stream)
 
     # Handle all errors from schema validation.
     process_exceptions(run, exceptions, config)

--- a/datacontract/engines/fastjsonschema/check_jsonschema.py
+++ b/datacontract/engines/fastjsonschema/check_jsonschema.py
@@ -50,17 +50,21 @@ def get_primary_key_value(schema: dict, model_name: str, json_object: dict) -> O
     return json_object.get(primary_key_field)
 
 
+def _get_error_limit(config: Config | None = None) -> int:
+    try:
+        configured_limit = Config.resolve(config).get_max_errors()
+        return 500 if configured_limit is None else configured_limit
+    except DataContractException:
+        # Fallback to default if the configured value is invalid.
+        return 500
+
+
 def process_exceptions(run, exceptions: List[DataContractException], config: Config | None = None):
     if not exceptions:
         return
 
     # Define the maximum number of errors to process (can be adjusted via configuration).
-    try:
-        configured_limit = Config.resolve(config).get_max_errors()
-        error_limit = 500 if configured_limit is None else configured_limit
-    except DataContractException:
-        # Fallback to default if the configured value is invalid.
-        error_limit = 500
+    error_limit = _get_error_limit(config)
 
     # Calculate the effective limit to avoid index out of range
     limit = min(len(exceptions), error_limit)
@@ -208,6 +212,7 @@ def process_s3_file(run, server, schema, model_name, validate, config: Config | 
     if "{model}" in s3_location:
         s3_location = s3_location.format(model=model_name)
     exceptions: List[DataContractException] = []
+    error_limit = _get_error_limit(config)
     found_file = False
 
     for file_content in yield_s3_files(s3_endpoint_url, s3_location, config):
@@ -219,6 +224,8 @@ def process_s3_file(run, server, schema, model_name, validate, config: Config | 
         else:
             json_stream = read_json_file_content(file_content)
         exceptions.extend(validate_json_stream(schema, model_name, validate, json_stream))
+        if len(exceptions) >= error_limit:
+            break
 
     if not found_file:
         raise DataContractException(

--- a/tests/test_test_s3_json_multiple_models.py
+++ b/tests/test_test_s3_json_multiple_models.py
@@ -5,6 +5,7 @@ import fastjsonschema
 import pytest
 from testcontainers.minio import MinioContainer
 
+from datacontract.config import Config
 from datacontract.data_contract import DataContract
 from datacontract.engines.fastjsonschema import check_jsonschema
 from datacontract.model.exceptions import DataContractException
@@ -59,6 +60,30 @@ def test_s3_json_validates_every_matching_file(monkeypatch):
         check_jsonschema.process_s3_file(MagicMock(), server, schema, "orders", fastjsonschema.compile(schema))
 
     assert "must be integer" in exc_info.value.reason
+
+
+def test_s3_json_stops_after_max_errors(monkeypatch):
+    schema = {
+        "type": "object",
+        "properties": {"order_id": {"type": "integer"}},
+        "required": ["order_id"],
+    }
+    server = MagicMock(
+        endpointUrl="http://minio:9000",
+        location="s3://bucket/orders/*.json",
+        delimiter="new_line",
+    )
+
+    def s3_files(*_):
+        yield b'{"order_id": "invalid"}\n'
+        raise AssertionError("files after the error limit should not be loaded")
+
+    monkeypatch.setattr(check_jsonschema, "yield_s3_files", s3_files)
+
+    with pytest.raises(DataContractException, match="must be integer"):
+        check_jsonschema.process_s3_file(
+            MagicMock(), server, schema, "orders", fastjsonschema.compile(schema), Config(max_errors=1)
+        )
 
 
 def _prepare_s3_files(minio_container):

--- a/tests/test_test_s3_json_multiple_models.py
+++ b/tests/test_test_s3_json_multiple_models.py
@@ -1,9 +1,13 @@
 import os
+from unittest.mock import MagicMock
 
+import fastjsonschema
 import pytest
 from testcontainers.minio import MinioContainer
 
 from datacontract.data_contract import DataContract
+from datacontract.engines.fastjsonschema import check_jsonschema
+from datacontract.model.exceptions import DataContractException
 
 datacontract = "./fixtures/s3-json-multiple-models/datacontract.yaml"
 data_directory = "./fixtures/s3-json-multiple-models/data/"
@@ -32,6 +36,29 @@ def test_test_s3_json(minio_container, monkeypatch):
 
     print(run.pretty())
     assert run.result == "passed"
+
+
+def test_s3_json_validates_every_matching_file(monkeypatch):
+    schema = {
+        "type": "object",
+        "properties": {"order_id": {"type": "integer"}},
+        "required": ["order_id"],
+    }
+    server = MagicMock(
+        endpointUrl="http://minio:9000",
+        location="s3://bucket/orders/*.json",
+        delimiter="new_line",
+    )
+    monkeypatch.setattr(
+        check_jsonschema,
+        "yield_s3_files",
+        lambda *_: [b'{"order_id": "invalid"}\n', b'{"order_id": 1}\n'],
+    )
+
+    with pytest.raises(DataContractException) as exc_info:
+        check_jsonschema.process_s3_file(MagicMock(), server, schema, "orders", fastjsonschema.compile(schema))
+
+    assert "must be integer" in exc_info.value.reason
 
 
 def _prepare_s3_files(minio_container):


### PR DESCRIPTION
Fixes #1511

## Summary

- validate every S3 object matched by the configured location while iterating the files
- accumulate schema errors across all matched objects before reporting them
- add a regression test with an invalid first object and valid final object

## Testing

- `.venv/bin/pytest tests/test_test_s3_json_multiple_models.py::test_s3_json_validates_every_matching_file tests/test_test_local_json.py tests/test_test_local_json_nd.py -q` (3 passed)
- `.venv/bin/ruff check datacontract/engines/fastjsonschema/check_jsonschema.py tests/test_test_s3_json_multiple_models.py`
- `.venv/bin/ruff format --check datacontract/engines/fastjsonschema/check_jsonschema.py tests/test_test_s3_json_multiple_models.py`

- [x] Tests pass (`uv run pytest`)
- [x] Code formatted (`uv run ruff check --fix && uv run ruff format`)
- [x] Docs updated (N/A; no documentation changes are needed)
- [x] CHANGELOG.md entry added
