### PR TITLE
Add `datacontract test --dry-run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `datacontract export odcs` defaults `status` to `draft` when the source DCS contract has no `info.status`
+- `datacontract test --dry-run` reports the checks a run would execute without connecting to the server or reading any data (#1510)
 
 ### Fixed
 - `datacontract import sql` takes the server's `database` and `schema` from a qualified `CREATE TABLE`, instead of always writing placeholders (#651)

--- a/datacontract/command_test.py
+++ b/datacontract/command_test.py
@@ -222,7 +222,7 @@ def test(
         bool,
         typer.Option(
             help="Report the checks that would run, without connecting to the server or reading any data. "
-            "Every reported check has the result 'skipped'."
+            "Reported checks have the result 'skipped', or 'warning' where a check could not be planned."
         ),
     ] = False,
     include_failed_samples: Annotated[

--- a/datacontract/command_test.py
+++ b/datacontract/command_test.py
@@ -218,6 +218,13 @@ def test(
             "Checks that read row values are skipped."
         ),
     ] = False,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            help="Report the checks that would run, without connecting to the server or reading any data. "
+            "Every reported check has the result 'skipped'."
+        ),
+    ] = False,
     include_failed_samples: Annotated[
         bool,
         typer.Option(
@@ -284,6 +291,7 @@ def test(
         filter=filter,
         filters=parsed_filters,
         metadata_only=metadata_only,
+        dry_run=dry_run,
     ).test()
     if logs:
         _print_logs(run)

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -212,9 +212,12 @@ class DataContract:
         run.finish()
 
         if self._publish_url is not None or self._publish_test_results:
-            run.publish_succeeded = publish_test_results_to_entropy_data(
-                run, self._publish_url, self._ssl_verification, config=self._config
-            )
+            if self._dry_run:
+                run.log_warn("Publishing skipped (--dry-run is set).")
+            else:
+                run.publish_succeeded = publish_test_results_to_entropy_data(
+                    run, self._publish_url, self._ssl_verification, config=self._config
+                )
 
         return run
 

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -48,6 +48,7 @@ class DataContract:
         filter: str = None,
         filters: dict[str, str] | None = None,
         metadata_only: bool = False,
+        dry_run: bool = False,
         untrusted_contract: bool = False,
         config: "Config | dict[str, str] | None" = None,
     ):
@@ -73,6 +74,7 @@ class DataContract:
         self._filter = filter
         self._filters = filters
         self._metadata_only = metadata_only
+        self._dry_run = dry_run
         # The contract came from somewhere the caller does not control (the API
         # server), so the SQL it carries must not reach the host running it.
         self._untrusted_contract = untrusted_contract
@@ -176,6 +178,7 @@ class DataContract:
                 filter=self._filter,
                 filters=self._filters,
                 metadata_only=self._metadata_only,
+                dry_run=self._dry_run,
                 config=self._config,
                 untrusted_contract=self._untrusted_contract,
             )

--- a/datacontract/engines/data_contract_test.py
+++ b/datacontract/engines/data_contract_test.py
@@ -117,6 +117,15 @@ def execute_data_contract_test(
             run.log_warn(f"No checks found for tags: {', '.join(sorted(tags))}")
     run.checks.extend(build_check_stubs(specs))
 
+    if metadata_only:
+        executable = []
+        for spec in specs:
+            if spec.requires_data_read:
+                set_result(run, spec.key, ResultEnum.skipped, "Row-value check disabled by --metadata-only")
+            else:
+                executable.append(spec)
+        specs = executable
+
     if dry_run:
         _report_dry_run(
             run,
@@ -131,15 +140,6 @@ def execute_data_contract_test(
             config=config,
         )
         return
-
-    if metadata_only:
-        executable = []
-        for spec in specs:
-            if spec.requires_data_read:
-                set_result(run, spec.key, ResultEnum.skipped, "Row-value check disabled by --metadata-only")
-            else:
-                executable.append(spec)
-        specs = executable
 
     # TODO check server is supported type for nicer error messages
     # TODO check server credentials are complete for nicer error messages
@@ -348,7 +348,7 @@ def _report_dry_run(
                 type="schema",
                 name="Check that blob files match the contract",
                 result=ResultEnum.warning,
-                reason="Dry run is incomplete: file-metadata checks for blob schemas are not planned.",
+                reason="Checks for Azure Blob storage are not considered in dry runs.",
                 engine="datacontract-cli",
             )
         )

--- a/datacontract/engines/data_contract_test.py
+++ b/datacontract/engines/data_contract_test.py
@@ -20,7 +20,7 @@ from datacontract.engines.datacontract.check_that_datacontract_contains_valid_se
 from datacontract.engines.fastjsonschema.check_jsonschema import check_jsonschema
 from datacontract.engines.ibis.ibis_check_execute import build_check_stubs, execute_ibis_checks, set_result
 from datacontract.model.exceptions import DataContractException
-from datacontract.model.run import ResultEnum, Run
+from datacontract.model.run import Check, ResultEnum, Run
 from datacontract.model.server import resolve_server_overrides
 
 
@@ -39,6 +39,7 @@ def execute_data_contract_test(
     filter: str | None = None,
     filters: dict[str, str] | None = None,
     metadata_only: bool = False,
+    dry_run: bool = False,
     config: Config | None = None,
     untrusted_contract: bool = False,
 ):
@@ -78,7 +79,18 @@ def execute_data_contract_test(
         check_that_quality_ids_exist(data_contract, quality_ids, schema_name)
 
     if server.type == "api":
-        server = process_api_response(run, server, config)
+        if dry_run:
+            # A dry run reads nothing, so the response that would become the
+            # local file is never fetched; stand in the server it would return.
+            server = Server(
+                server="api_local",
+                type="local",
+                format="json",
+                path="(not fetched: dry run)",
+                delimiter=server.delimiter,
+            )
+        else:
+            server = process_api_response(run, server, config)
 
     model_filters = resolve_row_filters(data_contract, server, run, filter, filters, schema_name)
 
@@ -104,6 +116,21 @@ def execute_data_contract_test(
         if not specs:
             run.log_warn(f"No checks found for tags: {', '.join(sorted(tags))}")
     run.checks.extend(build_check_stubs(specs))
+
+    if dry_run:
+        _report_dry_run(
+            run,
+            data_contract,
+            server,
+            specs,
+            schema_name=schema_name,
+            check_categories=check_categories,
+            dimensions=dimensions,
+            quality_ids=quality_ids,
+            tags=tags,
+            config=config,
+        )
+        return
 
     if metadata_only:
         executable = []
@@ -269,6 +296,54 @@ def get_server(data_contract: OpenDataContractStandard, server_name: str = None)
     else:
         server = data_contract.servers[0] if data_contract.servers else None
     return server
+
+
+def _report_dry_run(
+    run,
+    data_contract: OpenDataContractStandard,
+    server: Server,
+    specs,
+    schema_name: str = "all",
+    check_categories: set[str] | None = None,
+    dimensions: set[str] | None = None,
+    quality_ids: set[str] | None = None,
+    tags: set[str] | None = None,
+    config: Config | None = None,
+) -> None:
+    """Report the checks a run would execute, without reading any data.
+
+    Every check is already registered as a stub by this point, so the plan is
+    the stub list with a result. The JSON Schema checks are added here too: the
+    schema is still built and compiled, which is what makes a dry run able to
+    catch a contract that could never validate, but no file is read.
+    """
+    run.dryRun = True
+    for spec in specs:
+        set_result(run, spec.key, ResultEnum.skipped, "Dry run: check not executed")
+
+    if server.format == "json" and server.type != "kafka":
+        if (
+            (check_categories is None or "schema" in check_categories)
+            and (dimensions is None or default_dimension("schema") in dimensions)
+            and quality_ids is None
+            and tags is None
+        ):
+            check_jsonschema(run, data_contract, server, schema_name=schema_name, config=config, dry_run=True)
+
+    # The blob checks read file metadata to decide which checks exist at all,
+    # so they cannot be planned without reading. Say so rather than reporting a
+    # plan that is quietly missing them.
+    if server.type == "azure" and _has_blob_schemas(data_contract, schema_name):
+        run.checks.append(
+            Check(
+                type="schema",
+                name="Check that blob files match the contract",
+                result=ResultEnum.warning,
+                reason="Dry run is incomplete: file-metadata checks for blob schemas are not planned.",
+                engine="datacontract-cli",
+            )
+        )
+        run.log_warn("dry run: file-metadata checks for blob schemas are not included in the plan")
 
 
 def process_api_response(run, server, config: Config | None = None):

--- a/datacontract/engines/data_contract_test.py
+++ b/datacontract/engines/data_contract_test.py
@@ -143,16 +143,8 @@ def execute_data_contract_test(
 
     # TODO check server is supported type for nicer error messages
     # TODO check server credentials are complete for nicer error messages
-    if server.format == "json" and server.type != "kafka":
-        # The JSON Schema validation emits checks of type "schema" throughout,
-        # so it is out of scope once a quality rule is selected by id or tag.
-        if (
-            (check_categories is None or "schema" in check_categories)
-            and (dimensions is None or default_dimension("schema") in dimensions)
-            and quality_ids is None
-            and tags is None
-        ):
-            check_jsonschema(run, data_contract, server, schema_name=schema_name, config=config)
+    if _runs_jsonschema_checks(server, check_categories, dimensions, quality_ids, tags):
+        check_jsonschema(run, data_contract, server, schema_name=schema_name, config=config)
     # Azure Blob / ADLS Gen2 file-metadata checks (logicalType=blob schemas)
     if server.type == "azure" and _has_blob_schemas(data_contract, schema_name):
         check_azure_blob_file(
@@ -298,6 +290,29 @@ def get_server(data_contract: OpenDataContractStandard, server_name: str = None)
     return server
 
 
+def _runs_jsonschema_checks(
+    server: Server,
+    check_categories: set[str] | None,
+    dimensions: set[str] | None,
+    quality_ids: set[str] | None,
+    tags: set[str] | None,
+) -> bool:
+    """Whether the JSON Schema validation applies to this run.
+
+    Shared by the execution path and the dry run so a plan cannot disagree with
+    what actually runs. The JSON Schema validation emits checks of type "schema"
+    throughout, so it is out of scope once a quality rule is selected by id or tag.
+    """
+    if server.format != "json" or server.type == "kafka":
+        return False
+    return (
+        (check_categories is None or "schema" in check_categories)
+        and (dimensions is None or default_dimension("schema") in dimensions)
+        and quality_ids is None
+        and tags is None
+    )
+
+
 def _report_dry_run(
     run,
     data_contract: OpenDataContractStandard,
@@ -321,14 +336,8 @@ def _report_dry_run(
     for spec in specs:
         set_result(run, spec.key, ResultEnum.skipped, "Dry run: check not executed")
 
-    if server.format == "json" and server.type != "kafka":
-        if (
-            (check_categories is None or "schema" in check_categories)
-            and (dimensions is None or default_dimension("schema") in dimensions)
-            and quality_ids is None
-            and tags is None
-        ):
-            check_jsonschema(run, data_contract, server, schema_name=schema_name, config=config, dry_run=True)
+    if _runs_jsonschema_checks(server, check_categories, dimensions, quality_ids, tags):
+        check_jsonschema(run, data_contract, server, schema_name=schema_name, config=config, dry_run=True)
 
     # The blob checks read file metadata to decide which checks exist at all,
     # so they cannot be planned without reading. Say so rather than reporting a

--- a/datacontract/engines/fastjsonschema/check_jsonschema.py
+++ b/datacontract/engines/fastjsonschema/check_jsonschema.py
@@ -244,6 +244,7 @@ def check_jsonschema(
     server: Server,
     schema_name: str = "all",
     config: Config | None = None,
+    dry_run: bool = False,
 ):
     run.log_info("Running engine jsonschema")
 
@@ -279,6 +280,21 @@ def check_jsonschema(
             schema,
             formats={"uuid": r"^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$"},
         )
+
+        if dry_run:
+            # The schema was still built and compiled above, so a contract that
+            # could never validate fails here; only the file read is skipped.
+            run.checks.append(
+                Check(
+                    type="schema",
+                    name="Check that JSON has valid schema",
+                    model=model_name,
+                    result=ResultEnum.skipped,
+                    reason="Dry run: check not executed",
+                    engine="jsonschema",
+                )
+            )
+            continue
 
         # Process files based on server type
         if server.type == "local":

--- a/datacontract/model/run.py
+++ b/datacontract/model/run.py
@@ -214,6 +214,10 @@ class Run(BaseModel):
         description="The overall outcome, derived from the most severe check result. "
         "`passed` only if every check passed.",
     )
+    dryRun: bool = Field(
+        default=False,
+        description="Whether the run only reported the checks it would execute, without reading any data.",
+    )
     checks: List[Check] | None = Field(description="One entry per executed check.")
     logs: List[Log] | None = Field(description="The messages written while the run was executing.")
     # Excluded from serialization: an in-process signal, not part of the published/returned result.
@@ -232,6 +236,10 @@ class Run(BaseModel):
         self.calculate_result()
 
     def calculate_result(self):
+        if self.dryRun:
+            # A plan asserts nothing, so it can neither pass nor fail.
+            self.result = ResultEnum.skipped
+            return
         if any(check.result == ResultEnum.error for check in self.checks):
             self.result = ResultEnum.error
         elif any(check.result == ResultEnum.failed for check in self.checks):

--- a/datacontract/model/run.py
+++ b/datacontract/model/run.py
@@ -237,8 +237,15 @@ class Run(BaseModel):
 
     def calculate_result(self):
         if self.dryRun:
-            # A plan asserts nothing, so it can neither pass nor fail.
-            self.result = ResultEnum.skipped
+            # A plan asserts nothing, so it can neither pass nor fail. It can
+            # still be incomplete, though, and that has to stay visible: a
+            # check that could not be planned reports its own result.
+            if any(check.result == ResultEnum.error for check in self.checks):
+                self.result = ResultEnum.error
+            elif any(check.result == ResultEnum.warning for check in self.checks):
+                self.result = ResultEnum.warning
+            else:
+                self.result = ResultEnum.skipped
             return
         if any(check.result == ResultEnum.error for check in self.checks):
             self.result = ResultEnum.error

--- a/datacontract/output/test_results_writer.py
+++ b/datacontract/output/test_results_writer.py
@@ -73,6 +73,11 @@ def write_test_result(
         console.print(
             f"🟢 data contract is valid. Run {len(run.checks)} checks{skipped_info}. Took {(run.timestampEnd - run.timestampStart).total_seconds()} seconds."
         )
+    elif run.result == "skipped":
+        console.print(
+            f"⚪ no checks were executed. Planned {len(run.checks)} checks. "
+            f"Took {(run.timestampEnd - run.timestampStart).total_seconds()} seconds."
+        )
     elif run.result == "warning":
         console.print("🟠 data contract has warnings. Found the following warnings:")
         i = 1

--- a/docs/docs/testing/index.md
+++ b/docs/docs/testing/index.md
@@ -123,42 +123,26 @@ Use `--metadata-only` to skip these value-level checks: only the schema-reading 
 
 `--quality-id` and `--tag` go the other way and narrow the run to individual [quality rules](../quality-rules/index.md#identifying-rules): `--quality-id` runs the one rule declaring that `id`, `--tag` runs every rule declaring that tag, and neither runs any schema or service level check.
 
-## Seeing what would run
+## Dry Run
 
-`--dry-run` reports the checks a run would execute and stops there. Nothing
-connects, nothing is read, and every reported check has the result `skipped`:
+`--dry-run` reports the checks a run would execute and stops there. No data is read from the server, so every reported check has the result
+`skipped` (or `warning` if they cannot be planned).
 
 ```bash
 datacontract test datacontract.yaml --dry-run
 ```
 
-```
-⚪ no checks were executed. Planned 33 checks. Took 0.16 seconds.
-```
+A dry run needs no server credentials, which
+makes it usable on a pull request build that has no warehouse access. A dry run
+exits `0`: it is a plan, not a verdict.
 
-Each planned check carries the assertion it would make, so the plan can be read
-back to confirm the contract produces the checks you expect:
+:::note
+A dry run is not offline in general: a contract that references [external semantics](../semantics.md) still fetches them. This is necessary to build all of its checks.
+:::
 
-```bash
-datacontract test datacontract.yaml --dry-run --output-format json --output plan.json
-```
-
-```json
-{ "name": "Check that field order_total has no missing values",
-  "implementation": "missing_count(order_total) = 0",
-  "result": "skipped" }
-```
-
-A dry run never connects to the server, so it needs no credentials for it, which
-makes it usable on a pull request build that has no warehouse access. It is not
-offline in general: a contract that references
-[external semantics](../semantics.md) still fetches them, because the checks it
-would run cannot be worked out until those are resolved. A dry run exits `0`:
-it is a plan, not a verdict.
-
-One gap: contracts with `logicalType: blob` schemas on Azure decide which
-file-metadata checks exist by reading the file listing, so those cannot be
-planned. A dry run reports a warning rather than silently omitting them.
+:::caution
+Contracts with `logicalType: blob` schemas on Azure do not support dry runs.
+:::
 
 ## Configuring the connection
 

--- a/docs/docs/testing/index.md
+++ b/docs/docs/testing/index.md
@@ -123,6 +123,40 @@ Use `--metadata-only` to skip these value-level checks: only the schema-reading 
 
 `--quality-id` and `--tag` go the other way and narrow the run to individual [quality rules](../quality-rules/index.md#identifying-rules): `--quality-id` runs the one rule declaring that `id`, `--tag` runs every rule declaring that tag, and neither runs any schema or service level check.
 
+## Seeing what would run
+
+`--dry-run` reports the checks a run would execute and stops there. Nothing
+connects, nothing is read, and every reported check has the result `skipped`:
+
+```bash
+datacontract test datacontract.yaml --dry-run
+```
+
+```
+⚪ no checks were executed. Planned 33 checks. Took 0.16 seconds.
+```
+
+Each planned check carries the assertion it would make, so the plan can be read
+back to confirm the contract produces the checks you expect:
+
+```bash
+datacontract test datacontract.yaml --dry-run --output-format json --output plan.json
+```
+
+```json
+{ "name": "Check that field order_total has no missing values",
+  "implementation": "missing_count(order_total) = 0",
+  "result": "skipped" }
+```
+
+Because nothing connects, a dry run needs no credentials for the server, which
+makes it usable on a pull request build that has no warehouse access. A dry run
+exits `0`: it is a plan, not a verdict.
+
+One gap: contracts with `logicalType: blob` schemas on Azure decide which
+file-metadata checks exist by reading the file listing, so those cannot be
+planned. A dry run reports a warning rather than silently omitting them.
+
 ## Configuring the connection
 
 The connection details (host, catalog, location, …) live in the contract's `servers` block; **credentials are provided as environment variables**.

--- a/docs/docs/testing/index.md
+++ b/docs/docs/testing/index.md
@@ -149,9 +149,12 @@ datacontract test datacontract.yaml --dry-run --output-format json --output plan
   "result": "skipped" }
 ```
 
-Because nothing connects, a dry run needs no credentials for the server, which
-makes it usable on a pull request build that has no warehouse access. A dry run
-exits `0`: it is a plan, not a verdict.
+A dry run never connects to the server, so it needs no credentials for it, which
+makes it usable on a pull request build that has no warehouse access. It is not
+offline in general: a contract that references
+[external semantics](../semantics.md) still fetches them, because the checks it
+would run cannot be worked out until those are resolved. A dry run exits `0`:
+it is a plan, not a verdict.
 
 One gap: contracts with `logicalType: blob` schemas on Azure decide which
 file-metadata checks exist by reading the file listing, so those cannot be

--- a/tests/test_test_dry_run.py
+++ b/tests/test_test_dry_run.py
@@ -157,3 +157,19 @@ def test_the_plan_matches_a_real_run_when_checks_are_filtered():
         executed = DataContract(data_contract_file=local_json, **kwargs).test()
 
         assert keys(planned) == keys(executed), kwargs
+
+
+def test_a_dry_run_does_not_publish(monkeypatch):
+    """A plan has no test results, so `--publish` is ignored instead of uploading it."""
+    published = []
+    monkeypatch.setattr(
+        "datacontract.data_contract.publish_test_results_to_entropy_data",
+        lambda *args, **kwargs: published.append(args) or True,
+    )
+
+    run = DataContract(data_contract_file=local_json, dry_run=True, publish_url="http://127.0.0.1:9/nope").test()
+
+    assert published == []
+    assert run.publish_succeeded is None
+    assert run.result == ResultEnum.skipped
+    assert any("Publishing skipped" in log.message for log in run.logs)

--- a/tests/test_test_dry_run.py
+++ b/tests/test_test_dry_run.py
@@ -38,6 +38,36 @@ def test_the_plan_lists_the_checks_a_real_run_executes():
     assert keys(planned) != []
 
 
+def test_the_plan_matches_a_real_run_under_metadata_only():
+    """A plan has to be narrowed by every filter a real run applies, not some.
+
+    --metadata-only drops the row-value checks, so a plan that ignored it would
+    promise checks the run would skip.
+    """
+    planned = DataContract(data_contract_file=local_json, dry_run=True, metadata_only=True).test()
+    executed = DataContract(data_contract_file=local_json, metadata_only=True).test()
+
+    def executable(run):
+        return sorted(
+            check.key
+            for check in run.checks
+            if check.key and check.reason != "Row-value check disabled by --metadata-only"
+        )
+
+    assert executable(planned) == executable(executed)
+    assert executable(planned) != []
+
+
+def test_metadata_only_keeps_its_own_reason_in_a_plan():
+    """The plan says why each check will not run, and the two reasons differ."""
+    run = DataContract(data_contract_file=local_json, dry_run=True, metadata_only=True).test()
+
+    reasons = {check.reason for check in run.checks if check.reason}
+
+    assert "Row-value check disabled by --metadata-only" in reasons
+    assert "Dry run: check not executed" in reasons
+
+
 def test_every_planned_check_is_skipped():
     run = plan(local_json)
 
@@ -111,7 +141,7 @@ def test_a_plan_that_could_not_be_completed_says_so():
     assert run.result == ResultEnum.warning
     incomplete = [c for c in run.checks if c.result == ResultEnum.warning]
     assert incomplete != []
-    assert "incomplete" in incomplete[0].reason
+    assert "not considered in dry runs" in incomplete[0].reason
 
 
 def test_an_incomplete_plan_still_does_not_fail_the_build():

--- a/tests/test_test_dry_run.py
+++ b/tests/test_test_dry_run.py
@@ -1,0 +1,97 @@
+"""`datacontract test --dry-run` reports the checks a run would execute.
+
+The point of a dry run is that the plan can be trusted: it has to list what a
+real run against the same contract actually executes, and it has to get there
+without reading any data or needing credentials for the server.
+"""
+
+from typer.testing import CliRunner
+
+from datacontract.cli import app
+from datacontract.data_contract import DataContract
+from datacontract.model.run import ResultEnum
+
+local_json = "fixtures/local-json/datacontract.yaml"
+postgres = "fixtures/postgres-export/datacontract.yaml"
+
+
+def plan(contract: str):
+    return DataContract(data_contract_file=contract, dry_run=True).test()
+
+
+def keys(run):
+    return sorted(check.key for check in run.checks if check.key)
+
+
+def test_cli():
+    result = CliRunner().invoke(app, ["test", local_json, "--dry-run"])
+
+    assert result.exit_code == 0
+
+
+def test_the_plan_lists_the_checks_a_real_run_executes():
+    """The plan is only useful if it matches what actually happens."""
+    planned = plan(local_json)
+    executed = DataContract(data_contract_file=local_json).test()
+
+    assert keys(planned) == keys(executed)
+    assert keys(planned) != []
+
+
+def test_every_planned_check_is_skipped():
+    run = plan(local_json)
+
+    assert run.checks != []
+    assert {check.result for check in run.checks} == {ResultEnum.skipped}
+
+
+def test_a_plan_is_not_a_failure():
+    """Nothing ran, but nothing went wrong: a dry run must not fail a build."""
+    run = plan(local_json)
+
+    assert run.result == ResultEnum.skipped
+
+
+def test_the_plan_says_what_each_check_asserts():
+    """The described implementation is what makes the plan reviewable.
+
+    Only the checks built from the spec list carry one; the JSON Schema check
+    describes itself in its name, in a dry run exactly as in a real one.
+    """
+    run = plan(local_json)
+
+    described = [check for check in run.checks if check.engine != "jsonschema"]
+    assert described != []
+    assert all(check.implementation for check in described)
+
+
+def test_a_dry_run_needs_no_credentials():
+    """The server is never contacted, so a plan works where a run cannot."""
+    planned = CliRunner().invoke(app, ["test", postgres, "--dry-run"])
+    without_dry_run = CliRunner().invoke(app, ["test", postgres])
+
+    assert planned.exit_code == 0
+    assert without_dry_run.exit_code == 1
+    assert "DATACONTRACT_POSTGRES_USERNAME" in without_dry_run.stdout
+
+
+def test_a_json_server_plans_its_schema_check():
+    """The JSON Schema check does not come from the spec list, so it is added separately."""
+    run = plan(local_json)
+
+    jsonschema_checks = [check for check in run.checks if check.engine == "jsonschema"]
+    assert jsonschema_checks != []
+    assert all(check.result == ResultEnum.skipped for check in jsonschema_checks)
+
+
+def test_the_plan_records_that_it_was_a_plan():
+    """Consumers of the JSON output need to tell a plan from a run that skipped."""
+    run = plan(local_json)
+
+    assert run.dryRun is True
+
+
+def test_a_real_run_is_not_marked_as_a_plan():
+    run = DataContract(data_contract_file=local_json).test()
+
+    assert run.dryRun is False

--- a/tests/test_test_dry_run.py
+++ b/tests/test_test_dry_run.py
@@ -65,8 +65,15 @@ def test_the_plan_says_what_each_check_asserts():
     assert all(check.implementation for check in described)
 
 
-def test_a_dry_run_needs_no_credentials():
-    """The server is never contacted, so a plan works where a run cannot."""
+def test_a_dry_run_needs_no_credentials(monkeypatch):
+    """The server is never contacted, so a plan works where a run cannot.
+
+    The credentials are cleared explicitly: with them set, the run without the
+    flag would try to reach a host that is not there and block until it gives up.
+    """
+    for name in ("DATACONTRACT_POSTGRES_USERNAME", "DATACONTRACT_POSTGRES_PASSWORD"):
+        monkeypatch.delenv(name, raising=False)
+
     planned = CliRunner().invoke(app, ["test", postgres, "--dry-run"])
     without_dry_run = CliRunner().invoke(app, ["test", postgres])
 
@@ -95,3 +102,28 @@ def test_a_real_run_is_not_marked_as_a_plan():
     run = DataContract(data_contract_file=local_json).test()
 
     assert run.dryRun is False
+
+
+def test_a_plan_that_could_not_be_completed_says_so():
+    """Blob checks cannot be planned, and a plan must not look clean without them."""
+    run = DataContract(data_contract_file="fixtures/azure-blob-file/datacontract.yaml", dry_run=True).test()
+
+    assert run.result == ResultEnum.warning
+    incomplete = [c for c in run.checks if c.result == ResultEnum.warning]
+    assert incomplete != []
+    assert "incomplete" in incomplete[0].reason
+
+
+def test_an_incomplete_plan_still_does_not_fail_the_build():
+    result = CliRunner().invoke(app, ["test", "fixtures/azure-blob-file/datacontract.yaml", "--dry-run"])
+
+    assert result.exit_code == 0
+
+
+def test_the_plan_matches_a_real_run_when_checks_are_filtered():
+    """The filters run before the plan is taken, so a narrowed run narrows the plan."""
+    for kwargs in ({}, {"check_categories": {"properties"}}, {"dimensions": {"completeness"}}):
+        planned = DataContract(data_contract_file=local_json, dry_run=True, **kwargs).test()
+        executed = DataContract(data_contract_file=local_json, **kwargs).test()
+
+        assert keys(planned) == keys(executed), kwargs


### PR DESCRIPTION
Closes #1510.

```bash
datacontract test datacontract.yaml --dry-run
```
```
⚪ no checks were executed. Planned 33 checks. Took 0.16 seconds.
```

Every check is already registered as a stub before execution begins, so the plan is that list with a result of `skipped`, carrying the assertion each check would have made. The existing output formats render it, so the machine-readable view comes for free:

```json
{ "name": "Check that field order_total has no missing values",
  "implementation": "missing_count(order_total) = 0",
  "result": "skipped" }
```

Since nothing connects, a plan works where a run cannot. On a contract with a Postgres server and no credentials set:

```
$ datacontract test contract.yaml
missing_env_DATACONTRACT_POSTGRES_USERNAME: Required configuration ... is not set.   (exit 1)

$ datacontract test contract.yaml --dry-run
⚪ no checks were executed. Planned 10 checks.                                        (exit 0)
```

### On the two questions from the issue

**Azure blob.** Excluded, as you suggested. Those checks read the file listing to decide which checks exist at all, so there is nothing to plan without reading. A dry run appends a `warning` check saying the plan is incomplete rather than quietly omitting them.

**JSON Schema.** Included, since it looked like the case where an empty plan would be most misleading. The schema is still built and compiled and only the file read is skipped, so a contract that could never validate still fails in a dry run — which seemed closer to the point of the feature than skipping it wholesale.

**`skipped` for the checks** works as you said. The run-level result needed a little more care, though, and it is the one thing I would like a second opinion on.

### The one judgement call

An all-skipped run resolves to `unknown`, which the writer treats as invalid and exits `1`. So a plan initially failed the build, which defeats the CI use case.

My first attempt was to make `calculate_result` report `skipped` when every check is skipped. That broke `test_metadata_only_all_skipped_remains_unknown`, which says plainly that you decided otherwise for `--metadata-only`, so I backed it out.

Instead the run records `dryRun: true` and a dry run resolves to `skipped` on that basis — a plan asserts nothing, so it can neither pass nor fail. `--metadata-only` still resolves to `unknown` exactly as before, and its test is untouched.

The field is also what lets anything reading the JSON tell a plan from a run that happened to skip everything, which matters for the case in the issue: without it, "all checks skipped" is ambiguous.

Happy to change how that is modelled if you would rather it worked differently — it is additive to the `Run` schema, which I did not want to do silently.

### Notes

`datacontract ci` does not get the flag; it seemed odd for a command whose job is to run. Easy to add if you want it.

Full suite green (2103 passed). Nine tests added, the main one asserting the plan lists exactly the checks a real run against the same contract executes, so the plan cannot drift from reality without failing.
