### PR TITLE
fix: use unique servicelevel check keys

### DIFF
--- a/datacontract/engines/checks/create_checks.py
+++ b/datacontract/engines/checks/create_checks.py
@@ -846,7 +846,7 @@ def _freshness_check(data_contract: OpenDataContractStandard, sla) -> Optional[C
         return None
 
     return CheckSpec(
-        key="servicelevel_freshness",
+        key=f"{model}__{field}__servicelevel_freshness",
         category="servicelevel",
         type="servicelevel_freshness",
         name=f"Freshness of {model}.{field} < {sla.value}{unit[0]}",
@@ -871,7 +871,7 @@ def _retention_check(data_contract: OpenDataContractStandard, sla) -> Optional[C
     if seconds is None:
         return None
     return CheckSpec(
-        key="servicelevel_retention",
+        key=f"{model}__{field}__servicelevel_retention",
         category="servicelevel",
         type="servicelevel_retention",
         name=f"Retention of {model}.{field} < {seconds}s",

--- a/tests/test_test_quality_percent_severity.py
+++ b/tests/test_test_quality_percent_severity.py
@@ -108,6 +108,61 @@ def test_create_checks_percent_ignored_for_rowcount(caplog):
     assert "does not support unit: percent" in caplog.text
 
 
+def test_create_checks_servicelevel_keys_include_element():
+    contract = """
+apiVersion: v3.0.2
+kind: DataContract
+id: servicelevel_key_test
+version: 1.0.0
+status: active
+servers:
+  - server: local
+    type: local
+    path: ./fixtures/diagnostics/data/orders.csv
+    format: csv
+schema:
+  - name: orders
+    properties:
+      - name: order_id
+        logicalType: integer
+      - name: amount
+        logicalType: integer
+slaProperties:
+  - property: freshness
+    value: 24
+    unit: h
+    element: orders.order_id
+  - property: freshness
+    value: 48
+    unit: h
+    element: orders.amount
+  - property: retention
+    value: 1
+    unit: y
+    element: orders.order_id
+  - property: retention
+    value: 2
+    unit: y
+    element: orders.amount
+"""
+
+    servicelevel_specs = [spec for spec in _checks(contract) if spec.category == "servicelevel"]
+
+    assert [spec.type for spec in servicelevel_specs] == [
+        "servicelevel_freshness",
+        "servicelevel_freshness",
+        "servicelevel_retention",
+        "servicelevel_retention",
+    ]
+    assert [spec.key for spec in servicelevel_specs] == [
+        "orders__order_id__servicelevel_freshness",
+        "orders__amount__servicelevel_freshness",
+        "orders__order_id__servicelevel_retention",
+        "orders__amount__servicelevel_retention",
+    ]
+    assert len({spec.key for spec in servicelevel_specs}) == len(servicelevel_specs)
+
+
 # ---------------------------------------------------------------------------
 # end-to-end tests: ibis engine against local CSV (duckdb, in-process)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- give freshness and retention service-level checks element-specific keys
- add regression coverage for multiple freshness and retention SLA properties

Fixes #1515

## Verification
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/pytest -q` (2093 passed, 14 skipped, 1 xfailed)
- `.venv/bin/ruff check .`
- `git diff --check`