### PR TITLE
Resolve variables in runtime contract inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This release adds support for the [Open Data Contract Standard v3.2.0](https://github.com/bitol-io/open-data-contract-standard/blob/main/CHANGELOG.md). Development happens on the `odcs-3.2.0` branch, tracked in #1557.
 
 ### Added
+- `datacontract test` resolves variables in property names, enum values, nested type options, library quality arguments, and service levels (#1583)
 - Contracts declaring `apiVersion: v3.2.0` lint and round-trip, including `enum`, `map`, `vector`, `semanticType`, `synonyms`, `deprecated`, `context`, variables in string values, and the new server types (#1558)
 - `datacontract export avro-idl` writes `map<...>` and `array<float>` for `map` and `vector` properties; `datacontract export sqlalchemy` writes `JSON` and `ARRAY(Float)` (#1558)
 - `datacontract test` resolves `${VAR}` and `${VAR:-default}` references in server fields and SQL quality queries from the environment; an unset variable without a default fails the run with its name, and `export` keeps the references (#1559)

--- a/datacontract/config/variables.py
+++ b/datacontract/config/variables.py
@@ -15,6 +15,7 @@ import os
 import re
 
 from open_data_contract_standard.model import Server
+from pydantic import BaseModel
 
 _VARIABLE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}")
 
@@ -90,3 +91,43 @@ def resolve_server_variables(server: Server) -> Server:
 
 def _field_name(field: str) -> str:
     return "schema" if field == "schema_" else field
+
+
+# These fields document the contract rather than supply test inputs. SQL queries
+# resolve separately, after the engine substitutes its ${model}/${field} tokens;
+# servers resolve separately, after configuration overrides and server selection.
+_DEFERRED_FIELDS = {
+    "authoritativeDefinitions",
+    "businessName",
+    "context",
+    "description",
+    "examples",
+    "implementation",
+    "query",
+    "servers",
+    "synonyms",
+    "transformLogic",
+    "transformSourceObjects",
+}
+
+
+def resolve_runtime_variables(value, source: str = "contract"):
+    """Copy test inputs with variables resolved, recursively, without altering the contract.
+
+    Handles property names/types, enum values, logical type options, library
+    quality arguments, SLA values, and nested array/map definitions. Dictionary
+    keys are structural identifiers and are never interpolated.
+    """
+    if isinstance(value, BaseModel):
+        return value.model_copy(
+            update={
+                field: resolve_runtime_variables(getattr(value, field), f"{source}.{_field_name(field)}")
+                for field in type(value).model_fields
+                if field not in _DEFERRED_FIELDS
+            }
+        )
+    if isinstance(value, dict):
+        return {key: resolve_runtime_variables(item, f"{source}.{key}") for key, item in value.items()}
+    if isinstance(value, list):
+        return [resolve_runtime_variables(item, f"{source}[{index}]") for index, item in enumerate(value)]
+    return resolve_variables(value, source=source)

--- a/datacontract/engines/data_contract_test.py
+++ b/datacontract/engines/data_contract_test.py
@@ -13,7 +13,7 @@ if typing.TYPE_CHECKING:
     from duckdb.duckdb import DuckDBPyConnection
     from pyspark.sql import SparkSession
 
-from datacontract.config.variables import UnresolvedVariableError, resolve_server_variables
+from datacontract.config.variables import UnresolvedVariableError, resolve_runtime_variables, resolve_server_variables
 from datacontract.engines.datacontract.check_azure_blob_file import check_azure_blob_file
 from datacontract.engines.datacontract.check_that_datacontract_contains_valid_servers_configuration import (
     check_that_datacontract_contains_valid_server_configuration,
@@ -57,6 +57,26 @@ def execute_data_contract_test(
         server_name = data_contract.servers[0].server
     server = resolve_server_overrides(get_server(data_contract, server_name), config, run)
     server = _resolve_server_variables(server)
+    try:
+        # Leave unselected schemas untouched: their variables need not be set.
+        runtime_schemas = [
+            resolve_runtime_variables(schema, f"schema[{index}]")
+            if schema_name == "all" or schema.name == schema_name
+            else schema
+            for index, schema in enumerate(data_contract.schema_)
+        ]
+        data_contract = resolve_runtime_variables(data_contract.model_copy(update={"schema_": None})).model_copy(
+            update={"schema_": runtime_schemas}
+        )
+    except UnresolvedVariableError as e:
+        raise DataContractException(
+            type="schema",
+            name="Resolve contract variables",
+            result=ResultEnum.failed,
+            reason=str(e),
+            engine="datacontract-cli",
+            original_exception=e,
+        ) from e
     run.log_info(f"Running tests for data contract {data_contract.id} with server {server_name}")
     run.dataContractId = data_contract.id
     run.dataContractVersion = data_contract.version

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -53,7 +53,7 @@ schema:
         mustBe: 0
 ```
 
-The CLI resolves a reference at the moment it uses the value: when `datacontract test` opens the connection, and when it prepares a SQL quality query for execution. In queries, the CLI's own placeholders such as `${model}` and `${schema}` are substituted first. Values come from the environment, including a loaded `.env` file. A reference to an unset or empty variable without a default fails the run with the variable's name; an empty string is never substituted silently. The contract itself is never changed: `lint` accepts unresolved references, and `export` and `publish` write them back exactly as written.
+The CLI resolves references in test inputs: server fields, schema and property names, enum values, nested type options, library quality arguments, and service levels. SQL quality queries resolve when their checks are prepared; the CLI's own placeholders such as `${model}` and `${schema}` are substituted first. Values come from the environment, including a loaded `.env` file. A reference to an unset or empty variable without a default fails the run with the variable's name and field path; an empty string is never substituted silently. Unselected schemas and documentation fields such as descriptions and context do not need their variables set. The contract itself is never changed: `lint` accepts unresolved references, and `export` and `publish` write them back exactly as written.
 
 The [per-source override options](#all-options) such as `DATACONTRACT_POSTGRES_HOST` take precedence over the contract, so an override replaces a reference in the same field without resolving it.
 

--- a/tests/test_test_variables.py
+++ b/tests/test_test_variables.py
@@ -114,3 +114,46 @@ def test_export_keeps_the_references(orders_db, monkeypatch):
         exported["schema"][0]["quality"][1]["query"]
         == "SELECT count(*) FROM orders WHERE order_total > ${ORDER_TOTAL_LIMIT}"
     )
+
+
+@pytest.mark.parametrize("version", ["v3.1.0", "v3.2.0"])
+def test_property_and_library_values_resolve_without_changing_yaml(orders_db, monkeypatch, version):
+    monkeypatch.setenv("ORDERS_DB", orders_db)
+    monkeypatch.setenv("ORDER_TOTAL_LIMIT", "500")
+    monkeypatch.setenv("RUNTIME_TABLE", "orders")
+    monkeypatch.setenv("RUNTIME_COLUMN", "order_id")
+    monkeypatch.setenv("FIRST_ORDER", "1")
+    document = yaml.safe_load(CONTRACT)
+    document["apiVersion"] = version
+    schema = document["schema"][0]
+    schema["physicalName"] = "${RUNTIME_TABLE}"
+    prop = schema["properties"][0]
+    prop["physicalName"] = "${RUNTIME_COLUMN}"
+    prop["enum"] = [{"value": "${FIRST_ORDER}"}, {"value": "2"}]
+    prop["quality"] = [
+        {
+            "type": "library",
+            "metric": "invalidValues",
+            "arguments": {"validValues": ["${FIRST_ORDER}", "2"]},
+            "mustBe": 0,
+        }
+    ]
+    schema["quality"][0]["query"] = "SELECT count(*) FROM ${model}"
+    contract = DataContract(data_contract_str=yaml.safe_dump(document))
+    assert contract.lint().result == ResultEnum.passed
+    run = contract.test()
+    assert run.result == ResultEnum.passed, run.pretty()
+    assert yaml.safe_load(contract.export("odcs")) == document
+
+
+def test_unset_property_variable_reports_its_path(orders_db, monkeypatch):
+    monkeypatch.setenv("ORDERS_DB", orders_db)
+    monkeypatch.delenv("MISSING_PHYSICAL_TABLE", raising=False)
+    document = yaml.safe_load(CONTRACT)
+    document["schema"][0]["physicalName"] = "${MISSING_PHYSICAL_TABLE}"
+    run = DataContract(data_contract_str=yaml.safe_dump(document)).test()
+    assert run.result == ResultEnum.failed
+    failed = [c for c in run.checks if c.result == ResultEnum.failed]
+    assert len(failed) == 1
+    assert "MISSING_PHYSICAL_TABLE" in failed[0].reason
+    assert "schema[0].physicalName" in failed[0].reason

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -6,6 +6,7 @@ from open_data_contract_standard.model import CustomProperty, Server
 from datacontract.config.variables import (
     UnresolvedVariableError,
     contains_variables,
+    resolve_runtime_variables,
     resolve_server_variables,
     resolve_variables,
 )
@@ -125,3 +126,32 @@ def test_unresolvable_server_field_names_the_server_and_field(monkeypatch):
         resolve_server_variables(server)
 
     assert "server 'prod' host" in str(e.value)
+
+
+def test_runtime_resolution_covers_nested_maps_arrays_and_options(monkeypatch):
+    from open_data_contract_standard.model import SchemaProperty
+
+    monkeypatch.setenv("STATUS", "ready")
+    prop = SchemaProperty.model_validate(
+        {
+            "name": "attributes",
+            "logicalType": "map",
+            "description": "Keep ${DOCUMENTATION_TOKEN} verbatim",
+            "map": {
+                "key": {"logicalType": "string"},
+                "value": {
+                    "logicalType": "array",
+                    "items": {
+                        "logicalType": "string",
+                        "enum": [{"value": "${STATUS}"}],
+                        "logicalTypeOptions": {"pattern": "^${STATUS}$"},
+                    },
+                },
+            },
+        }
+    )
+    resolved = resolve_runtime_variables(prop)
+    assert resolved.map.value.items.enum[0].value == "ready"
+    assert resolved.map.value.items.logicalTypeOptions["pattern"] == "^ready$"
+    assert prop.map.value.items.enum[0].value == "${STATUS}"
+    assert resolved.description == prop.description


### PR DESCRIPTION
`datacontract test` now resolves variables in schema/property names, enum values, nested type options, library quality arguments, and service levels. A contract using `${TABLE}` for its physical table name and `${STATUS}` for an allowed value now tests the resolved data correctly, while ODCS export preserves the original tokens.

Server override precedence and deferred SQL placeholder handling are preserved. Documentation fields and unselected schemas do not require their variables to be set.

Validation: 37 variable-resolution and dry-run tests passed, including both ODCS 3.1.0 and 3.2.0 runtime round-trips. Ruff checks and formatting passed.

Closes #1583. Part of #1557.
