### PR TITLE
fix: apply the server override options downstream of the connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** the `engine` field of test results is now always one of `datacontract-cli`, `dbt` or `jsonschema`; the values `datacontract`, `ibis` and `dbt-sync` no longer occur (#1505)
 
 ### Fixed
-- Configuration options that override a server's location (`DATACONTRACT_BIGQUERY_PROJECT`, `DATACONTRACT_POSTGRES_SCHEMA`, and the like) now also apply to the table lookup and the physical type checks, not just to the connection; the effective location is logged when it differs from the contract's
+- Configuration options that override a server's location (`DATACONTRACT_BIGQUERY_PROJECT`, `DATACONTRACT_POSTGRES_SCHEMA`, and the like) now apply to the whole test run, not just to the connection
 - A `quality.type: sql` rule is read in the SQL dialect of its server type, so dialect-specific syntax (BigQuery backticks, Snowflake `SAMPLE`, SQL Server `TOP`) is no longer mistaken for an invalid query
 - A `quality.type: sql` rule must be a read-only query; DDL, DML, `COPY`, `ATTACH` and the like are reported as a failed check instead of being executed, for every data source
 - `datacontract api`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** the `engine` field of test results is now always one of `datacontract-cli`, `dbt` or `jsonschema`; the values `datacontract`, `ibis` and `dbt-sync` no longer occur (#1505)
 
 ### Fixed
+- Configuration options that override a server's location (`DATACONTRACT_BIGQUERY_PROJECT`, `DATACONTRACT_POSTGRES_SCHEMA`, and the like) now also apply to the table lookup and the physical type checks, not just to the connection; the effective location is logged when it differs from the contract's
 - A `quality.type: sql` rule is read in the SQL dialect of its server type, so dialect-specific syntax (BigQuery backticks, Snowflake `SAMPLE`, SQL Server `TOP`) is no longer mistaken for an invalid query
 - A `quality.type: sql` rule must be a read-only query; DDL, DML, `COPY`, `ATTACH` and the like are reported as a failed check instead of being executed, for every data source
 - `datacontract api`:

--- a/datacontract/config/settings.py
+++ b/datacontract/config/settings.py
@@ -38,6 +38,8 @@ SERVER_OVERRIDE_OPTIONS = {
     "databricks_server_hostname": "host",
     "databricks_catalog": "catalog",
     "databricks_schema": "schema",
+    "duckdb_database": "database",
+    "duckdb_schema": "schema",
     "impala_host": "host",
     "impala_port": "port",
     "impala_database": "database",

--- a/datacontract/engines/data_contract_test.py
+++ b/datacontract/engines/data_contract_test.py
@@ -21,6 +21,7 @@ from datacontract.engines.fastjsonschema.check_jsonschema import check_jsonschem
 from datacontract.engines.ibis.ibis_check_execute import build_check_stubs, execute_ibis_checks, set_result
 from datacontract.model.exceptions import DataContractException
 from datacontract.model.run import ResultEnum, Run
+from datacontract.model.server import resolve_server_overrides
 
 
 def execute_data_contract_test(
@@ -52,7 +53,7 @@ def execute_data_contract_test(
         )
     if server_name is None and data_contract.servers is not None and len(data_contract.servers) > 0:
         server_name = data_contract.servers[0].server
-    server = get_server(data_contract, server_name)
+    server = resolve_server_overrides(get_server(data_contract, server_name), config, run)
     run.log_info(f"Running tests for data contract {data_contract.id} with server {server_name}")
     run.dataContractId = data_contract.id
     run.dataContractVersion = data_contract.version

--- a/datacontract/model/server.py
+++ b/datacontract/model/server.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Tuple
 from open_data_contract_standard.model import CustomProperty, Server
 
 from datacontract.config import SERVER_OVERRIDE_OPTIONS, Config
+from datacontract.model.run import Run
 
 # datacontract-CLI supports server types that are not part of the ODCS
 # `Server.type` enum (e.g. a Spark `dataframe`). To stay compliant with the
@@ -69,12 +70,7 @@ def _get_custom_property(server: Server, name: str) -> Optional[str]:
     return None
 
 
-# The server type a config option prefix names, where the CLI accepts a second
-# spelling for the same system: the options are all `sqlserver_*`.
-_OPTION_PREFIX_ALIASES = {"mssql": "sqlserver"}
-
-
-def resolve_server_overrides(server: Optional[Server], config: Config, run) -> Optional[Server]:
+def resolve_server_overrides(server: Optional[Server], config: Config, run: Run) -> Optional[Server]:
     """Return the effective server: the contract's, with the override options applied.
 
     Applied once here so that the connection, the table lookup and the catalog
@@ -84,7 +80,8 @@ def resolve_server_overrides(server: Optional[Server], config: Config, run) -> O
     if server is None:
         return None
     server_type = get_server_type(server)
-    prefix = _OPTION_PREFIX_ALIASES.get(server_type, server_type)
+    # The mssql options are all spelled `sqlserver_*`.
+    prefix = "sqlserver" if server_type == "mssql" else server_type
     if prefix is None:
         return server
 

--- a/datacontract/model/server.py
+++ b/datacontract/model/server.py
@@ -2,6 +2,8 @@ from typing import List, Optional, Tuple
 
 from open_data_contract_standard.model import CustomProperty, Server
 
+from datacontract.config import SERVER_OVERRIDE_OPTIONS, Config
+
 # datacontract-CLI supports server types that are not part of the ODCS
 # `Server.type` enum (e.g. a Spark `dataframe`). To stay compliant with the
 # ODCS standard, such a server is written as `type: custom` and the real
@@ -65,3 +67,49 @@ def _get_custom_property(server: Server, name: str) -> Optional[str]:
         if prop.property == name:
             return prop.value
     return None
+
+
+# The server type a config option prefix names, where the CLI accepts a second
+# spelling for the same system: the options are all `sqlserver_*`.
+_OPTION_PREFIX_ALIASES = {"mssql": "sqlserver"}
+
+
+def resolve_server_overrides(server: Optional[Server], config: Config, run) -> Optional[Server]:
+    """Return the effective server: the contract's, with the override options applied.
+
+    Applied once here so that the connection, the table lookup and the catalog
+    reads behind physical type checks all see the same location. The contract's
+    own server is never mutated; a copy carries the overrides.
+    """
+    if server is None:
+        return None
+    server_type = get_server_type(server)
+    prefix = _OPTION_PREFIX_ALIASES.get(server_type, server_type)
+    if prefix is None:
+        return server
+
+    updates = {}
+    for option, property_name in SERVER_OVERRIDE_OPTIONS.items():
+        if option.split("_", 1)[0] != prefix:
+            continue
+        # Via the accessor, never the field: a programmatic `Config(postgres_schema=...)`
+        # and DATACONTRACT_POSTGRES_SCHEMA are distinct sources and only it sees both.
+        value = getattr(config, f"get_{option}")()
+        # An option set to an empty value leaves the contract's value in place,
+        # matching how the connection code reads it (`get_x() or server.y`).
+        if not value:
+            continue
+        field = "schema_" if property_name == "schema" else property_name
+        declared = getattr(server, field, None)
+        if declared == value:
+            continue
+        updates[field] = value
+        if declared is None:
+            run.log_info(f"Server '{server.server}': using {property_name} '{value}' from configuration")
+        else:
+            run.log_info(
+                f"Server '{server.server}': using {property_name} '{value}' from configuration, "
+                f"overriding '{declared}' from the contract"
+            )
+
+    return server.model_copy(update=updates) if updates else server

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -163,8 +163,8 @@ Every option, by its environment variable name and the matching `Config` field. 
 
 | Environment variable | `Config` field | Type | Notes |
 |---|---|---|---|
-| `DATACONTRACT_DUCKDB_DATABASE` | `duckdb_database` | string |  |
-| `DATACONTRACT_DUCKDB_SCHEMA` | `duckdb_schema` | string |  |
+| `DATACONTRACT_DUCKDB_DATABASE` | `duckdb_database` | string | Overrides `database` from the contract's `servers` block |
+| `DATACONTRACT_DUCKDB_SCHEMA` | `duckdb_schema` | string | Overrides `schema` from the contract's `servers` block |
 
 ### GCS
 

--- a/tests/test_server_overrides.py
+++ b/tests/test_server_overrides.py
@@ -77,28 +77,21 @@ def test_an_empty_option_leaves_the_contract_value_in_place(run, monkeypatch):
     assert effective.schema_ == "declared"
 
 
-def test_the_override_is_logged_with_both_values(run, monkeypatch):
+@pytest.mark.parametrize(
+    "declared, expected",
+    [
+        ("declared", "using schema 'configured' from configuration, overriding 'declared' from the contract"),
+        (None, "using schema 'configured' from configuration"),
+    ],
+    ids=["the contract declares the property", "the contract does not declare the property"],
+)
+def test_the_effective_value_is_logged(declared, expected, run, monkeypatch):
     monkeypatch.setenv("DATACONTRACT_POSTGRES_SCHEMA", "configured")
-    server = Server(server="production", type="postgres", schema="declared")
+    server = Server(server="production", type="postgres", schema=declared)
 
     resolve_server_overrides(server, Config.resolve(None), run)
 
-    assert any(
-        "Server 'production': using schema 'configured' from configuration, overriding 'declared' from the contract"
-        == log.message
-        for log in run.logs
-    ), [log.message for log in run.logs]
-
-
-def test_a_property_the_contract_does_not_declare_is_logged_without_a_contract_value(run, monkeypatch):
-    monkeypatch.setenv("DATACONTRACT_POSTGRES_SCHEMA", "configured")
-    server = Server(server="production", type="postgres")
-
-    resolve_server_overrides(server, Config.resolve(None), run)
-
-    assert any("using schema 'configured' from configuration" == log.message.split(": ", 1)[1] for log in run.logs), [
-        log.message for log in run.logs
-    ]
+    assert any(f"Server 'production': {expected}" == log.message for log in run.logs), [log.message for log in run.logs]
 
 
 def test_every_option_names_a_real_server_property():

--- a/tests/test_server_overrides.py
+++ b/tests/test_server_overrides.py
@@ -1,0 +1,111 @@
+"""`resolve_server_overrides` — the contract's server plus the override options.
+
+A server override option displaces one property of the contract's `servers`
+block. They are applied once, up front, so the connection, the table lookup and
+the catalog reads behind physical type checks all see the same location.
+"""
+
+import pytest
+from open_data_contract_standard.model import Server
+
+from datacontract.config import SERVER_OVERRIDE_OPTIONS, Config
+from datacontract.model.run import Run
+from datacontract.model.server import resolve_server_overrides
+
+
+@pytest.fixture
+def run():
+    return Run.create_run()
+
+
+def test_an_option_set_in_the_environment_overrides_the_contract(run, monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_POSTGRES_SCHEMA", "configured")
+    server = Server(server="production", type="postgres", schema="declared")
+
+    effective = resolve_server_overrides(server, Config.resolve(None), run)
+
+    assert effective.schema_ == "configured"
+    assert server.schema_ == "declared", "the contract's own server must not be mutated"
+
+
+def test_an_option_passed_programmatically_overrides_the_contract(run):
+    """Config fields and DATACONTRACT_* env vars are two distinct sources, and
+    only the `get_<option>()` accessor reads both."""
+    server = Server(server="production", type="postgres", schema="declared")
+
+    effective = resolve_server_overrides(server, Config(postgres_schema="configured"), run)
+
+    assert effective.schema_ == "configured"
+
+
+def test_every_option_of_the_server_type_is_applied(run, monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_BIGQUERY_PROJECT", "configured-project")
+    monkeypatch.setenv("DATACONTRACT_BIGQUERY_DATASET", "configured_dataset")
+    server = Server(server="production", type="bigquery", project="declared", dataset="declared")
+
+    effective = resolve_server_overrides(server, Config.resolve(None), run)
+
+    assert (effective.project, effective.dataset) == ("configured-project", "configured_dataset")
+
+
+def test_mssql_picks_up_the_sqlserver_options(run, monkeypatch):
+    """ODCS spells SQL Server `sqlserver`, ibis and ODBC call it `mssql`; the
+    options are `sqlserver_*` for both spellings."""
+    monkeypatch.setenv("DATACONTRACT_SQLSERVER_DATABASE", "configured")
+    server = Server(server="production", type="mssql", database="declared")
+
+    effective = resolve_server_overrides(server, Config.resolve(None), run)
+
+    assert effective.database == "configured"
+
+
+def test_an_option_of_another_server_type_is_ignored(run, monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_SNOWFLAKE_SCHEMA", "configured")
+    server = Server(server="production", type="postgres", schema="declared")
+
+    effective = resolve_server_overrides(server, Config.resolve(None), run)
+
+    assert effective.schema_ == "declared"
+
+
+def test_an_empty_option_leaves_the_contract_value_in_place(run, monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_POSTGRES_SCHEMA", "")
+    server = Server(server="production", type="postgres", schema="declared")
+
+    effective = resolve_server_overrides(server, Config.resolve(None), run)
+
+    assert effective.schema_ == "declared"
+
+
+def test_the_override_is_logged_with_both_values(run, monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_POSTGRES_SCHEMA", "configured")
+    server = Server(server="production", type="postgres", schema="declared")
+
+    resolve_server_overrides(server, Config.resolve(None), run)
+
+    assert any(
+        "Server 'production': using schema 'configured' from configuration, overriding 'declared' from the contract"
+        == log.message
+        for log in run.logs
+    ), [log.message for log in run.logs]
+
+
+def test_a_property_the_contract_does_not_declare_is_logged_without_a_contract_value(run, monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_POSTGRES_SCHEMA", "configured")
+    server = Server(server="production", type="postgres")
+
+    resolve_server_overrides(server, Config.resolve(None), run)
+
+    assert any("using schema 'configured' from configuration" == log.message.split(": ", 1)[1] for log in run.logs), [
+        log.message for log in run.logs
+    ]
+
+
+def test_every_option_names_a_real_server_property():
+    """A typo in the map would silently stop overriding that property."""
+    unknown = {
+        property_name
+        for property_name in SERVER_OVERRIDE_OPTIONS.values()
+        if ("schema_" if property_name == "schema" else property_name) not in Server.model_fields
+    }
+    assert not unknown, f"SERVER_OVERRIDE_OPTIONS names properties the ODCS Server has not: {sorted(unknown)}"

--- a/tests/test_test_duckdb.py
+++ b/tests/test_test_duckdb.py
@@ -156,3 +156,39 @@ def test_the_database_is_opened_read_only(duckdb_database):
         assert con.sql("SELECT count(*) FROM orders").fetchone()[0] == 2
     finally:
         con.close()
+
+
+@pytest.fixture
+def duckdb_database_without_a_main_table(tmp_path):
+    """A database whose only `orders` table lives in the `reporting` schema."""
+    database = tmp_path / "orders.duckdb"
+    con = duckdb.connect(str(database))
+    con.sql("CREATE SCHEMA reporting")
+    con.sql("CREATE TABLE reporting.orders (order_id VARCHAR NOT NULL, order_total INTEGER)")
+    con.sql("INSERT INTO reporting.orders VALUES ('order-1', 100), ('order-2', 200)")
+    con.close()
+    return database
+
+
+def test_the_configured_schema_also_qualifies_the_table_lookup(duckdb_database_without_a_main_table, monkeypatch):
+    """The contract names a schema the table is not in, so a run that reaches it
+    can only have resolved the table against the configured schema."""
+    monkeypatch.setenv("DATACONTRACT_DUCKDB_SCHEMA", "reporting")
+
+    run = DataContract(data_contract_str=_contract(duckdb_database_without_a_main_table, schema="main")).test()
+
+    assert run.result == ResultEnum.passed, [check.reason for check in run.checks if check.reason]
+    assert any(
+        "using schema 'reporting' from configuration, overriding 'main' from the contract" in log.message
+        for log in run.logs
+    ), [log.message for log in run.logs]
+
+
+def test_the_configured_schema_can_be_passed_programmatically(duckdb_database_without_a_main_table):
+    """Config fields and DATACONTRACT_* env vars are two distinct sources."""
+    run = DataContract(
+        data_contract_str=_contract(duckdb_database_without_a_main_table, schema="main"),
+        config={"DATACONTRACT_DUCKDB_SCHEMA": "reporting"},
+    ).test()
+
+    assert run.result == ResultEnum.passed, [check.reason for check in run.checks if check.reason]


### PR DESCRIPTION
The `DATACONTRACT_*` options that override a server's location (`DATACONTRACT_BIGQUERY_PROJECT`, `DATACONTRACT_POSTGRES_SCHEMA`, and the like) now also apply to the table lookup and the physical type checks, not just to the connection. Adds the missing duckdb options.