### PR TITLE
Require vector dimensions and unique enum values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This release adds support for the [Open Data Contract Standard v3.2.0](https://github.com/bitol-io/open-data-contract-standard/blob/main/CHANGELOG.md). Development happens on the `odcs-3.2.0` branch, tracked in #1557.
 
 ### Added
+- Lint requires vector dimensions and rejects duplicate enum values regardless of their labels (#1586)
 - Contracts declaring `apiVersion: v3.2.0` lint and round-trip, including `enum`, `map`, `vector`, `semanticType`, `synonyms`, `deprecated`, `context`, variables in string values, and the new server types (#1558)
 - `datacontract export avro-idl` writes `map<...>` and `array<float>` for `map` and `vector` properties; `datacontract export sqlalchemy` writes `JSON` and `ARRAY(Float)` (#1558)
 - `datacontract test` resolves `${VAR}` and `${VAR:-default}` references in server fields and SQL quality queries from the environment; an unset variable without a default fails the run with its name, and `export` keeps the references (#1559)

--- a/datacontract/lint/constraints.py
+++ b/datacontract/lint/constraints.py
@@ -1,0 +1,50 @@
+"""ODCS constraints that JSON Schema cannot express."""
+
+from datacontract.model.exceptions import DataContractException
+
+
+def enum_value_errors(contract: dict) -> list[DataContractException]:
+    """Require unique values, independently of labels/IDs, throughout the property tree.
+
+    JSON numbers compare by value (1 equals 1.0), but booleans and strings are
+    distinct types. Unlike uniqueItems, metadata does not participate in equality.
+    Invalid shapes are left to JSON Schema, including in --all-errors mode.
+    """
+    errors = []
+
+    def visit(node, path):
+        if not isinstance(node, dict):
+            return
+        seen = {}
+        entries = node.get("enum")
+        for index, entry in enumerate(entries if isinstance(entries, list) else []):
+            if not isinstance(entry, dict) or "value" not in entry:
+                continue
+            value = entry["value"]
+            if isinstance(value, (dict, list)):
+                continue
+            kind = "number" if type(value) in (int, float) else type(value).__name__
+            key = (kind, value)
+            if key in seen:
+                errors.append(
+                    DataContractException(
+                        type="lint",
+                        name="Check that enum values are unique",
+                        reason=f"{path}.enum[{index}].value duplicates enum[{seen[key]}].value ({value!r})",
+                    )
+                )
+            else:
+                seen[key] = index
+        properties = node.get("properties")
+        for index, prop in enumerate(properties if isinstance(properties, list) else []):
+            visit(prop, f"{path}.properties[{index}]")
+        visit(node.get("items"), f"{path}.items")
+        mapping = node.get("map")
+        if isinstance(mapping, dict):
+            for side in ("key", "value"):
+                visit(mapping.get(side), f"{path}.map.{side}")
+
+    schemas = contract.get("schema")
+    for index, schema in enumerate(schemas if isinstance(schemas, list) else []):
+        visit(schema, f"schema[{index}]")
+    return errors

--- a/datacontract/lint/resolve.py
+++ b/datacontract/lint/resolve.py
@@ -13,6 +13,7 @@ from open_data_contract_standard.model import OpenDataContractStandard, SchemaPr
 from pydantic import ConfigDict
 
 from datacontract.config import Config
+from datacontract.lint.constraints import enum_value_errors
 from datacontract.lint.resources import read_resource
 from datacontract.lint.schema import fetch_schema
 from datacontract.model.exceptions import (
@@ -616,7 +617,17 @@ def _resolve_data_contract_from_str(
         custom_schema = schema_location is not None
         if schema_location is None:
             schema_location = resources.files("datacontract").joinpath("schemas", "odcs-3.2.0.schema.json")
-        _validate_json_schema(yaml_dict, schema_location, all_errors=all_errors)
+        errors = []
+        try:
+            _validate_json_schema(yaml_dict, schema_location, all_errors=all_errors)
+        except DataContractValidationErrors as e:
+            errors.extend(e.errors)
+        if not custom_schema:
+            errors.extend(enum_value_errors(yaml_dict))
+        if errors:
+            if all_errors:
+                raise DataContractValidationErrors(errors)
+            raise errors[0]
 
         odcs = _parse_odcs_from_dict(yaml_dict, lax=custom_schema)
         if inline_references:

--- a/datacontract/schemas/download
+++ b/datacontract/schemas/download
@@ -12,3 +12,7 @@ curl -o odcs-3.2.0.schema.json https://raw.githubusercontent.com/bitol-io/open-d
 # forced to carry a `map` block. Reported upstream; drop the patch once the upstream schema has it.
 # It also adds `blob` to the schema-object `logicalType` enum, a CLI extension used by
 # `datacontract test` for Azure Blob file-metadata checks (same patch as in odcs-3.1.0.schema.json).
+# The vector conditional also requires logicalTypeOptions, so omitting the entire
+# options block cannot bypass its required dimensions field (#1586).
+# Enum value uniqueness is checked by lint/constraints.py: uniqueItems in JSON
+# Schema only rejects identical whole entries, including their metadata.

--- a/datacontract/schemas/odcs-3.2.0.schema.json
+++ b/datacontract/schemas/odcs-3.2.0.schema.json
@@ -3046,7 +3046,10 @@
                   "dimensions"
                 ]
               }
-            }
+            },
+            "required": [
+              "logicalTypeOptions"
+            ]
           }
         }
       ],

--- a/docs/docs/schema.md
+++ b/docs/docs/schema.md
@@ -99,6 +99,10 @@ A property can declare a portable `logicalType`, a native `physicalType`, or bot
 
 Properties of `logicalType: object`, `array` or `map` that declare `properties`, `items` or a `map` block (`key` and `value`, ODCS v3.2.0) also get a **nested type check** covering the full declared structure.
 
+ODCS v3.2.0 `logicalType: vector` requires `logicalTypeOptions.dimensions` to be a positive integer. Lint rejects a missing options block as well as missing or invalid dimensions, including in nested definitions.
+
+Property-level `enum` entries must have distinct values, even if their labels, IDs, or descriptions differ. Lint checks this throughout properties, array items, and map keys and values. JSON numbers compare by value (`1` equals `1.0`); strings and booleans remain distinct from numbers.
+
 :::note
 For file servers with `format: csv`, `json`, or `avro` **no type check is generated at all** — the file is read *as* the contract's types, so a mismatch surfaces as a read error instead. `format: json` is additionally validated against a JSON Schema derived from the contract. See [Data Source Reference](./reference/index.md#how-data-types-work) for the full type-mapping rules.
 :::

--- a/tests/test_lint_odcs_3_2_constraints.py
+++ b/tests/test_lint_odcs_3_2_constraints.py
@@ -1,0 +1,94 @@
+import pytest
+import yaml
+
+from datacontract.data_contract import DataContract
+
+
+def document(prop):
+    return {
+        "apiVersion": "v3.2.0",
+        "kind": "DataContract",
+        "id": "test",
+        "version": "1",
+        "status": "active",
+        "schema": [{"name": "orders", "properties": [{"name": "field", **prop}]}],
+    }
+
+
+def lint(prop, **kwargs):
+    return DataContract(data_contract_str=yaml.safe_dump(document(prop)), **kwargs).lint()
+
+
+@pytest.mark.parametrize(
+    "options", [None, {}, {"dimensions": 0}, {"dimensions": -1}, {"dimensions": 1.5}, {"dimensions": "3"}]
+)
+@pytest.mark.parametrize("all_errors", [False, True])
+def test_vector_requires_positive_integer_dimensions(options, all_errors):
+    prop = {"logicalType": "vector"}
+    if options is not None:
+        prop["logicalTypeOptions"] = options
+    assert lint(prop, all_errors=all_errors).result == "failed"
+
+
+@pytest.mark.parametrize("nesting", ["property", "object", "array", "map_key", "map_value"])
+@pytest.mark.parametrize("value", ["a", 1, True, None])
+def test_duplicate_enum_values_fail_regardless_of_labels(nesting, value):
+    prop = {"logicalType": "string", "enum": [{"value": value, "label": "First"}, {"value": value, "label": "Second"}]}
+    if nesting == "object":
+        prop = {"logicalType": "object", "properties": [{"name": "inner", **prop}]}
+    elif nesting == "array":
+        prop = {"logicalType": "array", "items": prop}
+    elif nesting.startswith("map_"):
+        side = nesting.removeprefix("map_")
+        prop = {
+            "logicalType": "map",
+            "map": {"key": {"logicalType": "string"}, "value": {"logicalType": "string"}, side: prop},
+        }
+    run = lint(prop)
+    assert run.result == "failed"
+    assert any("duplicates enum[0].value" in c.reason for c in run.checks if c.reason)
+
+
+def test_numeric_enum_values_compare_by_value():
+    assert lint({"enum": [{"value": 1, "label": "Integer"}, {"value": 1.0, "label": "Float"}]}).result == "failed"
+
+
+def test_distinct_json_types_and_labels_are_valid():
+    assert lint({"enum": [{"value": 1}, {"value": "1"}, {"value": True}, {"value": None}]}).result == "passed"
+    assert lint({"logicalType": "vector", "logicalTypeOptions": {"dimensions": 3}}).result == "passed"
+
+
+def test_all_errors_combines_schema_and_enum_violations():
+    doc = document({"logicalType": "vector"})
+    doc["schema"][0]["properties"].append(
+        {"name": "status", "enum": [{"value": "a", "label": "First"}, {"value": "a", "label": "Second"}]}
+    )
+    run = DataContract(data_contract_str=yaml.safe_dump(doc), all_errors=True).lint()
+    assert run.result == "failed"
+    reasons = [c.reason for c in run.checks]
+    assert any("logicalTypeOptions" in reason for reason in reasons)
+    assert any("duplicates enum" in reason for reason in reasons)
+
+
+@pytest.mark.parametrize("prop", [{"enum": [{"value": "a"}, {"value": "a"}]}, {"logicalType": "vector"}])
+def test_custom_schema_remains_the_source_of_truth(tmp_path, prop):
+    schema = tmp_path / "custom.json"
+    schema.write_text('{"type":"object"}')
+    assert lint(prop, schema_location=str(schema)).result == "passed"
+
+
+@pytest.mark.parametrize(
+    "prop",
+    [
+        {"logicalType": "array", "items": {"logicalType": "vector"}},
+        {"logicalType": "map", "map": {"key": {"logicalType": "string"}, "value": {"logicalType": "vector"}}},
+    ],
+)
+def test_nested_vectors_also_require_dimensions(prop):
+    assert lint(prop).result == "failed"
+
+
+def test_older_physical_only_properties_still_lint():
+    doc = document({"physicalType": "VARCHAR"})
+    doc["apiVersion"] = "v3.1.0"
+    assert DataContract(data_contract_str=yaml.safe_dump(doc)).lint().result == "passed"


### PR DESCRIPTION
Lint now rejects vectors without positive integer dimensions and enum entries that repeat a value with different labels or IDs. Both checks cover nested definitions; enum equality follows JSON types, so `1` equals `1.0` but differs from `true` and `"1"`.

The bundled schema requires the vector options block. Enum uniqueness is checked separately because JSON Schema uniqueItems compares entire entries. `--all-errors` combines schema and semantic errors, custom schemas retain authority, and ODCS 3.1.0 physical-only properties remain valid. The local schema patch is documented in the download instructions.

Validation: 92 lint, round-trip, enum, and vector tests passed; the expanded 40-test constraints suite also passed. Ruff checks and formatting passed.

Combined release validation with #1587, #1588, and #1589: 2,573 passed, 21 skipped, 1 expected failure; all 14 example contracts lint successfully. The conflict-resolved PR tree exactly matches that tested tree.

Closes #1586. Part of #1557.
