### PR TITLE
fix: keep the contract's project as the BigQuery data project (#1358)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** the `engine` field of test results is now always one of `datacontract-cli`, `dbt` or `jsonschema`; the values `datacontract`, `ibis` and `dbt-sync` no longer occur (#1505)
 
 ### Fixed
+- BigQuery: `DATACONTRACT_BIGQUERY_BILLING_PROJECT` no longer overrides the server's `project`, so tables are still read from the data project (#1358)
 - A `quality.type: sql` rule is read in the SQL dialect of its server type, so dialect-specific syntax (BigQuery backticks, Snowflake `SAMPLE`, SQL Server `TOP`) is no longer mistaken for an invalid query
 - A `quality.type: sql` rule must be a read-only query; DDL, DML, `COPY`, `ATTACH` and the like are reported as a failed check instead of being executed, for every data source
 - `datacontract api`:

--- a/datacontract/engines/ibis/connections/connect.py
+++ b/datacontract/engines/ibis/connections/connect.py
@@ -318,17 +318,13 @@ def _connect_bigquery(ibis, server: Server, config: Config):
     project = config.get_bigquery_project() or server.project
     dataset = config.get_bigquery_dataset() or server.dataset
 
-    if billing_project and billing_project != project:
-        from google.cloud import bigquery as bq_client_lib
-
-        client = bq_client_lib.Client(project=billing_project, credentials=credentials)
-        return ibis.bigquery.connect(
-            project_id=project,
-            dataset_id=dataset,
-            client=client,
-        )
-
-    kwargs = dict(project_id=project, dataset_id=dataset)
+    # ibis reads the billing project from ``project_id`` and the data project from a
+    # ``<project>.<dataset>`` qualified ``dataset_id``. Passing a pre-built client
+    # instead would make ibis take its project as both.
+    kwargs = dict(
+        project_id=billing_project or project,
+        dataset_id=f"{project}.{dataset}" if billing_project else dataset,
+    )
     if credentials:
         kwargs["credentials"] = credentials
     return ibis.bigquery.connect(**kwargs)

--- a/datacontract/engines/ibis/connections/connect.py
+++ b/datacontract/engines/ibis/connections/connect.py
@@ -317,6 +317,20 @@ def _connect_bigquery(ibis, server: Server, config: Config):
     billing_project = config.get_bigquery_billing_project()
     project = config.get_bigquery_project() or server.project
     dataset = config.get_bigquery_dataset() or server.dataset
+    if not project:
+        raise DataContractException(
+            type="bigquery-connection",
+            name="missing_project",
+            reason="Project is required for BigQuery connection.",
+            engine="datacontract-cli",
+        )
+    if not dataset:
+        raise DataContractException(
+            type="bigquery-connection",
+            name="missing_dataset",
+            reason="Dataset is required for BigQuery connection.",
+            engine="datacontract-cli",
+        )
 
     # ibis reads the billing project from ``project_id`` and the data project from a
     # ``<project>.<dataset>`` qualified ``dataset_id``. Passing a pre-built client

--- a/datacontract/engines/ibis/connections/connect.py
+++ b/datacontract/engines/ibis/connections/connect.py
@@ -153,25 +153,7 @@ def connect_ibis(
         return ibis.snowflake.connect(**_snowflake_connection_kwargs(server, run, config))
 
     if server_type == "bigquery":
-        credentials = _bigquery_credentials(config)
-        billing_project = config.get_bigquery_billing_project()
-        project = config.get_bigquery_project() or server.project
-        dataset = config.get_bigquery_dataset() or server.dataset
-
-        if billing_project and billing_project != project:
-            from google.cloud import bigquery as bq_client_lib
-
-            client = bq_client_lib.Client(project=billing_project, credentials=credentials)
-            return ibis.bigquery.connect(
-                project_id=project,
-                dataset_id=dataset,
-                client=client,
-            )
-
-        kwargs = dict(project_id=project, dataset_id=dataset)
-        if credentials:
-            kwargs["credentials"] = credentials
-        return ibis.bigquery.connect(**kwargs)
+        return _connect_bigquery(ibis, server, config)
 
     # `mssql` is what ODBC, ibis and dbt call SQL Server; ODCS spells it `sqlserver`.
     if server_type in ("sqlserver", "mssql"):
@@ -328,6 +310,28 @@ def _databricks_credentials_provider(service_principal: bool = False, **config_k
         return config.authenticate
 
     return credentials_provider
+
+
+def _connect_bigquery(ibis, server: Server, config: Config):
+    credentials = _bigquery_credentials(config)
+    billing_project = config.get_bigquery_billing_project()
+    project = config.get_bigquery_project() or server.project
+    dataset = config.get_bigquery_dataset() or server.dataset
+
+    if billing_project and billing_project != project:
+        from google.cloud import bigquery as bq_client_lib
+
+        client = bq_client_lib.Client(project=billing_project, credentials=credentials)
+        return ibis.bigquery.connect(
+            project_id=project,
+            dataset_id=dataset,
+            client=client,
+        )
+
+    kwargs = dict(project_id=project, dataset_id=dataset)
+    if credentials:
+        kwargs["credentials"] = credentials
+    return ibis.bigquery.connect(**kwargs)
 
 
 _BIGQUERY_SCOPES = ["https://www.googleapis.com/auth/bigquery"]

--- a/datacontract/engines/ibis/connections/connect.py
+++ b/datacontract/engines/ibis/connections/connect.py
@@ -317,18 +317,24 @@ def _connect_bigquery(ibis, server: Server, config: Config):
     billing_project = config.get_bigquery_billing_project()
     project = config.get_bigquery_project() or server.project
     dataset = config.get_bigquery_dataset() or server.dataset
-    if not project:
+    if billing_project and not project:
         raise DataContractException(
             type="bigquery-connection",
             name="missing_project",
-            reason="Project is required for BigQuery connection.",
+            reason=(
+                "Project is required for BigQuery connection when a billing project is set. "
+                "Set the server's `project` or DATACONTRACT_BIGQUERY_PROJECT."
+            ),
             engine="datacontract-cli",
         )
     if not dataset:
         raise DataContractException(
             type="bigquery-connection",
             name="missing_dataset",
-            reason="Dataset is required for BigQuery connection.",
+            reason=(
+                "Dataset is required for BigQuery connection. "
+                "Set the server's `dataset` or DATACONTRACT_BIGQUERY_DATASET."
+            ),
             engine="datacontract-cli",
         )
 
@@ -337,7 +343,7 @@ def _connect_bigquery(ibis, server: Server, config: Config):
     # instead would make ibis take its project as both.
     kwargs = dict(
         project_id=billing_project or project,
-        dataset_id=f"{project}.{dataset}" if billing_project else dataset,
+        dataset_id=f"{project}.{dataset}" if project else dataset,
     )
     if credentials:
         kwargs["credentials"] = credentials

--- a/docs/docs/reference/bigquery.md
+++ b/docs/docs/reference/bigquery.md
@@ -26,7 +26,7 @@ Authentication uses a Service Account Key or Application Default Credentials (AD
 | Variable | Example | Description |
 |---|---|---|
 | `DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH` | `~/service-access-key.json` | Service Account key JSON file used by `test`. If unset, ADC/WIF is used. |
-| `DATACONTRACT_BIGQUERY_BILLING_PROJECT` | `my-compute-project` | Optional. Project to bill query jobs to. Requires `bigquery.jobUser` on the billing project and `bigquery.dataViewer` on the data project. |
+| `DATACONTRACT_BIGQUERY_BILLING_PROJECT` | `my-compute-project` | Optional. Project to bill query jobs to. Requires `bigquery.jobUser` and `bigquery.readSessionUser` on the billing project (results are read through the Storage Read API, whose read session is created there) and `bigquery.dataViewer` on the data project. |
 | `DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT` | `runner@my-project.iam.gserviceaccount.com` | Optional. Service account to impersonate, using the key file above (or ADC) as the source principal. Requires `roles/iam.serviceAccountTokenCreator` on the target. |
 
 `project` and `dataset` come from the contract's `servers` block, and can be overridden with `DATACONTRACT_BIGQUERY_PROJECT` and `DATACONTRACT_BIGQUERY_DATASET`. `datacontract import bigquery` always uses ADC — set `GOOGLE_APPLICATION_CREDENTIALS` to point it at a key file.

--- a/docs/docs/reference/bigquery.md
+++ b/docs/docs/reference/bigquery.md
@@ -26,7 +26,7 @@ Authentication uses a Service Account Key or Application Default Credentials (AD
 | Variable | Example | Description |
 |---|---|---|
 | `DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH` | `~/service-access-key.json` | Service Account key JSON file used by `test`. If unset, ADC/WIF is used. |
-| `DATACONTRACT_BIGQUERY_BILLING_PROJECT` | `my-compute-project` | Optional. Project to bill query jobs to. Requires `bigquery.jobUser` and `bigquery.readSessionUser` on the billing project (results are read through the Storage Read API, whose read session is created there) and `bigquery.dataViewer` on the data project. |
+| `DATACONTRACT_BIGQUERY_BILLING_PROJECT` | `my-compute-project` | Optional. Project to bill query jobs to. Requires `bigquery.jobUser`, `bigquery.readSessionUser` on the billing project and `bigquery.dataViewer` on the data project. |
 | `DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT` | `runner@my-project.iam.gserviceaccount.com` | Optional. Service account to impersonate, using the key file above (or ADC) as the source principal. Requires `roles/iam.serviceAccountTokenCreator` on the target. |
 
 `project` and `dataset` come from the contract's `servers` block, and can be overridden with `DATACONTRACT_BIGQUERY_PROJECT` and `DATACONTRACT_BIGQUERY_DATASET`. `datacontract import bigquery` always uses ADC — set `GOOGLE_APPLICATION_CREDENTIALS` to point it at a key file.

--- a/docs/docs/testing/bigquery.md
+++ b/docs/docs/testing/bigquery.md
@@ -85,3 +85,4 @@ All authentication options (service-account keys, WIF, billing project) and the 
 - **`Your default credentials were not found`** — run `gcloud auth application-default login`, or set `GOOGLE_APPLICATION_CREDENTIALS` / `DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH` to a service-account key file.
 - **`403 Access Denied`** — the account is missing **BigQuery Job User** (to run query jobs) or **BigQuery Data Viewer** (to read the tables).
 - **Queries billed to the wrong project** — set `DATACONTRACT_BIGQUERY_BILLING_PROJECT`.
+- **`403 ... does not have 'bigquery.readsessions.create' permission`** — grant **BigQuery Read Session User** on the billing project. Results are read through the Storage Read API, whose read session is created there, so schema checks pass while every row-level check fails.

--- a/docs/docs/testing/bigquery.md
+++ b/docs/docs/testing/bigquery.md
@@ -85,4 +85,3 @@ All authentication options (service-account keys, WIF, billing project) and the 
 - **`Your default credentials were not found`** — run `gcloud auth application-default login`, or set `GOOGLE_APPLICATION_CREDENTIALS` / `DATACONTRACT_BIGQUERY_ACCOUNT_INFO_JSON_PATH` to a service-account key file.
 - **`403 Access Denied`** — the account is missing **BigQuery Job User** (to run query jobs) or **BigQuery Data Viewer** (to read the tables).
 - **Queries billed to the wrong project** — set `DATACONTRACT_BIGQUERY_BILLING_PROJECT`.
-- **`403 ... does not have 'bigquery.readsessions.create' permission`** — grant **BigQuery Read Session User** on the billing project. Results are read through the Storage Read API, whose read session is created there, so schema checks pass while every row-level check fails.

--- a/tests/test_connect_bigquery.py
+++ b/tests/test_connect_bigquery.py
@@ -10,6 +10,7 @@ import pytest
 from open_data_contract_standard.model import Server
 
 from datacontract.engines.ibis.connections.connect import connect_ibis
+from datacontract.model.exceptions import DataContractException
 from datacontract.model.run import Run
 
 BIGQUERY_ENV_VARS = [
@@ -30,13 +31,14 @@ def env(monkeypatch):
     return monkeypatch
 
 
-def _server():
-    return Server(server="bigquery", type="bigquery", project="my-project", dataset="my_dataset")
+def _server(**overrides):
+    kwargs = dict(server="bigquery", type="bigquery", project="my-project", dataset="my_dataset")
+    return Server(**{**kwargs, **overrides})
 
 
-def _connect():
+def _connect(**overrides):
     with patch("ibis.bigquery.connect") as connect:
-        connect_ibis(Run.create_run(), None, _server())
+        connect_ibis(Run.create_run(), None, _server(**overrides))
     return connect.call_args.kwargs
 
 
@@ -118,3 +120,11 @@ def test_env_variables_override_the_contract_project_and_dataset(env):
 
     assert kwargs["project_id"] == "env-project"
     assert kwargs["dataset_id"] == "env_dataset"
+
+
+@pytest.mark.parametrize("missing", ["project", "dataset"])
+def test_project_and_dataset_are_required(env, missing):
+    with pytest.raises(DataContractException) as e:
+        _connect(**{missing: None})
+
+    assert e.value.name == f"missing_{missing}"

--- a/tests/test_connect_bigquery.py
+++ b/tests/test_connect_bigquery.py
@@ -40,6 +40,16 @@ def _connect():
     return connect.call_args.kwargs
 
 
+def _connect_ibis():
+    """Connect through the real ibis BigQuery backend, stubbing out only the
+    Google clients, so the assertions cover how ibis reads our arguments.
+    Returns the connection and the patched ``bigquery.Client``."""
+    with patch("ibis.backends.bigquery.bq.Client") as client:
+        client.return_value.default_query_job_config = None
+        with patch("ibis.backends.bigquery.bqstorage.BigQueryReadClient"):
+            return connect_ibis(Run.create_run(), None, _server()), client
+
+
 def test_no_credentials_without_env_vars(env):
     """Nothing configured means ibis falls back to application default credentials."""
     kwargs = _connect()
@@ -83,18 +93,21 @@ def test_impersonation_uses_the_key_file_as_source_when_set(env, tmp_path):
     assert kwargs["credentials"] is impersonated.return_value
 
 
-def test_billing_project_client_uses_the_impersonated_credentials(env):
+def test_billing_project_keeps_the_contract_project_as_the_data_project(env):
+    """The billing project pays for the query jobs; the tables still live in the
+    contract's project. Drives the real ibis backend, as asserting our own kwargs
+    would not catch ibis resolving the data project differently."""
     env.setenv("DATACONTRACT_BIGQUERY_BILLING_PROJECT", "my-billing-project")
     env.setenv("DATACONTRACT_BIGQUERY_IMPERSONATION_ACCOUNT", SERVICE_ACCOUNT)
 
     with patch("google.auth.default", return_value=(MagicMock(), "my-project")):
         with patch("google.auth.impersonated_credentials.Credentials") as impersonated:
-            with patch("google.cloud.bigquery.Client") as client:
-                kwargs = _connect()
+            con, client = _connect_ibis()
 
-    assert client.call_args.kwargs["project"] == "my-billing-project"
+    assert con.data_project == "my-project"
+    assert con.billing_project == "my-billing-project"
+    assert con.dataset == "my_dataset"
     assert client.call_args.kwargs["credentials"] is impersonated.return_value
-    assert kwargs["client"] is client.return_value
 
 
 def test_env_variables_override_the_contract_project_and_dataset(env):

--- a/tests/test_connect_bigquery.py
+++ b/tests/test_connect_bigquery.py
@@ -57,7 +57,7 @@ def test_no_credentials_without_env_vars(env):
     kwargs = _connect()
 
     assert kwargs["project_id"] == "my-project"
-    assert kwargs["dataset_id"] == "my_dataset"
+    assert kwargs["dataset_id"] == "my-project.my_dataset"
     assert "credentials" not in kwargs
 
 
@@ -119,12 +119,30 @@ def test_env_variables_override_the_contract_project_and_dataset(env):
     kwargs = _connect()
 
     assert kwargs["project_id"] == "env-project"
-    assert kwargs["dataset_id"] == "env_dataset"
+    assert kwargs["dataset_id"] == "env-project.env_dataset"
 
 
-@pytest.mark.parametrize("missing", ["project", "dataset"])
-def test_project_and_dataset_are_required(env, missing):
+def test_dataset_is_required(env):
     with pytest.raises(DataContractException) as e:
-        _connect(**{missing: None})
+        _connect(dataset=None)
 
-    assert e.value.name == f"missing_{missing}"
+    assert e.value.name == "missing_dataset"
+
+
+def test_project_is_left_to_ibis_to_resolve_from_the_credentials(env):
+    """Without a project, ibis falls back to the project of the credentials."""
+    kwargs = _connect(project=None)
+
+    assert kwargs["project_id"] is None
+    assert kwargs["dataset_id"] == "my_dataset"
+
+
+def test_project_is_required_with_a_billing_project(env):
+    """The data project cannot be resolved from the credentials once ``project_id``
+    carries the billing project."""
+    env.setenv("DATACONTRACT_BIGQUERY_BILLING_PROJECT", "my-billing-project")
+
+    with pytest.raises(DataContractException) as e:
+        _connect(project=None)
+
+    assert e.value.name == "missing_project"


### PR DESCRIPTION
Fixes #1358.

`DATACONTRACT_BIGQUERY_BILLING_PROJECT` was passed to ibis as a pre-built `bigquery.Client`, and ibis prefers `client.project` over the `project_id` argument — so the billing project became the data project too, and every table was looked up in the wrong project.

Encode it the way ibis reads it instead: `project_id` is the billing project, `dataset_id` is `<data-project>.<dataset>`. The hand-built client is gone, so the configured credentials now also reach the Storage Read API client.

Also requires `project` and `dataset` for BigQuery connections, replacing an `AttributeError` from inside ibis with a clear error.