### PR TITLE
Give each docs page a single URL

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,49 @@ yarn build
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
 
+## URLs and redirects
+
+`static/staticwebapp.config.json` is the deployed redirect layer. Docusaurus
+emits a static site with no server, so this file is the only place a 301 can
+live. It ships because Docusaurus copies `static/` verbatim into `build/`.
+
+(The Deployment section below is stock Docusaurus boilerplate and describes
+`gh-pages`; the site actually deploys to Azure Static Web Apps from
+`.github/workflows/azure-static-web-apps-docs.yml`.)
+
+This works with `trailingSlash: false` in `docusaurus.config.ts`, and the two
+settings have to agree. Docusaurus decides what each page's canonical URL *is*;
+this file makes the host enforce it.
+
+Left unset, Docusaurus wrote `build/commands/index.html` while canonicalising to
+`/commands` — and Azure served every intermediate form too, so each page
+answered `200` at four URLs with only the canonical tag to sort them out:
+
+```
+/commands   /commands/   /commands/index.html   /commands/index
+```
+
+Worse, the site disagreed with itself: category index pages canonicalised
+*with* a slash (`/commands/dbt/`, `/commands/export/`, `/commands/import/`,
+`/scheduling/`) while the other 195 pages did not. No host-level rule can be
+right for both halves, which is why the Docusaurus setting had to change first
+rather than this one carrying the whole fix.
+
+Now every page emits a flat `commands/dbt.html`, canonicalises to
+`/commands/dbt`, and `"trailingSlash": "auto"` redirects the leftovers onto it.
+`auto` and `never` behave identically for a flat layout like this; `auto` is
+preferred because it is verified in production to leave `/` at `200`, and it is
+what the other Entropy Data sites use.
+
+The two `/index` routes exist because `auto` mishandles the root, and only the
+root: with no folder segment to fall back to, Azure strips `.html` like an
+ordinary file and lands on `/index`, which answers `200` straight back from
+`index.html`. The routes send both forms to `/`.
+
+Note that route rules drop the query string — Azure's `redirect` is a static
+string with no placeholder syntax. The `trailingSlash` redirects preserve it, so
+only the two explicit rules are affected.
+
 ## Deployment
 
 Using SSH:

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -55,6 +55,19 @@ const config: Config = {
   url: 'https://docs.datacontract.com',
   baseUrl: '/',
 
+  // One URL per page, without a trailing slash.
+  //
+  // Left unset, Docusaurus emits `commands/index.html` but canonicalises to
+  // `/commands` — except for category index pages, which canonicalise to
+  // `/commands/dbt/` *with* a slash. The site then disagrees with itself, and
+  // no host-level trailing-slash rule can be right for both halves.
+  //
+  // `false` settles it: every URL loses the slash and the build emits flat
+  // `commands/dbt.html`, so all 199 canonicals share one shape. The host then
+  // redirects the leftover forms onto it — see `trailingSlash` in
+  // `static/staticwebapp.config.json`, which has to stay consistent with this.
+  trailingSlash: false,
+
   organizationName: 'datacontract',
   projectName: 'datacontract-cli',
 

--- a/docs/static/staticwebapp.config.json
+++ b/docs/static/staticwebapp.config.json
@@ -1,6 +1,17 @@
 {
   "$schema": "https://json.schemastore.org/staticwebapp.config.json",
+  "trailingSlash": "auto",
   "routes": [
+    {
+      "route": "/index.html",
+      "redirect": "/",
+      "statusCode": 301
+    },
+    {
+      "route": "/index",
+      "redirect": "/",
+      "statusCode": 301
+    },
     {
       "route": "/assets/*",
       "headers": {


### PR DESCRIPTION
Every docs page currently answers `200` at four paths:

```
/commands   /commands/   /commands/index.html   /commands/index
```

199 pages × 4 forms, with only the canonical tag telling Google which one counts.

## Why the host setting alone couldn't fix it

The site disagreed with itself. Four category index pages canonicalised **with** a trailing slash while the other 195 did not:

| Page | Canonical |
|---|---|
| `/commands` | `.../commands` |
| `/commands/dbt` | `.../commands/dbt/` |
| `/commands/export` | `.../commands/export/` |
| `/commands/import` | `.../commands/import/` |
| `/scheduling` | `.../scheduling/` |

No trailing-slash rule is right for both halves — `never` would redirect those four away from their own canonical URL, `always` would do it to the other 195.

## The change

1. **`docusaurus.config.ts`: `trailingSlash: false`** settles the shape. Every URL drops the slash and the build emits flat `commands/dbt.html`. Four canonical URLs change, onto the form the other 195 already used.
2. **`static/staticwebapp.config.json`: `"trailingSlash": "auto"`** makes Azure `301` the leftover forms onto the canonical one, plus two routes for the root (`auto` strips `.html` there like an ordinary file and lands on `/index`, which answers `200` straight back from `index.html`).

`auto` and `never` behave identically for a flat layout; `auto` is verified in production on entropy-data.com to leave `/` at `200`, and matches the other Entropy Data sites.

## Verified on the local rebuild

- 0 folder `index.html` files (was 199)
- 0 canonicals ending in a slash, except the root
- all 201 sitemap `<loc>` entries resolve to a file — no sitemap URL will redirect

Please check the Azure preview deployment before merging, particularly that `/` still returns `200` and `/commands/dbt` resolves without a redirect.