### PR TITLE
Detect breaking enum and vector changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This release adds support for the [Open Data Contract Standard v3.2.0](https://g
 - `datacontract test` supports the `iceberg` server type: tables are read from the REST catalog named by `catalogUrl`, `namespace` and `warehouse` with pyiceberg (credentials via `DATACONTRACT_ICEBERG_CREDENTIAL` or `DATACONTRACT_ICEBERG_TOKEN`, data files via the S3 options; `DATACONTRACT_ICEBERG_CATALOG_TYPE` selects a `sql`, `glue` or `hive` catalog instead of `rest`, `DATACONTRACT_ICEBERG_S3_ENDPOINT` points at an S3-compatible store, Amazon S3 Tables and the Glue REST endpoint are signed with SigV4 from the AWS credentials, `DATACONTRACT_ICEBERG_PROPERTIES` passes further catalog properties through), and `datacontract import iceberg --catalog-url` creates a contract from a catalog table with a ready-to-test server (#1565)
 
 ### Changed
+- `datacontract breaking` detects enum restrictions and vector shape changes (#1584)
 - `datacontract init` and all importers write `apiVersion: v3.2.0` (#1558)
 - The bundled Data Contract Editor (`datacontract edit`) is updated to 0.1.13 (#1566)
 - `open-data-contract-standard` dependency bumped to 3.2.x (#1558)

--- a/datacontract/breaking/detector.py
+++ b/datacontract/breaking/detector.py
@@ -23,11 +23,38 @@ class BreakingChangeDetector:
     def detect(self, changelog: ChangelogResult) -> BreakingChangeResult:
         entries = [self._classify(entry) for entry in changelog.entries]
         # Nothing inside a newly added element can break a consumer: it did not exist before.
-        added = {entry.path for entry in entries if entry.change_type == ChangelogType.added}
+        added = {
+            entry.path
+            for entry in entries
+            if entry.change_type == ChangelogType.added
+            and (
+                entry.path.startswith("schema.")
+                and (len(entry.path.split(".")) == 2 or entry.path.split(".")[-2] == "properties")
+            )
+        }
+        removed_enums = {
+            entry.path
+            for entry in entries
+            if entry.change_type == ChangelogType.removed and entry.path.endswith(".enum")
+        }
+        # Stable IDs may change or swap without changing the set of allowed
+        # values. Match removed/updated values against additions in the same enum.
+        added_values = defaultdict(set)
+        for entry in entries:
+            if entry.rule_id == "enum-constraint-changed" and entry.path.endswith(".value"):
+                if entry.change_type in (ChangelogType.added, ChangelogType.updated):
+                    added_values[entry.path.rsplit(".enum.", 1)[0]].add(entry.new_value)
         for entry in entries:
             segments = entry.path.split(".")
             if any(".".join(segments[:i]) in added for i in range(1, len(segments))):
                 entry.level = BreakingChangeLevel.INFO
+            if entry.rule_id == "enum-constraint-changed":
+                if any(entry.path.startswith(path + ".") for path in removed_enums):
+                    entry.level = BreakingChangeLevel.INFO
+                elif entry.path.endswith(".value") and entry.old_value in added_values.get(
+                    entry.path.rsplit(".enum.", 1)[0], set()
+                ):
+                    entry.level = BreakingChangeLevel.INFO
         entries_by_prefix = defaultdict(list)
         for entry in entries:
             prefix = ""

--- a/datacontract/breaking/rules.py
+++ b/datacontract/breaking/rules.py
@@ -140,6 +140,43 @@ class MetadataFallbackRule(BreakingChangeRule):
         return RuleEvaluation(self.rule_id, BreakingChangeLevel.INFO, _change_message("contract", entry))
 
 
+class EnumConstraintRule(BreakingChangeRule):
+    rule_id = "enum-constraint-changed"
+
+    def evaluate(self, entry: ChangelogEntry) -> RuleEvaluation | None:
+        if not entry.path.startswith("schema.") or ".properties." not in entry.path:
+            return None
+        if entry.path.endswith(".enum"):
+            level = BreakingChangeLevel.ERROR if entry.type == ChangelogType.added else BreakingChangeLevel.INFO
+        elif (
+            ".enum." in entry.path
+            and entry.path.endswith(".value")
+            and ".customProperties." not in entry.path.rsplit(".enum.", 1)[1]
+            and ".authoritativeDefinitions." not in entry.path.rsplit(".enum.", 1)[1]
+        ):
+            level = BreakingChangeLevel.INFO if entry.type == ChangelogType.added else BreakingChangeLevel.ERROR
+        else:
+            return None
+        return RuleEvaluation(self.rule_id, level, _change_message("allowed values", entry))
+
+
+class VectorShapeRule(BreakingChangeRule):
+    rule_id = "vector-shape-changed"
+
+    def evaluate(self, entry: ChangelogEntry) -> RuleEvaluation | None:
+        if not entry.path.startswith("schema.") or not entry.path.endswith(
+            (".logicalTypeOptions.dimensions", ".logicalTypeOptions.elementType")
+        ):
+            return None
+        if entry.path.endswith(".elementType"):
+            old = entry.old_value or "float32"
+            new = entry.new_value or "float32"
+            level = BreakingChangeLevel.INFO if old == new else BreakingChangeLevel.ERROR
+        else:
+            level = BreakingChangeLevel.WARNING if entry.type == ChangelogType.removed else BreakingChangeLevel.ERROR
+        return RuleEvaluation(self.rule_id, level, _change_message("vector shape", entry))
+
+
 def _is_schema_property_path(segments: list[str]) -> bool:
     return len(segments) >= 3 and segments[0] == "schema" and segments[-2] == "properties"
 
@@ -192,5 +229,7 @@ DEFAULT_RULES: tuple[BreakingChangeRule, ...] = (
     UniqueConstraintRule(),
     KeyConstraintRule(),
     ValidationConstraintRule(),
+    EnumConstraintRule(),
+    VectorShapeRule(),
     MetadataFallbackRule(),
 )

--- a/tests/test_breaking_odcs_3_2.py
+++ b/tests/test_breaking_odcs_3_2.py
@@ -1,0 +1,94 @@
+import copy
+
+import pytest
+import yaml
+
+from datacontract.data_contract import DataContract
+
+
+def contract(properties):
+    return DataContract(
+        data_contract_str=yaml.safe_dump(
+            {
+                "apiVersion": "v3.2.0",
+                "kind": "DataContract",
+                "id": "test",
+                "version": "1",
+                "status": "active",
+                "schema": [{"name": "orders", "properties": properties}],
+            }
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "old,new,breaking",
+    [
+        ([{"value": "a"}, {"value": "b"}], [{"value": "a"}], True),
+        ([{"value": "a"}], [{"value": "a"}, {"value": "b"}], False),
+        (None, [{"value": "a"}], True),
+        ([{"value": "a"}], None, False),
+        ([{"id": "one", "value": "a"}], [{"id": "one", "value": "b"}], True),
+        ([{"id": "one", "value": "a"}], [{"id": "renamed", "value": "a"}], False),
+        ([{"value": "a", "label": "Old"}], [{"value": "a", "label": "New"}], False),
+    ],
+)
+@pytest.mark.parametrize("nested", [False, True])
+def test_enum_compatibility(old, new, breaking, nested):
+    def properties(entries):
+        prop = {"name": "status", "logicalType": "string"}
+        if entries is not None:
+            prop["enum"] = entries
+        if nested:
+            prop = {
+                "name": "attributes",
+                "logicalType": "map",
+                "map": {
+                    "key": {"logicalType": "string"},
+                    "value": {"logicalType": "object", "properties": [prop]},
+                },
+            }
+        return [prop]
+
+    result = contract(properties(old)).breaking(contract(properties(new)))
+    assert result.is_breaking is breaking, result.model_dump()
+
+
+@pytest.mark.parametrize(
+    "old,new,breaking",
+    [
+        ({"dimensions": 3}, {"dimensions": 4}, True),
+        ({"dimensions": 3}, {"dimensions": 3, "elementType": "float32"}, False),
+        ({"dimensions": 3}, {"dimensions": 3, "elementType": "float64"}, True),
+        ({"dimensions": 3, "elementType": "float64"}, {"dimensions": 3}, True),
+        ({"dimensions": 3, "elementType": "float32"}, {"dimensions": 3}, False),
+        ({"dimensions": 3}, {"dimensions": 3, "embeddingModel": "updated"}, False),
+    ],
+)
+def test_vector_shape_compatibility(old, new, breaking):
+    def properties(options):
+        return [{"name": "embedding", "logicalType": "vector", "logicalTypeOptions": options}]
+
+    assert contract(properties(old)).breaking(contract(properties(new))).is_breaking is breaking
+
+
+def test_adding_properties_with_enum_and_vector_constraints_is_not_breaking():
+    original = [{"name": "id", "logicalType": "integer"}]
+    added = copy.deepcopy(original) + [
+        {"name": "status", "logicalType": "string", "enum": [{"value": "a"}]},
+        {"name": "embedding", "logicalType": "vector", "logicalTypeOptions": {"dimensions": 3}},
+    ]
+    assert not contract(original).breaking(contract(added)).is_breaking
+
+
+def test_enum_custom_property_change_is_metadata():
+    original = [
+        {
+            "name": "status",
+            "logicalType": "string",
+            "enum": [{"value": "a", "customProperties": [{"property": "color", "value": "blue"}]}],
+        }
+    ]
+    updated = copy.deepcopy(original)
+    updated[0]["enum"][0]["customProperties"][0]["value"] = "green"
+    assert not contract(original).breaking(contract(updated)).is_breaking


### PR DESCRIPTION
Breaking-change detection now flags newly introduced enum constraints, removed/replaced allowed values, and changed vector dimensions or element types. Removing an enum constraint, editing labels or custom metadata, renaming enum IDs without changing values, and adding new properties remain non-breaking.

The implicit `float32` vector default is respected. New constraints on existing properties are no longer hidden by the addition of their options container.

Validation: 52 breaking-change tests passed, including nested map properties, stable IDs, metadata-only edits, and vector defaults. Ruff formatting applied.

Closes #1584. Part of #1557.
