### PR TITLE
fix: take the sql import server's database and schema from the table name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** the `engine` field of test results is now always one of `datacontract-cli`, `dbt` or `jsonschema`; the values `datacontract`, `ibis` and `dbt-sync` no longer occur (#1505)
 
 ### Fixed
+- `datacontract import sql` takes the server's `database` and `schema` from a qualified `CREATE TABLE`, instead of always writing placeholders (#651)
 - Configuration options that override a server's location (`DATACONTRACT_BIGQUERY_PROJECT`, `DATACONTRACT_POSTGRES_SCHEMA`, and the like) now apply to the whole test run, not just to the connection
 - BigQuery: `DATACONTRACT_BIGQUERY_BILLING_PROJECT` no longer overrides the server's `project`, so tables are still read from the data project (#1358)
 - A `quality.type: sql` rule is read in the SQL dialect of its server type, so dialect-specific syntax (BigQuery backticks, Snowflake `SAMPLE`, SQL Server `TOP`) is no longer mistaken for an invalid query

--- a/datacontract/imports/sql_importer.py
+++ b/datacontract/imports/sql_importer.py
@@ -42,7 +42,8 @@ def import_sql(source: str, import_args: dict = None) -> OpenDataContractStandar
     dialect = to_dialect(import_args)
 
     try:
-        parsed = sqlglot.parse_one(sql=sql, read=dialect)
+        # not parse_one: sqlglot below 29 gives it only the first statement of a script
+        statements = [s for s in sqlglot.parse(sql=sql, read=dialect) if s is not None]
     except Exception as e:
         logging.error(f"Error sqlglot SQL: {str(e)}")
         raise DataContractException(
@@ -59,7 +60,7 @@ def import_sql(source: str, import_args: dict = None) -> OpenDataContractStandar
     server_type = to_server_type(source, dialect)
     if server_type is not None:
         server_defaults = get_server_defaults(server_type)
-        server_defaults.update(get_created_location(parsed, server_type, variables))
+        server_defaults.update(get_created_location(statements, server_type, variables))
         odcs.servers = [create_server(name=server_type, server_type=server_type, **server_defaults)]
         logging.warning(
             "SQL import generated a server block with placeholder connection values. "
@@ -68,7 +69,7 @@ def import_sql(source: str, import_args: dict = None) -> OpenDataContractStandar
 
     tables = [
         t
-        for t in parsed.find_all(sqlglot.expressions.Table)
+        for t in find_all(statements, sqlglot.expressions.Table)
         if isinstance(t.find_ancestor(sqlglot.expressions.Create), sqlglot.expressions.Create)
     ]
 
@@ -77,7 +78,7 @@ def import_sql(source: str, import_args: dict = None) -> OpenDataContractStandar
         properties = []
 
         primary_key_position = 1
-        for column in parsed.find_all(sqlglot.exp.ColumnDef):
+        for column in find_all(statements, sqlglot.exp.ColumnDef):
             if column.parent.this.name != table_name:
                 continue
 
@@ -111,14 +112,14 @@ def import_sql(source: str, import_args: dict = None) -> OpenDataContractStandar
 
             properties.append(prop)
 
-        table_comment_property = parsed.find(sqlglot.expressions.SchemaCommentProperty)
+        table_comment_property = find_first(statements, sqlglot.expressions.SchemaCommentProperty)
 
         table_description = None
         if table_comment_property:
             table_description = table_comment_property.this.this
 
         table_tags = None
-        table_props = parsed.find(sqlglot.expressions.Properties)
+        table_props = find_first(statements, sqlglot.expressions.Properties)
         if table_props:
             tags = table_props.find(sqlglot.expressions.Tags)
             if tags:
@@ -165,13 +166,22 @@ def to_dialect(import_args: dict) -> Dialects | None:
 DATABASE_SCHEMA_SERVER_TYPES = ("snowflake", "sqlserver", "postgres", "redshift")
 
 
-def get_created_location(parsed, server_type: str, variables: set[str]) -> dict:
+def find_all(statements: list, *types):
+    for statement in statements:
+        yield from statement.find_all(*types)
+
+
+def find_first(statements: list, *types):
+    return next(find_all(statements, *types), None)
+
+
+def get_created_location(statements: list, server_type: str, variables: set[str]) -> dict:
     """Database and schema of the created tables, when every one of them names the same."""
     if server_type not in DATABASE_SCHEMA_SERVER_TYPES:
         return {}
 
     locations = set()
-    for create in parsed.find_all(sqlglot.expressions.Create):
+    for create in find_all(statements, sqlglot.expressions.Create):
         if (create.kind or "").upper() != "TABLE":
             continue
         target = create.this

--- a/datacontract/imports/sql_importer.py
+++ b/datacontract/imports/sql_importer.py
@@ -38,7 +38,7 @@ class SqlImporter(Importer):
 
 
 def import_sql(source: str, import_args: dict = None) -> OpenDataContractStandard:
-    sql = read_file(source)
+    sql, variables = read_file(source)
     dialect = to_dialect(import_args)
 
     try:
@@ -59,10 +59,11 @@ def import_sql(source: str, import_args: dict = None) -> OpenDataContractStandar
     server_type = to_server_type(source, dialect)
     if server_type is not None:
         server_defaults = get_server_defaults(server_type)
+        server_defaults.update(get_created_location(parsed, server_type, variables))
         odcs.servers = [create_server(name=server_type, server_type=server_type, **server_defaults)]
         logging.warning(
             "SQL import generated a server block with placeholder connection values. "
-            "Update host, port, database, and schema in the output before use."
+            "Review host, port, database, and schema in the output before use."
         )
 
     tables = [
@@ -156,6 +157,47 @@ def to_dialect(import_args: dict) -> Dialects | None:
     if dialect.upper() in Dialects.__members__:
         return Dialects[dialect.upper()]
     return None
+
+
+# Server types whose qualified table names mean database.schema. Elsewhere the parts mean
+# something else, such as project.dataset on BigQuery or the database alone on MySQL, and
+# belong in other server fields, so their DDL is left to the placeholders.
+DATABASE_SCHEMA_SERVER_TYPES = ("snowflake", "sqlserver", "postgres", "redshift")
+
+
+def get_created_location(parsed, server_type: str, variables: set[str]) -> dict:
+    """Database and schema of the created tables, when every one of them names the same."""
+    if server_type not in DATABASE_SCHEMA_SERVER_TYPES:
+        return {}
+
+    locations = set()
+    for create in parsed.find_all(sqlglot.expressions.Create):
+        if (create.kind or "").upper() != "TABLE":
+            continue
+        target = create.this
+        if isinstance(target, sqlglot.expressions.Schema):
+            target = target.this
+        if isinstance(target, sqlglot.expressions.Table):
+            locations.add((target.catalog, target.db))
+    if len(locations) != 1:
+        return {}
+
+    catalog, db = locations.pop()
+    location = {}
+    if catalog and not is_templated(catalog, variables):
+        location["database"] = catalog
+    if db and not is_templated(db, variables):
+        location["schema"] = db
+    return location
+
+
+def is_templated(name: str, variables: set[str]) -> bool:
+    """Whether an identifier carries substituted text, so is no more usable than a placeholder.
+
+    Substring matching keeps names like ${env}_DB out. It can also hold back a literal name
+    that happens to contain a variable name, which leaves the placeholder in place.
+    """
+    return any(variable in name for variable in variables)
 
 
 def get_server_defaults(server_type: str) -> dict:
@@ -374,14 +416,24 @@ def map_type_from_sql(sql_type: str) -> tuple[str | None, str | None]:
         return (None, None)
 
 
-def remove_variable_tokens(sql_script: str) -> str:
-    """Replace templating placeholders with bare variable names so sqlglot can parse the SQL."""
+def remove_variable_tokens(sql_script: str) -> tuple[str, set[str]]:
+    """Replace templating placeholders with bare variable names so sqlglot can parse the SQL.
+
+    Returns the rewritten script and the names that came from a placeholder.
+    """
     variable_pattern = re.compile(
         r"\$\((\w+)\)"  # $(var) — sqlcmd (T-SQL)
         r"|\$\{(\w+)\}"  # ${var} — Liquibase
         r"|\{\{(\w+)\}\}"  # {{var}} — Jinja / dbt
     )
-    return variable_pattern.sub(lambda m: m.group(1) or m.group(2) or m.group(3), sql_script)
+    variables = set()
+
+    def to_variable_name(match: re.Match) -> str:
+        name = match.group(1) or match.group(2) or match.group(3)
+        variables.add(name)
+        return name
+
+    return variable_pattern.sub(to_variable_name, sql_script), variables
 
 
 def read_file(path):

--- a/datacontract/imports/sql_importer.py
+++ b/datacontract/imports/sql_importer.py
@@ -60,11 +60,13 @@ def import_sql(source: str, import_args: dict = None) -> OpenDataContractStandar
     server_type = to_server_type(source, dialect)
     if server_type is not None:
         server_defaults = get_server_defaults(server_type)
-        server_defaults.update(get_created_location(statements, server_type, variables))
+        location = get_created_location(statements, server_type, variables)
+        server_defaults.update(location)
         odcs.servers = [create_server(name=server_type, server_type=server_type, **server_defaults)]
+        placeholders = ", ".join(field for field in server_defaults if field not in location)
         logging.warning(
-            "SQL import generated a server block with placeholder connection values. "
-            "Review host, port, database, and schema in the output before use."
+            f"SQL import generated a server block with placeholder connection values. "
+            f"Update the following values before use: {placeholders}"
         )
 
     tables = [

--- a/tests/test_import_sql_oracle.py
+++ b/tests/test_import_sql_oracle.py
@@ -167,7 +167,7 @@ servers:
     host: my_host
     port: 5432
     database: my_database
-    schema: public
+    schema: my_schema
 schema:
   - name: customer_location
     physicalType: table

--- a/tests/test_import_sql_postgres.py
+++ b/tests/test_import_sql_postgres.py
@@ -77,7 +77,7 @@ servers:
     host: my_host
     port: 5432
     database: my_database
-    schema: public
+    schema: my_schema
 schema:
   - name: customer_location
     physicalType: table

--- a/tests/test_import_sql_snowflake.py
+++ b/tests/test_import_sql_snowflake.py
@@ -1,3 +1,4 @@
+import pytest
 import yaml
 
 from datacontract.data_contract import DataContract
@@ -20,7 +21,7 @@ servers:
   host: my_host
   port: 443
   database: my_database
-  schema: my_schema
+  schema: PUBLIC
 schema:
 - name: my_table
   physicalType: table
@@ -190,3 +191,43 @@ def test_map_type_from_sql_time_with_precision():
     # must not swallow timestamps
     assert map_type_from_sql("timestamp(6)") == ("timestamp", None)
     assert map_type_from_sql("TIMESTAMP_NTZ(9)") == ("timestamp", None)
+
+
+@pytest.mark.parametrize(
+    ("ddl", "database", "schema"),
+    [
+        ("CREATE TABLE analytics.sales.orders (id INT);", "analytics", "sales"),
+        ("CREATE TABLE sales.orders (id INT);", "my_database", "sales"),
+        ("CREATE TABLE orders (id INT);", "my_database", "my_schema"),
+        # the qualifier belongs to the query source, not to the created table
+        ("CREATE TABLE orders AS SELECT * FROM analytics.sales.source;", "my_database", "my_schema"),
+        # tables in two different places name no single server location
+        ("CREATE TABLE a.b.one (id INT); CREATE TABLE c.d.two (id INT);", "my_database", "my_schema"),
+        # a templated name is no more usable than the placeholder it would replace
+        ("CREATE TABLE ${db}.PUBLIC.orders (id INT);", "my_database", "PUBLIC"),
+        ("CREATE TABLE ${env}_DB.PUBLIC.orders (id INT);", "my_database", "PUBLIC"),
+        # only created tables name the location
+        ("CREATE VIEW other.x.v AS SELECT 1 AS id; CREATE TABLE a.b.orders (id INT);", "a", "b"),
+    ],
+)
+def test_import_sql_server_location(tmp_path, ddl, database, schema):
+    ddl_file = tmp_path / "ddl.sql"
+    ddl_file.write_text(ddl)
+
+    result = DataContract().import_from_source("sql", str(ddl_file), dialect="snowflake")
+
+    server = yaml.safe_load(result.to_yaml())["servers"][0]
+    assert server["database"] == database
+    assert server["schema"] == schema
+
+
+@pytest.mark.parametrize("dialect", ["mysql", "oracle", "bigquery", "databricks"])
+def test_import_sql_server_location_only_where_the_parts_mean_database_and_schema(tmp_path, dialect):
+    ddl_file = tmp_path / "ddl.sql"
+    ddl_file.write_text("CREATE TABLE sales.orders (id INT);")
+
+    result = DataContract().import_from_source("sql", str(ddl_file), dialect=dialect)
+
+    server = yaml.safe_load(result.to_yaml())["servers"][0]
+    assert server["database"] == "my_database"
+    assert server["schema"] == "my_schema"

--- a/tests/test_import_sql_sqlserver.py
+++ b/tests/test_import_sql_sqlserver.py
@@ -21,7 +21,7 @@ servers:
     host: my_host
     port: 1433
     database: my_database
-    schema: my_schema
+    schema: dbo
 schema:
   - name: my_table
     physicalType: table


### PR DESCRIPTION
`datacontract import sql` parsed the catalog and schema of a qualified `CREATE TABLE` and then dropped them, so the generated `servers` block always carried the `my_database` and `my_schema` placeholders. They now come from the created tables.

The placeholders stay where the DDL identifies no single server: no qualifier, two created tables in different places, or a name carrying a substituted `${var}` token. Only `CREATE TABLE` counts, so a query source in a CTAS or a `CREATE VIEW` target cannot supply the location.

This applies to snowflake, sqlserver, postgres and redshift, where a qualified name means database.schema. On mysql, oracle, bigquery and databricks the parts mean something else and belong in other server fields, so their DDL is left to the placeholders.

Closes #651

- [x] Tests pass (`uv run pytest`)
- [x] Code formatted (`uv run ruff check --fix && uv run ruff format`)
- [x] Docs updated (if relevant)
- [x] CHANGELOG.md entry added
