### PR TITLE
Check vector element types reported by catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This release adds support for the [Open Data Contract Standard v3.2.0](https://github.com/bitol-io/open-data-contract-standard/blob/main/CHANGELOG.md). Development happens on the `odcs-3.2.0` branch, tracked in #1557.
 
+### Fixed
+- `datacontract test` checks vector element types when the data source reports them (#1585)
+
 ### Added
 - Contracts declaring `apiVersion: v3.2.0` lint and round-trip, including `enum`, `map`, `vector`, `semanticType`, `synonyms`, `deprecated`, `context`, variables in string values, and the new server types (#1558)
 - `datacontract export avro-idl` writes `map<...>` and `array<float>` for `map` and `vector` properties; `datacontract export sqlalchemy` writes `JSON` and `ARRAY(Float)` (#1558)

--- a/datacontract/engines/checks/type_normalize.py
+++ b/datacontract/engines/checks/type_normalize.py
@@ -17,7 +17,7 @@ from open_data_contract_standard.model import SchemaProperty
 
 from datacontract.engines.checks.physical_type_match import physical_type_matches
 from datacontract.model.map_type import get_map_key, get_map_value
-from datacontract.model.vector_type import vector_dimensions
+from datacontract.model.vector_type import observed_vector_element_type, vector_dimensions, vector_element_type
 
 # logicalType marker for a field whose type the backend cannot describe: a
 # dynamically-typed column (ibis json: Snowflake VARIANT, Postgres JSONB,
@@ -224,6 +224,10 @@ def _vector_mismatch(expected: SchemaProperty, actual: SchemaProperty, actual_ba
     expected_dimensions, actual_dimensions = vector_dimensions(expected), vector_dimensions(actual)
     if expected_dimensions is not None and actual_dimensions is not None and expected_dimensions != actual_dimensions:
         return f"expected {expected_dimensions} dimensions but got {actual_dimensions}"
+    actual_element = observed_vector_element_type(actual)
+    expected_element = vector_element_type(expected)
+    if actual_element is not None and actual_element != expected_element:
+        return f"expected vector element type '{expected_element}' but got '{actual_element}'"
     return None
 
 
@@ -299,7 +303,7 @@ def schema_property_mismatch_reasons(
     # A leaf that declares a physicalType is compared against the column's real
     # native type, where the backend reports one. The declared type wins over the
     # logicalType, as it does for the column itself.
-    if expected_base not in ("object", "array", "map") and expected.physicalType and actual.physicalType:
+    if expected_base not in ("object", "array", "map", "vector") and expected.physicalType and actual.physicalType:
         result, reason = physical_type_matches(expected.physicalType, actual.physicalType, dialect)
         if result is True:
             return errors

--- a/datacontract/engines/ibis/dtype_category.py
+++ b/datacontract/engines/ibis/dtype_category.py
@@ -84,11 +84,12 @@ def ibis_dtype_to_schema_property(dtype: DataType) -> SchemaProperty:
             return SchemaProperty(logicalType="object", properties=properties)
         if dtype.is_array():
             element = ibis_dtype_to_schema_property(dtype.value_type)
+            options = None
             if dtype.value_type.is_floating() or dtype.value_type.is_integer():
                 # Keep numeric width/sign for vector checks without changing the
-                # coarse integer/number categories used for ordinary arrays.
-                element = element.model_copy(update={"physicalType": str(dtype.value_type)})
-            return SchemaProperty(logicalType="array", items=element)
+                # physical-type comparison or diagnostics of ordinary arrays.
+                options = {"elementType": str(dtype.value_type)}
+            return SchemaProperty(logicalType="array", items=element, logicalTypeOptions=options)
         if dtype.is_map():
             return SchemaProperty(
                 logicalType="map",

--- a/datacontract/engines/ibis/dtype_category.py
+++ b/datacontract/engines/ibis/dtype_category.py
@@ -80,18 +80,14 @@ def ibis_dtype_to_schema_property(dtype: DataType) -> SchemaProperty:
             for field_name, ftype in dtype.fields.items():
                 # an unverifiable field type is still a field: keep it, so it is not reported missing
                 child = ibis_dtype_to_schema_property(ftype)
-                properties.append(
-                    SchemaProperty(
-                        name=field_name,
-                        logicalType=child.logicalType,
-                        physicalType=child.physicalType,
-                        items=child.items,
-                        properties=child.properties,
-                    )
-                )
+                properties.append(child.model_copy(update={"name": field_name}))
             return SchemaProperty(logicalType="object", properties=properties)
         if dtype.is_array():
             element = ibis_dtype_to_schema_property(dtype.value_type)
+            if dtype.value_type.is_floating() or dtype.value_type.is_integer():
+                # Keep numeric width/sign for vector checks without changing the
+                # coarse integer/number categories used for ordinary arrays.
+                element = element.model_copy(update={"physicalType": str(dtype.value_type)})
             return SchemaProperty(logicalType="array", items=element)
         if dtype.is_map():
             return SchemaProperty(

--- a/datacontract/model/vector_type.py
+++ b/datacontract/model/vector_type.py
@@ -78,3 +78,33 @@ def vector_element_type(prop: SchemaProperty) -> str:
 def is_double(prop: SchemaProperty) -> bool:
     """True when the elements need 64-bit floats."""
     return vector_element_type(prop) == "float64"
+
+
+def observed_vector_element_type(prop: SchemaProperty) -> Optional[str]:
+    """Return the element type a catalog actually reports, without inventing a default."""
+    explicit = (prop.logicalTypeOptions or {}).get("elementType")
+    if explicit:
+        return str(explicit).lower()
+    parsed = parse_vector_type(prop.physicalType)
+    if parsed:
+        return parsed[1]
+    if prop.items and prop.items.physicalType:
+        name = prop.items.physicalType.lower()
+        aliases = {
+            "half": "float16",
+            "float": "float32",
+            "real": "float32",
+            "float4": "float32",
+            "double": "float64",
+            "double precision": "float64",
+            "float8": "float64",
+            "tinyint": "int8",
+            "smallint": "int16",
+            "integer": "int32",
+            "int": "int32",
+            "bigint": "int64",
+        }
+        name = aliases.get(name, name)
+        if re.fullmatch(r"(?:u?int(?:8|16|32|64)|b?float(?:16|32|64)|binary)", name):
+            return name
+    return None

--- a/docs/docs/schema.md
+++ b/docs/docs/schema.md
@@ -99,6 +99,8 @@ A property can declare a portable `logicalType`, a native `physicalType`, or bot
 
 Properties of `logicalType: object`, `array` or `map` that declare `properties`, `items` or a `map` block (`key` and `value`, ODCS v3.2.0) also get a **nested type check** covering the full declared structure.
 
+Vector type checks compare dimensions and element types when the data source reports them. `logicalTypeOptions.elementType` defaults to `float32`; a column reported as `float64` or `int8` does not satisfy that declaration. Catalogs that expose only a numeric array without its element width cannot confirm an element-type mismatch.
+
 :::note
 For file servers with `format: csv`, `json`, or `avro` **no type check is generated at all** — the file is read *as* the contract's types, so a mismatch surfaces as a read error instead. `format: json` is additionally validated against a JSON Schema derived from the contract. See [Data Source Reference](./reference/index.md#how-data-types-work) for the full type-mapping rules.
 :::

--- a/tests/test_vector_type.py
+++ b/tests/test_vector_type.py
@@ -110,6 +110,84 @@ def test_vector_mismatches():
     assert not schema_property_matches(expected, SchemaProperty(logicalType="string"))
 
 
+@pytest.mark.parametrize(
+    "expected_element,actual_element",
+    [("float32", "float64"), ("float32", "int8"), ("float16", "bfloat16"), ("int8", "uint8")],
+)
+def test_vector_element_mismatches(expected_element, actual_element):
+    expected = _vector(3, elementType=expected_element)
+    actual = _vector(3, elementType=actual_element)
+    assert not schema_property_matches(expected, actual)
+    reason = schema_property_mismatch_reason(expected, actual)
+    assert expected_element in reason and actual_element in reason
+
+
+def test_unknown_actual_element_type_does_not_assume_float32():
+    assert schema_property_matches(_vector(3, elementType="float64"), SchemaProperty(logicalType="vector"))
+
+
+def test_equal_physical_types_do_not_hide_conflicting_vector_options():
+    expected = _vector(3, elementType="float64").model_copy(update={"physicalType": "FLOAT[3]"})
+    actual = SchemaProperty(logicalType="vector", physicalType="FLOAT[3]")
+    assert not schema_property_matches(expected, actual)
+    assert "float64" in schema_property_mismatch_reason(expected, actual)
+
+
+def test_nested_vector_elements_keep_catalog_information():
+    import ibis.expr.datatypes as dt
+
+    from datacontract.engines.ibis.dtype_category import ibis_dtype_to_schema_property
+
+    actual = ibis_dtype_to_schema_property(dt.Struct({"vectors": dt.Map(dt.string, dt.Array(dt.float64))}))
+    expected = SchemaProperty.model_validate(
+        {
+            "logicalType": "object",
+            "properties": [
+                {
+                    "name": "vectors",
+                    "logicalType": "map",
+                    "map": {
+                        "key": {"logicalType": "string"},
+                        "value": {
+                            "logicalType": "vector",
+                            "logicalTypeOptions": {"dimensions": 3, "elementType": "float32"},
+                        },
+                    },
+                }
+            ],
+        }
+    )
+    assert not schema_property_matches(expected, actual)
+    reason = schema_property_mismatch_reason(expected, actual)
+    assert "vectors[value]" in reason and "float64" in reason
+
+
+@pytest.mark.parametrize(
+    "native,expected_element,passes",
+    [
+        ("FLOAT[3]", "float32", True),
+        ("DOUBLE[3]", "float32", False),
+        ("DOUBLE[3]", "float64", True),
+        ("TINYINT[3]", "float32", False),
+        ("TINYINT[3]", "int8", True),
+    ],
+)
+def test_runtime_vector_elements_without_declared_physical_type(tmp_path, native, expected_element, passes):
+    path = str(tmp_path / "vectors.duckdb")
+    con = duckdb.connect(path)
+    con.execute(f"CREATE TABLE documents (embedding {native})")
+    con.close()
+    document = yaml.safe_load(CONTRACT.format(database=path, dimensions=3))
+    prop = document["schema"][0]["properties"][1]
+    prop.pop("physicalType")
+    prop["logicalTypeOptions"]["elementType"] = expected_element
+    document["schema"][0]["properties"] = [prop]
+    run = DataContract(data_contract_str=yaml.safe_dump(document)).test()
+    assert (run.result == ResultEnum.passed) is passes, run.pretty()
+    if not passes:
+        assert any("vector element type" in (c.reason or "") for c in run.checks if c.result == ResultEnum.failed)
+
+
 # --- datacontract test against DuckDB -----------------------------------------------------------
 
 


### PR DESCRIPTION
Vector checks now compare the declared element type with catalog-reported element types, including numeric array width and signedness. A `float32` contract fails against a `DOUBLE[3]` or `TINYINT[3]` column with an explicit mismatch reason; matching types pass.

Nested structs/maps preserve the type information needed for this comparison. Unknown catalog element types remain unasserted, and equal physical type strings no longer hide conflicting logical vector options.

Validation: 125 vector, dtype, map, nested-check, and Snowflake structured-type tests passed; an additional nested-vector regression passed in the subsequent 40-test vector run. Ruff checks and formatting passed.

Closes #1585. Part of #1557.
