### PR TITLE
fix: stop a posted data contract from reaching the machine that runs it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract api` no longer reloads on file changes by default; pass `--reload` to enable it (development only)
 
 ### Fixed
+- A `quality.type: sql` rule must be a read-only query; DDL, DML, `COPY`, `ATTACH` and the like are reported as a failed check instead of being executed, for every data source
+- `datacontract api` refuses `servers[].type: local`, so a posted data contract cannot read the files of the server running it; set `DATACONTRACT_CLI_API_ALLOW_LOCAL_FILES=true` to allow it
+- `datacontract api` confines the DuckDB connection of a file-based server to the data locations the posted data contract declares
 - The Entropy Data API key is only sent to the Entropy Data host, no longer to any host a data contract URL or `--publish` URL points at; set `ENTROPY_DATA_HOST` for a self-hosted deployment
 - `datacontract api` refuses to send an environment-held data source credential to a host named by the posted contract, preventing credential exfiltration through a crafted `servers` section
 - `datacontract export html` and `datacontract catalog` now HTML-escape data contract field values, closing a stored cross-site scripting hole

--- a/datacontract/api.py
+++ b/datacontract/api.py
@@ -251,6 +251,15 @@ that value, and answers `401` when the header is missing and `403` when it is wr
 Securing the API is strongly recommended: `POST /test` connects to your data sources, and test
 results may contain sensitive information.
 
+## Contracts are untrusted
+
+A posted contract carries SQL and names the hosts to connect to, so the server treats it as
+untrusted input: a `quality.type: sql` rule must be a read-only query, a credential held in the
+server's environment is never sent to a host the contract names, and `servers[].type: local` is
+refused so a caller cannot read the server's own files. Set
+`DATACONTRACT_CLI_API_ALLOW_LOCAL_FILES=true` if the deployment serves its own files on purpose;
+the contract is then still confined to the paths it declares.
+
 ## Connecting to data sources
 
 `POST /test` needs credentials for the server described in the contract's `servers` section. Provide
@@ -477,6 +486,65 @@ _AMBIENT_CREDENTIAL_TARGETS: dict[str, tuple[str, str | None, tuple[str, ...]]] 
 }
 
 
+def _selected_server(body: str, server_name: str | None, config):
+    """The server the request would test, or None if that cannot be determined.
+
+    A contract that does not resolve, or that names no such server, is reported
+    by test() itself -- the guards below simply have nothing to check.
+    """
+    from datacontract.engines.data_contract_test import get_server
+    from datacontract.lint import resolve
+
+    try:
+        data_contract = resolve.resolve_data_contract(data_contract_str=body, config=config)
+        return get_server(data_contract, server_name)
+    except Exception:
+        return None
+
+
+# Server types that read their data through the local filesystem of the machine
+# running the test, rather than from a remote data source.
+_LOCAL_SERVER_TYPES = frozenset({"local"})
+
+ALLOW_LOCAL_FILES_ENV = "DATACONTRACT_CLI_API_ALLOW_LOCAL_FILES"
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _local_files_allowed() -> bool:
+    """Whether the operator opted in to serving data from the server's own disk.
+
+    Off by default. A deployment that mounts the data next to the API -- the data
+    directory in the container, say -- turns it on, accepting that a caller then
+    picks the path.
+    """
+    return (os.getenv(ALLOW_LOCAL_FILES_ENV) or "").strip().lower() in _TRUTHY
+
+
+def _reject_local_server_type(body: str, server_name: str | None, config) -> None:
+    """Keep a posted contract from reading the server's own disk.
+
+    `type: local` points the test at a path on the machine running it. For the
+    API server that machine is not the caller's, so the path is not theirs to
+    name -- and the result would tell them what is in it.
+    """
+    from datacontract.config import Config
+
+    if _local_files_allowed():
+        return
+    server = _selected_server(body, server_name, Config.resolve(config))
+    if server is None or server.type not in _LOCAL_SERVER_TYPES:
+        return
+    raise HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        detail=(
+            f"Server type '{server.type}' reads from the file system of the server running this API, "
+            f"so it is refused. Use a server type that names a data source, such as s3, gcs, azure, "
+            f"postgres, or snowflake — or set {ALLOW_LOCAL_FILES_ENV}=true if this deployment serves "
+            f"its own files on purpose."
+        ),
+    )
+
+
 def _reject_ambient_credentials_to_untrusted_host(body: str, server_name: str | None, config) -> None:
     """Keep an environment-held data-source credential from reaching a host the
     posted contract chose.
@@ -492,15 +560,9 @@ def _reject_ambient_credentials_to_untrusted_host(body: str, server_name: str | 
     """
     from datacontract.config import Config
     from datacontract.config.settings import env_name
-    from datacontract.engines.data_contract_test import get_server
-    from datacontract.lint import resolve
 
     resolved = Config.resolve(config)
-    try:
-        data_contract = resolve.resolve_data_contract(data_contract_str=body, config=resolved)
-        server = get_server(data_contract, server_name)
-    except Exception:
-        return  # a broken contract or server selection is reported by test() itself
+    server = _selected_server(body, server_name, resolved)
     if server is None:
         return
     guard = _AMBIENT_CREDENTIAL_TARGETS.get(server.type)
@@ -644,8 +706,10 @@ async def test(
     logging.info("Testing data contract...")
     logging.info(body)
     config = config_from_headers(request.headers)
-    if getattr(request.app.state, "untrusted_contracts", False):
+    untrusted_contract = getattr(request.app.state, "untrusted_contracts", False)
+    if untrusted_contract:
         _reject_ambient_credentials_to_untrusted_host(body, server, config)
+        _reject_local_server_type(body, server, config)
     return DataContract(
         data_contract_str=body,
         server=server,
@@ -654,6 +718,7 @@ async def test(
         config=config,
         filter=filter,
         filters=parsed_filters,
+        untrusted_contract=untrusted_contract,
     ).test()
 
 

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -47,6 +47,7 @@ class DataContract:
         filter: str = None,
         filters: dict[str, str] | None = None,
         metadata_only: bool = False,
+        untrusted_contract: bool = False,
         config: "Config | dict[str, str] | None" = None,
     ):
         self._data_contract_file = data_contract_file
@@ -71,6 +72,9 @@ class DataContract:
         self._filter = filter
         self._filters = filters
         self._metadata_only = metadata_only
+        # The contract came from somewhere the caller does not control (the API
+        # server), so the SQL it carries must not reach the host running it.
+        self._untrusted_contract = untrusted_contract
         self._config = Config.resolve(config)
 
     @classmethod
@@ -172,6 +176,7 @@ class DataContract:
                 filters=self._filters,
                 metadata_only=self._metadata_only,
                 config=self._config,
+                untrusted_contract=self._untrusted_contract,
             )
 
         except DataContractException as e:

--- a/datacontract/engines/checks/create_checks.py
+++ b/datacontract/engines/checks/create_checks.py
@@ -23,6 +23,7 @@ from open_data_contract_standard.model import (
 
 from datacontract.engines.checks.check_spec import CheckSpec, MetricType, Op, Threshold
 from datacontract.engines.checks.dimensions import default_dimension
+from datacontract.engines.checks.sql_guard import is_read_only_query
 from datacontract.engines.checks.type_normalize import normalize_type_name
 from datacontract.engines.ibis.native_type import supports_native_type_introspection
 
@@ -630,6 +631,26 @@ def _quality_rule_checks(
         if threshold is None:
             logger.warning(f"Quality check {check_key} has no valid threshold")
             return []
+        dialect = getattr(quality, "dialect", None)
+        if not is_read_only_query(query, dialect):
+            return [
+                CheckSpec(
+                    key=check_key,
+                    category="quality",
+                    type=check_type,
+                    name=quality.description or "Quality Check",
+                    model=model,
+                    field=field,
+                    metric=MetricType.UNSUPPORTED,
+                    dimension=quality.dimension,
+                    severity=quality.severity,
+                    preset_result="failed",
+                    preset_reason=(
+                        "A quality rule query must be a single read-only query. This one is not, "
+                        "so it was not executed."
+                    ),
+                )
+            ]
         return [
             CheckSpec(
                 key=check_key,
@@ -641,7 +662,7 @@ def _quality_rule_checks(
                 metric=MetricType.CUSTOM_SQL,
                 threshold=threshold,
                 query=query,
-                dialect=getattr(quality, "dialect", None),
+                dialect=dialect,
                 severity=quality.severity,
                 dimension=quality.dimension,
             )

--- a/datacontract/engines/checks/sql_guard.py
+++ b/datacontract/engines/checks/sql_guard.py
@@ -1,0 +1,41 @@
+"""Keep a contract's custom SQL to reading.
+
+A `quality.type: sql` rule computes a number from the data, so a read-only query
+is all it ever needs. Anything else -- DDL, DML, `COPY` (a file write on duckdb
+and `COPY ... TO PROGRAM` on postgres), `ATTACH`, `INSTALL`/`LOAD`, `SET`,
+`PRAGMA`, `CALL` -- is refused, for every data source: a data contract is not
+always written by the person whose credentials run it.
+"""
+
+from typing import Optional
+
+import sqlglot
+from sqlglot import exp
+
+# `Subquery` covers a parenthesized select, `SetOperation` a UNION/INTERSECT/EXCEPT.
+# A `WITH ... SELECT` parses as a Select carrying the CTEs.
+_READ_ONLY = (exp.Select, exp.SetOperation, exp.Subquery)
+
+
+def is_read_only_query(query: str, dialect: Optional[str] = None) -> bool:
+    """True when `query` is a single read-only statement.
+
+    Fails closed: a query that does not parse is refused rather than passed
+    through, and so is one that holds a second statement -- a trailing
+    `; DROP TABLE orders` must never reach the data source.
+    """
+    try:
+        statements = sqlglot.parse(query, dialect=dialect)
+    except sqlglot.errors.ParseError:
+        return False
+    except Exception:
+        # An unknown dialect name is about the parser, not the query, so try the
+        # default dialect rather than refuse a query for how it was labelled.
+        try:
+            statements = sqlglot.parse(query)
+        except Exception:
+            return False
+
+    # A trailing semicolon parses as an extra empty statement.
+    statements = [statement for statement in statements if statement is not None]
+    return len(statements) == 1 and isinstance(statements[0], _READ_ONLY)

--- a/datacontract/engines/data_contract_test.py
+++ b/datacontract/engines/data_contract_test.py
@@ -39,6 +39,7 @@ def execute_data_contract_test(
     filters: dict[str, str] | None = None,
     metadata_only: bool = False,
     config: Config | None = None,
+    untrusted_contract: bool = False,
 ):
     config = Config.resolve(config)
     if data_contract.schema_ is None or len(data_contract.schema_) == 0:
@@ -148,6 +149,7 @@ def execute_data_contract_test(
         include_failed_samples=include_failed_samples,
         model_filters=model_filters,
         config=config,
+        untrusted_contract=untrusted_contract,
     )
 
 

--- a/datacontract/engines/ibis/connections/connect.py
+++ b/datacontract/engines/ibis/connections/connect.py
@@ -53,6 +53,7 @@ def connect_ibis(
     duckdb_connection=None,
     schema_name: str = "all",
     config: Config | None = None,
+    untrusted_contract: bool = False,
 ) -> "ibis.BaseBackend | None":
     """Return a connected ibis backend, or ``None`` if the server is unsupported.
 
@@ -69,7 +70,13 @@ def connect_ibis(
             return None
         run.log_info(f"Connecting to {server_type} {server.format} via duckdb")
         con = get_duckdb_connection(
-            data_contract, server, run, duckdb_connection, schema_name=schema_name, config=config
+            data_contract,
+            server,
+            run,
+            duckdb_connection,
+            schema_name=schema_name,
+            config=config,
+            untrusted_contract=untrusted_contract,
         )
         return ibis.duckdb.from_connection(con)
 

--- a/datacontract/engines/ibis/connections/duckdb_connection.py
+++ b/datacontract/engines/ibis/connections/duckdb_connection.py
@@ -33,10 +33,12 @@ def get_duckdb_connection(
     duckdb_connection: "duckdb.DuckDBPyConnection | None" = None,
     schema_name: str = "all",
     config: Config | None = None,
+    untrusted_contract: bool = False,
 ) -> "duckdb.DuckDBPyConnection":
     duckdb = _import_duckdb()
     config = Config.resolve(config)
-    if duckdb_connection is None:
+    own_connection = duckdb_connection is None
+    if own_connection:
         con = duckdb.connect(database=":memory:")
     else:
         con = duckdb_connection
@@ -54,14 +56,26 @@ def get_duckdb_connection(
         path = server.location
         setup_azure_connection(con, server, config)
 
+    if server.format == "delta":
+        # Updating an extension reaches the network and the extension directory,
+        # both of which the sandbox below takes away -- so do it first, and once
+        # for the whole connection rather than once per model.
+        con.sql("update extensions;")  # Make sure we have the latest delta extension
+
+    model_paths = _model_paths(data_contract, path, schema_name)
+    if untrusted_contract and own_connection:
+        # After the extensions are loaded and the secrets created -- both need
+        # access the sandbox takes away -- and before any contract-supplied SQL
+        # can run. Not applied to a connection the caller handed us: that one is
+        # theirs to configure.
+        restrict_to_paths(con, model_paths)
+
     if data_contract.schema_:
         for schema_obj in data_contract.schema_:
             model_name = schema_obj.name
             if schema_name != "all" and model_name != schema_name:
                 continue
-            model_path = path
-            if "{model}" in model_path:
-                model_path = model_path.format(model=model_name)
+            model_path = _model_path(path, model_name)
             run.log_info(f"Creating table {model_name} for {model_path}")
 
             if server.format == "json":
@@ -89,12 +103,73 @@ def get_duckdb_connection(
             elif server.format == "csv":
                 create_view_with_schema_union(con, schema_obj, model_path, "read_csv", to_csv_types)
             elif server.format == "delta":
-                con.sql("update extensions;")  # Make sure we have the latest delta extension
                 con.sql(f"""CREATE VIEW "{model_name}" AS SELECT * FROM delta_scan('{model_path}');""")
             table_info = con.sql(f'PRAGMA table_info("{model_name}");').fetchall()
             if table_info:
                 run.log_info(f"DuckDB Table Info: {table_info}")
     return con
+
+
+def _model_path(path: str, model_name: str) -> str:
+    """The data location of one model: the server path with `{model}` filled in."""
+    return path.format(model=model_name) if "{model}" in path else path
+
+
+def _model_paths(data_contract: OpenDataContractStandard, path: str, schema_name: str) -> list[str]:
+    """Every location this connection is going to read, one per model under test."""
+    if not path or not data_contract.schema_:
+        return []
+    return [
+        _model_path(path, schema_obj.name)
+        for schema_obj in data_contract.schema_
+        if schema_name == "all" or schema_obj.name == schema_name
+    ]
+
+
+# duckdb globs against the filesystem, so a location holding one of these has to be
+# allowed as a directory prefix rather than as an exact file.
+_GLOB_CHARACTERS = ("*", "?", "[")
+
+
+def restrict_to_paths(con, paths: list[str]) -> None:
+    """Confine the connection to `paths` and nothing else.
+
+    A data contract carries SQL (`quality.type: sql`) that runs on this
+    connection, and for a file server type that connection is duckdb -- which
+    reads and writes the local filesystem. So the contract's own data locations
+    are the only ones it may touch: `read_text('/etc/passwd')` and `COPY ... TO`
+    alike are then refused by duckdb itself.
+
+    `enable_external_access = false` is one-way -- duckdb refuses to re-enable it,
+    and refuses to widen `allowed_paths`/`allowed_directories` once it is off --
+    so the restriction holds without `lock_configuration`, which would also stop
+    ibis from setting the session timezone.
+
+    Must run after the extensions are loaded (installing one needs access this
+    takes away) and before any contract-supplied SQL.
+    """
+    directories = sorted({_glob_root(p) for p in paths if _is_glob(p)})
+    files = sorted({p for p in paths if not _is_glob(p)})
+    if directories:
+        con.sql(f"SET allowed_directories = {_sql_list(directories)}")
+    if files:
+        con.sql(f"SET allowed_paths = {_sql_list(files)}")
+    con.sql("SET enable_external_access = false")
+
+
+def _is_glob(path: str) -> bool:
+    return any(character in path for character in _GLOB_CHARACTERS) or path.endswith("/")
+
+
+def _glob_root(path: str) -> str:
+    """The fixed prefix of a glob, which is the directory duckdb has to be allowed into."""
+    cut = min((path.find(c) for c in _GLOB_CHARACTERS if c in path), default=len(path))
+    root = path[:cut].rstrip("/")
+    return root or "/"
+
+
+def _sql_list(values: list[str]) -> str:
+    return "[" + ", ".join(f"'{_sql_literal(value)}'" for value in values) + "]"
 
 
 def create_view_with_schema_union(con, schema_obj: SchemaObject, model_path: str, read_function: str, type_converter):

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -106,6 +106,7 @@ def execute_ibis_checks(
     include_failed_samples: bool = False,
     model_filters: Optional[dict[str, str]] = None,
     config=None,
+    untrusted_contract: bool = False,
 ):
     if data_contract is None:
         run.log_warn("Cannot run engine ibis, as data contract is invalid")
@@ -124,7 +125,9 @@ def execute_ibis_checks(
 
     run.log_info("Running engine ibis")
     try:
-        con = connect_ibis(run, data_contract, server, spark, duckdb_connection, schema_name, config)
+        con = connect_ibis(
+            run, data_contract, server, spark, duckdb_connection, schema_name, config, untrusted_contract
+        )
     except DataContractException:
         raise
     except ImportError:

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -104,6 +104,23 @@ export DATACONTRACT_CLI_API_KEY=<your-secret-key-such-as-a-random-uuid>
 Securing the API is highly recommended. Data contract tests may otherwise be subject to SQL injection or leak sensitive information.
 :::
 
+## Posted contracts are untrusted
+
+A data contract carries SQL and names the hosts to connect to, so a contract that arrives over HTTP is treated as untrusted input, whether or not the API key is set:
+
+- a `quality.type: sql` rule must be a **read-only query** — DDL, DML, `COPY`, `ATTACH` and the like are reported as a failed check instead of being executed;
+- a credential held in the server's environment is **never sent to a host the contract names** (see [Configuration](./configuration.md));
+- `servers[].type: local` is **refused**, so a caller cannot read the files of the machine running the API;
+- for a file-based server type (`s3`, `gcs`, `azure`), the DuckDB connection is **confined to the data locations the contract declares**.
+
+If the deployment serves its own files on purpose — the data mounted next to the API in the same container, say — allow it explicitly:
+
+```bash
+export DATACONTRACT_CLI_API_ALLOW_LOCAL_FILES=true
+```
+
+The contract is then still confined to the paths it declares, but a caller chooses those paths, so only turn this on where callers are trusted.
+
 ## Run as a Docker container
 
 The pre-built image can run the API in any container environment (Docker Compose, Kubernetes, Azure Container Apps, Google Cloud Run, …):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,8 +1,9 @@
 from unittest.mock import patch
 
+import pytest
 from fastapi.testclient import TestClient
 
-from datacontract.api import app
+from datacontract.api import ALLOW_LOCAL_FILES_ENV, app
 from datacontract.model.exceptions import DataContractException
 
 client = TestClient(app)
@@ -203,7 +204,7 @@ def test_unknown_config_header_is_rejected():
     assert "DATACONTRACT_SNOWFLAKE_TYPO" in response.json()["detail"]
 
 
-def test_test_endpoint_uses_config_from_headers():
+def test_test_endpoint_uses_config_from_headers(allow_local_files):
     with open("fixtures/local-json/datacontract.yaml", "r", encoding="utf-8") as f:
         data_contract_str = f.read()
 
@@ -221,12 +222,19 @@ def test_test_endpoint_uses_config_from_headers():
     assert config.get_postgres_password() == "pw"
 
 
+@pytest.fixture
+def allow_local_files(monkeypatch):
+    """These tests use a local fixture file as a convenient data source, which the
+    API refuses by default (see test_untrusted_contract.py)."""
+    monkeypatch.setenv(ALLOW_LOCAL_FILES_ENV, "true")
+
+
 def _row_filter_contract():
     with open("fixtures/row-filter/datacontract.yaml", "r", encoding="utf-8") as f:
         return f.read()
 
 
-def test_test_endpoint_filter_param():
+def test_test_endpoint_filter_param(allow_local_files):
     response = client.post(
         url="/test?filter=order_id <= 2",
         content=_row_filter_contract(),
@@ -238,7 +246,7 @@ def test_test_endpoint_filter_param():
     assert response.json()["filters"] == {"orders": "order_id <= 2"}
 
 
-def test_test_endpoint_filters_param():
+def test_test_endpoint_filters_param(allow_local_files):
     response = client.post(
         url='/test?filters={"orders": "order_id <= 2"}',
         content=_row_filter_contract(),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -175,9 +175,13 @@ def test_declared_snowflake_variables_are_not_reported(monkeypatch):
 
 # Env vars the code reads that are deliberately not Config fields: process-level
 # concerns, not per-operation connection config.
+# Settings of the machine running the CLI, not of a data source. Deliberately not
+# Config fields: a Config field is settable per request through a `datacontract-*`
+# header, which would let a caller of the API server change the server's own policy.
 _NON_CONFIG_ENV_VARS = {
     "DATACONTRACT_CLI_DEBUG",
     "DATACONTRACT_CLI_API_KEY",
+    "DATACONTRACT_CLI_API_ALLOW_LOCAL_FILES",
     "DATACONTRACT_SYSTEM_TRUSTSTORE",
 }
 

--- a/tests/test_untrusted_contract.py
+++ b/tests/test_untrusted_contract.py
@@ -1,0 +1,250 @@
+"""A data contract carries SQL, so a contract the caller did not write must not
+be able to reach the machine that runs it.
+
+Two independent controls, tested here:
+  1. custom SQL must be a read-only query -- for every data source
+  2. duckdb is confined to the contract's own data locations
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from datacontract.api import ALLOW_LOCAL_FILES_ENV, app
+from datacontract.data_contract import DataContract
+from datacontract.engines.checks.sql_guard import is_read_only_query
+from datacontract.engines.ibis.connections.duckdb_connection import restrict_to_paths
+from datacontract.model.run import ResultEnum
+
+client = TestClient(app)
+
+
+def _contract(path: str, query: str = None, must_be: int = 0) -> str:
+    quality = ""
+    if query is not None:
+        quality = f"""
+    quality:
+      - type: sql
+        query: "{query}"
+        mustBe: {must_be}
+"""
+    return f"""apiVersion: v3.0.2
+kind: DataContract
+id: orders
+name: Orders
+version: 1.0.0
+status: active
+servers:
+  - server: production
+    type: local
+    path: {path}
+    format: json
+schema:
+  - name: orders
+    properties:
+      - name: id
+        logicalType: string
+{quality}
+"""
+
+
+@pytest.fixture
+def data_file(tmp_path):
+    file = tmp_path / "orders.json"
+    file.write_text('{"id": "1"}\n')
+    return file
+
+
+@pytest.fixture
+def secret_file(tmp_path):
+    file = tmp_path / "secret.txt"
+    file.write_text("AWS_SECRET=super-secret-value")
+    return file
+
+
+# --- 1. custom SQL must be a read-only query -------------------------------
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT count(*) FROM orders",
+        "WITH counted AS (SELECT count(*) AS n FROM orders) SELECT n FROM counted",
+        "SELECT count(*) FROM orders UNION ALL SELECT count(*) FROM orders",
+        "(SELECT count(*) FROM orders)",
+        "SELECT count(*) FROM orders;",
+    ],
+)
+def test_a_query_is_read_only(query):
+    assert is_read_only_query(query)
+
+
+@pytest.mark.parametrize(
+    "statement",
+    [
+        "DROP TABLE orders",
+        "DELETE FROM orders",
+        "INSERT INTO orders VALUES ('1')",
+        "UPDATE orders SET id = '2'",
+        "CREATE TABLE pwn AS SELECT 1",
+        # a file write on duckdb, and command execution on postgres
+        "COPY (SELECT 1) TO '/tmp/pwn.csv'",
+        "COPY orders TO PROGRAM 'sh -c id'",
+        "ATTACH '/tmp/pwn.db' AS pwn",
+        "INSTALL httpfs",
+        "LOAD httpfs",
+        "SET enable_external_access = true",
+        "PRAGMA version",
+        # a second statement smuggled in behind a legitimate one
+        "SELECT count(*) FROM orders; DROP TABLE orders",
+        # not sql at all: refused rather than passed through
+        "not a query",
+    ],
+)
+def test_a_statement_that_is_not_a_query_is_refused(statement):
+    assert not is_read_only_query(statement)
+
+
+def test_an_unknown_dialect_does_not_reject_a_valid_query():
+    """The dialect labels the query; it is not a reason to refuse one."""
+    assert is_read_only_query("SELECT count(*) FROM orders", dialect="no-such-dialect")
+    assert not is_read_only_query("DROP TABLE orders", dialect="no-such-dialect")
+
+
+def test_a_quality_rule_that_is_not_a_query_fails_without_running(data_file, tmp_path):
+    written = tmp_path / "written-by-the-contract.csv"
+
+    run = DataContract(
+        data_contract_str=_contract(data_file, f"COPY (SELECT 1) TO '{written}'"),
+        inline_references=False,
+    ).test()
+
+    check = next(c for c in run.checks if c.type == "model_quality_sql")
+    assert check.result == ResultEnum.failed
+    assert "read-only query" in check.reason
+    assert not written.exists()
+
+
+# --- 2. duckdb is confined to the contract's own data locations -------------
+
+
+def test_an_untrusted_contract_cannot_read_another_file(data_file, secret_file):
+    """`read_text` is a read-only query, so it passes the first control and has
+    to be stopped by the second one."""
+    query = f"SELECT content FROM read_text('{secret_file}')"
+    assert is_read_only_query(query), "the point of this test is a query the first control lets through"
+
+    run = DataContract(
+        data_contract_str=_contract(data_file, query),
+        untrusted_contract=True,
+        inline_references=False,
+    ).test()
+
+    assert "super-secret-value" not in run.model_dump_json()
+    assert "Permission Error" in run.model_dump_json(), "duckdb should be the one refusing it"
+
+
+def test_a_trusted_contract_reads_the_file_the_user_named(data_file, secret_file):
+    """The counterpart: on the command line the file is the user's own, so the
+    sandbox is not applied and the same query runs. This is what makes the
+    assertion above a real result rather than a broken query."""
+    run = DataContract(
+        data_contract_str=_contract(data_file, f"SELECT content FROM read_text('{secret_file}')"),
+        inline_references=False,
+    ).test()
+
+    assert "super-secret-value" in run.model_dump_json()
+
+
+def test_an_untrusted_contract_still_reads_its_own_data(data_file):
+    run = DataContract(
+        data_contract_str=_contract(data_file, "SELECT count(*) FROM orders", must_be=1),
+        untrusted_contract=True,
+        inline_references=False,
+    ).test()
+
+    check = next(c for c in run.checks if c.type == "model_quality_sql")
+    assert check.result == ResultEnum.passed
+
+
+def test_the_sandbox_cannot_be_undone(tmp_path):
+    """`restrict_to_paths` relies on duckdb refusing to widen the restriction
+    once external access is off. If a future duckdb stops refusing, this fails
+    rather than the sandbox quietly becoming decorative."""
+    duckdb = pytest.importorskip("duckdb")
+    allowed = tmp_path / "orders.json"
+    allowed.write_text('{"id": "1"}\n')
+    secret = tmp_path / "secret.txt"
+    secret.write_text("super-secret-value")
+
+    con = duckdb.connect(database=":memory:")
+    restrict_to_paths(con, [str(allowed)])
+
+    assert con.sql(f"SELECT * FROM read_json_auto('{allowed}')").fetchall() == [("1",)]
+    for escape in (
+        f"SELECT content FROM read_text('{secret}')",
+        f"COPY (SELECT 1) TO '{tmp_path}/written.csv'",
+        f"ATTACH '{tmp_path}/pwn.db' AS pwn",
+        "SET enable_external_access = true",
+        f"SET allowed_paths = ['{secret}']",
+        "SET allowed_directories = ['/']",
+    ):
+        with pytest.raises(Exception):
+            con.sql(escape)
+    assert not (tmp_path / "written.csv").exists()
+
+
+def test_a_glob_location_allows_its_directory_only(tmp_path):
+    """A location duckdb has to glob cannot be pinned as an exact file, so the
+    directory it globs is allowed instead -- and nothing above it."""
+    duckdb = pytest.importorskip("duckdb")
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "a.json").write_text('{"id": "1"}\n')
+    (tmp_path / "secret.txt").write_text("super-secret-value")
+
+    con = duckdb.connect(database=":memory:")
+    restrict_to_paths(con, [f"{data_dir}/*.json"])
+
+    assert con.sql(f"SELECT * FROM read_json_auto('{data_dir}/*.json')").fetchall() == [("1",)]
+    with pytest.raises(Exception):
+        con.sql(f"SELECT content FROM read_text('{tmp_path}/secret.txt')")
+
+
+# --- 3. the API refuses a server type that reads its own disk ---------------
+
+
+def test_the_api_refuses_a_local_server_type(data_file):
+    response = client.post("/test", content=_contract(data_file), headers={"Content-Type": "application/yaml"})
+
+    assert response.status_code == 422
+    assert "file system of the server" in response.json()["detail"]
+
+
+def test_an_operator_can_allow_local_files(data_file, monkeypatch):
+    """A deployment that serves its own files on purpose opts in; the sandbox
+    still confines the contract to the path it declares."""
+    monkeypatch.setenv(ALLOW_LOCAL_FILES_ENV, "true")
+
+    response = client.post("/test", content=_contract(data_file), headers={"Content-Type": "application/yaml"})
+
+    assert response.status_code == 200
+
+
+def test_a_caller_cannot_opt_themselves_in(data_file):
+    """The opt-in is the operator's, so it is not a Config option and cannot be
+    set through a per-request `datacontract-*` header."""
+    response = client.post(
+        "/test",
+        content=_contract(data_file),
+        headers={"Content-Type": "application/yaml", "datacontract-cli-api-allow-local-files": "true"},
+    )
+
+    assert response.status_code != 200
+
+
+def test_the_cli_still_tests_a_local_server_type(data_file):
+    """The guard is about contracts arriving over HTTP; a file the user names on
+    the command line is theirs to read."""
+    run = DataContract(data_contract_str=_contract(data_file), inline_references=False).test()
+
+    assert run.result != ResultEnum.error


### PR DESCRIPTION
`POST /test` on `datacontract api` could read and write arbitrary files on the machine running the API — unauthenticated, unless `DATACONTRACT_CLI_API_KEY` is set.

A data contract may declare a `quality.type: sql` rule, whose query is executed verbatim. With `servers[].type: local` the backend is a local DuckDB, so the query runs against the API server's own filesystem rather than a data source the operator configured:

```yaml
servers:
  - server: production
    type: local
    path: /srv/data/orders.json
    format: json
schema:
  - name: orders
    quality:
      - type: sql
        query: "SELECT content FROM read_text('/etc/passwd')"   # returned in the response
        mustBe: 0
      - type: sql
        query: "COPY (SELECT 'x') TO '/home/nonroot/.bashrc'"   # written to disk
        mustBeGreaterThan: -1
```

Arbitrary file write is a path to code execution. `datacontract api --help` warns that tests "may be subject to SQL injection", which reads as *against your data source* — reaching the API host itself is a different asset.

## Three independent controls

**1. Custom SQL must be a read-only query — for every data source.** `quality.type: sql` computes a number from the data, so a query is all it ever needs. Anything else is reported as a failed check and never executed: DDL, DML, `COPY` (a file write on DuckDB and `COPY … TO PROGRAM` on Postgres), `ATTACH`, `INSTALL`/`LOAD`, `SET`, `PRAGMA`, and a second statement smuggled in behind a legitimate one. Validation runs on the query *after* placeholder substitution, uses sqlglot (already a dependency), and fails closed — a query that does not parse is refused rather than passed through.

This one applies to every run, CLI included: a quality rule that drops a table is never legitimate. All 47 quality queries in `tests/fixtures`, `examples` and `docs` pass it.

**2. DuckDB is confined to the contract's own data locations.** For a contract that arrives over HTTP, the connection gets `allowed_paths`/`allowed_directories` set to the locations the contract declares, and `enable_external_access = false`. Applied after extensions are loaded and secrets created, before any contract SQL can run — and never to a connection a Python-library caller passed in.

`lock_configuration` turned out to be both unnecessary and harmful: DuckDB already refuses to re-enable external access or widen the allowed paths once it is off, and locking the configuration stops ibis from setting the session timezone. `test_the_sandbox_cannot_be_undone` asserts the escape attempts stay blocked, so a future DuckDB that stops refusing fails the build rather than quietly making the sandbox decorative.

**3. `servers[].type: local` is refused by the API.** The sandbox confines the contract to the path it *declares* — which does not help when the declared path is `/etc/passwd`. So the API refuses the server type outright.

Deployments that mount their data next to the API serve local files on purpose, so there is an opt-in:

```bash
export DATACONTRACT_CLI_API_ALLOW_LOCAL_FILES=true
```

Deliberately **not** a `Config` field: those are settable per request through a `datacontract-*` header, which would let a caller opt themselves in. `test_a_caller_cannot_opt_themselves_in` covers that.

## Scope

`untrusted_contract` is threaded from `app.state.untrusted_contracts` (which already existed, set only by the API app) through `DataContract` to the engine, so nothing changes for the CLI or the Python library — a file the user names on the command line is still theirs to read. Control 1 is the exception and applies everywhere, by design.

Three existing tests in `tests/test_api.py` used a local fixture as a convenient data source; they now opt in through the new env var.

## What this does not change

An untrusted contract can still run a read-only query against a data source the operator configured. That is what `/test` is for, and it is why the docs tell operators to set `DATACONTRACT_CLI_API_KEY`. Narrowing it further would be a product decision, not a fix.

## Verification

Both original exploits are blocked by default (422) and remain blocked with `DATACONTRACT_CLI_API_ALLOW_LOCAL_FILES=true` (200, but the write is refused by control 1 and the read by control 2).

`tests/test_untrusted_contract.py` adds 30 tests: the read-only classification table, the sandbox escape attempts, a glob location allowing only its directory, the API refusal and its opt-in, and paired assertions that an untrusted contract cannot read another file *while a trusted one still can* — so the negative result cannot pass because of a broken query.

Full suite: 2014 passed. (`test_config_file.py::test_missing_config_file_fails_with_a_clear_message` fails identically on `main` under `pytest -n 8` and passes serially — a pre-existing parallel-mode flake, unrelated.)
