### PR TITLE
fix: sum every component of an ISO 8601 retention period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `datacontract import sql` takes the server's `database` and `schema` from a qualified `CREATE TABLE`, instead of always writing placeholders (#651)
 - `datacontract import sql` no longer fails on a DDL file that contains `CREATE SCHEMA` (#1529)
+- `datacontract test` sums every component of an ODCS retention period, instead of truncating `P2DT12H` to two days, and rejects an unparsable period (#1538)
 
 ## [1.1.2] - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `datacontract import sql` takes the server's `database` and `schema` from a qualified `CREATE TABLE`, instead of always writing placeholders (#651)
 - `datacontract import sql` no longer fails on a DDL file that contains `CREATE SCHEMA` (#1529)
-- `datacontract test` sums every component of an ODCS retention period, instead of truncating `P2DT12H` to two days, and rejects an unparsable period (#1538)
+- `datacontract test` now supports ISO 8601 retention periods correctly (previously, only the first component was considered) (#1538)
 
 ## [1.1.2] - 2026-08-26
 

--- a/datacontract/engines/checks/create_checks.py
+++ b/datacontract/engines/checks/create_checks.py
@@ -934,19 +934,25 @@ def _retention_value_to_seconds(value, unit: Optional[str]) -> Optional[int]:
     return None
 
 
+# P followed by integer-unit combinatinos (e.g. P1Y2M3DT4H5M6S), every component optional, but at least one required
+_ISO8601_DURATION = re.compile(
+    r"P(?=\d|T\d)"
+    r"(?:(\d+)Y)?"
+    r"(?:(\d+)M)?"
+    r"(?:(\d+)D)?"
+    r"(?:T(?=\d)"
+    r"(?:(\d+)H)?"
+    r"(?:(\d+)M)?"
+    r"(?:(\d+)S)?)?"
+)
+_COMPONENT_SECONDS = (365 * 86400, 30 * 86400, 86400, 3600, 60, 1)
+
+
 def _parse_iso8601_to_seconds(duration: str) -> Optional[int]:
     if not duration:
         return None
-    duration = duration.upper()
-    for pat, mult in (
-        (r"P(\d+)Y", 365 * 86400),
-        (r"P(\d+)M", 30 * 86400),
-        (r"P(\d+)D", 86400),
-        (r"PT(\d+)H", 3600),
-        (r"PT(\d+)M", 60),
-        (r"PT(\d+)S", 1),
-    ):
-        m = re.match(pat, duration)
-        if m:
-            return int(m.group(1)) * mult
-    return None
+    match = _ISO8601_DURATION.fullmatch(duration.upper())
+    if match is None:
+        logger.info(f"Unsupported retention period: {duration}")
+        return None
+    return sum(int(amount) * seconds for amount, seconds in zip(match.groups(), _COMPONENT_SECONDS) if amount)

--- a/datacontract/engines/checks/create_checks.py
+++ b/datacontract/engines/checks/create_checks.py
@@ -934,18 +934,19 @@ def _retention_value_to_seconds(value, unit: Optional[str]) -> Optional[int]:
     return None
 
 
-# P followed by integer-unit combinatinos (e.g. P1Y2M3DT4H5M6S), every component optional, but at least one required
+# P followed by number-unit combinations (e.g. P1Y2M3W4DT5H6M7S), every component optional, but at least one required
 _ISO8601_DURATION = re.compile(
     r"P(?=\d|T\d)"
-    r"(?:(\d+)Y)?"
-    r"(?:(\d+)M)?"
-    r"(?:(\d+)D)?"
+    r"(?:(\d+(?:\.\d+)?)Y)?"
+    r"(?:(\d+(?:\.\d+)?)M)?"
+    r"(?:(\d+(?:\.\d+)?)W)?"
+    r"(?:(\d+(?:\.\d+)?)D)?"
     r"(?:T(?=\d)"
-    r"(?:(\d+)H)?"
-    r"(?:(\d+)M)?"
-    r"(?:(\d+)S)?)?"
+    r"(?:(\d+(?:\.\d+)?)H)?"
+    r"(?:(\d+(?:\.\d+)?)M)?"
+    r"(?:(\d+(?:\.\d+)?)S)?)?"
 )
-_COMPONENT_SECONDS = (365 * 86400, 30 * 86400, 86400, 3600, 60, 1)
+_COMPONENT_SECONDS = (365 * 86400, 30 * 86400, 7 * 86400, 86400, 3600, 60, 1)
 
 
 def _parse_iso8601_to_seconds(duration: str) -> Optional[int]:
@@ -955,4 +956,4 @@ def _parse_iso8601_to_seconds(duration: str) -> Optional[int]:
     if match is None:
         logger.info(f"Unsupported retention period: {duration}")
         return None
-    return sum(int(amount) * seconds for amount, seconds in zip(match.groups(), _COMPONENT_SECONDS) if amount)
+    return round(sum(float(amount) * seconds for amount, seconds in zip(match.groups(), _COMPONENT_SECONDS) if amount))

--- a/docs/docs/service-levels.md
+++ b/docs/docs/service-levels.md
@@ -79,7 +79,7 @@ Retention also accepts an **ISO 8601 duration** as the `value`, in which case `u
 ```yaml
 slaProperties:
   - property: retention
-    value: P1Y        # also P6M, P30D, PT12H, PT30M, PT10S
+    value: P1Y6M      # 1 year and 6 months; also P7Y, P90D, P12W, PT48H
     element: orders.order_timestamp
 ```
 
@@ -104,8 +104,9 @@ A service level is skipped — without failing the run — when:
 - the `property` is anything other than `freshness` or `retention` (for example `latency`, `frequency`, or `timeOfAvailability`, which are documentation only),
 - `element` or `value` is missing,
 - `element` is not exactly one `schema.property` reference,
-- the referenced schema is not in the contract, or
-- the `unit` is not one of the values listed above.
+- the referenced schema is not in the contract,
+- the `unit` is not one of the values listed above, or
+- the `value` is a string that is not a supported ISO 8601 duration.
 
 Run with `--debug` to see the reasons. If the check *does* run but the column is empty or entirely `NULL`, the check **fails** with `No timestamp value found in '<field>'`.
 

--- a/tests/test_create_checks_retention_period.py
+++ b/tests/test_create_checks_retention_period.py
@@ -35,10 +35,16 @@ def _retention_checks(period):
         ("P30D", 30 * 86400),
         ("PT6M", 6 * 60),
         ("PT30S", 30),
+        ("P4W", 4 * 7 * 86400),
+        ("PT0.5H", 30 * 60),
+        ("P1.5D", 36 * 3600),
         ("P2DT12H", 2 * 86400 + 12 * 3600),
         ("P1Y6M", 365 * 86400 + 6 * 30 * 86400),
         ("PT1H30M", 3600 + 30 * 60),
-        ("P1Y2M3DT4H5M6S", 365 * 86400 + 2 * 30 * 86400 + 3 * 86400 + 4 * 3600 + 5 * 60 + 6),
+        (
+            "P1Y2M3W4DT5H6M7S",
+            365 * 86400 + 2 * 30 * 86400 + 3 * 7 * 86400 + 4 * 86400 + 5 * 3600 + 6 * 60 + 7,
+        ),
     ],
 )
 def test_retention_period_sums_every_component(period, seconds):
@@ -46,6 +52,6 @@ def test_retention_period_sums_every_component(period, seconds):
     assert check.seconds == seconds
 
 
-@pytest.mark.parametrize("period", ["P30Djunk", "garbage", "P", "PT", "P4W"])
+@pytest.mark.parametrize("period", ["P30Djunk", "garbage", "P", "PT", "P.5D", "P1,5D"])
 def test_unparsable_retention_period_yields_no_check(period):
     assert _retention_checks(period) == []

--- a/tests/test_create_checks_retention_period.py
+++ b/tests/test_create_checks_retention_period.py
@@ -1,0 +1,51 @@
+"""ISO 8601 retention periods are summed over all their components, or rejected."""
+
+import pytest
+from open_data_contract_standard.model import (
+    OpenDataContractStandard,
+    SchemaObject,
+    SchemaProperty,
+    Server,
+    ServiceLevelAgreementProperty,
+)
+
+from datacontract.engines.checks.create_checks import create_checks
+
+
+def _retention_checks(period):
+    contract = OpenDataContractStandard(
+        version="1",
+        kind="DataContract",
+        apiVersion="v3.1.0",
+        id="x",
+        schema=[SchemaObject(name="events", properties=[SchemaProperty(name="ts", logicalType="timestamp")])],
+        slaProperties=[
+            ServiceLevelAgreementProperty(property="retention", element="events.ts", value=period),
+        ],
+    )
+    checks = create_checks(contract, Server(server="s", type="snowflake"))
+    return [c for c in checks if c.type == "servicelevel_retention"]
+
+
+@pytest.mark.parametrize(
+    "period, seconds",
+    [
+        ("P1Y", 365 * 86400),
+        ("P6M", 6 * 30 * 86400),
+        ("P30D", 30 * 86400),
+        ("PT6M", 6 * 60),
+        ("PT30S", 30),
+        ("P2DT12H", 2 * 86400 + 12 * 3600),
+        ("P1Y6M", 365 * 86400 + 6 * 30 * 86400),
+        ("PT1H30M", 3600 + 30 * 60),
+        ("P1Y2M3DT4H5M6S", 365 * 86400 + 2 * 30 * 86400 + 3 * 86400 + 4 * 3600 + 5 * 60 + 6),
+    ],
+)
+def test_retention_period_sums_every_component(period, seconds):
+    (check,) = _retention_checks(period)
+    assert check.seconds == seconds
+
+
+@pytest.mark.parametrize("period", ["P30Djunk", "garbage", "P", "PT", "P4W"])
+def test_unparsable_retention_period_yields_no_check(period):
+    assert _retention_checks(period) == []


### PR DESCRIPTION
Fixes #1538.

`P2DT12H` was parsed as 2 days and `P30Djunk` as 30 days. The parser now matches the full ISO 8601 grammar and sums all components; an unparsable period is logged and the check skipped.