### PR TITLE
fix: resolve physicalName for slaProperties freshness/retention checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract export pydantic-model` exports the ODCS `date` logical type as `datetime.date` instead of `datetime.datetime`
 - `datacontract import pydantic-model` maps `datetime.datetime` to the `timestamp` logical type and `datetime.time` to `time`
 - `datacontract test --publish` no longer fails for runs with skipped checks (skipped checks are omitted from the published test results)
+- A `slaProperties` freshness/retention check now resolves the model's `physicalName` when the check runs, so it no longer fails with "Could not read model" for objects whose declared name differs from the physical table name
 - `datacontract export dcs` exports a `pii` custom property as a boolean instead of the string `'True'`
 
 

--- a/datacontract/engines/checks/create_checks.py
+++ b/datacontract/engines/checks/create_checks.py
@@ -806,11 +806,11 @@ def _to_servicelevel_checks(data_contract: OpenDataContractStandard, server: Opt
         return checks
     for sla in data_contract.slaProperties:
         if sla.property == "freshness":
-            check = _freshness_check(data_contract, sla)
+            check = _freshness_check(data_contract, sla, server)
             if check is not None:
                 checks.append(check)
         elif sla.property == "retention":
-            check = _retention_check(data_contract, sla)
+            check = _retention_check(data_contract, sla, server)
             if check is not None:
                 checks.append(check)
     return checks
@@ -823,7 +823,9 @@ def _split_element(element: Optional[str]) -> Optional[tuple[str, str]]:
     return model, field
 
 
-def _freshness_check(data_contract: OpenDataContractStandard, sla) -> Optional[CheckSpec]:
+def _freshness_check(
+    data_contract: OpenDataContractStandard, sla, server: Optional[Server] = None
+) -> Optional[CheckSpec]:
     if sla.element is None or sla.value is None:
         return None
     parts = _split_element(sla.element)
@@ -831,8 +833,10 @@ def _freshness_check(data_contract: OpenDataContractStandard, sla) -> Optional[C
         logger.info("freshness element is not a single model.field, skipping")
         return None
     model, field = parts
-    if _get_schema_by_name(data_contract, model) is None:
+    schema_object = _get_schema_by_name(data_contract, model)
+    if schema_object is None:
         return None
+    model = to_schema_name(schema_object, server.type if server and server.type else None)
 
     unit = (sla.unit or "d").lower()
     if unit in ("d", "day", "days"):
@@ -857,7 +861,9 @@ def _freshness_check(data_contract: OpenDataContractStandard, sla) -> Optional[C
     )
 
 
-def _retention_check(data_contract: OpenDataContractStandard, sla) -> Optional[CheckSpec]:
+def _retention_check(
+    data_contract: OpenDataContractStandard, sla, server: Optional[Server] = None
+) -> Optional[CheckSpec]:
     if sla.element is None or sla.value is None:
         return None
     parts = _split_element(sla.element)
@@ -865,8 +871,10 @@ def _retention_check(data_contract: OpenDataContractStandard, sla) -> Optional[C
         logger.info("retention element is not a single model.field, skipping")
         return None
     model, field = parts
-    if _get_schema_by_name(data_contract, model) is None:
+    schema_object = _get_schema_by_name(data_contract, model)
+    if schema_object is None:
         return None
+    model = to_schema_name(schema_object, server.type if server and server.type else None)
     seconds = _retention_value_to_seconds(sla.value, sla.unit)
     if seconds is None:
         return None

--- a/tests/test_create_checks_servicelevel.py
+++ b/tests/test_create_checks_servicelevel.py
@@ -1,0 +1,57 @@
+from open_data_contract_standard.model import (
+    OpenDataContractStandard,
+    SchemaObject,
+    SchemaProperty,
+    Server,
+    ServiceLevelAgreementProperty,
+)
+
+from datacontract.engines.checks.create_checks import create_checks
+
+
+def _contract(schema: SchemaObject, sla: ServiceLevelAgreementProperty):
+    return OpenDataContractStandard(
+        version="1",
+        kind="DataContract",
+        apiVersion="v3.1.0",
+        id="x",
+        schema=[schema],
+        slaProperties=[sla],
+    )
+
+
+def test_freshness_check_uses_physical_name_when_set():
+    schema = SchemaObject(
+        name="orders",
+        physicalName="RAW_ORDERS",
+        properties=[SchemaProperty(name="updated_at", logicalType="date")],
+    )
+    sla = ServiceLevelAgreementProperty(property="freshness", element="orders.updated_at", value=60, unit="m")
+    checks = create_checks(_contract(schema, sla), Server(server="s", type="bigquery"))
+
+    check = next(c for c in checks if c.type == "servicelevel_freshness")
+    assert check.model == "RAW_ORDERS"
+    assert check.field == "updated_at"
+
+
+def test_freshness_check_falls_back_to_name_without_physical_name():
+    schema = SchemaObject(name="orders", properties=[SchemaProperty(name="updated_at", logicalType="date")])
+    sla = ServiceLevelAgreementProperty(property="freshness", element="orders.updated_at", value=60, unit="m")
+    checks = create_checks(_contract(schema, sla), Server(server="s", type="bigquery"))
+
+    check = next(c for c in checks if c.type == "servicelevel_freshness")
+    assert check.model == "orders"
+
+
+def test_retention_check_uses_physical_name_when_set():
+    schema = SchemaObject(
+        name="orders",
+        physicalName="RAW_ORDERS",
+        properties=[SchemaProperty(name="created_at", logicalType="date")],
+    )
+    sla = ServiceLevelAgreementProperty(property="retention", element="orders.created_at", value=1, unit="y")
+    checks = create_checks(_contract(schema, sla), Server(server="s", type="bigquery"))
+
+    check = next(c for c in checks if c.type == "servicelevel_retention")
+    assert check.model == "RAW_ORDERS"
+    assert check.field == "created_at"


### PR DESCRIPTION
## Summary
- `_freshness_check`/`_retention_check` in `create_checks.py` built `CheckSpec.model` from the raw `sla.element` model segment, while schema checks already resolve through `to_schema_name()` (physicalName fallback).
- Whenever a schema object's `name` differs from its `physicalName`, the servicelevel check failed at execution time with `Could not read model '<name>'`, since the ibis engine resolves tables by `physicalName`.
- This PR makes freshness/retention checks resolve the model the same way schema checks do: `to_schema_name(schema_object, server_type)`.

This addresses suggestion 1 from the Slack thread repro (split out from suggestion 2, nested-field `element` support, per Jakob's request to keep the two independent).

## Test plan
- [x] Added `tests/test_create_checks_servicelevel.py` covering physicalName resolution and fallback-to-name for both freshness and retention checks
- [x] `pytest tests/test_create_checks_servicelevel.py tests/test_create_checks_sql_placeholders.py tests/test_create_checks_nested_type.py tests/test_create_checks_primary_key.py tests/test_create_checks_physical_type.py tests/test_test_dimension_filter.py tests/test_test_metadata_only.py` — 83 passed
- [x] `ruff check` / `ruff format --check` clean