### PR TITLE
Resolve ${VAR} references in contracts, port as string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This release adds support for the [Open Data Contract Standard v3.2.0](https://g
 ### Added
 - Contracts declaring `apiVersion: v3.2.0` lint and round-trip, including `enum`, `map`, `vector`, `semanticType`, `synonyms`, `deprecated`, `context`, variables in string values, and the new server types (#1558)
 - `datacontract export avro-idl` writes `map<...>` and `array<float>` for `map` and `vector` properties; `datacontract export sqlalchemy` writes `JSON` and `ARRAY(Float)` (#1558)
+- `datacontract test` resolves `${VAR}` and `${VAR:-default}` references in server fields and SQL quality queries from the environment; an unset variable without a default fails the run with its name, and `export` keeps the references (#1559)
+- Server `port` may be a string such as `${DB_PORT}`, including in Excel imports; config files accept `${VAR:-default}` (#1559)
 
 ### Changed
 - `datacontract init` and all importers write `apiVersion: v3.2.0` (#1558)

--- a/datacontract/config/settings.py
+++ b/datacontract/config/settings.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import os
-import re
 from pathlib import Path
 
 from pydantic import Field, SecretStr
@@ -309,9 +308,10 @@ class Config(BaseSettings):
 
         Nested keys join with ``_`` to form the field name (``snowflake.username``
         → ``snowflake_username``); top-level scalars address the general options
-        (``max_errors``). ``${VAR}`` references in string values are replaced with
-        the environment variable's value at load time, so files can be committed
-        without holding secrets. Unknown option names raise a ValueError.
+        (``max_errors``). ``${VAR}`` and ``${VAR:-default}`` references in string
+        values are replaced with the environment variable's value at load time,
+        so files can be committed without holding secrets. Unknown option names
+        raise a ValueError.
         """
         import yaml
 
@@ -909,18 +909,8 @@ def unknown_snowflake_env_names() -> list[str]:
     return sorted(name for name in os.environ if name.startswith("DATACONTRACT_SNOWFLAKE_") and name not in known)
 
 
-_ENV_REFERENCE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
-
-
 def _interpolate_env(value, path):
-    """Replace ``${VAR}`` references in string values with environment variable values."""
-    if not isinstance(value, str):
-        return value
+    """Replace ``${VAR}`` and ``${VAR:-default}`` references in string values with environment variable values."""
+    from datacontract.config.variables import resolve_variables
 
-    def replace(match):
-        name = match.group(1)
-        if name not in os.environ:
-            raise ValueError(f"Environment variable {name} referenced in {path} is not set.")
-        return os.environ[name]
-
-    return _ENV_REFERENCE.sub(replace, value)
+    return resolve_variables(value, source=f"config file {path}")

--- a/datacontract/config/variables.py
+++ b/datacontract/config/variables.py
@@ -1,0 +1,92 @@
+"""Variable references in string values, per ODCS v3.2.0 (RFC 0050).
+
+Any string value in a data contract may contain ``${VAR_NAME}`` or, with an
+inline default, ``${VAR_NAME:-default}``. References are resolved from the
+process environment (which includes a loaded ``.env`` file) at the moment a
+value is *used*: when a connection is opened or a quality query is executed.
+The loaded contract itself is never mutated, so ``export`` and ``publish``
+write the references back verbatim.
+
+A reference to an unset or empty variable without a default is an error;
+an empty string is never substituted silently.
+"""
+
+import os
+import re
+
+from open_data_contract_standard.model import Server
+
+_VARIABLE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}")
+
+
+class UnresolvedVariableError(ValueError):
+    """A ``${VAR}`` reference names a variable that is unset and has no default."""
+
+    def __init__(self, name: str, source: str = ""):
+        self.name = name
+        where = f" in {source}" if source else ""
+        super().__init__(f"Variable {name} referenced{where} is not set.")
+
+
+def contains_variables(value) -> bool:
+    """True if ``value`` is a string holding at least one ``${VAR}`` reference."""
+    return isinstance(value, str) and _VARIABLE.search(value) is not None
+
+
+def resolve_variables(value, source: str = ""):
+    """Return ``value`` with every ``${VAR}`` reference replaced.
+
+    Non-string values pass through unchanged. ``source`` names the value in
+    the error message (``"server 'prod' host"``, ``"config file x.yaml"``).
+    """
+    if not isinstance(value, str):
+        return value
+
+    def replace(match: re.Match) -> str:
+        name, default = match.group(1), match.group(2)
+        env_value = os.environ.get(name)
+        if env_value:
+            return env_value
+        if default is not None:
+            return default
+        raise UnresolvedVariableError(name, source)
+
+    return _VARIABLE.sub(replace, value)
+
+
+def resolve_server_variables(server: Server) -> Server:
+    """Return a copy of ``server`` with the references in its string fields resolved.
+
+    ``port`` may hold a reference (the schema allows a string there for that
+    reason); a resolved all-digit port becomes an int again. Custom property
+    values are resolved too. The contract's server is not mutated.
+    """
+    updates = {}
+    for field in Server.model_fields:
+        value = getattr(server, field)
+        if contains_variables(value):
+            updates[field] = resolve_variables(value, source=f"server '{server.server}' {_field_name(field)}")
+    port = updates.get("port", server.port)
+    if isinstance(port, str) and port.isdigit():
+        updates["port"] = int(port)
+    if server.customProperties:
+        custom_properties = []
+        changed = False
+        for prop in server.customProperties:
+            if contains_variables(prop.value):
+                changed = True
+                prop = prop.model_copy(
+                    update={
+                        "value": resolve_variables(
+                            prop.value, source=f"server '{server.server}' custom property '{prop.property}'"
+                        )
+                    }
+                )
+            custom_properties.append(prop)
+        if changed:
+            updates["customProperties"] = custom_properties
+    return server.model_copy(update=updates) if updates else server
+
+
+def _field_name(field: str) -> str:
+    return "schema" if field == "schema_" else field

--- a/datacontract/engines/checks/create_checks.py
+++ b/datacontract/engines/checks/create_checks.py
@@ -22,6 +22,7 @@ from open_data_contract_standard.model import (
     Server,
 )
 
+from datacontract.config.variables import UnresolvedVariableError, resolve_variables
 from datacontract.engines.checks.check_spec import CheckSpec, MetricType, Op, Threshold
 from datacontract.engines.checks.dimensions import default_dimension
 from datacontract.engines.checks.sql_guard import dialect_for_server_type, is_read_only_query
@@ -677,10 +678,8 @@ def _quality_rule_checks(
         if threshold is None:
             logger.warning(f"Quality check {check_key} has no valid threshold")
             return []
-        # The query is read as the dialect of the server it runs against, so
-        # dialect-specific syntax is not mistaken for something that is not a query.
-        parse_dialect = dialect_for_server_type(get_server_type(server))
-        if not is_read_only_query(query, parse_dialect):
+
+        def not_executed(reason: str) -> List[CheckSpec]:
             return [
                 CheckSpec(
                     key=check_key,
@@ -693,13 +692,27 @@ def _quality_rule_checks(
                     dimension=quality.dimension,
                     severity=quality.severity,
                     preset_result="failed",
-                    preset_reason=(
-                        f"A quality rule query must be a single read-only query, and this one could "
-                        f"not be read as one{f' ({parse_dialect} SQL)' if parse_dialect else ''}, "
-                        f"so it was not executed."
-                    ),
+                    preset_reason=reason,
                 )
             ]
+
+        # ``${VAR}`` references (ODCS v3.2.0) resolve from the environment now that
+        # the query is about to be used; the CLI's own ``${model}``-style placeholders
+        # were substituted first, so they are not mistaken for variables. The
+        # contract keeps the references.
+        try:
+            query = resolve_variables(query, source=f"the query of quality check '{check_key}'")
+        except UnresolvedVariableError as e:
+            return not_executed(f"{e} Set it in the environment or a .env file, or use ${{{e.name}:-default}}.")
+        # The query is read as the dialect of the server it runs against, so
+        # dialect-specific syntax is not mistaken for something that is not a query.
+        parse_dialect = dialect_for_server_type(get_server_type(server))
+        if not is_read_only_query(query, parse_dialect):
+            return not_executed(
+                f"A quality rule query must be a single read-only query, and this one could "
+                f"not be read as one{f' ({parse_dialect} SQL)' if parse_dialect else ''}, "
+                f"so it was not executed."
+            )
         return [
             CheckSpec(
                 key=check_key,

--- a/datacontract/engines/data_contract_test.py
+++ b/datacontract/engines/data_contract_test.py
@@ -13,6 +13,7 @@ if typing.TYPE_CHECKING:
     from duckdb.duckdb import DuckDBPyConnection
     from pyspark.sql import SparkSession
 
+from datacontract.config.variables import UnresolvedVariableError, resolve_server_variables
 from datacontract.engines.datacontract.check_azure_blob_file import check_azure_blob_file
 from datacontract.engines.datacontract.check_that_datacontract_contains_valid_servers_configuration import (
     check_that_datacontract_contains_valid_server_configuration,
@@ -55,6 +56,7 @@ def execute_data_contract_test(
     if server_name is None and data_contract.servers is not None and len(data_contract.servers) > 0:
         server_name = data_contract.servers[0].server
     server = resolve_server_overrides(get_server(data_contract, server_name), config, run)
+    server = _resolve_server_variables(server)
     run.log_info(f"Running tests for data contract {data_contract.id} with server {server_name}")
     run.dataContractId = data_contract.id
     run.dataContractVersion = data_contract.version
@@ -265,6 +267,28 @@ def check_that_quality_ids_exist(
         ),
         engine="datacontract-cli",
     )
+
+
+def _resolve_server_variables(server: Server | None) -> Server | None:
+    """Resolve ``${VAR}`` references in the server's fields, now that it is about to be used.
+
+    Overrides from the configuration were applied first, so they win over a
+    reference in the contract. An unresolvable reference fails the run with a
+    message naming the variable instead of surfacing later as a connection error.
+    """
+    if server is None:
+        return None
+    try:
+        return resolve_server_variables(server)
+    except UnresolvedVariableError as e:
+        raise DataContractException(
+            type="general",
+            name="Resolve variables in server configuration",
+            result=ResultEnum.failed,
+            reason=f"{e} Set the variable in the environment or a .env file, or give the reference a default "
+            "with ${" + e.name + ":-default}.",
+            engine="datacontract-cli",
+        )
 
 
 def get_server(data_contract: OpenDataContractStandard, server_name: str = None) -> Server | None:

--- a/datacontract/imports/excel_importer.py
+++ b/datacontract/imports/excel_importer.py
@@ -336,6 +336,18 @@ def parse_boolean(value):
     return value == "true" or value == "yes" or value == "1"
 
 
+def parse_port(value):
+    """Parse a port cell: an integer, or a string such as a ``${DB_PORT}`` reference (ODCS v3.2.0)."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+    text = str(value).strip()
+    if not text:
+        return None
+    return int(text) if text.isdigit() else text
+
+
 def parse_integer(value):
     """Parse a string value to integer"""
     if value is None:
@@ -699,7 +711,7 @@ def import_servers(workbook) -> Optional[List[Server]]:
                 elif server_type == "postgres":
                     server.database = get_server_cell_value(workbook, sheet, "servers.postgres.database", index)
                     server.host = get_server_cell_value(workbook, sheet, "servers.postgres.host", index)
-                    server.port = parse_integer(get_server_cell_value(workbook, sheet, "servers.postgres.port", index))
+                    server.port = parse_port(get_server_cell_value(workbook, sheet, "servers.postgres.port", index))
                     server.schema_ = get_server_cell_value(workbook, sheet, "servers.postgres.schema", index)
                 elif server_type == "s3":
                     server.delimiter = get_server_cell_value(workbook, sheet, "servers.s3.delimiter", index)
@@ -710,17 +722,17 @@ def import_servers(workbook) -> Optional[List[Server]]:
                     server.account = get_server_cell_value(workbook, sheet, "servers.snowflake.account", index)
                     server.database = get_server_cell_value(workbook, sheet, "servers.snowflake.database", index)
                     server.host = get_server_cell_value(workbook, sheet, "servers.snowflake.host", index)
-                    server.port = parse_integer(get_server_cell_value(workbook, sheet, "servers.snowflake.port", index))
+                    server.port = parse_port(get_server_cell_value(workbook, sheet, "servers.snowflake.port", index))
                     server.schema_ = get_server_cell_value(workbook, sheet, "servers.snowflake.schema", index)
                     server.warehouse = get_server_cell_value(workbook, sheet, "servers.snowflake.warehouse", index)
                 elif server_type == "sqlserver":
                     server.database = get_server_cell_value(workbook, sheet, "servers.sqlserver.database", index)
                     server.host = get_server_cell_value(workbook, sheet, "servers.sqlserver.host", index)
-                    server.port = parse_integer(get_server_cell_value(workbook, sheet, "servers.sqlserver.port", index))
+                    server.port = parse_port(get_server_cell_value(workbook, sheet, "servers.sqlserver.port", index))
                     server.schema_ = get_server_cell_value(workbook, sheet, "servers.sqlserver.schema", index)
                 elif server_type == "oracle":
                     server.host = get_server_cell_value(workbook, sheet, "servers.oracle.host", index)
-                    server.port = parse_integer(get_server_cell_value(workbook, sheet, "servers.oracle.port", index))
+                    server.port = parse_port(get_server_cell_value(workbook, sheet, "servers.oracle.port", index))
                     server.serviceName = get_server_cell_value(workbook, sheet, "servers.oracle.servicename", index)
                 else:
                     # Custom server type - grab all possible fields
@@ -734,7 +746,7 @@ def import_servers(workbook) -> Optional[List[Server]]:
                     server.host = get_server_cell_value(workbook, sheet, "servers.custom.host", index)
                     server.location = get_server_cell_value(workbook, sheet, "servers.custom.location", index)
                     server.path = get_server_cell_value(workbook, sheet, "servers.custom.path", index)
-                    server.port = parse_integer(get_server_cell_value(workbook, sheet, "servers.custom.port", index))
+                    server.port = parse_port(get_server_cell_value(workbook, sheet, "servers.custom.port", index))
                     server.project = get_server_cell_value(workbook, sheet, "servers.custom.project", index)
                     server.schema_ = get_server_cell_value(workbook, sheet, "servers.custom.schema", index)
                     server.stagingDir = get_server_cell_value(workbook, sheet, "servers.custom.stagingDir", index)

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -34,9 +34,32 @@ DATACONTRACT_POSTGRES_PASSWORD=postgres
 
 The `.env` values are exported into the process environment, so they also reach tools that read the environment directly, such as boto3 (`AWS_PROFILE`), the Databricks SDK, and Snowflake's `SNOWFLAKE_HOME`.
 
+## Variables in the data contract
+
+Since ODCS v3.2.0, any string value in a data contract may contain a `${VAR_NAME}` reference, optionally with an inline default: `${VAR_NAME:-default}`. This keeps hostnames, bucket paths, and other environment-specific values out of the contract, so the same file works in every environment.
+
+```yaml
+servers:
+  - server: production
+    type: postgresql
+    host: ${DB_HOST}
+    port: ${DB_PORT:-5432}
+    database: ${DB_NAME:-orders}
+schema:
+  - name: orders
+    quality:
+      - type: sql
+        query: SELECT COUNT(*) FROM orders WHERE created_at > '${CUTOFF_DATE}'
+        mustBe: 0
+```
+
+The CLI resolves a reference at the moment it uses the value: when `datacontract test` opens the connection, and when it prepares a SQL quality query for execution. In queries, the CLI's own placeholders such as `${model}` and `${schema}` are substituted first. Values come from the environment, including a loaded `.env` file. A reference to an unset or empty variable without a default fails the run with the variable's name; an empty string is never substituted silently. The contract itself is never changed: `lint` accepts unresolved references, and `export` and `publish` write them back exactly as written.
+
+The [per-source override options](#all-options) such as `DATACONTRACT_POSTGRES_HOST` take precedence over the contract, so an override replaces a reference in the same field without resolving it.
+
 ## Config file (YAML)
 
-A YAML config file groups options in sections per data source. Pass it with the global `--config-file` option, or place it at one of the default locations: `./datacontract-config.yaml` or `~/.datacontract/config.yaml`.
+A YAML config file groups options in sections per data source. String values may contain `${VAR}` and `${VAR:-default}` references, resolved when the file is loaded. Pass it with the global `--config-file` option, or place it at one of the default locations: `./datacontract-config.yaml` or `~/.datacontract/config.yaml`.
 
 ```yaml
 # datacontract-config.yaml

--- a/docs/docs/quality-rules/sql.md
+++ b/docs/docs/quality-rules/sql.md
@@ -63,6 +63,8 @@ Instead of hard-coding names, the query can reference the schema, the property, 
 
 The `$` is optional: `{schema}` works the same as `${schema}`. A placeholder the server has no value for falls back to the name of the schema object.
 
+Any other `${NAME}` or `${NAME:-default}` in the query is an ODCS v3.2.0 [variable reference](../configuration.md#variables-in-the-data-contract), resolved from the environment after the placeholders above. A reference to an unset variable without a default fails the check with the variable's name.
+
 ```yaml
 quality:
   - type: sql

--- a/docs/docs/testing/index.md
+++ b/docs/docs/testing/index.md
@@ -166,6 +166,8 @@ DATACONTRACT_POSTGRES_USERNAME=postgres
 DATACONTRACT_POSTGRES_PASSWORD=postgres
 ```
 
+Server fields may also hold `${VAR}` or `${VAR:-default}` references (ODCS v3.2.0), which `test` resolves from the environment when it connects; see [Variables in the data contract](../configuration.md#variables-in-the-data-contract).
+
 The page for each source above lists its `servers` fields and the environment variables it expects. Credentials can also come from a YAML config file (`--config-file`), the Python `Config` class, or per-request API headers; see [Configuration](../configuration.md) for all mechanisms and their precedence.
 
 ## Options

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -62,6 +62,13 @@ def test_from_yaml_interpolates_environment_references(tmp_path, monkeypatch):
     assert Config.from_yaml(path).get_snowflake_password() == "pw-from-env"
 
 
+def test_from_yaml_uses_the_inline_default_when_the_variable_is_unset(tmp_path, monkeypatch):
+    monkeypatch.delenv("SNOWFLAKE_WAREHOUSE", raising=False)
+    path = _write_config(tmp_path, "snowflake:\n  warehouse: ${SNOWFLAKE_WAREHOUSE:-COMPUTE_WH}\n")
+
+    assert Config.from_yaml(path).get_snowflake_warehouse() == "COMPUTE_WH"
+
+
 def test_from_yaml_rejects_references_to_unset_environment_variables(tmp_path, monkeypatch):
     monkeypatch.delenv("SNOWFLAKE_PASSWORD", raising=False)
     path = _write_config(tmp_path, "snowflake:\n  password: ${SNOWFLAKE_PASSWORD}\n")

--- a/tests/test_import_excel.py
+++ b/tests/test_import_excel.py
@@ -5,7 +5,7 @@ import yaml
 from typer.testing import CliRunner
 
 from datacontract.cli import app
-from datacontract.imports.excel_importer import import_excel_as_odcs
+from datacontract.imports.excel_importer import import_excel_as_odcs, parse_port
 
 # logging.basicConfig(level=logging.DEBUG, force=True)
 
@@ -38,3 +38,12 @@ def read_file(file):
     with open(file, "r") as file:
         file_content = file.read()
     return file_content
+
+
+def test_parse_port_keeps_variable_references():
+    assert parse_port(5432) == 5432
+    assert parse_port(5432.0) == 5432
+    assert parse_port(" 5432 ") == 5432
+    assert parse_port("${DB_PORT:-5432}") == "${DB_PORT:-5432}"
+    assert parse_port("") is None
+    assert parse_port(None) is None

--- a/tests/test_test_variables.py
+++ b/tests/test_test_variables.py
@@ -1,0 +1,116 @@
+"""``datacontract test`` resolves ``${VAR}`` references when it uses a value; the contract keeps them."""
+
+import duckdb
+import pytest
+import yaml
+
+from datacontract.data_contract import DataContract
+from datacontract.model.run import ResultEnum
+
+CONTRACT = """apiVersion: v3.2.0
+kind: DataContract
+id: orders-variables
+name: Orders
+version: 1.0.0
+status: active
+servers:
+  - server: production
+    type: duckdb
+    database: ${ORDERS_DB}
+schema:
+  - name: orders
+    properties:
+      - name: order_id
+        logicalType: string
+        physicalType: VARCHAR
+        required: true
+      - name: order_total
+        logicalType: integer
+        physicalType: INTEGER
+    quality:
+      - type: sql
+        description: The orders table is not empty
+        query: SELECT count(*) FROM ${ORDERS_TABLE:-orders}
+        mustBe: 2
+      - type: sql
+        description: No order total above the limit
+        query: SELECT count(*) FROM orders WHERE order_total > ${ORDER_TOTAL_LIMIT}
+        mustBe: 0
+"""
+
+
+@pytest.fixture
+def orders_db(tmp_path) -> str:
+    path = str(tmp_path / "orders.duckdb")
+    con = duckdb.connect(path)
+    con.execute("CREATE TABLE orders (order_id VARCHAR, order_total INTEGER)")
+    con.execute("INSERT INTO orders VALUES ('1', 100), ('2', 200)")
+    con.close()
+    return path
+
+
+def test_references_in_server_and_queries_are_resolved(orders_db, monkeypatch):
+    monkeypatch.setenv("ORDERS_DB", orders_db)
+    monkeypatch.delenv("ORDERS_TABLE", raising=False)
+    monkeypatch.setenv("ORDER_TOTAL_LIMIT", "500")
+
+    run = DataContract(data_contract_str=CONTRACT).test()
+
+    print(run.pretty())
+    assert run.result == ResultEnum.passed
+    sql_checks = [c for c in run.checks if c.implementation and "count(*)" in str(c.implementation)]
+    assert any("FROM orders WHERE order_total > 500" in str(c.implementation) for c in sql_checks)
+
+
+def test_unset_server_variable_fails_the_run_with_the_variable_name(orders_db, monkeypatch):
+    monkeypatch.delenv("ORDERS_DB", raising=False)
+    monkeypatch.setenv("ORDER_TOTAL_LIMIT", "500")
+
+    run = DataContract(data_contract_str=CONTRACT).test()
+
+    print(run.pretty())
+    assert run.result == ResultEnum.failed
+    failed = [c for c in run.checks if c.result == ResultEnum.failed]
+    assert len(failed) == 1
+    assert "ORDERS_DB" in failed[0].reason
+    assert "server 'production' database" in failed[0].reason
+
+
+def test_unset_query_variable_fails_only_that_check(orders_db, monkeypatch):
+    monkeypatch.setenv("ORDERS_DB", orders_db)
+    monkeypatch.delenv("ORDER_TOTAL_LIMIT", raising=False)
+
+    run = DataContract(data_contract_str=CONTRACT).test()
+
+    print(run.pretty())
+    assert run.result == ResultEnum.failed
+    failed = [c for c in run.checks if c.result == ResultEnum.failed]
+    assert len(failed) == 1
+    assert "ORDER_TOTAL_LIMIT" in failed[0].reason
+    assert sum(1 for c in run.checks if c.result == ResultEnum.passed) > 0
+
+
+def test_configuration_override_wins_over_a_reference_in_the_contract(orders_db, monkeypatch):
+    monkeypatch.delenv("ORDERS_DB", raising=False)
+    monkeypatch.setenv("DATACONTRACT_DUCKDB_DATABASE", orders_db)
+    monkeypatch.setenv("ORDER_TOTAL_LIMIT", "500")
+
+    run = DataContract(data_contract_str=CONTRACT).test()
+
+    print(run.pretty())
+    assert run.result == ResultEnum.passed
+
+
+def test_export_keeps_the_references(orders_db, monkeypatch):
+    monkeypatch.setenv("ORDERS_DB", orders_db)
+    monkeypatch.setenv("ORDER_TOTAL_LIMIT", "500")
+
+    data_contract = DataContract(data_contract_str=CONTRACT)
+    data_contract.test()
+    exported = yaml.safe_load(data_contract.export("odcs"))
+
+    assert exported["servers"][0]["database"] == "${ORDERS_DB}"
+    assert (
+        exported["schema"][0]["quality"][1]["query"]
+        == "SELECT count(*) FROM orders WHERE order_total > ${ORDER_TOTAL_LIMIT}"
+    )

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -1,0 +1,127 @@
+"""``${VAR}`` references in contract values (ODCS v3.2.0, RFC 0050)."""
+
+import pytest
+from open_data_contract_standard.model import CustomProperty, Server
+
+from datacontract.config.variables import (
+    UnresolvedVariableError,
+    contains_variables,
+    resolve_server_variables,
+    resolve_variables,
+)
+
+
+def test_reference_is_replaced_by_the_environment_value(monkeypatch):
+    monkeypatch.setenv("DB_HOST", "db.example.com")
+
+    assert resolve_variables("${DB_HOST}") == "db.example.com"
+
+
+def test_reference_may_be_a_substring_and_appear_more_than_once(monkeypatch):
+    monkeypatch.setenv("TABLE", "orders")
+    monkeypatch.setenv("CUTOFF", "2024-01-01")
+
+    query = "SELECT COUNT(*) FROM ${TABLE} WHERE created_at > '${CUTOFF}' AND t = '${TABLE}'"
+
+    assert resolve_variables(query) == "SELECT COUNT(*) FROM orders WHERE created_at > '2024-01-01' AND t = 'orders'"
+
+
+def test_default_is_used_when_the_variable_is_unset(monkeypatch):
+    monkeypatch.delenv("DB_PORT", raising=False)
+
+    assert resolve_variables("${DB_PORT:-5432}") == "5432"
+
+
+def test_default_is_used_when_the_variable_is_empty(monkeypatch):
+    monkeypatch.setenv("DB_PORT", "")
+
+    assert resolve_variables("${DB_PORT:-5432}") == "5432"
+
+
+def test_environment_wins_over_the_default(monkeypatch):
+    monkeypatch.setenv("DB_PORT", "6543")
+
+    assert resolve_variables("${DB_PORT:-5432}") == "6543"
+
+
+def test_default_may_be_empty_or_contain_punctuation(monkeypatch):
+    monkeypatch.delenv("DB_SCHEMA", raising=False)
+    monkeypatch.delenv("PATH_PREFIX", raising=False)
+
+    assert resolve_variables("${DB_SCHEMA:-}") == ""
+    assert resolve_variables("${PATH_PREFIX:-s3://bucket/raw/}orders") == "s3://bucket/raw/orders"
+
+
+def test_unset_variable_without_default_is_an_error_naming_the_variable(monkeypatch):
+    monkeypatch.delenv("DB_HOST", raising=False)
+
+    with pytest.raises(UnresolvedVariableError, match="DB_HOST") as e:
+        resolve_variables("${DB_HOST}", source="server 'prod' host")
+
+    assert "server 'prod' host" in str(e.value)
+    assert e.value.name == "DB_HOST"
+
+
+def test_empty_variable_without_default_is_an_error(monkeypatch):
+    monkeypatch.setenv("DB_HOST", "")
+
+    with pytest.raises(UnresolvedVariableError, match="DB_HOST"):
+        resolve_variables("${DB_HOST}")
+
+
+def test_values_without_references_pass_through_unchanged():
+    assert resolve_variables("plain") == "plain"
+    assert resolve_variables("$HOME and {braces}") == "$HOME and {braces}"
+    assert resolve_variables(5432) == 5432
+    assert resolve_variables(None) is None
+
+
+def test_contains_variables():
+    assert contains_variables("${X}")
+    assert contains_variables("prefix-${X:-d}-suffix")
+    assert not contains_variables("no reference")
+    assert not contains_variables(5432)
+
+
+def test_server_fields_are_resolved_into_a_copy(monkeypatch):
+    monkeypatch.setenv("DB_HOST", "db.example.com")
+    monkeypatch.setenv("DB_PORT", "6543")
+    monkeypatch.delenv("DB_NAME", raising=False)
+    monkeypatch.setenv("CUSTOM_TYPE", "trino")
+    server = Server(
+        server="prod",
+        type="postgresql",
+        host="${DB_HOST}",
+        port="${DB_PORT}",
+        database="${DB_NAME:-orders}",
+        schema="public",
+        customProperties=[CustomProperty(property="customType", value="${CUSTOM_TYPE}")],
+    )
+
+    resolved = resolve_server_variables(server)
+
+    assert resolved.host == "db.example.com"
+    assert resolved.port == 6543
+    assert resolved.database == "orders"
+    assert resolved.schema_ == "public"
+    assert resolved.customProperties[0].value == "trino"
+    # The contract's server keeps its references, so exports stay round-trip safe.
+    assert server.host == "${DB_HOST}"
+    assert server.port == "${DB_PORT}"
+    assert server.customProperties[0].value == "${CUSTOM_TYPE}"
+
+
+def test_server_without_references_is_returned_as_is():
+    server = Server(server="prod", type="postgresql", host="localhost", port=5432)
+
+    assert resolve_server_variables(server) is server
+
+
+def test_unresolvable_server_field_names_the_server_and_field(monkeypatch):
+    monkeypatch.delenv("DB_HOST", raising=False)
+    server = Server(server="prod", type="postgresql", host="${DB_HOST}")
+
+    with pytest.raises(UnresolvedVariableError, match="DB_HOST") as e:
+        resolve_server_variables(server)
+
+    assert "server 'prod' host" in str(e.value)


### PR DESCRIPTION
Part of #1559 (#1557). Targets the `odcs-3.2.0` branch.

ODCS v3.2.0 (RFC 0050) allows `${VAR_NAME}` and `${VAR_NAME:-default}` in any string value. Tools must resolve them before use, should error on unresolvable ones, and must preserve them when serializing.

### Design
- **Resolved at use time, never on the model.** `datacontract test` resolves the server's fields right after the configuration overrides are applied, and each SQL quality query when the check is prepared. The loaded contract keeps the references, so `lint` accepts them and `export`/`publish` write them back verbatim (covered by a test).
- **One resolver** in `datacontract/config/variables.py`. The config file loader now uses it too and gains the `${VAR:-default}` form.
- **Precedence.** `DATACONTRACT_<SERVER>_<FIELD>` overrides still win over the contract. In queries the CLI's own `${model}`, `${schema}`, ... placeholders are substituted first, so they are not mistaken for variables.
- **Errors.** An unset (or empty) variable without a default fails the run with the variable name and the field (`server 'prod' host`), or fails just that quality check when it is in a query. Never an empty-string substitution.
- **Port.** A `port` holding a reference resolves to an int again; Excel import keeps a `${DB_PORT}` cell as a string instead of dropping it.

### Tests
Unit tests for the resolver and server resolution, end-to-end DuckDB tests (resolved server and queries, unset server variable, unset query variable, override wins, export keeps references), config file default form, Excel port parsing. Full suite: 2314 passed.

### Docs
New "Variables in the data contract" section on the configuration page, a note on the SQL quality rules page (placeholders first, then variables), and a pointer on the testing index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1xhK6DjRLWND1ntBcS8fG
