### PR TITLE
Test and import Iceberg tables through a catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This release adds support for the [Open Data Contract Standard v3.2.0](https://g
 - `datacontract test` reads CSV files from local, s3, gcs and azure servers and Kafka JSON messages in the server's declared `encoding`, and uses the Athena `workgroup` (also `DATACONTRACT_ATHENA_WORKGROUP`), which makes `stagingDir` optional (#1564)
 - The ODCS v3.2.0 server types `hana`, `iceberg`, `exasol`, `teradata`, `ingres`, `vectorwise`, `versant` and `poet` lint and export; `test` explains that it cannot connect to them yet, and the synonyms `fastobjects` and `btrieve` resolve to `poet` and `zen` (#1564)
 - `datacontract export sql --sql-server-type auto` warns before falling back to the snowflake dialect for a server type without one (#1564)
+- `datacontract test` supports the `iceberg` server type: tables are read from the REST catalog named by `catalogUrl`, `namespace` and `warehouse` with pyiceberg (credentials via `DATACONTRACT_ICEBERG_CREDENTIAL` or `DATACONTRACT_ICEBERG_TOKEN`, data files via the S3 options; `DATACONTRACT_ICEBERG_CATALOG_TYPE` selects a `sql`, `glue` or `hive` catalog instead of `rest`), and `datacontract import iceberg --catalog-url` creates a contract from a catalog table with a ready-to-test server (#1565)
 
 ### Changed
 - `datacontract init` and all importers write `apiVersion: v3.2.0` (#1558)

--- a/datacontract/command_import.py
+++ b/datacontract/command_import.py
@@ -461,13 +461,29 @@ def import_spark(
 
 @import_app.command(
     name="iceberg",
-    epilog="Example: datacontract import iceberg --source schema.json --table orders --output datacontract.yaml",
+    epilog="Examples: datacontract import iceberg --source schema.json --table orders --output datacontract.yaml; "
+    "datacontract import iceberg --catalog-url https://polaris.example.com/api/catalog --namespace sales --table orders",
 )
 def import_iceberg(
-    source: Annotated[Optional[str], typer.Option(help="Path to the Iceberg schema JSON file.")] = None,
+    source: Annotated[
+        Optional[str], typer.Option(help="Path to the Iceberg schema JSON file. Omit to read from a REST catalog.")
+    ] = None,
     table: Annotated[
         Optional[str],
-        typer.Option(help="Table name to assign to the model created from the Iceberg schema."),
+        typer.Option(
+            help="Table name to assign to the model created from the Iceberg schema, or the table to load from the catalog."
+        ),
+    ] = None,
+    catalog_url: Annotated[
+        Optional[str],
+        typer.Option(help="REST catalog endpoint to load the table from (DATACONTRACT_ICEBERG_CATALOG_URL)."),
+    ] = None,
+    catalog: Annotated[Optional[str], typer.Option(help="Name of the catalog (DATACONTRACT_ICEBERG_CATALOG).")] = None,
+    namespace: Annotated[
+        Optional[str], typer.Option(help="Namespace of the table in the catalog (DATACONTRACT_ICEBERG_NAMESPACE).")
+    ] = None,
+    warehouse: Annotated[
+        Optional[str], typer.Option(help="Warehouse passed to the catalog (DATACONTRACT_ICEBERG_WAREHOUSE).")
     ] = None,
     output: output_option = None,
     schema: schema_option = None,
@@ -475,10 +491,20 @@ def import_iceberg(
     id: id_option = None,
     debug: debug_option = None,
 ):
-    """Import a data contract from an Iceberg schema."""
+    """Import a data contract from an Iceberg schema file or a REST catalog."""
     enable_debug_logging(debug)
     result = DataContract.import_from_source(
-        config=cli_config(), format="iceberg", source=source, schema=schema, iceberg_table=table, owner=owner, id=id
+        config=cli_config(),
+        format="iceberg",
+        source=source,
+        schema=schema,
+        iceberg_table=table,
+        iceberg_catalog_url=catalog_url,
+        iceberg_catalog=catalog,
+        iceberg_namespace=namespace,
+        iceberg_warehouse=warehouse,
+        owner=owner,
+        id=id,
     )
     _write_result(result, output)
 

--- a/datacontract/config/settings.py
+++ b/datacontract/config/settings.py
@@ -40,6 +40,10 @@ SERVER_OVERRIDE_OPTIONS = {
     "databricks_schema": "schema",
     "duckdb_database": "database",
     "duckdb_schema": "schema",
+    "iceberg_catalog_url": "catalogUrl",
+    "iceberg_catalog": "catalog",
+    "iceberg_namespace": "namespace",
+    "iceberg_warehouse": "warehouse",
     "impala_host": "host",
     "impala_port": "port",
     "impala_database": "database",
@@ -141,6 +145,16 @@ class Config(BaseSettings):
     # gcs
     gcs_key_id: str | None = None
     gcs_secret: SecretStr | None = None
+
+    # iceberg (REST catalog by default; data files use the s3_* options)
+    iceberg_catalog_type: str | None = None
+    iceberg_credential: SecretStr | None = None
+    iceberg_token: SecretStr | None = None
+    # overrides for the contract's servers block
+    iceberg_catalog_url: str | None = None
+    iceberg_catalog: str | None = None
+    iceberg_namespace: str | None = None
+    iceberg_warehouse: str | None = None
 
     # impala
     impala_username: str | None = None
@@ -540,6 +554,28 @@ class Config(BaseSettings):
 
     def get_gcs_secret(self, required: bool = False) -> str | None:
         return self._str_option("gcs_secret", required)
+
+    # --- iceberg ---
+    def get_iceberg_catalog_type(self, required: bool = False) -> str | None:
+        return self._str_option("iceberg_catalog_type", required)
+
+    def get_iceberg_credential(self, required: bool = False) -> str | None:
+        return self._str_option("iceberg_credential", required)
+
+    def get_iceberg_token(self, required: bool = False) -> str | None:
+        return self._str_option("iceberg_token", required)
+
+    def get_iceberg_catalog_url(self, required: bool = False) -> str | None:
+        return self._str_option("iceberg_catalog_url", required)
+
+    def get_iceberg_catalog(self, required: bool = False) -> str | None:
+        return self._str_option("iceberg_catalog", required)
+
+    def get_iceberg_namespace(self, required: bool = False) -> str | None:
+        return self._str_option("iceberg_namespace", required)
+
+    def get_iceberg_warehouse(self, required: bool = False) -> str | None:
+        return self._str_option("iceberg_warehouse", required)
 
     # --- impala ---
     def get_impala_username(self, required: bool = False) -> str | None:

--- a/datacontract/engines/ibis/connections/connect.py
+++ b/datacontract/engines/ibis/connections/connect.py
@@ -83,6 +83,13 @@ def connect_ibis(
     if server_type == "duckdb":
         return _connect_duckdb_database(ibis, server, run, config)
 
+    if server_type == "iceberg":
+        from datacontract.engines.ibis.connections.iceberg import read_iceberg_tables
+
+        run.log_info(f"Connecting to iceberg catalog {server.catalogUrl} via duckdb")
+        con = read_iceberg_tables(data_contract, server, run, duckdb_connection, schema_name=schema_name, config=config)
+        return ibis.duckdb.from_connection(con)
+
     if server_type == "kafka":
         from datacontract.engines.ibis.connections.kafka import read_kafka_topic
 

--- a/datacontract/engines/ibis/connections/iceberg.py
+++ b/datacontract/engines/ibis/connections/iceberg.py
@@ -1,0 +1,143 @@
+"""Read Apache Iceberg tables through a REST catalog (ODCS v3.2.0 `type: iceberg`).
+
+The server names the catalog (``catalog``), its REST endpoint (``catalogUrl``),
+and optionally the ``namespace`` and ``warehouse``. Each schema object is one
+table in that namespace. The table is loaded with pyiceberg, scanned to Arrow,
+and registered in DuckDB, where the checks run like they do for file sources.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from open_data_contract_standard.model import OpenDataContractStandard, Server
+
+from datacontract.config import Config
+from datacontract.model.exceptions import DataContractException
+from datacontract.model.run import ResultEnum, Run
+
+if TYPE_CHECKING:
+    import duckdb
+    from pyiceberg.catalog import Catalog
+    from pyiceberg.table import Table
+
+
+def catalog_properties(server: Server, config: Config | None = None) -> dict[str, str]:
+    """The pyiceberg properties of the server's REST catalog.
+
+    The configuration overrides win over the contract, like the other server
+    details. Credentials come from the configuration only: an OAuth2 client
+    credential (``DATACONTRACT_ICEBERG_CREDENTIAL``, ``client_id:client_secret``)
+    or a bearer token (``DATACONTRACT_ICEBERG_TOKEN``), plus the S3 options for
+    the data files.
+    """
+    config = Config.resolve(config)
+    uri = config.get_iceberg_catalog_url() or getattr(server, "catalogUrl", None)
+    if not uri:
+        raise DataContractException(
+            type="iceberg-connection",
+            name="missing_catalog_url",
+            reason="catalogUrl is required for an Iceberg server (the catalog's REST endpoint or connection URI).",
+            engine="datacontract-cli",
+        )
+    # pyiceberg catalog implementations: rest (default), sql, glue, hive, dynamodb, in-memory
+    properties: dict[str, str] = {"type": config.get_iceberg_catalog_type() or "rest", "uri": uri}
+    warehouse = config.get_iceberg_warehouse() or server.warehouse
+    if warehouse:
+        properties["warehouse"] = warehouse
+    credential = config.get_iceberg_credential()
+    if credential:
+        properties["credential"] = credential
+    token = config.get_iceberg_token()
+    if token:
+        properties["token"] = token
+    for option, key in (
+        (config.get_s3_access_key_id(), "s3.access-key-id"),
+        (config.get_s3_secret_access_key(), "s3.secret-access-key"),
+        (config.get_s3_session_token(), "s3.session-token"),
+        (config.get_s3_region(), "s3.region"),
+    ):
+        if option:
+            properties[key] = option
+    endpoint = getattr(config, "get_s3_endpoint_url", None)
+    endpoint_url = endpoint() if callable(endpoint) else None
+    if endpoint_url:
+        properties["s3.endpoint"] = endpoint_url
+    return properties
+
+
+def load_iceberg_catalog(server: Server, config: Config | None = None) -> Catalog:
+    """Open the server's REST catalog with pyiceberg."""
+    try:
+        from pyiceberg.catalog import load_catalog
+    except ImportError as e:
+        raise DataContractException(
+            type="iceberg-connection",
+            name="missing_dependency",
+            reason=f"pyiceberg is required for Iceberg servers: pip install 'datacontract-cli[iceberg]' ({e})",
+            engine="datacontract-cli",
+        )
+    config = Config.resolve(config)
+    name = config.get_iceberg_catalog() or server.catalog or "default"
+    return load_catalog(name, **catalog_properties(server, config))
+
+
+def table_identifier(server: Server, table_name: str, config: Config | None = None) -> str:
+    """``namespace.table`` for the catalog; a table name that already carries a namespace is kept."""
+    config = Config.resolve(config)
+    namespace = config.get_iceberg_namespace() or server.namespace
+    if namespace and "." not in table_name:
+        return f"{namespace}.{table_name}"
+    return table_name
+
+
+def load_iceberg_table(catalog: Catalog, server: Server, table_name: str, config: Config | None = None) -> Table:
+    identifier = table_identifier(server, table_name, config)
+    try:
+        from pyiceberg.exceptions import NoSuchTableError
+    except ImportError:  # pragma: no cover - pyiceberg is present when a catalog was loaded
+        NoSuchTableError = Exception
+    try:
+        return catalog.load_table(identifier)
+    except NoSuchTableError as e:
+        raise DataContractException(
+            type="iceberg-connection",
+            name="missing_table",
+            reason=f"Table '{identifier}' was not found in the Iceberg catalog: {e}",
+            engine="datacontract-cli",
+        )
+
+
+def read_iceberg_tables(
+    data_contract: OpenDataContractStandard,
+    server: Server,
+    run: Run,
+    duckdb_connection: duckdb.DuckDBPyConnection | None = None,
+    schema_name: str = "all",
+    config: Config | None = None,
+) -> duckdb.DuckDBPyConnection:
+    """Register every schema object of the contract as a DuckDB view over the Iceberg table's Arrow data."""
+    import duckdb
+
+    con = duckdb_connection if duckdb_connection is not None else duckdb.connect(database=":memory:")
+    catalog = load_iceberg_catalog(server, config)
+    for schema_obj in data_contract.schema_ or []:
+        if schema_name != "all" and schema_obj.name != schema_name:
+            continue
+        table_name = schema_obj.physicalName or schema_obj.name
+        run.log_info(f"Reading Iceberg table {table_identifier(server, table_name, config)}")
+        try:
+            table = load_iceberg_table(catalog, server, table_name, config)
+            arrow_table = table.scan().to_arrow()
+        except DataContractException:
+            raise
+        except Exception as e:
+            raise DataContractException(
+                type="iceberg-connection",
+                name="read_table",
+                result=ResultEnum.failed,
+                reason=f"Cannot read Iceberg table '{table_name}': {e}",
+                engine="datacontract-cli",
+            )
+        con.register(schema_obj.name, arrow_table)
+    return con

--- a/datacontract/engines/ibis/ibis_check_execute.py
+++ b/datacontract/engines/ibis/ibis_check_execute.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 # are read with duckdb, so naming the server type would send users to an extra
 # that does not exist (`local`) or to an unrelated one (`api` installs the web
 # server dependencies, not a test backend).
-_INSTALL_EXTRAS = {"local": "duckdb", "api": "duckdb"}
+_INSTALL_EXTRAS = {"local": "duckdb", "api": "duckdb", "iceberg": "iceberg"}
 
 
 def install_extra_for(server_type: Optional[str]) -> str:

--- a/datacontract/imports/iceberg_importer.py
+++ b/datacontract/imports/iceberg_importer.py
@@ -3,22 +3,62 @@ from pydantic import ValidationError
 from pyiceberg import types as iceberg_types
 from pyiceberg.schema import Schema
 
+from datacontract.config import Config
 from datacontract.imports.importer import Importer
 from datacontract.imports.odcs_helper import (
     create_odcs,
     create_property,
     create_schema_object,
+    create_server,
 )
 from datacontract.model.exceptions import DataContractException
 
 
 class IcebergImporter(Importer):
-    def import_source(self, source: str, import_args: dict) -> OpenDataContractStandard:
+    def import_source(self, source: str, import_args: dict, config: "Config | None" = None) -> OpenDataContractStandard:
+        config = Config.resolve(config)
+        catalog_url = import_args.get("iceberg_catalog_url") or config.get_iceberg_catalog_url()
+        if source is None and catalog_url:
+            return import_from_catalog(import_args, config, catalog_url)
+        if source is None:
+            raise DataContractException(
+                type="schema",
+                name="Import iceberg",
+                reason="Pass --source with a schema JSON file, or --catalog-url and --table to read from a REST catalog.",
+                engine="datacontract-cli",
+            )
         schema = load_and_validate_iceberg_schema(source)
         return import_iceberg(
             schema,
             import_args.get("iceberg_table"),
         )
+
+
+def import_from_catalog(import_args: dict, config: "Config", catalog_url: str) -> OpenDataContractStandard:
+    """Import a table's schema from a REST catalog and describe the catalog as the contract's server."""
+    from datacontract.engines.ibis.connections.iceberg import load_iceberg_catalog, load_iceberg_table
+
+    table_name = import_args.get("iceberg_table")
+    if not table_name:
+        raise DataContractException(
+            type="schema",
+            name="Import iceberg",
+            reason="--table is required when importing from a catalog.",
+            engine="datacontract-cli",
+        )
+    server = create_server(
+        name="production",
+        server_type="iceberg",
+        catalog=import_args.get("iceberg_catalog") or config.get_iceberg_catalog(),
+        warehouse=import_args.get("iceberg_warehouse") or config.get_iceberg_warehouse(),
+    )
+    server.catalogUrl = catalog_url
+    server.namespace = import_args.get("iceberg_namespace") or config.get_iceberg_namespace()
+    catalog = load_iceberg_catalog(server, config)
+    table = load_iceberg_table(catalog, server, table_name, config)
+    odcs = import_iceberg(table.schema(), table_name.split(".")[-1])
+    odcs.servers = [server]
+    return odcs
 
 
 def load_and_validate_iceberg_schema(source: str) -> Schema:

--- a/datacontract/model/server.py
+++ b/datacontract/model/server.py
@@ -34,7 +34,6 @@ LINT_ONLY_SERVER_TYPES = {
     "exasol",
     "hana",
     "hive",
-    "iceberg",
     "informix",
     "ingres",
     "poet",

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -197,6 +197,18 @@ Every option, by its environment variable name and the matching `Config` field. 
 | `DATACONTRACT_GCS_KEY_ID` | `gcs_key_id` | string |  |
 | `DATACONTRACT_GCS_SECRET` | `gcs_secret` | string (secret) |  |
 
+### Iceberg
+
+| Environment variable | `Config` field | Type | Notes |
+|---|---|---|---|
+| `DATACONTRACT_ICEBERG_CATALOG_TYPE` | `iceberg_catalog_type` | string |  |
+| `DATACONTRACT_ICEBERG_CREDENTIAL` | `iceberg_credential` | string (secret) |  |
+| `DATACONTRACT_ICEBERG_TOKEN` | `iceberg_token` | string (secret) |  |
+| `DATACONTRACT_ICEBERG_CATALOG_URL` | `iceberg_catalog_url` | string | Overrides `catalogUrl` from the contract's `servers` block |
+| `DATACONTRACT_ICEBERG_CATALOG` | `iceberg_catalog` | string | Overrides `catalog` from the contract's `servers` block |
+| `DATACONTRACT_ICEBERG_NAMESPACE` | `iceberg_namespace` | string | Overrides `namespace` from the contract's `servers` block |
+| `DATACONTRACT_ICEBERG_WAREHOUSE` | `iceberg_warehouse` | string | Overrides `warehouse` from the contract's `servers` block |
+
 ### Impala
 
 | Environment variable | `Config` field | Type | Notes |

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -135,7 +135,7 @@ Available extras:
 | DuckDB (local file and API response testing) | `pip install datacontract-cli[duckdb]` |
 | Excel | `pip install datacontract-cli[excel]` |
 | GCS integration | `pip install datacontract-cli[gcs]` |
-| Iceberg | `pip install datacontract-cli[iceberg]` |
+| Apache Iceberg (schema import and export, REST catalog testing) | `pip install datacontract-cli[iceberg]` |
 | Impala | `pip install datacontract-cli[impala]` |
 | Kafka integration | `pip install datacontract-cli[kafka]` |
 | MySQL integration | `pip install datacontract-cli[mysql]` |

--- a/docs/docs/reference/api.md
+++ b/docs/docs/reference/api.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 10
 title: "HTTP API Reference"
 sidebar_label: "HTTP API"
 description: "All HTTP API authentication options and data type handling."

--- a/docs/docs/reference/azure.md
+++ b/docs/docs/reference/azure.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 title: "Azure Blob / ADLS Reference"
 sidebar_label: "Azure Blob / ADLS"
 description: "All Azure storage authentication options and data type handling."

--- a/docs/docs/reference/bigquery.md
+++ b/docs/docs/reference/bigquery.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 title: "Google BigQuery Reference"
 sidebar_label: "Google BigQuery"
 description: "All BigQuery authentication options and data type mappings."

--- a/docs/docs/reference/databricks.md
+++ b/docs/docs/reference/databricks.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 title: "Databricks Reference"
 sidebar_label: "Databricks"
 description: "All Databricks authentication options and data type mappings."

--- a/docs/docs/reference/dataframe.md
+++ b/docs/docs/reference/dataframe.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 17
+sidebar_position: 18
 title: "Spark DataFrame Reference"
 sidebar_label: "Spark DataFrame"
 description: "Data type mappings for in-memory Spark DataFrames."

--- a/docs/docs/reference/gcs.md
+++ b/docs/docs/reference/gcs.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 title: "Google Cloud Storage Reference"
 sidebar_label: "Google Cloud Storage"
 description: "All GCS authentication options and data type handling."

--- a/docs/docs/reference/iceberg.md
+++ b/docs/docs/reference/iceberg.md
@@ -1,0 +1,64 @@
+---
+sidebar_position: 4
+title: "Apache Iceberg Reference"
+sidebar_label: "Apache Iceberg"
+description: "Authentication and data type handling for Apache Iceberg REST catalogs."
+---
+
+# <img className="page-icon" src="/img/icons/iceberg.svg" alt="" /> Apache Iceberg Reference
+
+Authentication and data type handling for [Apache Iceberg connections](../testing/iceberg.md).
+
+## Server
+
+```yaml
+servers:
+  - server: production
+    type: iceberg
+    catalog: main                                       # the catalog's name
+    catalogUrl: https://polaris.example.com/api/catalog # the REST catalog endpoint
+    namespace: sales                                    # optional; prefixed to every table name
+    warehouse: s3://warehouse                           # optional; passed to the catalog
+```
+
+## Configuration
+
+| Environment variable | Purpose |
+|---|---|
+| `DATACONTRACT_ICEBERG_CREDENTIAL` | OAuth2 client credential for the catalog, as `client_id:client_secret` |
+| `DATACONTRACT_ICEBERG_TOKEN` | Bearer token for the catalog, instead of a credential |
+| `DATACONTRACT_ICEBERG_CATALOG_URL`, `DATACONTRACT_ICEBERG_CATALOG`, `DATACONTRACT_ICEBERG_NAMESPACE`, `DATACONTRACT_ICEBERG_WAREHOUSE` | Override the matching field of the contract's `servers` block |
+| `DATACONTRACT_ICEBERG_CATALOG_TYPE` | The pyiceberg catalog implementation: `rest` (default), `sql`, `glue`, `hive`, `dynamodb`. For `sql`, `catalogUrl` is the SQLAlchemy connection URI |
+| `DATACONTRACT_S3_ACCESS_KEY_ID`, `DATACONTRACT_S3_SECRET_ACCESS_KEY`, `DATACONTRACT_S3_SESSION_TOKEN`, `DATACONTRACT_S3_REGION` | Credentials for the data files on S3; not needed when the catalog vends them |
+
+The full list is on the [Configuration](../configuration.md) page.
+
+## Data types
+
+### Importing
+
+`datacontract import iceberg` reads the table schema from the catalog (or from a schema JSON file with `--source`):
+
+| Iceberg type | `logicalType` |
+|---|---|
+| `string`, `uuid` | `string` |
+| `int`, `long` | `integer` |
+| `float`, `double`, `decimal(p,s)` | `number` |
+| `boolean` | `boolean` |
+| `date` | `date` |
+| `timestamp`, `timestamptz` | `timestamp` |
+| `time` | `time` |
+| `struct<...>` | `object` with `properties` |
+| `list<...>` | `array` with `items` |
+| `map<k,v>` | `map` with `key` and `value` |
+| `binary`, `fixed` | `string` |
+
+The Iceberg type is kept as `physicalType`, and the field id as the `icebergFieldId` custom property.
+
+### Testing
+
+The table is scanned to Arrow and registered in DuckDB, so the type checks compare the declared `logicalType` against the DuckDB type of the Arrow column: structs become `STRUCT`, lists `LIST`, and maps `MAP`, which the nested type checks walk. `physicalType` checks against the catalog's declared type are not run for Iceberg; the logical type check runs instead.
+
+### Exporting
+
+`datacontract export iceberg` writes an Iceberg schema JSON from the contract; the mapping is the reverse of the import table above, with `number` becoming `decimal(38,0)` and `integer` becoming `long`.

--- a/docs/docs/reference/impala.md
+++ b/docs/docs/reference/impala.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 title: "Apache Impala Reference"
 sidebar_label: "Apache Impala"
 description: "All Impala authentication options and data type handling."

--- a/docs/docs/reference/index.md
+++ b/docs/docs/reference/index.md
@@ -44,6 +44,10 @@ Independent of the type checks, `logicalTypeOptions` (`minimum`, `maximum`, `min
     <img src="/img/icons/s3.svg" alt="" />
     <span><span className="doc-card-title">Amazon S3</span><span className="doc-card-desc">Authentication and data types</span></span>
   </a>
+  <a className="doc-card" href="/reference/iceberg">
+    <img src="/img/icons/iceberg.svg" alt="" />
+    <span><span className="doc-card-title">Apache Iceberg</span><span className="doc-card-desc">Authentication and data types</span></span>
+  </a>
   <a className="doc-card" href="/reference/impala">
     <img src="/img/icons/impala.svg" alt="" />
     <span><span className="doc-card-title">Apache Impala</span><span className="doc-card-desc">Authentication and data types</span></span>

--- a/docs/docs/reference/kafka.md
+++ b/docs/docs/reference/kafka.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 11
 title: "Kafka Reference"
 sidebar_label: "Kafka"
 description: "All Kafka authentication options and data type mappings."

--- a/docs/docs/reference/local.md
+++ b/docs/docs/reference/local.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 title: "Local Files Reference"
 sidebar_label: "Local files"
 description: "Data type handling for local CSV, JSON, Parquet, and Delta files."

--- a/docs/docs/reference/mysql.md
+++ b/docs/docs/reference/mysql.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 14
 title: "MySQL Reference"
 sidebar_label: "MySQL"
 description: "All MySQL authentication options and data type mappings."

--- a/docs/docs/reference/oracle.md
+++ b/docs/docs/reference/oracle.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 15
 title: "Oracle Reference"
 sidebar_label: "Oracle"
 description: "All Oracle authentication options and data type mappings."

--- a/docs/docs/reference/postgres.md
+++ b/docs/docs/reference/postgres.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 16
 title: "Postgres Reference"
 sidebar_label: "Postgres"
 description: "All Postgres authentication options and data type mappings."

--- a/docs/docs/reference/snowflake.md
+++ b/docs/docs/reference/snowflake.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 17
 title: "Snowflake Reference"
 sidebar_label: "Snowflake"
 description: "All Snowflake authentication options and data type mappings."

--- a/docs/docs/reference/sqlserver.md
+++ b/docs/docs/reference/sqlserver.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 13
 title: "Microsoft SQL Server Reference"
 sidebar_label: "Microsoft SQL Server"
 description: "All SQL Server authentication options and data type mappings."

--- a/docs/docs/reference/trino.md
+++ b/docs/docs/reference/trino.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 18
+sidebar_position: 19
 title: "Trino Reference"
 sidebar_label: "Trino"
 description: "All Trino authentication options and data type handling."

--- a/docs/docs/testing/api.md
+++ b/docs/docs/testing/api.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 11
 title: "HTTP API"
 description: "Create a data contract from a JSON HTTP API and test the responses against it (GET requests only)."
 ---

--- a/docs/docs/testing/azure.md
+++ b/docs/docs/testing/azure.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 title: "Azure Blob / ADLS"
 description: "Create a data contract from files on Azure Blob storage or ADLS Gen2 and test them against it."
 ---

--- a/docs/docs/testing/bigquery.md
+++ b/docs/docs/testing/bigquery.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 title: "Google BigQuery"
 description: "Create a data contract from your BigQuery tables and test the actual data against it — in about 5 minutes."
 ---

--- a/docs/docs/testing/databricks.md
+++ b/docs/docs/testing/databricks.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 title: "Databricks"
 description: "Create a data contract from Unity Catalog and test the actual data against it — in about 5 minutes."
 ---

--- a/docs/docs/testing/dataframe.md
+++ b/docs/docs/testing/dataframe.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 18
+sidebar_position: 19
 title: "Spark DataFrame"
 description: "Test in-memory Spark DataFrames in a pipeline (programmatic)."
 ---

--- a/docs/docs/testing/duckdb.md
+++ b/docs/docs/testing/duckdb.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 title: "DuckDB"
 description: "Test the tables inside a DuckDB database file."
 ---

--- a/docs/docs/testing/gcs.md
+++ b/docs/docs/testing/gcs.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 10
 title: "Google Cloud Storage"
 description: "Create a data contract from files on Google Cloud Storage and test them against it."
 ---

--- a/docs/docs/testing/iceberg.md
+++ b/docs/docs/testing/iceberg.md
@@ -1,0 +1,84 @@
+---
+sidebar_position: 4
+title: "Apache Iceberg"
+description: "Test Apache Iceberg tables through a REST catalog (Polaris, Nessie, Unity Catalog, Glue, S3 Tables) in 5 minutes."
+---
+
+# <img className="page-icon" src="/img/icons/iceberg.svg" alt="" /> Apache Iceberg
+
+Test Apache Iceberg tables through a REST catalog such as Polaris, Nessie, Unity Catalog, AWS Glue, or S3 Tables. The CLI loads each table with [pyiceberg](https://py.iceberg.apache.org/), scans it to Arrow, and runs the checks in DuckDB.
+
+## 1. Install
+
+```bash
+uv tool install --python python3.11 --upgrade 'datacontract-cli[iceberg]'
+```
+
+See [Installation](../installation.md) for pip, pipx, and Docker.
+
+## 2. Authenticate
+
+The catalog and the data files are separate. The catalog takes an OAuth2 client credential or a bearer token; the data files on S3 use the same `DATACONTRACT_S3_*` options as the [S3](./s3.md) source.
+
+```bash
+# catalog: one of
+export DATACONTRACT_ICEBERG_CREDENTIAL=client_id:client_secret
+export DATACONTRACT_ICEBERG_TOKEN=eyJ...
+
+# data files (skip when the catalog vends credentials)
+export DATACONTRACT_S3_ACCESS_KEY_ID=...
+export DATACONTRACT_S3_SECRET_ACCESS_KEY=...
+export DATACONTRACT_S3_REGION=eu-central-1
+```
+
+## 3. Create a contract from a table
+
+```bash
+datacontract import iceberg --catalog-url https://polaris.example.com/api/catalog \
+  --namespace sales --table orders --output datacontract.yaml
+```
+
+The contract gets the table's schema, with `map`, `list`, and `struct` columns expanded, and a ready-to-test `servers` block:
+
+```yaml
+servers:
+  - server: production
+    type: iceberg
+    catalog: main
+    catalogUrl: https://polaris.example.com/api/catalog
+    namespace: sales
+```
+
+`datacontract import iceberg --source schema.json` still imports from a schema file, without a server.
+
+## 4. Test the actual data
+
+```bash
+datacontract test datacontract.yaml
+```
+
+Each schema object is one table in the namespace. A `physicalName` on the schema object names the table when it differs from the schema name; a name with a dot is used as the full identifier.
+
+## 5. Let it catch a violation
+
+Add a `quality` rule to the contract and run the test again:
+
+```yaml
+    quality:
+      - type: sql
+        description: No order without lines
+        query: SELECT count(*) FROM orders WHERE cardinality(lines) = 0
+        mustBe: 0
+```
+
+The query runs in DuckDB against the scanned table, so DuckDB's SQL dialect applies.
+
+## Reference
+
+All options and the data type handling: **[Apache Iceberg Reference](../reference/iceberg.md)**.
+
+## Troubleshooting
+
+- **`catalogUrl is required`** — the server needs the REST endpoint in `catalogUrl`, or `DATACONTRACT_ICEBERG_CATALOG_URL`.
+- **`Table 'sales.orders' was not found`** — check `namespace`; the identifier the CLI asked for is in the message.
+- **`403` while reading data files** — the catalog answered, but the data files on object storage did not. Set the `DATACONTRACT_S3_*` options, or use a catalog that vends credentials.

--- a/docs/docs/testing/impala.md
+++ b/docs/docs/testing/impala.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 title: "Apache Impala"
 description: "Create a data contract from your Impala tables and test the actual data against it."
 ---

--- a/docs/docs/testing/index.md
+++ b/docs/docs/testing/index.md
@@ -52,6 +52,10 @@ datacontract test --server production datacontract.yaml
     <img src="/img/icons/athena.svg" alt="" />
     <span><span className="doc-card-title">Amazon Athena</span><span className="doc-card-desc">Athena over data in S3</span></span>
   </a>
+  <a className="doc-card" href="/testing/iceberg">
+    <img src="/img/icons/iceberg.svg" alt="" />
+    <span><span className="doc-card-title">Apache Iceberg</span><span className="doc-card-desc">Tables in a REST catalog (Polaris, Nessie, Unity, Glue, S3 Tables)</span></span>
+  </a>
   <a className="doc-card" href="/testing/impala">
     <img src="/img/icons/impala.svg" alt="" />
     <span><span className="doc-card-title">Apache Impala</span><span className="doc-card-desc">Impala</span></span>
@@ -100,7 +104,7 @@ Missing a source? [Open an issue on GitHub](https://github.com/datacontract/data
 
 Each connection requires the matching [optional dependency (extra)](../installation.md#optional-dependencies-extras), or install everything with `datacontract-cli[all]`.
 
-Every other server `type` in ODCS, including the ones added in v3.2.0 (`hana`, `iceberg`, `exasol`, `teradata`, `ingres`, `vectorwise`, `versant`, `poet`), lints and exports, but `test` reports a warning that it cannot connect. `fastobjects` and `btrieve` are the ODCS synonyms of `poet` and `zen`, and `postgresql` of `postgres`.
+Every other server `type` in ODCS, including the ones added in v3.2.0 (`hana`, `exasol`, `teradata`, `ingres`, `vectorwise`, `versant`, `poet`), lints and exports, but `test` reports a warning that it cannot connect. `fastobjects` and `btrieve` are the ODCS synonyms of `poet` and `zen`, and `postgresql` of `postgres`.
 
 ## How it works
 

--- a/docs/docs/testing/kafka.md
+++ b/docs/docs/testing/kafka.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 title: "Kafka"
 description: "Create a data contract for a Kafka topic and test the messages against it (experimental)."
 ---

--- a/docs/docs/testing/local.md
+++ b/docs/docs/testing/local.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 13
 title: "Local files"
 description: "Test local files in Parquet, JSON, CSV, or Delta format — the fastest way to try the CLI, no credentials needed."
 ---

--- a/docs/docs/testing/mysql.md
+++ b/docs/docs/testing/mysql.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 15
 title: "MySQL"
 description: "Create a data contract from your MySQL tables and test the actual data against it."
 ---

--- a/docs/docs/testing/oracle.md
+++ b/docs/docs/testing/oracle.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 16
 title: "Oracle"
 description: "Create a data contract from your Oracle tables and test the actual data against it."
 ---

--- a/docs/docs/testing/postgres.md
+++ b/docs/docs/testing/postgres.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 17
 title: "Postgres"
 description: "Create a data contract from your Postgres tables and test the actual data against it — in about 5 minutes."
 ---

--- a/docs/docs/testing/snowflake.md
+++ b/docs/docs/testing/snowflake.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 17
+sidebar_position: 18
 title: "Snowflake"
 description: "Create a data contract from your Snowflake tables and test the actual data against it — in about 5 minutes."
 ---

--- a/docs/docs/testing/sqlserver.md
+++ b/docs/docs/testing/sqlserver.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 14
 title: "Microsoft SQL Server"
 description: "Create a data contract from your SQL Server tables and test the actual data against it."
 ---

--- a/docs/docs/testing/trino.md
+++ b/docs/docs/testing/trino.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 19
+sidebar_position: 20
 title: "Trino"
 description: "Create a data contract from your Trino tables and test the actual data against it."
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,8 @@ databricks-runtime = [
 ]
 
 iceberg = [
-  "pyiceberg==0.11.1"
+  "pyiceberg[pyarrow]==0.11.1",
+  "datacontract-cli[duckdb]"
 ]
 
 # Kafka needs no JVM: the topic is consumed with confluent-kafka, decoded in

--- a/tests/test_test_iceberg.py
+++ b/tests/test_test_iceberg.py
@@ -1,0 +1,229 @@
+"""`type: iceberg` (ODCS v3.2.0): test and import through a REST catalog, with the catalog faked."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pyarrow
+import pytest
+from open_data_contract_standard.model import Server
+from pyiceberg.exceptions import NoSuchTableError
+from pyiceberg.schema import Schema
+from pyiceberg.types import IntegerType, MapType, NestedField, StringType
+
+from datacontract.data_contract import DataContract
+from datacontract.engines.ibis.connections.iceberg import catalog_properties, table_identifier
+from datacontract.model.exceptions import DataContractException
+from datacontract.model.run import ResultEnum
+
+CONTRACT = """apiVersion: v3.2.0
+kind: DataContract
+id: orders-iceberg
+name: Orders
+version: 1.0.0
+status: active
+servers:
+  - server: production
+    type: iceberg
+    catalog: main
+    catalogUrl: https://polaris.example.com/api/catalog
+    namespace: sales
+schema:
+  - name: orders
+    properties:
+      - name: order_id
+        logicalType: string
+        required: true
+        unique: true
+      - name: order_total
+        logicalType: integer
+        logicalTypeOptions:
+          minimum: 0
+      - name: attributes
+        logicalType: map
+        map:
+          key:
+            logicalType: string
+          value:
+            logicalType: integer
+    quality:
+      - type: sql
+        description: two orders
+        query: SELECT count(*) FROM orders
+        mustBe: 2
+"""
+
+ORDERS = pyarrow.table(
+    {
+        "order_id": pyarrow.array(["1", "2"]),
+        "order_total": pyarrow.array([100, 200], type=pyarrow.int64()),
+        "attributes": pyarrow.array([[("a", 1)], [("b", 2)]], type=pyarrow.map_(pyarrow.string(), pyarrow.int64())),
+    }
+)
+
+ORDERS_SCHEMA = Schema(
+    NestedField(1, "order_id", StringType(), required=True),
+    NestedField(2, "order_total", IntegerType(), required=False),
+    NestedField(3, "attributes", MapType(4, StringType(), 5, IntegerType(), value_required=False), required=False),
+    identifier_field_ids=[1],
+)
+
+
+class FakeCatalog:
+    def __init__(self, tables: dict[str, pyarrow.Table]):
+        self.tables = tables
+        self.loaded: list[str] = []
+
+    def load_table(self, identifier):
+        self.loaded.append(identifier)
+        if identifier not in self.tables:
+            raise NoSuchTableError(identifier)
+        arrow = self.tables[identifier]
+        return SimpleNamespace(scan=lambda: SimpleNamespace(to_arrow=lambda: arrow), schema=lambda: ORDERS_SCHEMA)
+
+
+@pytest.fixture
+def catalog(monkeypatch):
+    for name in [
+        "DATACONTRACT_ICEBERG_CATALOG_URL",
+        "DATACONTRACT_ICEBERG_CATALOG",
+        "DATACONTRACT_ICEBERG_NAMESPACE",
+        "DATACONTRACT_ICEBERG_WAREHOUSE",
+        "DATACONTRACT_ICEBERG_TOKEN",
+        "DATACONTRACT_ICEBERG_CREDENTIAL",
+    ]:
+        monkeypatch.delenv(name, raising=False)
+    fake = FakeCatalog({"sales.orders": ORDERS})
+    with patch("pyiceberg.catalog.load_catalog", return_value=fake) as load_catalog:
+        fake.load_catalog = load_catalog
+        yield fake
+
+
+def test_test_reads_the_tables_from_the_catalog(catalog):
+    run = DataContract(data_contract_str=CONTRACT).test()
+
+    print(run.pretty())
+    assert run.result == ResultEnum.passed
+    assert catalog.loaded == ["sales.orders"]
+    name, properties = catalog.load_catalog.call_args.args[0], catalog.load_catalog.call_args.kwargs
+    assert name == "main"
+    assert properties == {"type": "rest", "uri": "https://polaris.example.com/api/catalog"}
+    assert any(c.type == "field_nested_type" and c.result == ResultEnum.passed for c in run.checks)
+
+
+def test_a_missing_table_fails_with_the_identifier(catalog):
+    contract = CONTRACT.replace("    namespace: sales\n", "    namespace: finance\n")
+
+    run = DataContract(data_contract_str=contract).test()
+
+    assert run.result == ResultEnum.failed
+    reason = next(c.reason for c in run.checks if c.result == ResultEnum.failed)
+    assert "finance.orders" in reason and "not found" in reason
+
+
+def test_configuration_overrides_and_credentials(catalog, monkeypatch):
+    monkeypatch.setenv("DATACONTRACT_ICEBERG_CATALOG_URL", "https://nessie.example.com/iceberg")
+    monkeypatch.setenv("DATACONTRACT_ICEBERG_WAREHOUSE", "s3://warehouse")
+    monkeypatch.setenv("DATACONTRACT_ICEBERG_CREDENTIAL", "id:secret")
+    monkeypatch.setenv("DATACONTRACT_S3_ACCESS_KEY_ID", "AKIA")
+    monkeypatch.setenv("DATACONTRACT_S3_SECRET_ACCESS_KEY", "s3cr3t")
+    monkeypatch.setenv("DATACONTRACT_S3_REGION", "eu-central-1")
+
+    server = Server(server="production", type="iceberg", catalogUrl="https://polaris.example.com/api/catalog")
+
+    assert catalog_properties(server) == {
+        "type": "rest",
+        "uri": "https://nessie.example.com/iceberg",
+        "warehouse": "s3://warehouse",
+        "credential": "id:secret",
+        "s3.access-key-id": "AKIA",
+        "s3.secret-access-key": "s3cr3t",
+        "s3.region": "eu-central-1",
+    }
+
+
+def test_a_missing_catalog_url_is_an_error():
+    with pytest.raises(DataContractException, match="catalogUrl"):
+        catalog_properties(Server(server="production", type="iceberg"))
+
+
+def test_table_identifier_uses_the_namespace_unless_the_name_carries_one():
+    server = Server(server="production", type="iceberg", namespace="sales")
+    assert table_identifier(server, "orders") == "sales.orders"
+    assert table_identifier(server, "finance.invoices") == "finance.invoices"
+    assert table_identifier(Server(server="production", type="iceberg"), "orders") == "orders"
+
+
+def test_import_from_the_catalog_writes_schema_and_server(catalog):
+    result = DataContract.import_from_source(
+        "iceberg",
+        iceberg_catalog_url="https://polaris.example.com/api/catalog",
+        iceberg_catalog="main",
+        iceberg_namespace="sales",
+        iceberg_table="orders",
+    )
+
+    assert catalog.loaded == ["sales.orders"]
+    schema = result.schema_[0]
+    assert schema.name == "orders"
+    assert [p.name for p in schema.properties] == ["order_id", "order_total", "attributes"]
+    assert schema.properties[0].primaryKey is True
+    assert schema.properties[2].logicalType == "map"
+    assert schema.properties[2].map.value.logicalType == "integer"
+    server = result.servers[0]
+    assert server.type == "iceberg"
+    assert server.catalog == "main"
+    assert server.catalogUrl == "https://polaris.example.com/api/catalog"
+    assert server.namespace == "sales"
+
+
+def test_import_from_a_schema_file_still_works():
+    result = DataContract.import_from_source("iceberg", "fixtures/iceberg/simple_schema.json", iceberg_table="orders")
+
+    assert result.schema_[0].name == "orders"
+    assert not result.servers
+
+
+# --- a real catalog: pyiceberg's SQL catalog with an Iceberg table written to a temp directory ------
+
+
+@pytest.fixture
+def sql_catalog(tmp_path, monkeypatch):
+    pytest.importorskip("sqlalchemy")
+    from pyiceberg.catalog import load_catalog
+
+    uri = f"sqlite:///{tmp_path}/catalog.db"
+    warehouse = f"file://{tmp_path}/warehouse"
+    catalog = load_catalog("test", type="sql", uri=uri, warehouse=warehouse)
+    catalog.create_namespace("sales")
+    catalog.create_table("sales.orders", schema=ORDERS.schema).append(ORDERS)
+    monkeypatch.setenv("DATACONTRACT_ICEBERG_CATALOG_TYPE", "sql")
+    for name in ["DATACONTRACT_ICEBERG_TOKEN", "DATACONTRACT_ICEBERG_CREDENTIAL"]:
+        monkeypatch.delenv(name, raising=False)
+    return uri, warehouse
+
+
+def test_test_against_a_real_iceberg_table(sql_catalog):
+    uri, warehouse = sql_catalog
+    contract = CONTRACT.replace(
+        "    catalogUrl: https://polaris.example.com/api/catalog\n",
+        f"    catalogUrl: {uri}\n    warehouse: {warehouse}\n",
+    ).replace("    catalog: main\n", "    catalog: test\n")
+
+    run = DataContract(data_contract_str=contract).test()
+
+    print(run.pretty())
+    assert run.result == ResultEnum.passed, [c.reason for c in run.checks if c.reason]
+
+
+def test_import_from_a_real_iceberg_table(sql_catalog):
+    uri, warehouse = sql_catalog
+
+    result = DataContract.import_from_source(
+        "iceberg", iceberg_catalog_url=uri, iceberg_catalog="test", iceberg_namespace="sales", iceberg_table="orders"
+    )
+
+    properties = {p.name: p for p in result.schema_[0].properties}
+    assert properties["order_total"].logicalType == "integer"
+    assert properties["attributes"].logicalType == "map"
+    assert properties["attributes"].map.key.logicalType == "string"
+    assert result.servers[0].catalogUrl == uri

--- a/update_config_options.py
+++ b/update_config_options.py
@@ -30,6 +30,7 @@ GROUPS = {
     "databricks": "Databricks",
     "duckdb": "DuckDB",
     "gcs": "GCS",
+    "iceberg": "Iceberg",
     "impala": "Impala",
     "kafka": "Kafka",
     "mysql": "MySQL",


### PR DESCRIPTION
Part of #1565 (#1557). Targets the `odcs-3.2.0` branch.

### `datacontract test` with `type: iceberg`
`datacontract/engines/ibis/connections/iceberg.py` opens the catalog named by `catalog`, `catalogUrl`, `namespace` and `warehouse` with pyiceberg, loads each schema object's table (`physicalName` or `name`, prefixed with the namespace unless the name already carries one), scans it to Arrow and registers it in DuckDB. The checks then run exactly like they do for file sources, including the nested type checks for structs, lists and maps.

- Catalog credentials: `DATACONTRACT_ICEBERG_CREDENTIAL` (`client_id:client_secret`) or `DATACONTRACT_ICEBERG_TOKEN`. Data files: the existing `DATACONTRACT_S3_*` options, passed as pyiceberg's `s3.*` properties.
- Overrides: `DATACONTRACT_ICEBERG_CATALOG_URL`, `_CATALOG`, `_NAMESPACE`, `_WAREHOUSE`, like the other servers.
- `DATACONTRACT_ICEBERG_CATALOG_TYPE` selects the pyiceberg implementation: `rest` by default, or `sql`, `glue`, `hive`, `dynamodb`.
- A missing table fails with the identifier the CLI asked for; a missing `catalogUrl` and a missing pyiceberg install fail with an explanation.

### `datacontract import iceberg --catalog-url`
Reads the table schema from the catalog (with `--catalog`, `--namespace`, `--warehouse`, `--table`) and writes a contract with a ready-to-test `iceberg` server. `--source schema.json` still imports a schema file without a server.

### Extras and docs
The `iceberg` extra now pulls in `pyiceberg[pyarrow]` and duckdb. New `testing/iceberg.md` and `reference/iceberg.md` pages, cards on both index pages, sidebar positions shifted, `iceberg` removed from the lint-only list, configuration page regenerated.

### Tests
`tests/test_test_iceberg.py`: with a faked catalog (dispatch, identifiers, missing table, overrides and credential properties, import), and with a real one: pyiceberg's SQL catalog writes an Iceberg table with string, integer and map columns to a temp directory, and `test` and `import` read it back through the real scan path. No REST server is exercised; that would need a container such as `tabulario/iceberg-rest` plus object storage and belongs in the testcontainers suite if wanted. Full suite: 2492 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1xhK6DjRLWND1ntBcS8fG
