### PR TITLE
Give each servicelevel freshness/retention check a unique key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract import sql` takes the server's `database` and `schema` from a qualified `CREATE TABLE`, instead of always writing placeholders (#651)
 - `datacontract import sql` no longer fails on a DDL file that contains `CREATE SCHEMA` (#1529)
 - `datacontract test` now supports ISO 8601 retention periods correctly (previously, only the first component was considered) (#1538)
+- `datacontract test` reports each freshness and retention check result on its own check, instead of writing every result to the first one (#1515)
 
 ## [1.1.2] - 2026-08-26
 

--- a/datacontract/engines/checks/create_checks.py
+++ b/datacontract/engines/checks/create_checks.py
@@ -909,7 +909,7 @@ def _freshness_check(
         return None
 
     return CheckSpec(
-        key="servicelevel_freshness",
+        key=f"{model}__{field}__servicelevel_freshness",
         category="servicelevel",
         type="servicelevel_freshness",
         name=f"Freshness of {model}.{field} < {sla.value}{unit[0]}",
@@ -934,7 +934,7 @@ def _retention_check(
     if seconds is None:
         return None
     return CheckSpec(
-        key="servicelevel_retention",
+        key=f"{model}__{field}__servicelevel_retention",
         category="servicelevel",
         type="servicelevel_retention",
         name=f"Retention of {model}.{field} < {seconds}s",

--- a/datacontract/export/sodacl_check_builder.py
+++ b/datacontract/export/sodacl_check_builder.py
@@ -1086,7 +1086,7 @@ def to_sla_freshness_check(
         return None
 
     check_type = "servicelevel_freshness"
-    check_key = "servicelevel_freshness"
+    check_key = f"{model_name}__{field_name}__{check_type}"
     quoted_field = _quote_identifier_if_needed(field_name, server)
     sodacl_check_dict = {
         f"checks for {model_name}": [
@@ -1152,7 +1152,7 @@ def to_servicelevel_retention_check(
         return None
 
     check_type = "servicelevel_retention"
-    check_key = "servicelevel_retention"
+    check_key = f"{model_name}__{field_name}__{check_type}"
     quoted_field = _quote_identifier_if_needed(field_name, server)
     sodacl_check_dict = {
         f"checks for {model_name}": [

--- a/tests/test_create_checks_servicelevel.py
+++ b/tests/test_create_checks_servicelevel.py
@@ -69,6 +69,31 @@ def test_servicelevel_checks_fall_back_to_names_without_physical_names():
     assert check.field == "ts"
 
 
+def test_multiple_servicelevel_promises_get_distinct_keys():
+    """Each promise needs its own key, or every result lands on the first check (#1515)."""
+    schema = SchemaObject(
+        name="events",
+        properties=[
+            SchemaProperty(name="ts", logicalType="timestamp"),
+            SchemaProperty(name="updated", logicalType="timestamp"),
+        ],
+    )
+    contract = _contract(
+        schema,
+        ServiceLevelAgreementProperty(property="freshness", element="events.ts", value=48, unit="h"),
+        ServiceLevelAgreementProperty(property="freshness", element="events.updated", value=2, unit="h"),
+        ServiceLevelAgreementProperty(property="retention", element="events.ts", value=1, unit="y"),
+        ServiceLevelAgreementProperty(property="retention", element="events.updated", value=2, unit="y"),
+    )
+
+    checks = create_checks(contract, Server(server="s", type="snowflake"))
+
+    freshness_keys = [c.key for c in _of_type(checks, "servicelevel_freshness")]
+    retention_keys = [c.key for c in _of_type(checks, "servicelevel_retention")]
+    assert freshness_keys == ["events__ts__servicelevel_freshness", "events__updated__servicelevel_freshness"]
+    assert retention_keys == ["events__ts__servicelevel_retention", "events__updated__servicelevel_retention"]
+
+
 def test_servicelevel_checks_keep_kafka_logical_name():
     """to_schema_name reads the Spark SQL view (logical name) on kafka, not the topic."""
     schema = SchemaObject(

--- a/tests/test_export_sodacl.py
+++ b/tests/test_export_sodacl.py
@@ -67,10 +67,10 @@ checks for orders:
         FROM orders
   - row_count > 10
   - orders_servicelevel_retention < 31536000:
-      name: servicelevel_retention
+      name: orders__processed_timestamp__servicelevel_retention
       orders_servicelevel_retention expression: TIMESTAMPDIFF(SECOND, MIN(processed_timestamp), CURRENT_TIMESTAMP)
   - freshness(order_timestamp) < 24h:
-      name: servicelevel_freshness
+      name: orders__order_timestamp__servicelevel_freshness
 """
 
     data_contract = resolve_data_contract_from_location("./fixtures/sodacl/datacontract.odcs.yaml")
@@ -79,6 +79,40 @@ checks for orders:
     result = exporter.export(data_contract, "all", None, "auto", None)
 
     assert yaml.safe_load(expected) == yaml.safe_load(result)
+
+
+def test_multiple_servicelevel_promises_get_distinct_check_keys():
+    """Each promise needs its own key, matching the engine check path (#1515)."""
+    from open_data_contract_standard.model import ServiceLevelAgreementProperty
+
+    contract = OpenDataContractStandard(
+        version="1",
+        kind="DataContract",
+        apiVersion="v3.1.0",
+        id="x",
+        schema=[
+            SchemaObject(
+                name="events",
+                properties=[
+                    SchemaProperty(name="ts", logicalType="timestamp"),
+                    SchemaProperty(name="updated", logicalType="timestamp"),
+                ],
+            )
+        ],
+        slaProperties=[
+            ServiceLevelAgreementProperty(property="freshness", element="events.ts", value=48, unit="h"),
+            ServiceLevelAgreementProperty(property="freshness", element="events.updated", value=2, unit="h"),
+            ServiceLevelAgreementProperty(property="retention", element="events.ts", value=1, unit="y"),
+            ServiceLevelAgreementProperty(property="retention", element="events.updated", value=2, unit="y"),
+        ],
+    )
+
+    checks = create_checks(contract, Server(server="s", type="snowflake"))
+
+    freshness_keys = [c.key for c in checks if c.type == "servicelevel_freshness"]
+    retention_keys = [c.key for c in checks if c.type == "servicelevel_retention"]
+    assert freshness_keys == ["events__ts__servicelevel_freshness", "events__updated__servicelevel_freshness"]
+    assert retention_keys == ["events__ts__servicelevel_retention", "events__updated__servicelevel_retention"]
 
 
 def test_export_sodacl_numeric_retention():

--- a/tests/test_export_sodacl.py
+++ b/tests/test_export_sodacl.py
@@ -1,7 +1,13 @@
 import logging
 
 import yaml
-from open_data_contract_standard.model import OpenDataContractStandard, SchemaObject, SchemaProperty, Server
+from open_data_contract_standard.model import (
+    OpenDataContractStandard,
+    SchemaObject,
+    SchemaProperty,
+    Server,
+    ServiceLevelAgreementProperty,
+)
 
 from datacontract.export.sodacl_check_builder import _retention_value_to_seconds, check_property_type, create_checks
 from datacontract.export.sodacl_exporter import SodaExporter
@@ -83,8 +89,6 @@ checks for orders:
 
 def test_multiple_servicelevel_promises_get_distinct_check_keys():
     """Each promise needs its own key, matching the engine check path (#1515)."""
-    from open_data_contract_standard.model import ServiceLevelAgreementProperty
-
     contract = OpenDataContractStandard(
         version="1",
         kind="DataContract",


### PR DESCRIPTION
Fixes #1515

With more than one freshness or retention promise in a contract, every check got the same key (`servicelevel_freshness` / `servicelevel_retention`). Results are written to the first check with a matching key, so all outcomes landed on the first check and the others stayed without a result.

This keys each check by its model and field, following the convention the schema checks already use (`{model}__{field}__{check_type}`), in both the engine check path and the SodaCL export path, which intentionally use the same key strings.

**Note to reviewers:** this changes the `key` field in the test results output.
- Before: every freshness check had `key: servicelevel_freshness` and every retention check `key: servicelevel_retention`, regardless of what it checked.
- After: each check's key names the table and column it checks, e.g. `key: orders__order_timestamp__servicelevel_freshness`.

**Not fixed here:**
- In the SodaCL export, two retention promises on the same table still produce two metrics with the same name (`{model}_servicelevel_retention`), which collide inside Soda. That looks like a separate, smaller fix.
- Two promises of the same kind on the same column (say, two freshness promises on `orders.order_timestamp`) would still share one key. This could be covered too, for example by numbering the checks the way the quality checks already do, but I'm not sure it's worth adding logic for a case no one has reported. Happy to include it if you'd like.

Verified with `pytest` (2188 passed), `ruff check .`, `ruff format --check .`, `git diff --check`.