### PR TITLE
Say why pattern does not replace format on a date property

### DIFF
--- a/docs/docs/schema.md
+++ b/docs/docs/schema.md
@@ -176,7 +176,7 @@ properties:
 These are common sources of confusion. They are valid ODCS and appear in exports, but they generate no check:
 
 - **`isNullable`** — the CLI reads `required`, not `isNullable`. Write `required: true` to assert that a column has no nulls.
-- **`logicalTypeOptions.format`** (`email`, `uuid`, `uri`, …) — use `pattern` for an enforceable equivalent.
+- **`logicalTypeOptions.format`** — never enforced, on any property. On a `string` property (`email`, `uuid`, `uri`, …) use `pattern` for an enforceable equivalent. On a `date`, `timestamp` or `time` property `format` holds a date pattern such as `yyyy-MM-dd`, and `pattern` is *not* an equivalent there: by the time a check runs, the column has already been parsed as a date, so there is no string left to match. Such a column is validated as a date, in whatever format the server stores it.
 - **Descriptive attributes** — `description`, `businessName`, `examples`, `tags`, `classification`, `criticalDataElement`, `transformSourceObjects`, and `customProperties`. `authoritativeDefinitions` generates no check either, but it *is* resolved and inlined before the checks are built — see [Link your Semantics](./semantics.md).
 - **Schema-level attributes** other than `name`, `physicalName`, `properties`, and `quality`.
 

--- a/docs/docs/testing/index.md
+++ b/docs/docs/testing/index.md
@@ -106,7 +106,7 @@ The CLI uses different engines based on the server `type`. Internally it connect
 
 Checks fall into categories you can select with `--checks`:
 
-- `properties` — the [schema](../schema.md) attributes: presence, types, `required`, `unique`, primary keys, and `logicalTypeOptions`. `schema` is kept as a legacy alias.
+- `properties` — the [schema](../schema.md) attributes: presence, types, `required`, `unique`, primary keys, and `logicalTypeOptions`. `schema` is kept as a legacy alias. Not every ODCS attribute produces a check — see [What is not checked](../schema.md#what-is-not-checked) if one you declared appears to have no effect.
 - `quality` — the [quality rules](../quality-rules/index.md) defined in the contract.
 - `slaProperties` — the [service levels](../service-levels.md) defined in the contract. `servicelevel` is kept as a legacy alias.
 - `custom` — custom checks.


### PR DESCRIPTION
The docs changes from #1514.

**`pattern` is not a substitute for `format` on a date property.** The bullet listed `format`'s string values (`email`, `uuid`, `uri`), so it reads as being about string formats — and there `pattern` genuinely does replace it. On a `date`, `timestamp` or `time` property `format` holds a date pattern such as `yyyy-MM-dd`, and `pattern` cannot stand in: by the time a check runs the column has been parsed as a date, so there is no string left to match. Someone following the current advice for a date column would write a `pattern` that never fires.

**A pointer from the testing page.** The list lives under Schema, which is where you look when authoring a contract. The moment you need it is different — you have declared something, it appears to do nothing, and you are looking at `datacontract test`. The `properties` bullet now links to it.

That is also the honest answer to where I searched: I came from the ODCS side tracing where a value ended up, not from the docs asking what gets checked, so I never searched for the list at all. The link is aimed at the person who would.
