### PR TITLE
Read enum on properties everywhere allowed values are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ This release adds support for the [Open Data Contract Standard v3.2.0](https://g
 - `datacontract export avro-idl` writes `map<...>` and `array<float>` for `map` and `vector` properties; `datacontract export sqlalchemy` writes `JSON` and `ARRAY(Float)` (#1558)
 - `datacontract test` resolves `${VAR}` and `${VAR:-default}` references in server fields and SQL quality queries from the environment; an unset variable without a default fails the run with its name, and `export` keeps the references (#1559)
 - Server `port` may be a string such as `${DB_PORT}`, including in Excel imports; config files accept `${VAR:-default}` (#1559)
+- `enum` on properties is read by `datacontract test`, the jsonschema, avro, avro-idl, protobuf, pydantic-model, dcs, great-expectations, sodacl and data-caterer exporters, and dbt test mapping, ahead of `logicalTypeOptions.enum`, the `enum` custom property and the `invalidValues` rule; HTML export lists the values with labels and descriptions (#1560)
+- `datacontract import` from JSON Schema, Avro, Protobuf and DCS writes allowed values as `enum` entries instead of an `invalidValues` quality rule or custom properties (#1560)
+- `datacontract export pydantic-model` types an enumerated string or integer property as `typing.Literal` (#1560)
 
 ### Changed
 - `datacontract init` and all importers write `apiVersion: v3.2.0` (#1558)

--- a/datacontract/engines/checks/create_checks.py
+++ b/datacontract/engines/checks/create_checks.py
@@ -28,6 +28,7 @@ from datacontract.engines.checks.dimensions import default_dimension
 from datacontract.engines.checks.sql_guard import dialect_for_server_type, is_read_only_query
 from datacontract.engines.checks.type_normalize import normalize_type_name
 from datacontract.engines.ibis.native_type import supports_native_type_introspection
+from datacontract.model.enum_values import get_enum_values
 from datacontract.model.server import get_server_type
 
 logger = logging.getLogger(__name__)
@@ -493,7 +494,7 @@ def _to_schema_checks(schema_object: SchemaObject, server: Optional[Server]) -> 
                 )
             )
 
-        enum_values = _get_logical_type_option(prop, "enum")
+        enum_values = get_enum_values(prop, include_quality_rule=False)
         if enum_values:
             checks.append(
                 _invalid_count_check(

--- a/datacontract/export/avro_exporter.py
+++ b/datacontract/export/avro_exporter.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Union
 from open_data_contract_standard.model import SchemaObject, SchemaProperty
 
 from datacontract.export.exporter import Exporter, _check_schema_name_for_export
+from datacontract.model.enum_values import get_enum_values
 
 
 class AvroExporter(Exporter):
@@ -58,31 +59,6 @@ def _get_logical_type_option(prop: SchemaProperty, key: str):
     return prop.logicalTypeOptions.get(key)
 
 
-def _get_enum_values(prop: SchemaProperty):
-    """Get enum values from logicalTypeOptions, customProperties, or quality rules."""
-    import json
-
-    # First check logicalTypeOptions (legacy/direct ODCS)
-    enum_values = _get_logical_type_option(prop, "enum")
-    if enum_values:
-        return enum_values
-    # Then check customProperties (converted from DCS)
-    enum_str = _get_config_value(prop, "enum")
-    if enum_str:
-        try:
-            return json.loads(enum_str)
-        except (json.JSONDecodeError, TypeError):
-            pass
-    # Finally check quality rules for invalidValues with validValues
-    if prop.quality:
-        for q in prop.quality:
-            if q.metric == "invalidValues" and q.arguments:
-                valid_values = q.arguments.get("validValues")
-                if valid_values:
-                    return valid_values
-    return None
-
-
 def _parse_default_value(value: str):
     """Parse a default value string to its proper type (bool, int, float, or string)."""
     if value.lower() == "true":
@@ -114,7 +90,7 @@ def to_avro_field(prop: SchemaProperty) -> dict:
     avro_field["type"] = avro_type if is_required_avro else ["null", avro_type]
 
     # Handle enum types - both required and optional
-    enum_values = _get_enum_values(prop)
+    enum_values = get_enum_values(prop)
     avro_config_type = _get_config_value(prop, "avroType")
 
     if avro_type == "enum" or (isinstance(avro_field["type"], list) and "enum" in avro_field["type"]):
@@ -159,14 +135,13 @@ def to_avro_type(prop: SchemaProperty) -> Union[str, dict]:
     if avro_type:
         return avro_type
 
-    # Check for enum fields based on presence of enum list and avroType config
-    enum_values = _get_enum_values(prop)
-    if enum_values and avro_type == "enum":
-        return "enum"
-
     # Use physicalType for more specific type mappings, fall back to logicalType
     physical_type = prop.physicalType.lower() if prop.physicalType else None
     field_type = prop.logicalType
+
+    # A property declared as an enum with allowed values becomes an Avro enum
+    if physical_type == "enum" and get_enum_values(prop):
+        return "enum"
 
     # Handle specific physical types that need special treatment
     if physical_type in ["float"]:

--- a/datacontract/export/data_caterer_exporter.py
+++ b/datacontract/export/data_caterer_exporter.py
@@ -4,6 +4,7 @@ import yaml
 from open_data_contract_standard.model import OpenDataContractStandard, SchemaObject, SchemaProperty, Server
 
 from datacontract.export.exporter import Exporter
+from datacontract.model.enum_values import get_enum_values
 
 
 class DataCatererExporter(Exporter):
@@ -46,33 +47,6 @@ def _get_custom_property_value(prop: SchemaProperty, key: str):
     for cp in prop.customProperties:
         if cp.property == key:
             return cp.value
-    return None
-
-
-def _get_enum_values(prop: SchemaProperty):
-    """Get enum values from logicalTypeOptions, customProperties, or quality rules."""
-    import json
-
-    # First check logicalTypeOptions
-    enum_values = _get_logical_type_option(prop, "enum")
-    if enum_values:
-        return enum_values
-    # Then check customProperties
-    enum_str = _get_custom_property_value(prop, "enum")
-    if enum_str:
-        try:
-            if isinstance(enum_str, list):
-                return enum_str
-            return json.loads(enum_str)
-        except (json.JSONDecodeError, TypeError):
-            pass
-    # Finally check quality rules for invalidValues with validValues
-    if prop.quality:
-        for q in prop.quality:
-            if q.metric == "invalidValues" and q.arguments:
-                valid_values = q.arguments.get("validValues")
-                if valid_values:
-                    return valid_values
     return None
 
 
@@ -171,7 +145,7 @@ def _to_field(field_name: str, prop: SchemaProperty) -> dict:
             else:
                 dc_generator_opts["arrayType"] = "string"
 
-    enum_values = _get_enum_values(prop)
+    enum_values = get_enum_values(prop)
     if enum_values is not None and len(enum_values) > 0:
         dc_generator_opts["oneOf"] = enum_values
     if prop.unique is not None and prop.unique:

--- a/datacontract/export/dcs_exporter.py
+++ b/datacontract/export/dcs_exporter.py
@@ -25,6 +25,7 @@ from open_data_contract_standard.model import (
 )
 
 from datacontract.export.exporter import Exporter
+from datacontract.model.enum_values import get_enum_values
 
 
 class DcsExporter(Exporter):
@@ -237,10 +238,12 @@ def _convert_property_to_field(prop: SchemaProperty) -> Field:
             field.exclusiveMinimum = opts["exclusiveMinimum"]
         if "exclusiveMaximum" in opts:
             field.exclusiveMaximum = opts["exclusiveMaximum"]
-        if "enum" in opts:
-            field.enum = opts["enum"]
         if "format" in opts:
             field.format = opts["format"]
+
+    enum_values = get_enum_values(prop)
+    if enum_values:
+        field.enum = enum_values
 
     # Convert custom properties
     if prop.customProperties:

--- a/datacontract/export/great_expectations_exporter.py
+++ b/datacontract/export/great_expectations_exporter.py
@@ -14,6 +14,7 @@ from datacontract.export.exporter import (
     Exporter,
     _check_schema_name_for_export,
 )
+from datacontract.model.enum_values import get_enum_values
 
 
 class GreatExpectationsEngine(str, Enum):
@@ -72,18 +73,6 @@ def _get_logical_type_option(prop: SchemaProperty, key: str):
     if prop.logicalTypeOptions is None:
         return None
     return prop.logicalTypeOptions.get(key)
-
-
-def _get_enum_from_custom_properties(prop: SchemaProperty) -> Optional[List[str]]:
-    """Get enum values from customProperties (used when importing from DCS)."""
-    if prop.customProperties is None:
-        return None
-    for cp in prop.customProperties:
-        if cp.property == "enum" and cp.value:
-            if isinstance(cp.value, list):
-                return cp.value
-            return json.loads(cp.value)
-    return None
 
 
 def to_great_expectations(
@@ -219,8 +208,8 @@ def add_field_expectations(
     if minimum is not None or maximum is not None:
         expectations.append(to_column_min_max_exp(field_name, minimum, maximum))
 
-    enum_values = _get_logical_type_option(prop, "enum") or _get_enum_from_custom_properties(prop)
-    if enum_values is not None and len(enum_values) != 0:
+    enum_values = get_enum_values(prop)
+    if enum_values:
         expectations.append(to_column_enum_exp(field_name, enum_values))
 
     return expectations

--- a/datacontract/export/jsonschema_exporter.py
+++ b/datacontract/export/jsonschema_exporter.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 from open_data_contract_standard.model import OpenDataContractStandard, SchemaObject, SchemaProperty
 
 from datacontract.export.exporter import Exporter, _check_schema_name_for_export
+from datacontract.model.enum_values import get_enum_values
 
 
 class JsonSchemaExporter(Exporter):
@@ -47,18 +48,6 @@ def _get_config_value(prop: SchemaProperty, key: str):
     for cp in prop.customProperties:
         if cp.property == key:
             return cp.value
-    return None
-
-
-def _get_enum_from_quality(prop: SchemaProperty):
-    """Get enum values from quality rules (invalidValues metric with validValues)."""
-    if prop.quality is None:
-        return None
-    for q in prop.quality:
-        if q.metric == "invalidValues" and q.arguments:
-            valid_values = q.arguments.get("validValues")
-            if valid_values:
-                return valid_values
     return None
 
 
@@ -107,19 +96,7 @@ def to_property(prop: SchemaProperty) -> dict:
     if pattern:
         property_dict["pattern"] = pattern
 
-    # Check logicalTypeOptions, customProperties, or quality rules for enum
-    enum_values = _get_logical_type_option(prop, "enum")
-    if not enum_values:
-        enum_from_custom = _get_config_value(prop, "enum")
-        if enum_from_custom:
-            # Parse JSON string from customProperties
-            try:
-                enum_values = json.loads(enum_from_custom)
-            except (json.JSONDecodeError, TypeError):
-                enum_values = None
-    if not enum_values:
-        # Check quality rules for invalidValues metric with validValues
-        enum_values = _get_enum_from_quality(prop)
+    enum_values = get_enum_values(prop)
     if enum_values:
         property_dict["enum"] = enum_values
 

--- a/datacontract/export/protobuf_exporter.py
+++ b/datacontract/export/protobuf_exporter.py
@@ -116,10 +116,10 @@ def _is_array_of_objects(prop: SchemaProperty) -> bool:
 
 def _is_enum_field(prop: SchemaProperty) -> bool:
     """
-    Returns True if the field has a non-empty "enumValues" property (via customProperties).
+    Returns True if the field declares allowed values: an ODCS ``enum`` or a non-empty
+    "enumValues" custom property (name -> number).
     """
-    values = _get_config_value(prop, "enumValues")
-    return bool(values)
+    return bool(prop.enum) or bool(_get_config_value(prop, "enumValues"))
 
 
 def _get_enum_name(prop: SchemaProperty) -> str:
@@ -135,11 +135,20 @@ def _get_enum_name(prop: SchemaProperty) -> str:
 
 def _get_enum_values(prop: SchemaProperty) -> dict:
     """
-    Returns the enum values from the field.
+    Returns the enum constants of the field as name -> number.
+
+    The "enumValues" custom property carries the numbers a protobuf import found. An ODCS
+    ``enum`` uses each entry's ``id`` when it is a number, and the position otherwise.
     """
     values = _get_config_value(prop, "enumValues")
     if values and isinstance(values, dict):
         return values
+    if prop.enum:
+        result = {}
+        for position, entry in enumerate(prop.enum):
+            number = int(entry.id) if entry.id is not None and str(entry.id).lstrip("-").isdigit() else position
+            result[str(entry.value)] = number
+        return result
     return {}
 
 

--- a/datacontract/export/pydantic_exporter.py
+++ b/datacontract/export/pydantic_exporter.py
@@ -5,6 +5,7 @@ from typing import Optional
 from open_data_contract_standard.model import OpenDataContractStandard, SchemaObject, SchemaProperty
 
 from datacontract.export.exporter import Exporter
+from datacontract.model.enum_values import get_enum_values
 
 
 class PydanticExporter(Exporter):
@@ -87,6 +88,17 @@ def constant_field_annotation(
 ) -> tuple[type_annotation_type, typing.Optional[ast.ClassDef]]:
     prop_type = _get_type(prop)
     physical_type = _get_physical_type(prop)
+
+    enum_values = get_enum_values(prop)
+    if enum_values and prop_type in ("string", "integer") and all(isinstance(v, (str, int)) for v in enum_values):
+        return (
+            ast.Subscript(
+                value=ast.Attribute(value=ast.Name(id="typing", ctx=ast.Load()), attr="Literal", ctx=ast.Load()),
+                slice=ast.Tuple(elts=[ast.Constant(v) for v in enum_values], ctx=ast.Load()),
+                ctx=ast.Load(),
+            ),
+            None,
+        )
 
     match prop_type:
         case "string":

--- a/datacontract/export/sodacl_check_builder.py
+++ b/datacontract/export/sodacl_check_builder.py
@@ -23,6 +23,7 @@ from open_data_contract_standard.model import (
 )
 
 from datacontract.export.sql_type_converter import convert_to_sql_type
+from datacontract.model.enum_values import get_enum_values
 from datacontract.model.run import Check
 
 logger = logging.getLogger(__name__)
@@ -226,8 +227,8 @@ def to_schema_checks(schema_object: SchemaObject, server: Server) -> List[Check]
         if pattern is not None:
             checks.append(check_property_regex(schema_name, property_name, pattern, quoting_config))
 
-        enum_values = _get_logical_type_option(prop, "enum")
-        if enum_values is not None and len(enum_values) > 0:
+        enum_values = get_enum_values(prop, include_quality_rule=False)
+        if enum_values:
             checks.append(check_property_enum(schema_name, property_name, enum_values, quoting_config))
 
         if prop.quality is not None and len(prop.quality) > 0:

--- a/datacontract/imports/avro_importer.py
+++ b/datacontract/imports/avro_importer.py
@@ -126,6 +126,7 @@ def import_avro_field(field: avro.schema.Field) -> SchemaProperty:
                 description=field.doc,
                 required=False,
                 custom_properties={**custom_props, "avroType": "enum"} if custom_props else {"avroType": "enum"},
+                enum=enum_schema.symbols,
             )
         else:
             logical_type, physical_type = import_type_of_optional_field(field)
@@ -189,9 +190,8 @@ def import_avro_field(field: avro.schema.Field) -> SchemaProperty:
             physical_type="enum",
             description=field.doc,
             required=True,
-            custom_properties={**custom_props, "avroType": "enum", "avroSymbols": field.type.symbols}
-            if custom_props
-            else {"avroType": "enum", "avroSymbols": field.type.symbols},
+            custom_properties={**custom_props, "avroType": "enum"} if custom_props else {"avroType": "enum"},
+            enum=field.type.symbols,
         )
     else:
         # Primitive types

--- a/datacontract/imports/dcs_importer.py
+++ b/datacontract/imports/dcs_importer.py
@@ -10,6 +10,7 @@ from open_data_contract_standard.model import (
     CustomProperty,
     DataQuality,
     Description,
+    EnumValue,
     OpenDataContractStandard,
     Relationship,
     SchemaObject,
@@ -478,17 +479,10 @@ def _convert_field_to_property(
 
     # Convert config to customProperties
     custom_properties = []
-    # Handle enum as quality rule (invalidValues with validValues, mustBe: 0)
-    quality_rules = []
     if field.enum:
-        quality_rules.append(
-            DataQuality(
-                type="library",
-                metric="invalidValues",
-                arguments={"validValues": field.enum},
-                mustBe=0,
-            )
-        )
+        prop.enum = [EnumValue(value=value) for value in field.enum]
+
+    quality_rules = []
     if field.pii is not None:
         custom_properties.append(CustomProperty(property="pii", value=str(field.pii)))
     if field.precision is not None:
@@ -549,7 +543,7 @@ def _convert_field_to_property(
     if custom_properties:
         prop.customProperties = custom_properties
 
-    # Convert quality rules (merge enum quality rule with field-level quality)
+    # Convert quality rules
     if field.quality:
         quality_rules.extend(_convert_quality_list(field.quality))
     if quality_rules:

--- a/datacontract/imports/jsonschema_importer.py
+++ b/datacontract/imports/jsonschema_importer.py
@@ -2,7 +2,7 @@ import json
 from typing import Any, Dict, List
 
 import fastjsonschema
-from open_data_contract_standard.model import DataQuality, OpenDataContractStandard, SchemaProperty
+from open_data_contract_standard.model import OpenDataContractStandard, SchemaProperty
 
 from datacontract.imports.importer import Importer
 from datacontract.imports.odcs_helper import (
@@ -125,18 +125,7 @@ def schema_to_property(name: str, prop_schema: Dict[str, Any], is_required: bool
         # Draft-06+: number value
         exclusive_maximum = raw_exclusive_max
 
-    # Handle enum as quality rule (invalidValues with validValues, mustBe: 0)
     quality_rules = []
-    enum_values = prop_schema.get("enum")
-    if enum_values:
-        quality_rules.append(
-            DataQuality(
-                type="library",
-                metric="invalidValues",
-                arguments={"validValues": enum_values},
-                mustBe=0,
-            )
-        )
 
     # Build custom properties for attributes not directly mapped
     custom_props = {}
@@ -186,6 +175,7 @@ def schema_to_property(name: str, prop_schema: Dict[str, Any], is_required: bool
         properties=nested_properties,
         items=items_prop,
         custom_properties=custom_props if custom_props else None,
+        enum=prop_schema.get("enum"),
     )
 
     # Set title as businessName if present

--- a/datacontract/imports/odcs_helper.py
+++ b/datacontract/imports/odcs_helper.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List
 from open_data_contract_standard.model import (
     CustomProperty,
     DataQuality,
+    EnumValue,
     OpenDataContractStandard,
     Role,
     SchemaObject,
@@ -88,8 +89,12 @@ def create_property(
     custom_properties: Dict[str, Any] = None,
     id: str = None,
     quality: List[DataQuality] = None,
+    enum: List[Any] = None,
 ) -> SchemaProperty:
-    """Create a SchemaProperty (equivalent to DCS Field)."""
+    """Create a SchemaProperty (equivalent to DCS Field).
+
+    ``enum`` lists the allowed values, as plain values or ``EnumValue`` entries (ODCS v3.2.0).
+    """
     prop = SchemaProperty(name=name, id=id)
     prop.logicalType = logical_type
 
@@ -149,6 +154,9 @@ def create_property(
     # Data quality
     if quality:
         prop.quality = quality
+
+    if enum:
+        prop.enum = [entry if isinstance(entry, EnumValue) else EnumValue(value=entry) for entry in enum]
 
     return prop
 

--- a/datacontract/imports/protobuf_importer.py
+++ b/datacontract/imports/protobuf_importer.py
@@ -10,7 +10,7 @@ import os
 import re
 from typing import Dict, List
 
-from open_data_contract_standard.model import OpenDataContractStandard, SchemaProperty
+from open_data_contract_standard.model import EnumValue, OpenDataContractStandard, SchemaProperty
 from proto_schema_parser import ast as proto_ast
 from proto_schema_parser.parser import Parser
 
@@ -185,6 +185,7 @@ def _convert_field(field, messages: Dict[str, proto_ast.Message], enums: Dict[st
             description=f"Enum field {field.name}",
             required=required,
             custom_properties={"enumValues": enum_values} if enum_values else None,
+            enum=[EnumValue(value=name, id=str(number)) for name, number in enum_values.items()] or None,
         )
 
     # Scalar field. Emit the protobuf type number as physicalType, matching the

--- a/datacontract/integration/dbt_test_mapping.py
+++ b/datacontract/integration/dbt_test_mapping.py
@@ -4,10 +4,11 @@ Shared between `datacontract export dbt` and (eventually) `datacontract dbt sync
 so the two paths cannot drift while both emit dbt tests.
 """
 
-import json
 from typing import Any, List, Optional
 
 from open_data_contract_standard.model import SchemaProperty
+
+from datacontract.model.enum_values import get_enum_values
 
 
 def _get_custom_property_value(prop: SchemaProperty, key: str) -> Optional[str]:
@@ -23,32 +24,6 @@ def get_logical_type_option(prop: SchemaProperty, key: str) -> Any:
     if prop.logicalTypeOptions is None:
         return None
     return prop.logicalTypeOptions.get(key)
-
-
-def _get_enum_values(prop: SchemaProperty) -> Optional[list]:
-    """Resolve enum values from logicalTypeOptions, customProperties, or quality.invalidValues."""
-
-    # First check logicalTypeOptions
-    enum_values = get_logical_type_option(prop, "enum")
-    if enum_values:
-        return enum_values
-    # Then check customProperties
-    enum_str = _get_custom_property_value(prop, "enum")
-    if enum_str:
-        try:
-            if isinstance(enum_str, list):
-                return enum_str
-            return json.loads(enum_str)
-        except (json.JSONDecodeError, TypeError):
-            pass
-    # Finally check quality rules for invalidValues with validValues
-    if prop.quality:
-        for q in prop.quality:
-            if q.metric == "invalidValues" and q.arguments:
-                valid_values = q.arguments.get("validValues")
-                if valid_values:
-                    return valid_values
-    return None
 
 
 def get_table_name_and_column_name(references: str) -> tuple:
@@ -81,7 +56,7 @@ def field_to_data_tests(
         if prop.unique or (is_primary_key and is_single_pk):
             tests.append("unique")
 
-    enum_values = _get_enum_values(prop)
+    enum_values = get_enum_values(prop)
     if enum_values and len(enum_values) > 0:
         tests.append({"accepted_values": {"values": enum_values}})
 

--- a/datacontract/model/enum_values.py
+++ b/datacontract/model/enum_values.py
@@ -1,0 +1,60 @@
+"""The allowed values of a property, from whichever place a contract declares them.
+
+ODCS v3.2.0 (RFC 0033) declares them as ``enum``, a list of objects with at
+least a ``value``. Older contracts and some importers use three other
+representations, which stay readable: ``logicalTypeOptions.enum`` (a plain
+list), an ``enum`` custom property (a list or a JSON string, from DCS), and the
+``invalidValues`` quality rule with ``validValues``.
+"""
+
+import json
+from typing import Any, Optional
+
+from open_data_contract_standard.model import EnumValue, SchemaProperty
+
+
+def get_enum_entries(prop: SchemaProperty, include_quality_rule: bool = True) -> Optional[list[EnumValue]]:
+    """The allowed values as ``EnumValue`` entries, or ``None`` if the property has none.
+
+    Values from the legacy representations become entries with only a ``value``.
+    """
+    if prop.enum:
+        return list(prop.enum)
+    values = _legacy_enum_values(prop, include_quality_rule)
+    if values is None:
+        return None
+    return [EnumValue(value=value) for value in values]
+
+
+def get_enum_values(prop: SchemaProperty, include_quality_rule: bool = True) -> Optional[list[Any]]:
+    """The allowed values as a plain list, or ``None`` if the property has none.
+
+    ``enum`` wins, then ``logicalTypeOptions.enum``, the ``enum`` custom property,
+    and the ``invalidValues`` quality rule. Callers that turn the quality rules
+    into checks of their own pass ``include_quality_rule=False``, so the rule is
+    not checked twice.
+    """
+    if prop.enum:
+        return [entry.value for entry in prop.enum]
+    return _legacy_enum_values(prop, include_quality_rule)
+
+
+def _legacy_enum_values(prop: SchemaProperty, include_quality_rule: bool) -> Optional[list[Any]]:
+    if prop.logicalTypeOptions and prop.logicalTypeOptions.get("enum"):
+        return list(prop.logicalTypeOptions["enum"])
+    for custom_property in prop.customProperties or []:
+        if custom_property.property == "enum" and custom_property.value:
+            if isinstance(custom_property.value, list):
+                return list(custom_property.value)
+            try:
+                parsed = json.loads(custom_property.value)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if isinstance(parsed, list):
+                return parsed
+    for quality in (prop.quality or []) if include_quality_rule else []:
+        if quality.metric == "invalidValues" and quality.arguments:
+            valid_values = quality.arguments.get("validValues")
+            if valid_values:
+                return list(valid_values)
+    return None

--- a/datacontract/templates/macros/schema.html
+++ b/datacontract/templates/macros/schema.html
@@ -106,6 +106,22 @@
           </div>
         {% endif %}
 
+        {% set property_enum = property.enum if property.enum is defined and property.enum and property.enum is sequence and property.enum is not string else [] %}
+        {% if property_enum|length > 0 %}
+          <div class="mt-1">
+            <span class="text-gray-500">Allowed values</span>
+            <ul class="ml-4 list-disc">
+              {% for entry in property_enum %}
+                <li>
+                  <code class="text-xs">{{ entry.value }}</code>
+                  {% if entry.label is defined and entry.label %}<span class="ml-1">{{ entry.label }}</span>{% endif %}
+                  {% if entry.description is defined and entry.description %}<span class="ml-1 text-gray-500">{{ entry.description }}</span>{% endif %}
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+
         <div class="mt-1 flex gap-x-1 items-center flex-wrap">
           {% if property.primaryKey %}
             <span class="inline-flex items-center rounded-md bg-gray-50 px-1 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10">

--- a/docs/docs/schema.md
+++ b/docs/docs/schema.md
@@ -28,7 +28,7 @@ datacontract test --checks schema datacontract.yaml
 | `logicalTypeOptions.minimum` / `maximum` | property | Value within bounds (inclusive) |
 | `logicalTypeOptions.exclusiveMinimum` / `exclusiveMaximum` | property | Value within bounds (exclusive) |
 | `logicalTypeOptions.pattern` | property | Value matches the regular expression |
-| `logicalTypeOptions.enum` | property | Value is one of the listed values |
+| `enum` | property | Value is one of the listed values (ODCS v3.2.0; `logicalTypeOptions.enum` is still accepted) |
 | `logicalTypeOptions.minItems` / `maxItems` | array property | Number of elements within bounds |
 | `logicalTypeOptions.uniqueItems` | array property | Elements of the array are distinct |
 | `quality` | schema, property | See [Define your Quality Rules](./quality-rules/index.md) |
@@ -47,8 +47,13 @@ schema:
       - name: order_status
         logicalType: string
         required: true
-        logicalTypeOptions:
-          enum: ['pending', 'shipped', 'delivered']
+        enum:
+          - value: pending
+          - value: shipped
+            label: Shipped
+          - value: delivered
+            label: Delivered
+            description: Handed over to the customer
       - name: order_total
         logicalType: integer
         physicalType: integer
@@ -147,8 +152,10 @@ properties:
       pattern: '^[A-Z]{2}$'
   - name: order_status
     logicalType: string
-    logicalTypeOptions:
-      enum: ['pending', 'shipped', 'delivered']
+    enum:
+      - value: pending
+      - value: shipped
+      - value: delivered
   - name: tags
     logicalType: array
     items:
@@ -165,7 +172,7 @@ properties:
 | `minimum` / `maximum` | below / above the bound (the bound itself passes) |
 | `exclusiveMinimum` / `exclusiveMaximum` | below / above **or equal to** the bound |
 | `pattern` | not matching the regular expression |
-| `enum` | not one of the listed values |
+| `enum` (property level, or `logicalTypeOptions.enum`) | not one of the listed values |
 | `minItems` / `maxItems` | an array with fewer / more elements than the bound |
 | `uniqueItems` | an array that repeats an element |
 

--- a/tests/fixtures/protobuf/expected/sample_data.odcs.yaml
+++ b/tests/fixtures/protobuf/expected/sample_data.odcs.yaml
@@ -38,6 +38,15 @@ schema:
         CATEGORY_HOME_APPLIANCES: 3
     logicalType: string
     required: false
+    enum:
+    - id: '0'
+      value: CATEGORY_UNKNOWN
+    - id: '1'
+      value: CATEGORY_ELECTRONICS
+    - id: '2'
+      value: CATEGORY_CLOTHING
+    - id: '3'
+      value: CATEGORY_HOME_APPLIANCES
   - name: tags
     physicalType: '9'
     description: Field tags

--- a/tests/test_enum_values.py
+++ b/tests/test_enum_values.py
@@ -1,0 +1,177 @@
+"""``enum`` on properties (ODCS v3.2.0, RFC 0033): one resolver, every consumer."""
+
+import json
+
+import duckdb
+import pytest
+import yaml
+from open_data_contract_standard.model import CustomProperty, DataQuality, EnumValue, SchemaProperty
+
+from datacontract.data_contract import DataContract
+from datacontract.model.enum_values import get_enum_entries, get_enum_values
+from datacontract.model.run import ResultEnum
+
+CONTRACT = """apiVersion: v3.2.0
+kind: DataContract
+id: orders-enum
+name: Orders
+version: 1.0.0
+status: active
+servers:
+  - server: production
+    type: duckdb
+    database: {database}
+schema:
+  - name: orders
+    properties:
+      - name: order_id
+        logicalType: string
+        physicalType: VARCHAR
+      - name: status
+        logicalType: string
+        physicalType: VARCHAR
+        enum:
+          - value: placed
+            label: Placed
+          - value: shipped
+            label: Shipped
+            description: Handed to the carrier
+      - name: priority
+        logicalType: integer
+        physicalType: INTEGER
+        enum:
+          - value: 1
+          - value: 2
+"""
+
+
+def _property(**kwargs) -> SchemaProperty:
+    return SchemaProperty(name="status", logicalType="string", **kwargs)
+
+
+def test_enum_entries_win_over_every_legacy_representation():
+    prop = _property(
+        enum=[EnumValue(value="a", label="A")],
+        logicalTypeOptions={"enum": ["legacy"]},
+        customProperties=[CustomProperty(property="enum", value='["custom"]')],
+        quality=[DataQuality(metric="invalidValues", arguments={"validValues": ["rule"]})],
+    )
+
+    assert get_enum_values(prop) == ["a"]
+    assert get_enum_entries(prop)[0].label == "A"
+
+
+def test_legacy_representations_are_read_in_order():
+    assert get_enum_values(_property(logicalTypeOptions={"enum": ["a", "b"]})) == ["a", "b"]
+    assert get_enum_values(_property(customProperties=[CustomProperty(property="enum", value='["c"]')])) == ["c"]
+    assert get_enum_values(_property(customProperties=[CustomProperty(property="enum", value=["d"])])) == ["d"]
+    rule = DataQuality(metric="invalidValues", arguments={"validValues": ["e"]})
+    assert get_enum_values(_property(quality=[rule])) == ["e"]
+    assert get_enum_values(_property(quality=[rule]), include_quality_rule=False) is None
+    assert get_enum_values(_property()) is None
+    assert get_enum_entries(_property()) is None
+
+
+def test_legacy_values_become_entries():
+    entries = get_enum_entries(_property(logicalTypeOptions={"enum": ["a"]}))
+
+    assert [e.value for e in entries] == ["a"]
+    assert entries[0].label is None
+
+
+@pytest.fixture
+def orders_db(tmp_path) -> str:
+    path = str(tmp_path / "orders.duckdb")
+    con = duckdb.connect(path)
+    con.execute("CREATE TABLE orders (order_id VARCHAR, status VARCHAR, priority INTEGER)")
+    con.execute("INSERT INTO orders VALUES ('1', 'placed', 1), ('2', 'shipped', 2)")
+    con.close()
+    return path
+
+
+def test_test_checks_enum_entries(orders_db):
+    run = DataContract(data_contract_str=CONTRACT.format(database=orders_db)).test()
+
+    print(run.pretty())
+    assert run.result == ResultEnum.passed
+    assert {c.type for c in run.checks if c.type == "field_enum"} == {"field_enum"}
+    assert sum(1 for c in run.checks if c.type == "field_enum") == 2
+
+
+def test_test_fails_on_a_value_outside_the_enum(orders_db):
+    con = duckdb.connect(orders_db)
+    con.execute("INSERT INTO orders VALUES ('3', 'lost', 9)")
+    con.close()
+
+    run = DataContract(data_contract_str=CONTRACT.format(database=orders_db)).test()
+
+    failed = [c for c in run.checks if c.result == ResultEnum.failed]
+    assert {c.type for c in failed} == {"field_enum"}
+    assert len(failed) == 2
+
+
+def test_exporters_read_enum_entries():
+    data_contract = DataContract(data_contract_str=CONTRACT.format(database="orders.duckdb"))
+
+    json_schema = json.loads(data_contract.export("jsonschema"))
+    assert json_schema["properties"]["status"]["enum"] == ["placed", "shipped"]
+    assert json_schema["properties"]["priority"]["enum"] == [1, 2]
+
+    pydantic_model = data_contract.export("pydantic-model")
+    assert "typing.Literal['placed', 'shipped']" in pydantic_model
+    assert "typing.Literal[1, 2]" in pydantic_model
+
+    avro_contract = CONTRACT.format(database="orders.duckdb").replace(
+        "      - name: status\n        logicalType: string\n        physicalType: VARCHAR\n",
+        "      - name: status\n        logicalType: string\n        physicalType: enum\n",
+    )
+    avro = json.loads(DataContract(data_contract_str=avro_contract).export("avro"))
+    status = next(f for f in avro["fields"] if f["name"] == "status")
+    assert status["type"]["type"] == "enum"
+    assert status["type"]["symbols"] == ["placed", "shipped"]
+
+    protobuf = data_contract.export("protobuf")
+    assert "enum Status {" in protobuf
+    assert "PLACED = 0;" in protobuf and "SHIPPED = 1;" in protobuf
+
+    html = data_contract.export("html")
+    assert "Allowed values" in html
+    assert "Handed to the carrier" in html
+
+    dcs = yaml.safe_load(data_contract.export("dcs"))
+    assert dcs["models"]["orders"]["fields"]["status"]["enum"] == ["placed", "shipped"]
+
+
+def test_jsonschema_import_writes_enum_entries(tmp_path):
+    schema = {
+        "type": "object",
+        "properties": {"status": {"type": "string", "enum": ["placed", "shipped"]}},
+    }
+    path = tmp_path / "orders.schema.json"
+    path.write_text(json.dumps(schema))
+
+    result = DataContract.import_from_source("jsonschema", str(path))
+
+    status = result.schema_[0].properties[0]
+    assert [e.value for e in status.enum] == ["placed", "shipped"]
+    assert status.quality is None
+
+
+def test_dcs_import_writes_enum_entries():
+    dcs = """dataContractSpecification: 1.2.0
+id: orders
+info:
+  title: Orders
+  version: 1.0.0
+models:
+  orders:
+    fields:
+      status:
+        type: string
+        enum: [placed, shipped]
+"""
+    result = DataContract(data_contract_str=dcs).get_data_contract()
+
+    status = result.schema_[0].properties[0]
+    assert [e.value for e in status.enum] == ["placed", "shipped"]
+    assert status.quality is None

--- a/tests/test_import_avro.py
+++ b/tests/test_import_avro.py
@@ -97,13 +97,12 @@ schema:
     customProperties:
     - property: avroType
       value: enum
-    - property: avroSymbols
-      value:
-      - PLACED
-      - SHIPPED
-      - DELIVERED
-      - CANCELLED
     logicalType: string
+    enum:
+    - value: PLACED
+    - value: SHIPPED
+    - value: DELIVERED
+    - value: CANCELLED
     required: true
   - name: metadata
     physicalType: map
@@ -403,12 +402,11 @@ schema:
     customProperties:
     - property: avroType
       value: enum
-    - property: avroSymbols
-      value:
-      - RED
-      - GREEN
-      - BLUE
     logicalType: string
+    enum:
+    - value: RED
+    - value: GREEN
+    - value: BLUE
     required: true
   - name: optional_enum
     physicalType: enum
@@ -417,6 +415,10 @@ schema:
       value: enum
     logicalType: string
     required: false
+    enum:
+    - value: ACTIVE
+    - value: INACTIVE
+    - value: PENDING
 """
     print("Result:\n", result.to_yaml())
     assert yaml.safe_load(result.to_yaml()) == yaml.safe_load(expected)


### PR DESCRIPTION
Part of #1560 (#1557). Targets the `odcs-3.2.0` branch.

ODCS v3.2.0 (RFC 0033) declares allowed values as `enum`, a list of entries with a `value` and optional `label`, `description`, `id`, `tags`, `customProperties`, `authoritativeDefinitions`.

### One resolver
`datacontract/model/enum_values.py` reads `enum` first, then the legacy representations in order: `logicalTypeOptions.enum`, the `enum` custom property (list or JSON string, from DCS), the `invalidValues` quality rule. It replaces seven private copies in the avro, jsonschema, great-expectations, data-caterer and sodacl exporters, the check builder and the dbt test mapping. The check builder and sodacl export pass `include_quality_rule=False`, because they turn the quality rule into a check of its own and would otherwise check it twice.

### Producers
`datacontract import` from JSON Schema, Avro (including optional enums in unions, whose symbols were dropped before), Protobuf and DCS writes `enum` entries instead of an `invalidValues` rule or `avroSymbols`/`enumValues` custom properties (`enumValues` stays for the protobuf numbers). `create_property` gained an `enum` argument.

### Consumers that can carry more than values
- `datacontract test`: `field_enum` check from the entries
- pydantic-model: enumerated string and integer properties become `typing.Literal[...]`
- protobuf: `enum` blocks numbered from each entry's `id` when numeric, else by position
- avro: a property with `physicalType: enum` and values exports as an Avro enum without needing the `avroType` custom property
- html: an "Allowed values" list with label and description
- dcs: `field.enum` from any representation

### Tests
New `tests/test_enum_values.py` (resolver priority, DuckDB end-to-end pass and fail, every exporter, JSON Schema and DCS import). Avro and protobuf import expectations updated to the entries. Full suite: 2323 passed.

Docs: `docs/docs/schema.md` uses `enum` entries in its examples and notes that `logicalTypeOptions.enum` is still accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1xhK6DjRLWND1ntBcS8fG
