### PR TITLE
Honor physicalName in Avro and JSON Schema exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** the `engine` field of test results is now always one of `datacontract-cli`, `dbt` or `jsonschema`; the values `datacontract`, `ibis` and `dbt-sync` no longer occur (#1505)
 
 ### Fixed
+- Avro and JSON Schema exports use `physicalName` for schemas and properties when it is provided (#1494)
 - Configuration options that override a server's location (`DATACONTRACT_BIGQUERY_PROJECT`, `DATACONTRACT_POSTGRES_SCHEMA`, and the like) now apply to the whole test run, not just to the connection
 - BigQuery: `DATACONTRACT_BIGQUERY_BILLING_PROJECT` no longer overrides the server's `project`, so tables are still read from the data project (#1358)
 - A `quality.type: sql` rule is read in the SQL dialect of its server type, so dialect-specific syntax (BigQuery backticks, Snowflake `SAMPLE`, SQL Server `TOP`) is no longer mistaken for an invalid query

--- a/datacontract/export/avro_exporter.py
+++ b/datacontract/export/avro_exporter.py
@@ -14,7 +14,7 @@ class AvroExporter(Exporter):
 
 def to_avro_schema(model_name: str, model: SchemaObject) -> dict:
     namespace = _get_config_value(model, "namespace")
-    return to_avro_record(model_name, model.properties or [], model.description, namespace)
+    return to_avro_record(model.physicalName or model_name, model.properties or [], model.description, namespace)
 
 
 def to_avro_schema_json(model_name: str, model: SchemaObject) -> str:
@@ -106,7 +106,7 @@ def _parse_default_value(value: str):
 
 
 def to_avro_field(prop: SchemaProperty) -> dict:
-    avro_field = {"name": prop.name}
+    avro_field = {"name": prop.physicalName or prop.name}
     if prop.description is not None:
         avro_field["doc"] = prop.description
     is_required_avro = prop.required if prop.required is not None else True
@@ -118,7 +118,7 @@ def to_avro_field(prop: SchemaProperty) -> dict:
     avro_config_type = _get_config_value(prop, "avroType")
 
     if avro_type == "enum" or (isinstance(avro_field["type"], list) and "enum" in avro_field["type"]):
-        title = prop.businessName or prop.name
+        title = prop.physicalName or prop.businessName or prop.name
         enum_def = {
             "type": "enum",
             "name": title,
@@ -244,7 +244,7 @@ def to_avro_type(prop: SchemaProperty) -> Union[str, dict]:
             return "bytes"
     elif field_type.lower() in ["object", "record", "struct"]:
         namespace = _get_config_value(prop, "namespace")
-        return to_avro_record(prop.name, prop.properties or [], prop.description, namespace)
+        return to_avro_record(prop.physicalName or prop.name, prop.properties or [], prop.description, namespace)
     elif field_type.lower() in ["binary"]:
         return "bytes"
     elif field_type.lower() in ["array"]:

--- a/datacontract/export/jsonschema_exporter.py
+++ b/datacontract/export/jsonschema_exporter.py
@@ -16,8 +16,9 @@ def to_jsonschemas(data_contract: OpenDataContractStandard) -> dict:
     jsonschemas = {}
     if data_contract.schema_:
         for schema_obj in data_contract.schema_:
-            jsonschema = to_jsonschema(schema_obj.name, schema_obj)
-            jsonschemas[schema_obj.name] = jsonschema
+            schema_name = schema_obj.physicalName or schema_obj.name
+            jsonschema = to_jsonschema(schema_name, schema_obj)
+            jsonschemas[schema_name] = jsonschema
     return jsonschemas
 
 
@@ -29,7 +30,7 @@ def to_jsonschema_json(model_key: str, model_value: SchemaObject) -> str:
 def to_properties(properties: List[SchemaProperty]) -> dict:
     result = {}
     for prop in properties:
-        result[prop.name] = to_property(prop)
+        result[prop.physicalName or prop.name] = to_property(prop)
     return result
 
 
@@ -94,7 +95,7 @@ def to_property(prop: SchemaProperty) -> dict:
     if json_type == "object":
         nested_props = prop.properties or []
         # TODO: any better idea to distinguish between properties and patternProperties?
-        if nested_props and nested_props[0].name.startswith("^"):
+        if nested_props and (nested_props[0].physicalName or nested_props[0].name).startswith("^"):
             property_dict["patternProperties"] = to_properties(nested_props)
         else:
             property_dict["properties"] = to_properties(nested_props)
@@ -171,7 +172,7 @@ def to_required(properties: List[SchemaProperty]) -> list:
     required = []
     for prop in properties:
         if prop.required is True:
-            required.append(prop.name)
+            required.append(prop.physicalName or prop.name)
     return required
 
 

--- a/tests/test_export_avro.py
+++ b/tests/test_export_avro.py
@@ -1,13 +1,59 @@
 import json
 
 from datacontract_specification.model import DataContractSpecification
+from open_data_contract_standard.model import SchemaObject, SchemaProperty
 from typer.testing import CliRunner
 
 from datacontract.cli import app
-from datacontract.export.avro_exporter import to_avro_schema_json
+from datacontract.export.avro_exporter import to_avro_schema, to_avro_schema_json
 from datacontract.imports.dcs_importer import convert_dcs_to_odcs
 
 # logging.basicConfig(level=logging.DEBUG, force=True)
+
+
+def test_to_avro_schema_uses_physical_names():
+    model = SchemaObject(
+        name="logical_record",
+        physicalName="physical_record",
+        properties=[
+            SchemaProperty(
+                name="logical_field",
+                physicalName="physical_field",
+                logicalType="string",
+                required=True,
+            ),
+            SchemaProperty(
+                name="logical_nested",
+                physicalName="physical_nested",
+                logicalType="object",
+                required=True,
+                properties=[
+                    SchemaProperty(
+                        name="logical_child",
+                        physicalName="physical_child",
+                        logicalType="string",
+                        required=True,
+                    )
+                ],
+            ),
+        ],
+    )
+
+    assert to_avro_schema(model.name, model) == {
+        "type": "record",
+        "name": "physical_record",
+        "fields": [
+            {"name": "physical_field", "type": "string"},
+            {
+                "name": "physical_nested",
+                "type": {
+                    "type": "record",
+                    "name": "physical_nested",
+                    "fields": [{"name": "physical_child", "type": "string"}],
+                },
+            },
+        ],
+    }
 
 
 def test_cli():

--- a/tests/test_export_jsonschema.py
+++ b/tests/test_export_jsonschema.py
@@ -2,6 +2,7 @@ import json
 import os
 import sys
 
+from open_data_contract_standard.model import OpenDataContractStandard, SchemaObject, SchemaProperty
 from typer.testing import CliRunner
 
 from datacontract.cli import app
@@ -10,6 +11,52 @@ from datacontract.export.jsonschema_exporter import to_jsonschemas
 from datacontract.lint.resolve import resolve_data_contract
 
 # logging.basicConfig(level=logging.DEBUG, force=True)
+
+
+def test_to_jsonschemas_uses_physical_names():
+    model = SchemaObject(
+        name="logical_record",
+        physicalName="physical_record",
+        properties=[
+            SchemaProperty(
+                name="logical_field",
+                physicalName="physical_field",
+                logicalType="string",
+                required=True,
+            ),
+            SchemaProperty(
+                name="logical_nested",
+                physicalName="physical_nested",
+                logicalType="object",
+                required=True,
+                properties=[
+                    SchemaProperty(
+                        name="logical_child",
+                        physicalName="physical_child",
+                        logicalType="string",
+                        required=True,
+                    )
+                ],
+            ),
+        ],
+    )
+    data_contract = OpenDataContractStandard(schema=[model])
+
+    assert to_jsonschemas(data_contract) == {
+        "physical_record": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "physical_field": {"type": "string"},
+                "physical_nested": {
+                    "type": "object",
+                    "properties": {"physical_child": {"type": "string"}},
+                    "required": ["physical_child"],
+                },
+            },
+            "required": ["physical_field", "physical_nested"],
+        }
+    }
 
 
 def test_cli():


### PR DESCRIPTION
## Summary
- prefer ODCS `physicalName` with a `name` fallback for Avro schemas, records, fields, and enum names
- keep JSON Schema schema keys, properties, `required`, and pattern properties aligned with physical names
- add focused nested-schema regressions and a changelog entry

## Validation
- `uv run pytest -n0 tests/test_export_avro.py tests/test_export_jsonschema.py tests/test_roundtrip_jsonschema.py` (18 passed)
- `uv run pytest -n0` (2,110 passed, 14 skipped, 1 xfailed; Docker-dependent container files were not collected because no daemon was available)
- `uv run ruff check`
- `uv run ruff format --check`
- `uv run python lint_examples.py` (12/12)
- `uv run pre-commit run --all-files`
- `uv build --wheel` and CLI smoke exports for Avro and JSON Schema

- [x] Tests pass (`uv run pytest`)
- [x] Code formatted (`uv run ruff check --fix && uv run ruff format`)
- [x] Docs updated (not required for this behavior fix)
- [x] CHANGELOG.md entry added

Fixes #1494