### PR TITLE
feat: Add dry run flag for dbt sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `--dry-run` flag for `datacontract dbt sync` that reports the same plan as a real sync, but writes nothing to disk
+
 ### Fixed
 - `datacontract test --publish` no longer fails for runs with skipped checks (skipped checks are omitted from the published test results)
 

--- a/datacontract/command_dbt.py
+++ b/datacontract/command_dbt.py
@@ -172,10 +172,11 @@ def _count(n: int, noun: str) -> str:
 _MAX_LISTED_FILES = 5
 
 
-def _print_sync_summary(gen, project_dir: Path, *, debug: bool = False) -> None:
+def _print_sync_summary(gen, project_dir: Path, *, debug: bool = False, dry_run: bool = False) -> None:
     """Print the per-contract sync summary, naming the touched files."""
     prefix = f"{gen.contract_path.name}: "
-    line = f"{prefix}Synced {_count(len(gen.resolved_models), 'model')}: updated {_count(len(gen.written_yaml), 'YAML file')}"
+    verb = "Would sync" if dry_run else "Synced"
+    line = f"{prefix}{verb} {_count(len(gen.resolved_models), 'model')}: updated {_count(len(gen.written_yaml), 'YAML file')}"
     if gen.written_sql:
         line += f", wrote {_count(len(gen.written_sql), 'singular SQL test')}"
     if gen.deleted_files:
@@ -315,6 +316,12 @@ def sync_command(
         bool,
         typer.Option(help="Remove model columns and tags that are not declared in the contract."),
     ] = False,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run/--no-dry-run", help="Run in dry-run mode, without applying any changes to the dbt project."
+        ),
+    ] = False,
     run_tests_flag: Annotated[
         bool,
         typer.Option(
@@ -336,7 +343,8 @@ def sync_command(
     Generate dbt tests and model metadata from one or more ODCS contracts.
 
     Modifies the existing dbt model YAML in place (preserving comments and formatting), and creates new model YAML files
-    or singular SQL tests if needed. Use `datacontract dbt test` or pass --run-tests to run the generated tests.
+    or singular SQL tests if needed (if not run in dry-run mode). Use `datacontract dbt test` or pass --run-tests to run
+    the generated tests.
     """
     enable_debug_logging(debug)
     validate_publish_url(publish)
@@ -390,6 +398,7 @@ def sync_command(
                 prune=prune,
                 model_version=dbt_version,
                 server=server,
+                dry_run=dry_run,
             )
         except Exception as e:
             if not multiple_contracts:
@@ -398,7 +407,7 @@ def sync_command(
             continue
         if not contract and not multiple_contracts:
             console.print(f"Resolved contract {gen.contract_path}")
-        _print_sync_summary(gen, project_dir, debug=bool(debug))
+        _print_sync_summary(gen, project_dir, debug=bool(debug), dry_run=dry_run)
         if not prune:
             _warn_prunable(gen, project_dir)
         ctxs.append(_ContractCtx(gen.contract_path, gen.odcs, gen.resolved_models, gen.generation_run, dbt_version))

--- a/datacontract/integration/dbt_sync.py
+++ b/datacontract/integration/dbt_sync.py
@@ -1621,19 +1621,22 @@ class _EditSession:
         pf.yaml.dump(pf.data, buf)
         return buf.getvalue()
 
-    def apply(self) -> tuple[list[Path], list[Path]]:
+    def apply(self, dry_run: bool = False) -> tuple[list[Path], list[Path]]:
+        """Write the planned changes to disk, or (with `dry_run`) just report what would change."""
         written: list[Path] = []
         deleted: list[Path] = []
         for pf in self.files.values():
             if pf.deleted:
                 if pf.path.exists():
-                    pf.path.unlink()
+                    if not dry_run:
+                        pf.path.unlink()
                     deleted.append(pf.path)
                 continue
             new_text = self._render(pf)
             if new_text != (pf.original_text or ""):
-                pf.path.parent.mkdir(parents=True, exist_ok=True)
-                pf.path.write_text(new_text, encoding="utf-8")
+                if not dry_run:
+                    pf.path.parent.mkdir(parents=True, exist_ok=True)
+                    pf.path.write_text(new_text, encoding="utf-8")
                 written.append(pf.path)
         return written, deleted
 
@@ -2684,12 +2687,14 @@ def generate_dbt_tests(
     prune: bool = False,
     model_version: Optional[str] = None,
     server: Optional[str] = None,
+    dry_run: bool = False,
 ) -> DbtTestGenerationResult:
     """Resolve the contract, merge its tests + metadata into the dbt project's model YAML in place.
 
     `model_version` (a dbt model version like "2", from the contract filename) merges this contract
     into a versioned model — a `versions:` block — additively, leaving sibling versions untouched.
     `server` selects the ODCS server whose `type` maps `logicalType`s to a `data_type`.
+    `dry_run` computes and reports the same plan without writing, deleting, or moving any files.
     """
     explicit_project_dir = project_dir is not None
     project_dir = (project_dir or Path.cwd()).resolve()
@@ -2844,23 +2849,26 @@ def generate_dbt_tests(
     if contract_subdir.is_dir():
         for sql in contract_subdir.glob(f"{own_prefix}*.sql"):
             if sql not in desired:
-                sql.unlink()
+                if not dry_run:
+                    sql.unlink()
                 deleted_sql.append(sql)
     for path, sql in desired.items():
-        path.parent.mkdir(parents=True, exist_ok=True)
         if not path.exists() or path.read_text(encoding="utf-8") != sql:
-            path.write_text(sql, encoding="utf-8")
+            if not dry_run:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(sql, encoding="utf-8")
             written_sql.append(path)
 
-    # Migrate v1.0.9's flat layout: remove our top-level `*.sql` (the dir is CLI-owned wholesale).
-    for stale in tests_dir.glob("*.sql"):
-        stale.unlink()
-        deleted_sql.append(stale)
-    # Drop the subdir if this contract (and its resolved siblings) left it empty.
-    if contract_subdir.is_dir() and not any(contract_subdir.iterdir()):
-        contract_subdir.rmdir()
-    _remove_legacy_dir(legacy_dir)
-    written_yaml, deleted_yaml = session.apply()
+    if not dry_run:
+        # Migrate v1.0.9's flat layout: remove our top-level `*.sql` (the dir is CLI-owned wholesale).
+        for stale in tests_dir.glob("*.sql"):
+            stale.unlink()
+            deleted_sql.append(stale)
+        # Drop the subdir if this contract (and its resolved siblings) left it empty.
+        if contract_subdir.is_dir() and not any(contract_subdir.iterdir()):
+            contract_subdir.rmdir()
+        _remove_legacy_dir(legacy_dir)
+    written_yaml, deleted_yaml = session.apply(dry_run=dry_run)
     # Regenerated SQL is unlinked then rewritten; report only the ones not written back as deletions.
     written_sql_set = set(written_sql)
     deleted_files = [p for p in deleted_sql if p not in written_sql_set] + deleted_yaml

--- a/docs/docs/dbt.md
+++ b/docs/docs/dbt.md
@@ -41,6 +41,9 @@ datacontract dbt sync --run-tests
 
 # Generate, run, and publish results to an Entropy Data instance 
 datacontract dbt sync orders.odcs.yaml --run-tests --publish https://api.entropy-data.com/api/test-results
+
+# Preview changes without applying them
+datacontract dbt sync orders.odcs.yaml --dry-run
 ```
 
 A list of all options can be found at the [`dbt` command reference](./commands/dbt/sync.md).

--- a/tests/test_dbt_sync.py
+++ b/tests/test_dbt_sync.py
@@ -87,6 +87,7 @@ def sync(
     profiles_dir: Optional[Path] = None,
     skip_tests: bool = False,
     prune: bool = False,
+    dry_run: bool = False,
 ) -> _SyncResult:
     """End-to-end orchestration helper for tests — mirrors what the CLI does."""
     if not skip_tests:
@@ -97,6 +98,7 @@ def sync(
         schema_name=schema_name,
         model_resolution=model_resolution,
         prune=prune,
+        dry_run=dry_run,
     )
     if skip_tests:
         gen.generation_run.log_info("Skipped `dbt test` (--skip-tests).")
@@ -994,6 +996,112 @@ def test_sync_with_no_resolvable_schemas_still_wipes_stale_artifacts(tmp_path: P
 
     assert not stale_sql.exists()  # this contract's stale singular SQL is wiped + regenerated
     assert not (project / GENERATED_MODELS_DIR).exists()  # legacy parallel-YAML dir is migrated away
+
+
+# ---------------------------------------------------------------------------
+# --dry-run
+# ---------------------------------------------------------------------------
+
+
+def test_sync_dry_run_creates_no_files(tmp_path: Path):
+    """`dry_run` reports the same plan as a real sync, but writes nothing to disk."""
+    project = _copy_dbt_project(tmp_path)
+    _orders_model_sql(project)  # no YAML entry → a real sync would create a sidecar + singular SQL
+
+    result = sync(contract=str(CONTRACT_PATH), project_dir=project, skip_tests=True, dry_run=True)
+
+    assert len(result.written_yaml) == 1
+    assert len(result.written_sql) == 5
+    for path in result.written_yaml + result.written_sql:
+        assert not path.exists()
+    assert not (project / "models" / "orders.yml").exists()
+    assert not (project / GENERATED_TESTS_DIR).exists()
+
+
+def test_sync_dry_run_does_not_modify_existing_yaml(tmp_path: Path):
+    """An in-place merge into a user's existing model entry is reported but not written."""
+    project = _copy_dbt_project(tmp_path)
+    _orders_model_sql(project)
+    schema = _user_orders_schema(project)
+    original_text = schema.read_text()
+
+    result = sync(contract=str(CONTRACT_PATH), project_dir=project, skip_tests=True, dry_run=True)
+
+    assert schema in result.written_yaml  # merge would have changed the file...
+    assert schema.read_text() == original_text  # ...but it was left untouched
+
+
+def test_sync_dry_run_preserves_stale_artifacts(tmp_path: Path):
+    """Stale generated files that a real sync would wipe are left in place under --dry-run."""
+    project = _copy_dbt_project(tmp_path)
+    stale_legacy = project / GENERATED_MODELS_DIR / "stale.yml"
+    stale_sql = project / GENERATED_TESTS_DIR / "empty_contract__stale.sql"
+    stale_legacy.parent.mkdir(parents=True, exist_ok=True)
+    stale_sql.parent.mkdir(parents=True, exist_ok=True)
+    stale_legacy.write_text("# stale")
+    stale_sql.write_text("-- stale")
+
+    empty_contract = tmp_path / "empty.odcs.yaml"
+    empty_contract.write_text(
+        "kind: DataContract\napiVersion: v3.1.0\nid: empty-contract\nname: Empty\nversion: 1.0.0\nstatus: active\n"
+    )
+
+    sync(contract=str(empty_contract), project_dir=project, skip_tests=True, dry_run=True)
+
+    assert stale_sql.exists()
+    assert stale_legacy.exists()
+
+
+def test_cli_dry_run_flag_writes_nothing(tmp_path: Path):
+    project = _copy_dbt_project(tmp_path)
+    _orders_model_sql(project)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["dbt", "sync", str(CONTRACT_PATH), "--project-dir", str(project), "--dry-run"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Would sync 1 model" in result.stdout
+    assert not (project / "models" / "orders.yml").exists()
+    assert not (project / GENERATED_TESTS_DIR).exists()
+
+
+def test_cli_no_dry_run_flag_writes_files(tmp_path: Path):
+    """`--no-dry-run` is the explicit-off form of the flag — behaves like a plain sync."""
+    project = _copy_dbt_project(tmp_path)
+    _orders_model_sql(project)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["dbt", "sync", str(CONTRACT_PATH), "--project-dir", str(project), "--no-dry-run"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Synced 1 model" in result.stdout
+    assert "Would sync" not in result.stdout
+    assert (project / "models" / "orders.yml").exists()
+    assert (project / GENERATED_TESTS_DIR).is_dir()
+
+
+def test_sync_no_dry_run_matches_default_behavior(tmp_path: Path):
+    """`dry_run=False` (the default) and an explicit `--no-dry-run` write identical files."""
+    project_default = _copy_dbt_project(tmp_path / "default")
+    _orders_model_sql(project_default)
+    project_explicit = _copy_dbt_project(tmp_path / "explicit")
+    _orders_model_sql(project_explicit)
+
+    result_default = sync(contract=str(CONTRACT_PATH), project_dir=project_default, skip_tests=True)
+    result_explicit = sync(contract=str(CONTRACT_PATH), project_dir=project_explicit, skip_tests=True, dry_run=False)
+
+    assert len(result_default.written_yaml) == len(result_explicit.written_yaml) == 1
+    assert len(result_default.written_sql) == len(result_explicit.written_sql) == 5
+    for path in result_default.written_yaml + result_default.written_sql:
+        assert path.exists()
+    for path in result_explicit.written_yaml + result_explicit.written_sql:
+        assert path.exists()
 
 
 def test_sync_missing_contract_raises(tmp_path: Path):


### PR DESCRIPTION
Adds a dry-run flag to dbt sync for CICD and pre-commit synchronization checks. 

- [ X ] Tests pass (`uv run pytest`)
- [ X ] Code formatted (`uv run ruff check --fix && uv run ruff format`)
- [ X ] Docs updated (if relevant)
- [ X ] CHANGELOG.md entry added
