### PR TITLE
fix: qualify BigQuery dataset_id with the data project when billing separately

### DIFF
--- a/datacontract/engines/ibis/connections/connect.py
+++ b/datacontract/engines/ibis/connections/connect.py
@@ -162,9 +162,12 @@ def connect_ibis(
             from google.cloud import bigquery as bq_client_lib
 
             client = bq_client_lib.Client(project=billing_project, credentials=credentials)
+            # ibis's do_connect prefers client.project over project_id when a
+            # client is passed, so qualify dataset_id or it resolves against
+            # billing_project instead of project.
             return ibis.bigquery.connect(
                 project_id=project,
-                dataset_id=dataset,
+                dataset_id=f"{project}.{dataset}",
                 client=client,
             )
 

--- a/tests/test_connect_bigquery.py
+++ b/tests/test_connect_bigquery.py
@@ -95,6 +95,10 @@ def test_billing_project_client_uses_the_impersonated_credentials(env):
     assert client.call_args.kwargs["project"] == "my-billing-project"
     assert client.call_args.kwargs["credentials"] is impersonated.return_value
     assert kwargs["client"] is client.return_value
+    # ibis prefers client.project over project_id when a client is passed, so
+    # dataset_id must carry the data project itself or queries resolve
+    # against the billing project instead.
+    assert kwargs["dataset_id"] == "my-project.my_dataset"
 
 
 def test_env_variables_override_the_contract_project_and_dataset(env):


### PR DESCRIPTION
## Summary
- `DATACONTRACT_BIGQUERY_BILLING_PROJECT` lets a run bill/execute BigQuery jobs under a different project than the one holding the data. The bigquery branch in `connect.py` builds a `bigquery.Client(project=billing_project)` and passes it into `ibis.bigquery.connect(project_id=project, dataset_id=dataset, client=client)` — with `dataset_id` unqualified.
- `ibis.backends.bigquery.Backend.do_connect` prefers `client.project` over the `project_id` argument whenever a `client` is passed in (`client_project_id or project_id or default_project_id`). Since the client's project is the billing project, `parse_project_and_dataset` ends up splitting `billing_project` as *both* the data project and the billing project — the `project_id` we asked for is silently discarded.
- Net effect: every query looks for the dataset in the billing project instead of the data project, e.g. `Not found: Dataset <billing_project>:<dataset>`.
- Fix: qualify `dataset_id` as `f"{project}.{dataset}"` in that branch, so `parse_project_and_dataset` splits data project vs. billing project correctly regardless of which project the client bills to.

## Test plan
- [x] Added `test_billing_project_client_uses_the_impersonated_credentials` assertion covering the qualified `dataset_id`
- [x] `pytest tests/test_connect_bigquery.py` passes (5/5)