### PR TITLE
Pin open-data-contract-standard to 3.1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `datacontract test` now supports ISO 8601 retention periods correctly (previously, only the first component was considered) (#1538)
 - `datacontract test` reports each freshness and retention check result on its own check, instead of writing every result to the first one (#1515)
 
+### Changed
+- The `open-data-contract-standard` dependency is pinned to 3.1.x; ODCS v3.2.0 support will come with a dedicated release
+
 ## [1.1.2] - 2026-08-26
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dependencies = [
   "Jinja2>=3.1.5,<4.0.0",
   "jinja_partials>=0.2.1,<1.0.0",
   "datacontract-specification>=1.2.3,<2.0.0",
-  "open-data-contract-standard>=3.1.2,<4.0.0",
+  "open-data-contract-standard>=3.1.2,<3.2.0",
   "deepdiff>=6.0.0,<10.0.0",
 ]
 


### PR DESCRIPTION
Keeps `main` on the ODCS 3.1.x model line. `open-data-contract-standard` 3.2.0 was just released with the ODCS v3.2.0 fields (enum, map, semanticType, synonyms, deprecated, context, vendor, port as string, new server fields). The CLI does not interpret those yet, and the previous `<4.0.0` bound would have picked 3.2.0 up on the next install. ODCS v3.2.0 support will come as a dedicated release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1xhK6DjRLWND1ntBcS8fG