### PR TITLE
fix: import only the tables that CREATE TABLE statements create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **breaking:** the `engine` field of test results is now always one of `datacontract-cli`, `dbt` or `jsonschema`; the values `datacontract`, `ibis` and `dbt-sync` no longer occur (#1505)
 
 ### Fixed
+- `datacontract import sql` no longer fails on a DDL file that contains `CREATE SCHEMA` (#1529)
 - Configuration options that override a server's location (`DATACONTRACT_BIGQUERY_PROJECT`, `DATACONTRACT_POSTGRES_SCHEMA`, and the like) now apply to the whole test run, not just to the connection
 - BigQuery: `DATACONTRACT_BIGQUERY_BILLING_PROJECT` no longer overrides the server's `project`, so tables are still read from the data project (#1358)
 - A `quality.type: sql` rule is read in the SQL dialect of its server type, so dialect-specific syntax (BigQuery backticks, Snowflake `SAMPLE`, SQL Server `TOP`) is no longer mistaken for an invalid query

--- a/datacontract/imports/sql_importer.py
+++ b/datacontract/imports/sql_importer.py
@@ -67,21 +67,15 @@ def import_sql(source: str, import_args: dict = None) -> OpenDataContractStandar
 
     # Only a CREATE TABLE creates one. CREATE SCHEMA carries a table node with no table name,
     # and a CTAS or CREATE VIEW carries its query sources.
-    tables = [
-        create.this.find(sqlglot.expressions.Table)
-        for create in parsed.find_all(sqlglot.expressions.Create)
-        if create.kind == "TABLE"
-    ]
+    creates = [create for create in parsed.find_all(sqlglot.expressions.Create) if create.kind == "TABLE"]
 
-    for table in tables:
+    for create in creates:
+        table = create.this.find(sqlglot.expressions.Table)
         table_name = table.this.name
         properties = []
 
         primary_key_position = 1
-        for column in parsed.find_all(sqlglot.exp.ColumnDef):
-            if column.parent.this.name != table_name:
-                continue
-
+        for column in create.find_all(sqlglot.exp.ColumnDef):
             col_name = column.this.name
             col_type = to_col_type(column, dialect)
             logical_type, format = map_type_from_sql(col_type)

--- a/datacontract/imports/sql_importer.py
+++ b/datacontract/imports/sql_importer.py
@@ -65,10 +65,12 @@ def import_sql(source: str, import_args: dict = None) -> OpenDataContractStandar
             "Update host, port, database, and schema in the output before use."
         )
 
+    # Only a CREATE TABLE creates one. CREATE SCHEMA carries a table node with no table name,
+    # and a CTAS or CREATE VIEW carries its query sources.
     tables = [
-        t
-        for t in parsed.find_all(sqlglot.expressions.Table)
-        if isinstance(t.find_ancestor(sqlglot.expressions.Create), sqlglot.expressions.Create)
+        create.this.find(sqlglot.expressions.Table)
+        for create in parsed.find_all(sqlglot.expressions.Create)
+        if create.kind == "TABLE"
     ]
 
     for table in tables:

--- a/tests/test_import_sql_postgres.py
+++ b/tests/test_import_sql_postgres.py
@@ -156,3 +156,17 @@ def test_import_sql_ignores_create_schema(tmp_path):
     result = DataContract.import_from_source("sql", str(ddl), dialect="postgres")
 
     assert [schema_object.name for schema_object in result.schema_] == ["orders"]
+
+
+def test_import_sql_keeps_same_named_tables_in_different_schemas_apart(tmp_path):
+    ddl = tmp_path / "ddl.sql"
+    ddl.write_text(
+        "CREATE SCHEMA sales;\nCREATE TABLE orders (order_id VARCHAR(36));\nCREATE TABLE sales.orders (amount INT);"
+    )
+
+    result = DataContract.import_from_source("sql", str(ddl), dialect="postgres")
+
+    assert [[prop.name for prop in schema_object.properties] for schema_object in result.schema_] == [
+        ["order_id"],
+        ["amount"],
+    ]

--- a/tests/test_import_sql_postgres.py
+++ b/tests/test_import_sql_postgres.py
@@ -147,3 +147,12 @@ schema:
     """
     print("Result", result.to_yaml())
     assert yaml.safe_load(result.to_yaml()) == yaml.safe_load(expected)
+
+
+def test_import_sql_ignores_create_schema(tmp_path):
+    ddl = tmp_path / "ddl.sql"
+    ddl.write_text("CREATE SCHEMA sales;\nCREATE TABLE sales.orders (order_id VARCHAR(36));")
+
+    result = DataContract.import_from_source("sql", str(ddl), dialect="postgres")
+
+    assert [schema_object.name for schema_object in result.schema_] == ["orders"]


### PR DESCRIPTION
`datacontract import sql` failed with `AttributeError: 'NoneType' object has no attribute 'name'` on any DDL file containing `CREATE SCHEMA`.

The importer collected every table node beneath a `CREATE` rather than the table each `CREATE TABLE` creates, and `CREATE SCHEMA sales` parses to a table node with no table name. It now reads the target of each `CREATE TABLE`, which also drops the empty schema objects `CREATE DATABASE` and `CREATE VIEW` produced, and the duplicates from their query sources.

Fixes #1529

- [x] Tests pass (`uv run pytest`)
- [x] Code formatted (`uv run ruff check --fix && uv run ruff format`)
- [x] Docs updated (if relevant)
- [x] CHANGELOG.md entry added

The four `test_import_sql_*` files pass. The full suite matches `main`, with one extra pass for the new test; the remaining failures are optional extras and Docker missing locally.
