### PR TITLE
Add more information to check results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `postgresql` is accepted as the ODCS synonym of the `postgres` server type
 - `--dry-run` flag for `datacontract dbt sync` that reports the same plan as a real sync, but writes nothing to disk
 - `datacontract import pydantic-model` reads the contract description from the module docstring
+- Test results carry the data quality dimension a check measures and, for a check from a `quality` rule, that rule as YAML
+- Published test results report how many rows a check found bad and how many rows it looked at
 
 ### Changed
 - `datacontract api` no longer sends permissive `Access-Control-Allow-Origin: *` headers; it serves no CORS headers at all, since the only browser client is the same-origin Swagger UI
 - `datacontract api` no longer reloads on file changes by default; pass `--reload` to enable it (development only)
 - **breaking:** the `engine` field of test results is now always one of `datacontract-cli`, `dbt` or `jsonschema`; the values `datacontract`, `ibis` and `dbt-sync` no longer occur (#1505)
+- Test results published to Entropy Data use the field names its API reads
+- **breaking:** published test results no longer repeat `qualityId` and `failedSamples` under their deprecated `quality_id` and `failed_samples` spellings
+- A service level check is identified by its `slaProperties[].id`, so `datacontract test --quality-id` can select one
 - A JSON Schema check that was not run because the server type is unsupported is now reported as `skipped` instead of `info`
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract api` no longer sends permissive `Access-Control-Allow-Origin: *` headers; it serves no CORS headers at all, since the only browser client is the same-origin Swagger UI
 - `datacontract api` no longer reloads on file changes by default; pass `--reload` to enable it (development only)
 - **breaking:** the `engine` field of test results is now always one of `datacontract-cli`, `dbt` or `jsonschema`; the values `datacontract`, `ibis` and `dbt-sync` no longer occur (#1505)
-- Test results published to Entropy Data use the field names its API reads
-- **breaking:** published test results no longer repeat `qualityId` and `failedSamples` under their deprecated `quality_id` and `failed_samples` spellings
+- Test results published to Entropy Data carry the field names its API reads, in addition to the names they were already published under
+- **breaking:** published `failedSamples` are JSON documents, as the API reads them; the deprecated `failed_samples` field still carries the raw rows
 - A service level check is identified by its `slaProperties[].id`, so `datacontract test --quality-id` can select one
 - A JSON Schema check that was not run because the server type is unsupported is now reported as `skipped` instead of `info`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `postgresql` is accepted as the ODCS synonym of the `postgres` server type
 - `--dry-run` flag for `datacontract dbt sync` that reports the same plan as a real sync, but writes nothing to disk
 - `datacontract import pydantic-model` reads the contract description from the module docstring
-- Additional information in test results (data quality dimension, number of failed and total rows, `quality` rules as YAML)
+- Test results report how many rows a check found bad out of the rows it read, plus the data quality dimension and the `quality` rule a check comes from
 
 ### Changed
 - `datacontract api` no longer sends permissive `Access-Control-Allow-Origin: *` headers; it serves no CORS headers at all, since the only browser client is the same-origin Swagger UI
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A JSON Schema check that could not be run is reported as `skipped`, not `info`
 
 ### Fixed
+- Test results published to Entropy Data no longer drop the quality rule id, category, rule definition and failed samples
 - Configuration options that override a server's location (`DATACONTRACT_BIGQUERY_PROJECT`, `DATACONTRACT_POSTGRES_SCHEMA`, and the like) now apply to the whole test run, not just to the connection
 - BigQuery: `DATACONTRACT_BIGQUERY_BILLING_PROJECT` no longer overrides the server's `project`, so tables are still read from the data project (#1358)
 - A `quality.type: sql` rule is read in the SQL dialect of its server type, so dialect-specific syntax (BigQuery backticks, Snowflake `SAMPLE`, SQL Server `TOP`) is no longer mistaken for an invalid query

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract api` no longer sends permissive `Access-Control-Allow-Origin: *` headers; it serves no CORS headers at all, since the only browser client is the same-origin Swagger UI
 - `datacontract api` no longer reloads on file changes by default; pass `--reload` to enable it (development only)
 - **breaking:** the `engine` field of test results is now always one of `datacontract-cli`, `dbt` or `jsonschema`; the values `datacontract`, `ibis` and `dbt-sync` no longer occur (#1505)
+- A JSON Schema check that was not run because the server type is unsupported is now reported as `skipped` instead of `info`
 
 ### Fixed
+- Publishing a run to Entropy Data no longer fails outright when it contains a JSON Schema check that could not be run
 - Configuration options that override a server's location (`DATACONTRACT_BIGQUERY_PROJECT`, `DATACONTRACT_POSTGRES_SCHEMA`, and the like) now apply to the whole test run, not just to the connection
 - BigQuery: `DATACONTRACT_BIGQUERY_BILLING_PROJECT` no longer overrides the server's `project`, so tables are still read from the data project (#1358)
 - A `quality.type: sql` rule is read in the SQL dialect of its server type, so dialect-specific syntax (BigQuery backticks, Snowflake `SAMPLE`, SQL Server `TOP`) is no longer mistaken for an invalid query

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,20 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `postgresql` is accepted as the ODCS synonym of the `postgres` server type
 - `--dry-run` flag for `datacontract dbt sync` that reports the same plan as a real sync, but writes nothing to disk
 - `datacontract import pydantic-model` reads the contract description from the module docstring
-- Test results carry the data quality dimension a check measures and, for a check from a `quality` rule, that rule as YAML
-- Published test results report how many rows a check found bad and how many rows it looked at
+- Additional information in test results (data quality dimension, number of failed and total rows, `quality` rules as YAML)
 
 ### Changed
 - `datacontract api` no longer sends permissive `Access-Control-Allow-Origin: *` headers; it serves no CORS headers at all, since the only browser client is the same-origin Swagger UI
 - `datacontract api` no longer reloads on file changes by default; pass `--reload` to enable it (development only)
 - **breaking:** the `engine` field of test results is now always one of `datacontract-cli`, `dbt` or `jsonschema`; the values `datacontract`, `ibis` and `dbt-sync` no longer occur (#1505)
-- Test results published to Entropy Data carry the field names its API reads, in addition to the names they were already published under
-- **breaking:** published `failedSamples` are JSON documents, as the API reads them; the deprecated `failed_samples` field still carries the raw rows
-- A service level check is identified by its `slaProperties[].id`, so `datacontract test --quality-id` can select one
-- A JSON Schema check that was not run because the server type is unsupported is now reported as `skipped` instead of `info`
+- A JSON Schema check that could not be run is reported as `skipped`, not `info`
 
 ### Fixed
-- Publishing a run to Entropy Data no longer fails outright when it contains a JSON Schema check that could not be run
 - Configuration options that override a server's location (`DATACONTRACT_BIGQUERY_PROJECT`, `DATACONTRACT_POSTGRES_SCHEMA`, and the like) now apply to the whole test run, not just to the connection
 - BigQuery: `DATACONTRACT_BIGQUERY_BILLING_PROJECT` no longer overrides the server's `project`, so tables are still read from the data project (#1358)
 - A `quality.type: sql` rule is read in the SQL dialect of its server type, so dialect-specific syntax (BigQuery backticks, Snowflake `SAMPLE`, SQL Server `TOP`) is no longer mistaken for an invalid query

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -10,6 +10,7 @@ if typing.TYPE_CHECKING:
     from pyspark.sql import SparkSession
 
 from datacontract.config import Config
+from datacontract.engines.checks.dimensions import default_dimension
 from datacontract.engines.data_contract_test import execute_data_contract_test
 from datacontract.export.exporter import ExportFormat
 from datacontract.export.exporter_factory import exporter_factory
@@ -183,6 +184,7 @@ class DataContract:
             run.checks.append(
                 Check(
                     type=e.type,
+                    dimension=default_dimension(e.type),
                     name=e.name,
                     result=e.result,
                     reason=e.reason,

--- a/datacontract/engines/checks/check_spec.py
+++ b/datacontract/engines/checks/check_spec.py
@@ -136,6 +136,11 @@ class CheckSpec:
     # check comes from. `test --tag` selects rules by them.
     tags: Optional[List[str]] = None
 
+    # The ODCS quality rule this check comes from, rendered as YAML, so a
+    # consumer of the test results can show what the check asserts. None for
+    # schema and service level checks, which no rule declared.
+    quality_definition: Optional[str] = None
+
     # --- metric arguments -------------------------------------------------
     missing_values: Optional[List[Any]] = None  # MISSING_COUNT / INVALID_COUNT
     valid_values: Optional[List[Any]] = None  # INVALID_COUNT

--- a/datacontract/engines/checks/check_spec.py
+++ b/datacontract/engines/checks/check_spec.py
@@ -136,9 +136,8 @@ class CheckSpec:
     # check comes from. `test --tag` selects rules by them.
     tags: Optional[List[str]] = None
 
-    # The ODCS quality rule this check comes from, rendered as YAML, so a
-    # consumer of the test results can show what the check asserts. None for
-    # schema and service level checks, which no rule declared.
+    # The ODCS quality rule this check comes from, rendered as YAML.
+    # None for schema and service level checks, which no rule declared.
     quality_definition: Optional[str] = None
 
     # --- metric arguments -------------------------------------------------

--- a/datacontract/engines/checks/create_checks.py
+++ b/datacontract/engines/checks/create_checks.py
@@ -106,11 +106,8 @@ def _nested_type_check(model: str, field: str, prop: SchemaProperty, physical: b
 
 
 def quality_definition_yaml(quality: DataQuality) -> str:
-    """The quality rule as YAML, as the CLI understood it.
-
-    Not the author's text: ODCS keys the model does not know are dropped when the
-    contract is parsed, and comments with them.
-    """
+    """The quality rule as YAML, as the CLI parsed it: ODCS keys the model does not
+    know are dropped, and comments with them."""
     return yaml.safe_dump(quality.model_dump(exclude_none=True), sort_keys=False)
 
 

--- a/datacontract/engines/checks/create_checks.py
+++ b/datacontract/engines/checks/create_checks.py
@@ -13,6 +13,7 @@ import logging
 import re
 from typing import List, Optional
 
+import yaml
 from open_data_contract_standard.model import (
     DataQuality,
     OpenDataContractStandard,
@@ -102,6 +103,15 @@ def _nested_type_check(model: str, field: str, prop: SchemaProperty, physical: b
         expected_type_label=_declared_type_label(prop, physical),
         expected_schema_property=prop,
     )
+
+
+def quality_definition_yaml(quality: DataQuality) -> str:
+    """The quality rule as YAML, as the CLI understood it.
+
+    Not the author's text: ODCS keys the model does not know are dropped when the
+    contract is parsed, and comments with them.
+    """
+    return yaml.safe_dump(quality.model_dump(exclude_none=True), sort_keys=False)
 
 
 _PERCENT_UNITS = {"percent", "percentage", "%"}
@@ -591,6 +601,7 @@ def _quality_checks(
         for check in rule_checks:
             check.quality_id = quality.id
             check.tags = list(quality.tags) if quality.tags else None
+            check.quality_definition = quality_definition_yaml(quality)
         checks.extend(rule_checks)
     return checks
 
@@ -853,6 +864,7 @@ def _freshness_check(data_contract: OpenDataContractStandard, sla) -> Optional[C
         model=model,
         field=field,
         metric=MetricType.FRESHNESS,
+        quality_id=sla.id,
         seconds=seconds,
     )
 
@@ -878,6 +890,7 @@ def _retention_check(data_contract: OpenDataContractStandard, sla) -> Optional[C
         model=model,
         field=field,
         metric=MetricType.RETENTION,
+        quality_id=sla.id,
         seconds=seconds,
     )
 

--- a/datacontract/engines/datacontract/check_azure_blob_file.py
+++ b/datacontract/engines/datacontract/check_azure_blob_file.py
@@ -17,6 +17,8 @@ from open_data_contract_standard.model import (
 
 from datacontract.config import Config
 from datacontract.engines.checks.check_filter import CheckFilter
+from datacontract.engines.checks.create_checks import quality_definition_yaml
+from datacontract.engines.checks.dimensions import default_dimension
 from datacontract.model.exceptions import DataContractException
 from datacontract.model.run import Check, ResultEnum, Run
 
@@ -612,10 +614,11 @@ def _append_check(
     """
     quality_id = quality.id if quality is not None else None
     tags = list(quality.tags) if quality is not None and quality.tags else None
+    dimension = quality.dimension if quality is not None else None
     if not check_filter.matches(
         category=category,
         check_type=check_type,
-        dimension=quality.dimension if quality is not None else None,
+        dimension=dimension,
         quality_id=quality_id,
         tags=tags,
     ):
@@ -631,6 +634,8 @@ def _append_check(
             field=field,
             qualityId=quality_id,
             tags=tags,
+            dimension=dimension or default_dimension(check_type),
+            qualityDefinition=quality_definition_yaml(quality) if quality is not None else None,
             engine="datacontract-cli",
             language="python",
             result=result,

--- a/datacontract/engines/fastjsonschema/check_jsonschema.py
+++ b/datacontract/engines/fastjsonschema/check_jsonschema.py
@@ -10,6 +10,7 @@ from fastjsonschema import JsonSchemaValueException
 from open_data_contract_standard.model import OpenDataContractStandard, Server
 
 from datacontract.config import Config
+from datacontract.engines.checks.dimensions import default_dimension
 from datacontract.engines.fastjsonschema.s3.s3_read_files import yield_s3_files
 from datacontract.export.jsonschema_exporter import to_jsonschema
 from datacontract.model.exceptions import DataContractException
@@ -71,6 +72,7 @@ def process_exceptions(run, exceptions: List[DataContractException], config: Con
         [
             Check(
                 type=exception.type,
+                dimension=default_dimension(exception.type),
                 name=exception.name,
                 result=exception.result,
                 reason=exception.reason,
@@ -165,6 +167,7 @@ def process_local_file(run, server, schema, model_name, validate, config: Config
     if not path:
         raise DataContractException(
             type="schema",
+            dimension=default_dimension("schema"),
             name="Check that JSON has valid schema",
             result=ResultEnum.warning,
             reason="For server with type 'local', a 'path' must be defined.",
@@ -190,6 +193,7 @@ def process_local_file(run, server, schema, model_name, validate, config: Config
     if not all_files:
         raise DataContractException(
             type="schema",
+            dimension=default_dimension("schema"),
             name="Check that JSON has valid schema",
             result=ResultEnum.warning,
             reason=f"No files found in '{path}'.",
@@ -220,6 +224,7 @@ def process_s3_file(run, server, schema, model_name, validate, config: Config | 
     if json_stream is None:
         raise DataContractException(
             type="schema",
+            dimension=default_dimension("schema"),
             name="Check that JSON has valid schema",
             result=ResultEnum.warning,
             reason=f"Cannot find any file in {s3_location}",
@@ -247,6 +252,7 @@ def check_jsonschema(
         run.checks.append(
             Check(
                 type="schema",
+                dimension=default_dimension("schema"),
                 name="Check that JSON has valid schema",
                 result=ResultEnum.warning,
                 reason="Server format is not 'json'. Skip validating jsonschema.",
@@ -283,6 +289,7 @@ def check_jsonschema(
             run.checks.append(
                 Check(
                     type="schema",
+                    dimension=default_dimension("schema"),
                     name="Check that JSON has valid schema",
                     model=model_name,
                     result=ResultEnum.skipped,
@@ -294,6 +301,7 @@ def check_jsonschema(
             run.checks.append(
                 Check(
                     type="schema",
+                    dimension=default_dimension("schema"),
                     name="Check that JSON has valid schema",
                     model=model_name,
                     result=ResultEnum.skipped,
@@ -305,6 +313,7 @@ def check_jsonschema(
             run.checks.append(
                 Check(
                     type="schema",
+                    dimension=default_dimension("schema"),
                     name="Check that JSON has valid schema",
                     model=model_name,
                     result=ResultEnum.warning,
@@ -317,6 +326,7 @@ def check_jsonschema(
         run.checks.append(
             Check(
                 type="schema",
+                dimension=default_dimension("schema"),
                 name="Check that JSON has valid schema",
                 model=model_name,
                 result=ResultEnum.passed,

--- a/datacontract/engines/fastjsonschema/check_jsonschema.py
+++ b/datacontract/engines/fastjsonschema/check_jsonschema.py
@@ -285,7 +285,7 @@ def check_jsonschema(
                     type="schema",
                     name="Check that JSON has valid schema",
                     model=model_name,
-                    result=ResultEnum.info,
+                    result=ResultEnum.skipped,
                     reason="JSON Schema check skipped for GCS, as GCS is currently not supported",
                     engine="jsonschema",
                 )
@@ -296,7 +296,7 @@ def check_jsonschema(
                     type="schema",
                     name="Check that JSON has valid schema",
                     model=model_name,
-                    result=ResultEnum.info,
+                    result=ResultEnum.skipped,
                     reason="JSON Schema check skipped for azure, as azure is currently not supported",
                     engine="jsonschema",
                 )

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -13,6 +13,7 @@ import logging
 import re
 import uuid
 from collections import defaultdict
+from functools import cache
 from typing import List, Optional
 
 from open_data_contract_standard.model import OpenDataContractStandard, SchemaProperty, Server
@@ -264,15 +265,12 @@ def _run_model(
             if not specs:
                 return
 
-    # The model's row count, computed at most once and only if a check needs it as
-    # a denominator. The batched aggregation reads its own within the same query.
-    row_counts: List[int] = []
-
+    # Read at most once, and only for a check that needs a denominator; the batched
+    # aggregation reads its own row count within the same query.
+    @cache
     def model_row_count() -> int:
-        if not row_counts:
-            rc = t.count().execute()
-            row_counts.append(0 if rc is None else int(rc))
-        return row_counts[0]
+        rc = t.count().execute()
+        return 0 if rc is None else int(rc)
 
     agg_exprs = []  # list[(spec, named_expr)]
     for spec in specs:
@@ -664,11 +662,8 @@ def _constraint_info(spec: CheckSpec) -> dict:
 # dedicated check runners
 # ---------------------------------------------------------------------------
 def _run_duplicate(run: Run, t, columns, spec: CheckSpec, row_count: int):
-    """Count the duplicated key values, and the rows they cost.
-
-    The key count is what the threshold compares against; the row count is what is
-    reported as failed, so it can be read against the model's row count.
-    """
+    """The threshold is compared against the duplicated key count; the rows those
+    keys span are what is reported as failed."""
     import pandas as pd
 
     cols = [_resolve_col(columns, c) for c in (spec.columns or [spec.field])]

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -68,6 +68,8 @@ def build_check_stubs(specs: List[CheckSpec]) -> List[Check]:
                 field=spec.field,
                 qualityId=spec.quality_id,
                 tags=spec.tags,
+                dimension=spec.dimension,
+                qualityDefinition=spec.quality_definition,
                 engine="datacontract-cli",
                 implementation=_describe(spec),
             )
@@ -262,6 +264,16 @@ def _run_model(
             if not specs:
                 return
 
+    # The model's row count, computed at most once and only if a check needs it as
+    # a denominator. The batched aggregation reads its own within the same query.
+    row_counts: List[int] = []
+
+    def model_row_count() -> int:
+        if not row_counts:
+            rc = t.count().execute()
+            row_counts.append(0 if rc is None else int(rc))
+        return row_counts[0]
+
     agg_exprs = []  # list[(spec, named_expr)]
     for spec in specs:
         try:
@@ -277,11 +289,11 @@ def _run_model(
                 if expr is None:
                     # No validity constraints => nothing can be invalid.
                     _set_impl(run, spec.key, "invalid_count = 0 (no validity constraints configured)", None)
-                    _evaluate(run, spec, 0)
+                    _evaluate(run, spec, 0, row_count=model_row_count())
                 else:
                     named = _count_true(expr).name(spec.key)
             elif spec.metric == MetricType.DUPLICATE_COUNT:
-                _run_duplicate(run, t, columns, spec)
+                _run_duplicate(run, t, columns, spec, model_row_count())
             elif spec.metric == MetricType.FIELD_PRESENT:
                 _run_present(run, con, model, columns, spec)
             elif spec.metric == MetricType.FIELD_TYPE:
@@ -651,16 +663,32 @@ def _constraint_info(spec: CheckSpec) -> dict:
 # ---------------------------------------------------------------------------
 # dedicated check runners
 # ---------------------------------------------------------------------------
-def _run_duplicate(run: Run, t, columns, spec: CheckSpec):
+def _run_duplicate(run: Run, t, columns, spec: CheckSpec, row_count: int):
+    """Count the duplicated key values, and the rows they cost.
+
+    The key count is what the threshold compares against; the row count is what is
+    reported as failed, so it can be read against the model's row count.
+    """
+    import pandas as pd
+
     cols = [_resolve_col(columns, c) for c in (spec.columns or [spec.field])]
     grouped = t.group_by(cols).aggregate(_dup_n=t.count())
     dup_groups = grouped.filter(grouped["_dup_n"] > 1)
     _record_sql(run, spec, dup_groups)
-    dup_count = dup_groups.count().execute()
-    dup_count = int(dup_count) if dup_count is not None else 0
-    _evaluate(run, spec, dup_count)
+    totals = dup_groups.aggregate(
+        _dup_keys=dup_groups["_dup_n"].count(), _dup_rows=dup_groups["_dup_n"].sum()
+    ).execute()
+
+    def _int(value) -> int:
+        return 0 if (value is None or pd.isna(value)) else int(value)
+
+    row = totals.iloc[0]
+    dup_count = _int(row["_dup_keys"])
+    _evaluate(run, spec, dup_count, row_count=row_count)
+    extra = {"failed_rows": _int(row["_dup_rows"])}
     if len(cols) > 1:
-        _update_diagnostics(run, spec.key, {"columns": cols})
+        extra["columns"] = cols
+    _update_diagnostics(run, spec.key, extra)
 
 
 def _run_present(run: Run, con, model: str, columns, spec: CheckSpec):
@@ -968,9 +996,10 @@ def _evaluate(run: Run, spec: CheckSpec, value, row_count: Optional[int] = None)
         severity=spec.severity,
         threshold=spec.threshold.describe() if spec.threshold is not None else None,
     )
+    if row_count is not None:
+        diag["row_count"] = row_count
     # For "bad row" metrics, show how many of the total rows failed.
     if row_count is not None and is_bad_row:
-        diag["row_count"] = row_count
         diag["failed_fraction"] = round(value / row_count, 6) if row_count else 0.0
     if percent is not None:
         diag["percent"] = percent

--- a/datacontract/integration/dbt_sync.py
+++ b/datacontract/integration/dbt_sync.py
@@ -28,6 +28,7 @@ from ruamel.yaml.error import CommentMark
 from ruamel.yaml.tokens import CommentToken
 from ruamel.yaml.util import load_yaml_guess_indent
 
+from datacontract.engines.checks.dimensions import default_dimension
 from datacontract.export.sql_type_converter import _get_config_value, convert_to_sql_type
 from datacontract.integration.dbt_test_mapping import field_to_data_tests, get_logical_type_option
 from datacontract.lint.resolve import resolve_data_contract
@@ -2579,6 +2580,7 @@ def parse_run_results_file(
             Check(
                 key=check_key,
                 type=check_type,
+                dimension=default_dimension(check_type),
                 name=description or fallback_name,
                 model=model,
                 field=column,

--- a/datacontract/integration/entropy_data.py
+++ b/datacontract/integration/entropy_data.py
@@ -49,29 +49,22 @@ def _host_and_port(url: str) -> tuple[str | None, int | None]:
         return None, None
 
 
-# The check fields the `/api/test-results` API reads under the name the CLI uses.
-_CHECK_PASS_THROUGH = ("type", "name", "result", "engine", "model", "field", "reason", "dimension")
-
-# ... and the ones it reads under a different name.
+# The check fields the `/api/test-results` API reads under a different name than the
+# CLI writes them. Both names are published.
 _CHECK_RENAMED = {
     "qualityId": "qualityReference",
     "category": "qualityCategory",
     "qualityDefinition": "qualityCheckDefinition",
 }
 
-# The metrics whose value is a count of bad rows, and so can be published as a
-# failed row count. `custom_sql` is not one: its value is whatever the author's
-# query returned.
+# The metrics whose value counts bad rows. `custom_sql` is not one: its value is
+# whatever the author's query returned.
 _FAILED_ROW_METRICS = ("missing_count", "invalid_count", "duplicate_count")
 
 
 def to_test_results_payload(run: Run) -> dict:
-    """`run` as the `/api/test-results` API expects it.
-
-    The API and the CLI model the same run differently, so the checks are
-    translated rather than dumped: the API names some fields differently, and
-    reads the failed and total row counts the CLI keeps in `diagnostics`.
-    """
+    """`run` as the `/api/test-results` API expects it: the renamed check fields and the
+    row counts from `diagnostics`, added on top of the dumped run."""
     payload = json.loads(run.model_dump_json(exclude_none=True))
     payload["id"] = str(run.runId)
     payload["checks"] = [_to_check_payload(check) for check in payload.get("checks") or []]
@@ -79,7 +72,7 @@ def to_test_results_payload(run: Run) -> dict:
 
 
 def _to_check_payload(check: dict) -> dict:
-    published = {name: check[name] for name in _CHECK_PASS_THROUGH if name in check}
+    published = dict(check)
     published.update({name: check[old] for old, name in _CHECK_RENAMED.items() if old in check})
     if check.get("failedSamples"):
         published["failedSamples"] = [json.dumps(row) for row in check["failedSamples"]]
@@ -90,9 +83,8 @@ def _to_check_payload(check: dict) -> dict:
 def _row_counts(diagnostics: dict) -> dict:
     """The failed and total row counts a check measured, both in rows or neither.
 
-    They are summed across checks into a row-level quality score, so a count in
-    any other unit -- duplicated keys, an author's own query result -- is left out
-    rather than published as if it were rows.
+    The API sums them across checks into a row-level quality score, so a count in any
+    other unit -- duplicated keys, an author's own query result -- is left out.
     """
     metric = diagnostics.get("metric")
     if metric in _FAILED_ROW_METRICS:

--- a/datacontract/integration/entropy_data.py
+++ b/datacontract/integration/entropy_data.py
@@ -1,3 +1,4 @@
+import json
 from urllib.parse import urlparse
 
 import requests
@@ -48,6 +49,62 @@ def _host_and_port(url: str) -> tuple[str | None, int | None]:
         return None, None
 
 
+# The check fields the `/api/test-results` API reads under the name the CLI uses.
+_CHECK_PASS_THROUGH = ("type", "name", "result", "engine", "model", "field", "reason", "dimension")
+
+# ... and the ones it reads under a different name.
+_CHECK_RENAMED = {
+    "qualityId": "qualityReference",
+    "category": "qualityCategory",
+    "qualityDefinition": "qualityCheckDefinition",
+}
+
+# The metrics whose value is a count of bad rows, and so can be published as a
+# failed row count. `custom_sql` is not one: its value is whatever the author's
+# query returned.
+_FAILED_ROW_METRICS = ("missing_count", "invalid_count", "duplicate_count")
+
+
+def to_test_results_payload(run: Run) -> dict:
+    """`run` as the `/api/test-results` API expects it.
+
+    The API and the CLI model the same run differently, so the checks are
+    translated rather than dumped: the API names some fields differently, and
+    reads the failed and total row counts the CLI keeps in `diagnostics`.
+    """
+    payload = json.loads(run.model_dump_json(exclude_none=True))
+    payload["id"] = str(run.runId)
+    payload["checks"] = [_to_check_payload(check) for check in payload.get("checks") or []]
+    return payload
+
+
+def _to_check_payload(check: dict) -> dict:
+    published = {name: check[name] for name in _CHECK_PASS_THROUGH if name in check}
+    published.update({name: check[old] for old, name in _CHECK_RENAMED.items() if old in check})
+    if check.get("failedSamples"):
+        published["failedSamples"] = [json.dumps(row) for row in check["failedSamples"]]
+    published.update(_row_counts(check.get("diagnostics") or {}))
+    return {name: value for name, value in published.items() if value is not None}
+
+
+def _row_counts(diagnostics: dict) -> dict:
+    """The failed and total row counts a check measured, both in rows or neither.
+
+    They are summed across checks into a row-level quality score, so a count in
+    any other unit -- duplicated keys, an author's own query result -- is left out
+    rather than published as if it were rows.
+    """
+    metric = diagnostics.get("metric")
+    if metric in _FAILED_ROW_METRICS:
+        return {
+            "failedNumber": diagnostics.get("failed_rows", diagnostics.get("value")),
+            "totalNumber": diagnostics.get("row_count"),
+        }
+    if metric == "row_count":
+        return {"totalNumber": diagnostics.get("value")}
+    return {}
+
+
 def publish_test_results_to_entropy_data(
     run: Run, publish_url: str, ssl_verification: bool, config: Config | None = None
 ) -> bool:
@@ -78,11 +135,9 @@ def publish_test_results_to_entropy_data(
         published_run = run.model_copy(
             update={"checks": [check for check in (run.checks or []) if check.result != ResultEnum.skipped]}
         )
-        request_body = published_run.model_dump_json()
-        # print("Request Body:", request_body)
         response = requests.post(
             url,
-            data=request_body,
+            json=to_test_results_payload(published_run),
             headers=headers,
             verify=ssl_verification,
         )

--- a/datacontract/model/run.py
+++ b/datacontract/model/run.py
@@ -86,12 +86,23 @@ class Check(BaseModel):
     qualityId: str | None = Field(
         default=None,
         validation_alias=AliasChoices("qualityId", "quality_id"),
-        description="The ODCS `quality.id` of the rule this check comes from, so it can be traced back "
-        "to (and re-run through `test --quality-id`) the rule that declared it. Absent for built-in checks.",
+        description="The ODCS `quality.id` of the rule this check comes from, or the `slaProperties` "
+        "id for a service level check, so it can be traced back to (and re-run through "
+        "`test --quality-id`) the declaration it came from. Absent for built-in schema checks.",
     )
     tags: list[str] | None = Field(
         default=None,
         description="The ODCS `quality.tags` of the rule this check comes from.",
+    )
+    dimension: str | None = Field(
+        default=None,
+        description="The data quality dimension this check measures, either declared by the rule "
+        "(`quality.dimension`) or the one its check type measures.",
+        examples=["completeness"],
+    )
+    qualityDefinition: str | None = Field(
+        default=None,
+        description="The ODCS quality rule this check comes from, as YAML. Absent for checks that no rule declared.",
     )
 
     engine: str | None = Field(

--- a/tests/test_check_quality_provenance.py
+++ b/tests/test_check_quality_provenance.py
@@ -1,0 +1,84 @@
+"""What a check records about the contract element it was derived from.
+
+An executed check carries the dimension it measures and, where a quality rule
+declared it, that rule as YAML -- so a test result can be read back against what
+the contract asked for.
+"""
+
+from open_data_contract_standard.model import OpenDataContractStandard
+
+from datacontract.engines.checks.create_checks import create_checks
+from datacontract.engines.ibis.ibis_check_execute import build_check_stubs
+
+CONTRACT = """
+apiVersion: v3.0.2
+kind: DataContract
+id: quality_provenance
+version: 1.0.0
+status: active
+servers:
+  - server: local
+    type: local
+    path: ./fixtures/diagnostics/data/orders.csv
+    format: csv
+slaProperties:
+  - id: freshness-sla
+    property: freshness
+    element: orders.processed_timestamp
+    value: 3650
+    unit: d
+schema:
+  - name: orders
+    properties:
+      - name: order_id
+        logicalType: integer
+        required: true
+        quality:
+          - id: order_id_is_unique
+            description: order_id identifies an order.
+            type: library
+            metric: duplicateValues
+            dimension: uniqueness
+            mustBe: 0
+      - name: processed_timestamp
+        logicalType: date
+"""
+
+
+def _stubs():
+    data_contract = OpenDataContractStandard.from_string(CONTRACT)
+    checks = build_check_stubs(create_checks(data_contract, data_contract.servers[0]))
+    return {check.type: check for check in checks}
+
+
+def test_a_check_from_a_quality_rule_carries_the_rule_it_came_from():
+    check = _stubs()["field_duplicate_values"]
+
+    assert check.qualityId == "order_id_is_unique"
+    assert check.dimension == "uniqueness"
+    assert check.qualityDefinition == (
+        "id: order_id_is_unique\n"
+        "description: order_id identifies an order.\n"
+        "dimension: uniqueness\n"
+        "type: library\n"
+        "metric: duplicateValues\n"
+        "mustBe: 0\n"
+    )
+
+
+def test_a_schema_check_carries_the_dimension_it_measures_but_no_rule():
+    """No rule declared it, so there is no definition to show -- but it still
+    measures a dimension, and is selectable by it."""
+    check = _stubs()["field_required"]
+
+    assert check.dimension == "completeness"
+    assert check.qualityDefinition is None
+    assert check.qualityId is None
+
+
+def test_a_service_level_check_is_identified_by_its_sla_property_id():
+    check = _stubs()["servicelevel_freshness"]
+
+    assert check.qualityId == "freshness-sla"
+    assert check.dimension == "timeliness"
+    assert check.qualityDefinition is None

--- a/tests/test_check_quality_provenance.py
+++ b/tests/test_check_quality_provenance.py
@@ -1,9 +1,4 @@
-"""What a check records about the contract element it was derived from.
-
-An executed check carries the dimension it measures and, where a quality rule
-declared it, that rule as YAML -- so a test result can be read back against what
-the contract asked for.
-"""
+"""What a check records about the contract element it was derived from."""
 
 from open_data_contract_standard.model import OpenDataContractStandard
 
@@ -67,8 +62,6 @@ def test_a_check_from_a_quality_rule_carries_the_rule_it_came_from():
 
 
 def test_a_schema_check_carries_the_dimension_it_measures_but_no_rule():
-    """No rule declared it, so there is no definition to show -- but it still
-    measures a dimension, and is selectable by it."""
     check = _stubs()["field_required"]
 
     assert check.dimension == "completeness"

--- a/tests/test_publish_test_results.py
+++ b/tests/test_publish_test_results.py
@@ -1,5 +1,3 @@
-import json
-
 from datacontract.integration.entropy_data import publish_test_results_to_entropy_data
 from datacontract.model.run import Check, ResultEnum, Run
 
@@ -26,8 +24,8 @@ def test_publish_omits_skipped_checks(monkeypatch):
 
     posted = {}
 
-    def fake_post(url, data, headers, verify):
-        posted["body"] = json.loads(data)
+    def fake_post(url, json, headers, verify):  # noqa: A002 -- the requests keyword
+        posted["body"] = json
         return _Response()
 
     monkeypatch.setattr("datacontract.integration.entropy_data.requests.post", fake_post)
@@ -45,7 +43,7 @@ def _publish_and_capture(monkeypatch, publish_url: str) -> dict:
     run.dataContractId = "orders"
     sent = {}
 
-    def fake_post(url, data, headers, verify):
+    def fake_post(url, json, headers, verify):  # noqa: A002 -- the requests keyword
         sent.update(headers)
         return _Response()
 

--- a/tests/test_publish_test_results_payload.py
+++ b/tests/test_publish_test_results_payload.py
@@ -1,0 +1,146 @@
+"""The payload the `/api/test-results` API is published with.
+
+The API and the CLI model a run differently, so the checks are translated rather
+than dumped: some fields are named differently, and the failed/total row counts
+the API reads live in the CLI's `diagnostics`.
+"""
+
+from datacontract.integration.entropy_data import to_test_results_payload
+from datacontract.model.run import Check, ResultEnum, Run
+
+
+def _published(check: Check) -> dict:
+    run = Run.create_run()
+    run.dataContractId = "orders"
+    run.checks = [check]
+    return to_test_results_payload(run)["checks"][0]
+
+
+def _counted(metric: str, **diagnostics) -> dict:
+    return _published(
+        Check(
+            type="field_required",
+            result=ResultEnum.failed,
+            diagnostics={"metric": metric, **diagnostics},
+        )
+    )
+
+
+def test_the_run_is_identified_by_id_as_well_as_run_id():
+    run = Run.create_run()
+    run.dataContractId = "orders"
+
+    payload = to_test_results_payload(run)
+
+    assert payload["id"] == str(run.runId)
+    assert payload["runId"] == str(run.runId)
+
+
+def test_missing_values_are_published_as_failed_rows_of_the_total():
+    assert _counted("missing_count", value=3, row_count=10) == {
+        "type": "field_required",
+        "result": "failed",
+        "failedNumber": 3,
+        "totalNumber": 10,
+    }
+
+
+def test_invalid_values_are_published_as_failed_rows_of_the_total():
+    counts = _counted("invalid_count", value=1, row_count=10)
+
+    assert (counts["failedNumber"], counts["totalNumber"]) == (1, 10)
+
+
+def test_duplicates_are_published_as_the_rows_they_cost_not_the_duplicated_keys():
+    """`value` counts key values occurring more than once; `failed_rows` counts the
+    rows those keys span. Only the latter is in the same unit as the denominator,
+    and the two are summed across checks into a row-level quality score."""
+    counts = _counted("duplicate_count", value=2, failed_rows=5, row_count=10)
+
+    assert (counts["failedNumber"], counts["totalNumber"]) == (5, 10)
+
+
+def test_a_row_count_check_is_published_as_a_total_without_a_failed_count():
+    counts = _counted("row_count", value=10)
+
+    assert counts["totalNumber"] == 10
+    assert "failedNumber" not in counts
+
+
+def test_a_custom_query_result_is_not_published_as_a_row_count():
+    """The value is whatever the author's query returned -- a count, a ratio, an
+    age -- so it cannot be summed with other checks' row counts."""
+    counts = _counted("custom_sql", value=42)
+
+    assert "failedNumber" not in counts
+    assert "totalNumber" not in counts
+
+
+def test_a_check_that_measures_no_rows_publishes_no_counts():
+    for metric in ("field_type", "field_present", "freshness", "retention"):
+        counts = _counted(metric, value=1)
+
+        assert "failedNumber" not in counts, metric
+        assert "totalNumber" not in counts, metric
+
+
+def test_a_check_without_diagnostics_publishes_no_counts():
+    counts = _published(Check(type="schema", result=ResultEnum.failed, engine="jsonschema"))
+
+    assert "failedNumber" not in counts
+    assert "totalNumber" not in counts
+
+
+def test_the_api_reads_the_quality_fields_under_its_own_names():
+    published = _published(
+        Check(
+            type="field_unique",
+            result=ResultEnum.failed,
+            category="quality",
+            qualityId="order_id_is_unique",
+            dimension="uniqueness",
+            qualityDefinition="id: order_id_is_unique\ntype: library\n",
+        )
+    )
+
+    assert published["qualityReference"] == "order_id_is_unique"
+    assert published["qualityCategory"] == "quality"
+    assert published["qualityCheckDefinition"] == "id: order_id_is_unique\ntype: library\n"
+    # dimension is the one field of the four the API names the same way
+    assert published["dimension"] == "uniqueness"
+    assert "qualityId" not in published
+    assert "category" not in published
+
+
+def test_failed_samples_are_published_as_json_documents():
+    published = _published(
+        Check(
+            type="field_required",
+            result=ResultEnum.failed,
+            failedSamples=[{"order_id": "B", "amount": None}],
+        )
+    )
+
+    assert published["failedSamples"] == ['{"order_id": "B", "amount": null}']
+
+
+def test_a_field_the_check_does_not_have_is_left_out_rather_than_published_as_null():
+    published = _published(Check(type="field_required", result=ResultEnum.passed))
+
+    assert published == {"type": "field_required", "result": "passed"}
+
+
+def test_the_deprecated_check_field_names_are_not_published():
+    """The API reads `qualityReference` and `failedSamples`; the snake_case names
+    the CLI still writes to its own output are not part of the payload."""
+    published = _published(
+        Check(
+            type="field_unique",
+            result=ResultEnum.failed,
+            qualityId="order_id_is_unique",
+            failedSamples=[{"order_id": "A"}],
+        )
+    )
+
+    assert "quality_id" not in published
+    assert "failed_samples" not in published

--- a/tests/test_publish_test_results_payload.py
+++ b/tests/test_publish_test_results_payload.py
@@ -1,9 +1,4 @@
-"""The payload the `/api/test-results` API is published with.
-
-The API and the CLI model a run differently, so the checks are translated rather
-than dumped: some fields are named differently, and the failed/total row counts
-the API reads live in the CLI's `diagnostics`.
-"""
+"""The payload the `/api/test-results` API is published with."""
 
 from datacontract.integration.entropy_data import to_test_results_payload
 from datacontract.model.run import Check, ResultEnum, Run
@@ -42,6 +37,7 @@ def test_missing_values_are_published_as_failed_rows_of_the_total():
         "result": "failed",
         "failedNumber": 3,
         "totalNumber": 10,
+        "diagnostics": {"metric": "missing_count", "value": 3, "row_count": 10},
     }
 
 
@@ -52,9 +48,8 @@ def test_invalid_values_are_published_as_failed_rows_of_the_total():
 
 
 def test_duplicates_are_published_as_the_rows_they_cost_not_the_duplicated_keys():
-    """`value` counts key values occurring more than once; `failed_rows` counts the
-    rows those keys span. Only the latter is in the same unit as the denominator,
-    and the two are summed across checks into a row-level quality score."""
+    """`value` counts key values occurring more than once; `failed_rows` counts the rows
+    those keys span, which is the unit the denominator is in."""
     counts = _counted("duplicate_count", value=2, failed_rows=5, row_count=10)
 
     assert (counts["failedNumber"], counts["totalNumber"]) == (5, 10)
@@ -108,8 +103,8 @@ def test_the_api_reads_the_quality_fields_under_its_own_names():
     assert published["qualityCheckDefinition"] == "id: order_id_is_unique\ntype: library\n"
     # dimension is the one field of the four the API names the same way
     assert published["dimension"] == "uniqueness"
-    assert "qualityId" not in published
-    assert "category" not in published
+    assert published["qualityId"] == "order_id_is_unique"
+    assert published["category"] == "quality"
 
 
 def test_failed_samples_are_published_as_json_documents():
@@ -130,9 +125,9 @@ def test_a_field_the_check_does_not_have_is_left_out_rather_than_published_as_nu
     assert published == {"type": "field_required", "result": "passed"}
 
 
-def test_the_deprecated_check_field_names_are_not_published():
-    """The API reads `qualityReference` and `failedSamples`; the snake_case names
-    the CLI still writes to its own output are not part of the payload."""
+def test_the_deprecated_check_field_names_are_still_published():
+    """`failedSamples` changes shape to the JSON documents the API reads, so the
+    deprecated `failed_samples` is what still carries the raw rows."""
     published = _published(
         Check(
             type="field_unique",
@@ -142,5 +137,5 @@ def test_the_deprecated_check_field_names_are_not_published():
         )
     )
 
-    assert "quality_id" not in published
-    assert "failed_samples" not in published
+    assert published["quality_id"] == "order_id_is_unique"
+    assert published["failed_samples"] == [{"order_id": "A"}]

--- a/tests/test_test_diagnostics.py
+++ b/tests/test_test_diagnostics.py
@@ -61,6 +61,9 @@ def test_diagnostics_passing_check_reports_zero_fraction():
 def test_diagnostics_duplicate_and_present():
     run = DataContract(data_contract_file="fixtures/diagnostics/datacontract.yaml").test()
 
+    # One order_id occurs twice, so one key value is duplicated and two of the
+    # five rows are: the threshold is compared against the key count, and the row
+    # count is what is reported as failed.
     unique = _find(run, "field_unique", "order_id")
     assert unique.result == ResultEnum.failed
     assert unique.diagnostics == {
@@ -68,6 +71,8 @@ def test_diagnostics_duplicate_and_present():
         "field": "order_id",
         "value": 1,
         "threshold": "= 0",
+        "row_count": 5,
+        "failed_rows": 2,
     }
 
     present = _find(run, "field_is_present", "order_id")

--- a/tests/test_test_diagnostics.py
+++ b/tests/test_test_diagnostics.py
@@ -61,9 +61,7 @@ def test_diagnostics_passing_check_reports_zero_fraction():
 def test_diagnostics_duplicate_and_present():
     run = DataContract(data_contract_file="fixtures/diagnostics/datacontract.yaml").test()
 
-    # One order_id occurs twice, so one key value is duplicated and two of the
-    # five rows are: the threshold is compared against the key count, and the row
-    # count is what is reported as failed.
+    # One order_id occurs twice: one duplicated key value spanning two of the five rows.
     unique = _find(run, "field_unique", "order_id")
     assert unique.result == ResultEnum.failed
     assert unique.diagnostics == {

--- a/tests/test_test_dimension_filter.py
+++ b/tests/test_test_dimension_filter.py
@@ -286,3 +286,12 @@ def test_dimension_cli_spaces_after_comma():
         ["test", "--dimension", "completeness, uniqueness", "./fixtures/quality-dimensions/datacontract.yaml"],
     )
     assert result.exit_code == 0
+
+
+def test_a_json_schema_check_carries_the_conformity_dimension():
+    """Every check the engine emits shares the type "schema", so one dimension covers all."""
+    run = DataContract(data_contract_file="fixtures/local-json/datacontract.yaml").test()
+
+    schema_checks = [c for c in run.checks if c.engine == "jsonschema"]
+    assert schema_checks
+    assert all(c.dimension == "conformity" for c in schema_checks)


### PR DESCRIPTION
A check now reports how many rows it found bad out of how many it read, so Entropy Data can sum them across checks into a row-level quality score. Published only when both count rows: a uniqueness check reports the rows a duplication costs, not the duplicated key values its threshold compares against, and a `type: sql` rule reports neither, since its value is whatever the author's query returned.

Fixed along the way: published checks carry the field names the API reads alongside the existing ones (the payload was `Run.model_dump_json()`, so the CLI's internal model was the wire format), checks gained the data quality dimension and the `quality` rule as YAML, and a JSON Schema check that could not be run is reported as `skipped` rather than `info`.

Verified end-to-end against a live instance.
